### PR TITLE
feat: include the new setupProxy.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "typescript": "^4.3.2"
   },
   "devDependencies": {
+    "@types/express": "^4.17.13",
+    "@types/supertest": "^2.0.11",
     "jest-spec-reporter": "^1.0.17",
     "tslib": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "dependencies": {
     "@types/jest": "^26.0.23",
     "@types/rimraf": "^3.0.0",
+    "express": "^4.16.2",
     "fp-future": "^1.0.1",
     "jest": "^27.0.1",
     "rimraf": "^3.0.2",
+    "supertest": "^6.1.4",
     "ts-jest": "^27.0.1",
     "typescript": "^4.3.2"
   },

--- a/packages/@dcl/dcl-rollup/ecs.config.ts
+++ b/packages/@dcl/dcl-rollup/ecs.config.ts
@@ -52,21 +52,21 @@ const plugins = [
 
 const config: RollupOptions = {
   input: './src/index.ts',
-  context: 'globalThis',
+  context: 'self',
   plugins,
   external: /@decentraland\//,
   output: [
     {
       file: packageJson.main,
       format: 'iife',
-      name: 'globalThis',
+      name: 'self',
       extend: true,
       sourcemap: 'inline'
     },
     {
       file: packageJson.main.replace(/\.js$/, '.min.js'),
       format: 'iife',
-      name: 'globalThis',
+      name: 'self',
       extend: true,
       sourcemap: 'hidden',
       compact: true,

--- a/packages/decentraland-ecs/.gitignore
+++ b/packages/decentraland-ecs/.gitignore
@@ -5,3 +5,5 @@ docs
 docs-yaml
 artifacts
 *.tgz
+
+!src/setupProxy.js

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -27,7 +27,7 @@
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
     "@dcl/posix": "^1.0.0-20210529225617.commit-f7f0ee9",
-    "@dcl/unity-renderer": "latest",
+    "@dcl/unity-renderer": "1.0.2773",
     "decentraland-kernel": "latest"
   }
 }

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -27,6 +27,7 @@
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
     "@dcl/posix": "^1.0.0-20210529225617.commit-f7f0ee9",
-    "@dcl/unity-renderer": "latest"
+    "@dcl/unity-renderer": "latest",
+    "decentraland-kernel": "latest"
   }
 }

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -20,7 +20,8 @@
     "docs",
     "LICENSE",
     "docs-yaml",
-    "artifacts"
+    "artifacts",
+    "src/setupProxy.js"
   ],
   "dependencies": {
     "@dcl/amd": "file:../@dcl/amd",

--- a/packages/decentraland-ecs/src/setupProxy.js
+++ b/packages/decentraland-ecs/src/setupProxy.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 module.exports = function (dcl, app, express) {
     const dclKernelPath = path.dirname(require.resolve('decentraland-kernel/package.json', {paths: [dcl.getWorkingDir()]}));
     const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
+    const dclKernelImagesDecentralandConnect = path.resolve(dclKernelPath, 'images', 'decentraland-connect');
     const dclUnityRenderer = path.resolve(dclKernelPath, 'unity-renderer');
 
     const routeMappingPath = {
@@ -25,7 +26,8 @@ module.exports = function (dcl, app, express) {
         });
     }
     
-    createStaticRoutes(app, '/@/artifacts/unity-renderer/*', dclUnityRenderer)
+    createStaticRoutes(app, '/@/artifacts/unity-renderer/*', dclUnityRenderer);
+    createStaticRoutes(app, '/images/decentraland-connect/*', dclKernelImagesDecentralandConnect);
 
     app.use('/default-profile/', express.static(dclKernelDefaultProfilePath));
 };

