### PR TITLE
feat: add setupExport function

### DIFF
--- a/packages/decentraland-ecs/src/setupExport.ts
+++ b/packages/decentraland-ecs/src/setupExport.ts
@@ -1,6 +1,63 @@
-const setupExport = async (workDir: string, exportDir: string, mappings: any, sceneJson: any): Promise<void> => {
-  console.log('test')
+import * as path from 'path'
+import { promises } from 'fs'
+
+const fs = promises
+
+const setupExport = async ({
+  workDir,
+  exportDir,
+  mappings,
+  sceneJson
+}: {
+  workDir: string
+  exportDir: string
+  mappings: any
+  sceneJson: any
+}): Promise<void> => {
+  try {
+    const ecsPath = path.dirname(
+      require.resolve('decentraland-ecs/package.json', {
+        paths: [workDir, __dirname + '/../../', __dirname + '/../']
+      })
+    )
+    const dclKernelPath = path.dirname(require.resolve('@dcl/kernel/package.json', { paths: [workDir, ecsPath] }))
+    const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile')
+    const dclUnityRenderer = path.dirname(
+      require.resolve('@dcl/unity-renderer/package.json', { paths: [workDir, ecsPath] })
+    )
+
+    // Change HTML title name
+    const content = await fs.readFile(path.resolve(dclKernelPath, 'export.html'), 'utf-8')
+    const finalContent = content.replace('{{ scene.display.title }}', sceneJson.display.title)
+
+    await Promise.all([
+      // copy project
+      fs.writeFile(path.resolve(exportDir, 'index.html'), finalContent, 'utf-8'),
+      fs.writeFile(path.resolve(exportDir, 'mappings'), JSON.stringify(mappings), 'utf-8'),
+
+      // copy dependencies
+      copyDir(dclUnityRenderer, path.resolve(exportDir, 'unity-renderer')),
+      copyDir(dclKernelDefaultProfilePath, path.resolve(exportDir, 'default-profile')),
+      fs.copyFile(path.resolve(dclKernelPath, 'index.js'), path.resolve(exportDir, 'index.js'))
+    ])
+  } catch (err) {
+    console.error('Export failed.', err)
+    throw err
+  }
   return
+}
+
+// instead of using fs-extra, create a custom function to no need to rollup
+async function copyDir(src: string, dest: string) {
+  await fs.mkdir(dest, { recursive: true })
+  let entries = await fs.readdir(src, { withFileTypes: true })
+
+  for (let entry of entries) {
+    let srcPath = path.join(src, entry.name)
+    let destPath = path.join(dest, entry.name)
+
+    entry.isDirectory() ? await copyDir(srcPath, destPath) : await fs.copyFile(srcPath, destPath)
+  }
 }
 
 export = setupExport

--- a/test/decentraland-ecs/setup-export.spec.ts
+++ b/test/decentraland-ecs/setup-export.spec.ts
@@ -1,10 +1,37 @@
-import { resolve } from 'path'
+import * as path from 'path'
+import * as fs from 'fs'
+import { ensureFileExists } from '../../scripts/helpers'
 
-const ecsLocation = resolve(__dirname, '../../packages/decentraland-ecs')
+const ecsLocation = path.resolve(__dirname, '../../packages/decentraland-ecs')
 
 describe('decentraland-ecs: setupExport.js', () => {
   const setupExport = require(`${ecsLocation}/src/setupExport.js`)
-  test(`require and call successfully`, async () => {
-    await setupExport('', '', {}, {})
+  test(`export fake project`, async () => {
+    const workDir = path.resolve(__dirname, 'simple-scene')
+    const exportDir = path.resolve(workDir, 'export')
+    const mappings: string[] = []
+    const sceneJson = { display: { title: 'test' } }
+
+    if (fs.existsSync(workDir)) {
+      await fs.promises.rmdir(workDir, { recursive: true })
+    }
+
+    await fs.promises.mkdir(workDir)
+    await fs.promises.mkdir(exportDir)
+
+    await setupExport({
+      workDir,
+      exportDir,
+      mappings,
+      sceneJson
+    })
+
+    ensureFileExists('index.js', exportDir)
+    ensureFileExists('index.html', exportDir)
+    ensureFileExists('unity-renderer/unity.wasm', exportDir)
+    ensureFileExists('unity-renderer/unity.data', exportDir)
+    ensureFileExists('unity-renderer/unity.framework.js', exportDir)
+    ensureFileExists('unity-renderer/unity.loader.js', exportDir)
+    ensureFileExists('unity-renderer/index.js', exportDir)
   })
 })


### PR DESCRIPTION
# Whats ?
Add the setupExport function adapted to new package @dcl/kernel and @dcl/unity-renderer. It creates the export directory with the project files and dependencies.

# Why?
In accordance with the new responsibility to this package to export the project and serve the dependencies.

# How to test it?
1. Clone this repository and checkout this branch
2. Install dependencies with `make install`
3. Build with `make build`
4. Link decentraland-ecs and @dcl/build-ecs with `cd packages/decentraland-ecs && npm link && cd ../@dcl/build-ecs && npm link`
5. Go to project folder and run `npm install @dcl/kernel@next && npm link decentraland-ecs @dcl/build-ecs`
6. Run `dcl export`