--- a/packages/decentraland-ecs/src/setupProxy.js
+++ b/packages/decentraland-ecs/src/setupProxy.js
@@ -2,35 +2,40 @@ const path = require('path')
 const fs = require('fs')
 
 module.exports = function (dcl, app, express) {
-    const dclKernelPath = path.dirname(require.resolve('decentraland-kernel/package.json', {paths: [dcl.getWorkingDir()]}));
-    const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
-    const dclKernelImagesDecentralandConnect = path.resolve(dclKernelPath, 'images', 'decentraland-connect');
-    const dclUnityRenderer = path.dirname(require.resolve('@dcl/unity-renderer/package.json', {paths: [dcl.getWorkingDir()]}));
+  const dclKernelPath = path.dirname(require.resolve('decentraland-kernel/package.json', {paths: [dcl.getWorkingDir()]}));
+  const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
+  const dclKernelImagesDecentralandConnect = path.resolve(dclKernelPath, 'images', 'decentraland-connect');
+  const dclKernelLoaderPath = path.resolve(dclKernelPath, 'loader');
+  const dclUnityRenderer = path.dirname(require.resolve('@dcl/unity-renderer/package.json', {paths: [dcl.getWorkingDir()]}));
 
-    const routeMappingPath = {
-        '/': {
-            path: path.resolve(dclKernelPath, 'preview.html'), 
-            type: 'text/html'
-        },
-        '/@/artifacts/preview.js': {
-            path: path.resolve(dclKernelPath, 'dist', 'preview.js'), 
-            type: 'text/javascript'
-        },
-    };
-    
-    for (const route in routeMappingPath){
-        app.get(route, async (req, res) => {
-            res.setHeader('Content-Type', routeMappingPath[route].type);
-            const contentFile = fs.readFileSync(routeMappingPath[route].path);
-            res.send(contentFile);
-        });
-    }
-    
-    createStaticRoutes(app, '/@/artifacts/unity-renderer/*', dclUnityRenderer);
-    createStaticRoutes(app, '/images/decentraland-connect/*', dclKernelImagesDecentralandConnect);
-
-    app.use('/default-profile/', express.static(dclKernelDefaultProfilePath));
-};
+  const routeMappingPath = {
+      '/': {
+          path: path.resolve(dclKernelPath, 'preview.html'), 
+          type: 'text/html'
+      },
+      '/favicon.ico': {
+          path: path.resolve(dclKernelPath, 'favicon.ico'), 
+          type: 'text/html'
+      },
+      '/@/artifacts/preview.js': {
+          path: path.resolve(dclKernelPath, 'dist', 'preview.js'), 
+          type: 'text/javascript'
+      },
+  };
+  
+  for (const route in routeMappingPath){
+      app.get(route, async (req, res) => {
+          res.setHeader('Content-Type', routeMappingPath[route].type);
+          const contentFile = fs.readFileSync(routeMappingPath[route].path);
+          res.send(contentFile);
+      });
+  }
+  
+  createStaticRoutes(app, '/images/decentraland-connect/*', dclKernelImagesDecentralandConnect);
+  createStaticRoutes(app, '/@/artifacts/unity-renderer/*', dclUnityRenderer);
+  createStaticRoutes(app, '/@/artifacts/loader/*', dclKernelLoaderPath);
+  createStaticRoutes(app, '/default-profile/*', dclKernelDefaultProfilePath);
+}
 
 function createStaticRoutes(app, route, localFolder) {
     app.use(route, (req, res, next) => {

--- a/packages/decentraland-ecs/src/setupProxy.js
+++ b/packages/decentraland-ecs/src/setupProxy.js
@@ -5,7 +5,7 @@ module.exports = function (dcl, app, express) {
     const dclKernelPath = path.dirname(require.resolve('decentraland-kernel/package.json', {paths: [dcl.getWorkingDir()]}));
     const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
     const dclKernelImagesDecentralandConnect = path.resolve(dclKernelPath, 'images', 'decentraland-connect');
-    const dclUnityRenderer = path.resolve(dclKernelPath, 'unity-renderer');
+    const dclUnityRenderer = path.dirname(require.resolve('@dcl/unity-renderer/package.json', {paths: [dcl.getWorkingDir()]}));
 
     const routeMappingPath = {
         '/': {

--- a/packages/decentraland-ecs/src/setupProxy.js
+++ b/packages/decentraland-ecs/src/setupProxy.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 module.exports = function (dcl, app, express) {
     const dclKernelPath = path.resolve(dcl.getWorkingDir(), 'node_modules', 'decentraland-kernel');
     const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
-    const dclUnityRenderer = path.resolve(dcl.getWorkingDir(), 'node_modules', '@dcl', 'unity-renderer');
+    const dclUnityRenderer = path.resolve(dclKernelPath, 'unity-renderer');
 
     const routeMappingPath = {
         '/': {
@@ -20,15 +20,15 @@ module.exports = function (dcl, app, express) {
             type: 'text/javascript'
         },
         '/@/artifacts/unity-renderer/unity.data.unityweb': {
-            path: path.resolve(dclUnityRenderer, 'unity.data'), 
+            path: path.resolve(dclUnityRenderer, 'unity.data.unityweb'), 
             type: 'text/plain'
         },
         '/@/artifacts/unity-renderer/unity.framework.js.unityweb':{
-            path: path.resolve(dclUnityRenderer, 'unity.framework.js'), 
+            path: path.resolve(dclUnityRenderer, 'unity.framework.js.unityweb'), 
             type: 'text/javascript'
         },
         '/@/artifacts/unity-renderer/unity.wasm.unityweb':{
-            path: path.resolve(dclUnityRenderer, 'unity.wasm'), 
+            path: path.resolve(dclUnityRenderer, 'unity.wasm.unityweb'), 
             type: 'application/wasm'
         },
     };

--- a/packages/decentraland-ecs/src/setupProxy.js
+++ b/packages/decentraland-ecs/src/setupProxy.js
@@ -1,0 +1,45 @@
+const path = require('path')
+const fs = require('fs')
+
+module.exports = function (dcl, app, express) {
+    const dclKernelPath = path.resolve(dcl.getWorkingDir(), 'node_modules', 'decentraland-kernel');
+    const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile');
+    const dclUnityRenderer = path.resolve(dcl.getWorkingDir(), 'node_modules', '@dcl', 'unity-renderer');
+
+    const routeMappingPath = {
+        '/': {
+            path: path.resolve(dclKernelPath, 'preview.html'), 
+            type: 'text/html'
+        },
+        '/@/artifacts/preview.js': {
+            path: path.resolve(dclKernelPath, 'dist', 'preview.js'), 
+            type: 'text/javascript'
+        },
+        '/@/artifacts/unity-renderer/index.js': {
+            path: path.resolve(dclUnityRenderer, 'index.js'), 
+            type: 'text/javascript'
+        },
+        '/@/artifacts/unity-renderer/unity.data.unityweb': {
+            path: path.resolve(dclUnityRenderer, 'unity.data'), 
+            type: 'text/plain'
+        },
+        '/@/artifacts/unity-renderer/unity.framework.js.unityweb':{
+            path: path.resolve(dclUnityRenderer, 'unity.framework.js'), 
+            type: 'text/javascript'
+        },
+        '/@/artifacts/unity-renderer/unity.wasm.unityweb':{
+            path: path.resolve(dclUnityRenderer, 'unity.wasm'), 
+            type: 'application/wasm'
+        },
+    };
+    
+    for (const route in routeMappingPath){
+        app.get(route, async (req, res) => {
+            res.setHeader('Content-Type', routeMappingPath[route].type);
+            const contentFile = fs.readFileSync(routeMappingPath[route].path);
+            res.send(contentFile);
+        });
+    }
+
+    app.use('/default-profile/', express.static(dclKernelDefaultProfilePath));
+};

--- a/test/decentraland-ecs/setup-proxy.spec.ts
+++ b/test/decentraland-ecs/setup-proxy.spec.ts
@@ -1,11 +1,12 @@
 import { resolve } from 'path'
+import * as express from 'express'
+import * as supertest from 'supertest'
 
 const ecsLocation = resolve(__dirname, '../../packages/decentraland-ecs')
-const express = require('express')
 const mockDclObject = {
     getWorkingDir: () => ecsLocation
 }
-const supertest = require('supertest')
+
 
 describe('decentraland-ecs: setupProxy.js resolve endpoints successful', () => {
     const setupProxy = require(`${ecsLocation}/src/setupProxy.js`)

--- a/test/decentraland-ecs/setup-proxy.spec.ts
+++ b/test/decentraland-ecs/setup-proxy.spec.ts
@@ -1,0 +1,32 @@
+import { resolve } from 'path'
+
+const ecsLocation = resolve(__dirname, '../../packages/decentraland-ecs')
+const express = require('express')
+const mockDclObject = {
+    getWorkingDir: () => ecsLocation
+}
+const supertest = require('supertest')
+
+describe('decentraland-ecs: setupProxy.js resolve endpoints successful', () => {
+    const setupProxy = require(`${ecsLocation}/src/setupProxy.js`)
+
+    const app = express()
+
+    setupProxy(mockDclObject, app, express);
+    const request = supertest(app);
+
+    const criticalEndpoints = [
+        '/',
+        '/@/artifacts/preview.js',
+        '/@/artifacts/unity-renderer/unity.wasm',
+        '/@/artifacts/unity-renderer/unity.framework.js',
+        '/@/artifacts/unity-renderer/unity.data',
+        '/@/artifacts/unity-renderer/index.js'
+    ]
+
+    for (const endpoint of criticalEndpoints){
+        test(`endpoint '${endpoint}'`, async () => {
+            await request.get(endpoint).expect(200)
+        });
+    }
+})

--- a/test/decentraland-ecs/setup-proxy.spec.ts
+++ b/test/decentraland-ecs/setup-proxy.spec.ts
@@ -19,9 +19,9 @@ describe('decentraland-ecs: setupProxy.js resolve endpoints successful', () => {
     const criticalEndpoints = [
         '/',
         '/@/artifacts/preview.js',
-        '/@/artifacts/unity-renderer/unity.wasm',
-        '/@/artifacts/unity-renderer/unity.framework.js',
-        '/@/artifacts/unity-renderer/unity.data',
+        '/@/artifacts/unity-renderer/unity.wasm.unityweb',
+        '/@/artifacts/unity-renderer/unity.framework.js.unityweb',
+        '/@/artifacts/unity-renderer/unity.data.unityweb',
         '/@/artifacts/unity-renderer/index.js'
     ]
 


### PR DESCRIPTION
# Whats?
Add the setupProxy.js to the package and fix the context that rollup build.

# Why?
The setupProxy.js is a proxy loaded by the CLI which allows mapping different endpoints.
See more https://github.com/decentraland/sdk/issues/12
https://github.com/decentraland/cli/pull/569