### PR TITLE
chore: add a local decentraland-ecs built artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
       - name: build
         run: make build
       - name: prepare local decentraland-ecs package
-        run: make prepare-pr && mv ./packages/decentraland-ecs/decentraland-ecs-0.0.0.tgz ./packages/decentraland-ecs/decentraland-ecs-local.tgz
+        run: make prepare-pr 
       - name: 'Upload Local decentraland-ecs'
         uses: actions/upload-artifact@v2
         with:
           name: local-decentraland-ecs
-          path: "packages/decentraland-ecs/decentraland-ecs-local.tgz"
+          path: "packages/decentraland-ecs/local-decentraland-ecs.tgz"
           retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 14.x
       - name: install
         run: make install
+      - name: prepare local decentraland-ecs package
+        run: make prepare-pr && mv ./packages/decentraland-ecs/decentraland-ecs-0.0.0.tgz ./packages/decentraland-ecs/decentraland-ecs-local.tgz
       - name: update version of packages/@dcl/dcl-rollup
         uses: menduz/oddish-action@staging
         with:
@@ -47,6 +49,12 @@ jobs:
         run: make test
       - name: prepare releasable packages
         run: make prepare
+      - name: 'Upload Local decentraland-ecs'
+        uses: actions/upload-artifact@v2
+        with:
+          name: local-decentraland-ecs
+          path: "packages/decentraland-ecs/decentraland-ecs-local.tgz"
+          retention-days: 5
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
           node-version: 14.x
       - name: install
         run: make install
-      - name: prepare local decentraland-ecs package
-        run: make prepare-pr && mv ./packages/decentraland-ecs/decentraland-ecs-0.0.0.tgz ./packages/decentraland-ecs/decentraland-ecs-local.tgz
       - name: update version of packages/@dcl/dcl-rollup
         uses: menduz/oddish-action@staging
         with:
@@ -49,12 +47,6 @@ jobs:
         run: make test
       - name: prepare releasable packages
         run: make prepare
-      - name: 'Upload Local decentraland-ecs'
-        uses: actions/upload-artifact@v2
-        with:
-          name: local-decentraland-ecs
-          path: "packages/decentraland-ecs/decentraland-ecs-local.tgz"
-          retention-days: 5
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2
         with:
@@ -131,3 +123,24 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  local-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: install
+        run: make install
+      - name: build
+        run: make build
+      - name: prepare local decentraland-ecs package
+        run: make prepare-pr && mv ./packages/decentraland-ecs/decentraland-ecs-0.0.0.tgz ./packages/decentraland-ecs/decentraland-ecs-local.tgz
+      - name: 'Upload Local decentraland-ecs'
+        uses: actions/upload-artifact@v2
+        with:
+          name: local-decentraland-ecs
+          path: "packages/decentraland-ecs/decentraland-ecs-local.tgz"
+          retention-days: 5

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,7 @@ build:
 prepare:
 	node_modules/.bin/jest --detectOpenHandles --colors --runInBand --runTestsByPath scripts/prepare.spec.ts
 
+prepare-pr:
+	node_modules/.bin/jest --detectOpenHandles --colors --runInBand --runTestsByPath scripts/prepare-local-ecs.spec.ts
+
 .PHONY: build test install

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
-    "@dcl/kernel": "latest",
+    "@dcl/kernel": "1.0.0-1103242784.commit-c1c0d95",
     "@dcl/posix": "^1.0.0-20210529225617.commit-f7f0ee9",
     "@dcl/unity-renderer": "latest",
     "glob": "^7.1.7",

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -33,7 +33,7 @@ export function runCommand(command: string, cwd: string, env?: Record<string, st
 }
 
 export function itExecutes(command: string, cwd: string, env?: Record<string, string>) {
-  it(command, async () => runCommand(command, cwd, env), 30000)
+  it(command, async () => await runCommand(command, cwd, env), 30000)
 }
 
 export function itDeletesFolder(folder: string, cwd: string) {

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -16,26 +16,24 @@ export function ensureFileExists(file: string, root?: string) {
   return x
 }
 
-export function itExecutes(command: string, cwd: string, env?: Record<string, string>) {
-  it(
-    command,
-    async () => {
-      await new Promise<string>((onSuccess, onError) => {
-        process.stdout.write('∑ ' + cwd + '; ' + command + '\n')
-        exec(command, { cwd, env }, (error, stdout, stderr) => {
-          stdout.trim().length && process.stdout.write('  ' + stdout.replace(/\n/g, '\n  ') + '\n')
-          stderr.trim().length && process.stderr.write('! ' + stderr.replace(/\n/g, '\n  ') + '\n')
+export function runCommand(command: string, cwd: string, env?: Record<string, string>): Promise<string> {
+  return new Promise<string>((onSuccess, onError) => {
+    process.stdout.write('∑ ' + cwd + '; ' + command + '\n')
+    exec(command, { cwd, env }, (error, stdout, stderr) => {
+      stdout.trim().length && process.stdout.write('  ' + stdout.replace(/\n/g, '\n  ') + '\n')
+      stderr.trim().length && process.stderr.write('! ' + stderr.replace(/\n/g, '\n  ') + '\n')
 
-          if (error) {
-            onError(stderr)
-          } else {
-            onSuccess(stdout)
-          }
-        })
-      })
-    },
-    30000
-  )
+      if (error) {
+        onError(stderr)
+      } else {
+        onSuccess(stdout)
+      }
+    })
+  })
+}
+
+export function itExecutes(command: string, cwd: string, env?: Record<string, string>) {
+  it(command, async () => runCommand(command, cwd, env), 30000)
 }
 
 export function itDeletesFolder(folder: string, cwd: string) {

--- a/scripts/prepare-local-ecs.spec.ts
+++ b/scripts/prepare-local-ecs.spec.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { flow, commonChecks, ECS_PATH, BUILD_ECS_PATH, DECENTRALAND_AMD_PATH, ROLLUP_CONFIG_PATH } from './common'
-import { itExecutes, patchJson, readJson } from './helpers'
+import { patchJson, runCommand } from './helpers'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 
 flow('build local ecs package', () => {
@@ -11,9 +11,9 @@ flow('build local ecs package', () => {
   const ecsPackageJsonPath = resolve(ECS_PATH, 'package.json')
   const ecsPackageLockJsonPath = resolve(ECS_PATH, 'package-lock.json')
 
-  // This information can be found in `npm pack --json` output
-  let dclAmdTgzFilename = 'dcl-amd-0.0.0.tgz'
-  let dclBuildEcsTgzFilename = 'dcl-build-ecs-0.0.0.tgz'
+  const dclAmdTgzFilename = 'local-dcl-amd.tgz'
+  const dclBuildEcsTgzFilename = 'local-dcl-build-ecs.tgz'
+  const dclEcsTgzFilename = 'local-decentraland-ecs.tgz'
 
   let backupPackageJson = '',
     backupPackageLockJson = ''
@@ -38,22 +38,35 @@ flow('build local ecs package', () => {
     if (backupPackageLockJson.length > 0) {
       patchJson('package-lock.json', ECS_PATH, redux)
     }
-
   })
 
-  flow('pack every package', () => {
-    
-    itExecutes('npm pack', DECENTRALAND_AMD_PATH)
-    itExecutes('npm pack', ROLLUP_CONFIG_PATH)
-    itExecutes('npm pack', BUILD_ECS_PATH)
+  it('pack every package', async () => {
+    const amdPackJson = JSON.parse(await runCommand('npm pack --json', DECENTRALAND_AMD_PATH))
+    const rollUpPackJson = JSON.parse(await runCommand('npm pack --json', ROLLUP_CONFIG_PATH))
+    const buildEcsPackJson = JSON.parse(await runCommand('npm pack --json', BUILD_ECS_PATH))
 
-    itExecutes(`cp ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename} ${ECS_PATH}`, rootPath)
-    itExecutes(`cp ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename} ${ECS_PATH}`, rootPath)
+    expect(buildEcsPackJson[0]['filename']).toBeTruthy()
+    expect(amdPackJson[0]['filename']).toBeTruthy()
 
-    itExecutes('npm pack', ECS_PATH)
+    await runCommand(
+      `cp ${resolve(DECENTRALAND_AMD_PATH, amdPackJson[0]['filename'])} ${resolve(ECS_PATH, dclAmdTgzFilename)}`,
+      rootPath
+    )
+    await runCommand(
+      `cp ${resolve(BUILD_ECS_PATH, buildEcsPackJson[0]['filename'])} ${resolve(ECS_PATH, dclBuildEcsTgzFilename)}`,
+      rootPath
+    )
+
+    const ecsPackJson = JSON.parse(await runCommand('npm pack --json', ECS_PATH))
+    expect(ecsPackJson[0]['filename']).toBeTruthy()
+
+    await runCommand(
+      `mv ${resolve(ECS_PATH, ecsPackJson[0]['filename'])} ${resolve(ECS_PATH, dclEcsTgzFilename)}`,
+      rootPath
+    )
   })
 
-  afterAll(() => {
+  afterAll(async () => {
     // restore package.json to original version?
     // itExecutes(`rm ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename}`, rootPath)
     // itExecutes(`rm ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename}`, rootPath)
@@ -63,5 +76,4 @@ flow('build local ecs package', () => {
       writeFileSync(ecsPackageLockJsonPath, backupPackageLockJson)
     }
   })
-
 })

--- a/scripts/prepare-local-ecs.spec.ts
+++ b/scripts/prepare-local-ecs.spec.ts
@@ -3,30 +3,26 @@ import { flow, commonChecks, ECS_PATH, BUILD_ECS_PATH, DECENTRALAND_AMD_PATH, RO
 import { itExecutes, patchJson, readJson } from './helpers'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 
-flow('build-all', () => {
+flow('build local ecs package', () => {
   ;``
   commonChecks()
 
-  flow('pack every package', () => {
-    const rootPath = resolve(__dirname, '..')
-    const ecsPackageJsonPath = resolve(ECS_PATH, 'package.json')
-    const ecsPackageLockJsonPath = resolve(ECS_PATH, 'package-lock.json')
+  const rootPath = resolve(__dirname, '..')
+  const ecsPackageJsonPath = resolve(ECS_PATH, 'package.json')
+  const ecsPackageLockJsonPath = resolve(ECS_PATH, 'package-lock.json')
 
-    // This information can be found in `npm pack --json` output
-    let dclAmdTgzFilename = 'dcl-amd-0.0.0.tgz'
-    let dclBuildEcsTgzFilename = 'dcl-build-ecs-0.0.0.tgz'
+  // This information can be found in `npm pack --json` output
+  let dclAmdTgzFilename = 'dcl-amd-0.0.0.tgz'
+  let dclBuildEcsTgzFilename = 'dcl-build-ecs-0.0.0.tgz'
 
-    itExecutes('npm pack', DECENTRALAND_AMD_PATH)
-    itExecutes('npm pack', ROLLUP_CONFIG_PATH)
-    itExecutes('npm pack', BUILD_ECS_PATH)
+  let backupPackageJson = '',
+    backupPackageLockJson = ''
 
-    itExecutes(`cp ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename} ${ECS_PATH}`, rootPath)
-    itExecutes(`cp ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename} ${ECS_PATH}`, rootPath)
-
-    const backupPackageJson = readFileSync(ecsPackageJsonPath).toString()
-    const backupPackageLockJson = existsSync(ecsPackageLockJsonPath)
-      ? readFileSync(ecsPackageLockJsonPath).toString()
-      : ''
+  beforeAll(() => {
+    backupPackageJson = readFileSync(ecsPackageJsonPath).toString()
+    if (existsSync(ecsPackageLockJsonPath)) {
+      backupPackageLockJson = readFileSync(ecsPackageLockJsonPath).toString()
+    }
 
     const redux = ($: any) => ({
       ...$,
@@ -43,15 +39,29 @@ flow('build-all', () => {
       patchJson('package-lock.json', ECS_PATH, redux)
     }
 
-    itExecutes('npm pack', ECS_PATH)
+  })
 
-    // restore
-    itExecutes(`rm ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename}`, rootPath)
-    itExecutes(`rm ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename}`, rootPath)
+  flow('pack every package', () => {
+    
+    itExecutes('npm pack', DECENTRALAND_AMD_PATH)
+    itExecutes('npm pack', ROLLUP_CONFIG_PATH)
+    itExecutes('npm pack', BUILD_ECS_PATH)
+
+    itExecutes(`cp ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename} ${ECS_PATH}`, rootPath)
+    itExecutes(`cp ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename} ${ECS_PATH}`, rootPath)
+
+    itExecutes('npm pack', ECS_PATH)
+  })
+
+  afterAll(() => {
+    // restore package.json to original version?
+    // itExecutes(`rm ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename}`, rootPath)
+    // itExecutes(`rm ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename}`, rootPath)
 
     writeFileSync(ecsPackageJsonPath, backupPackageJson)
     if (backupPackageJson.length > 0) {
       writeFileSync(ecsPackageLockJsonPath, backupPackageLockJson)
     }
   })
+
 })

--- a/scripts/prepare-local-ecs.spec.ts
+++ b/scripts/prepare-local-ecs.spec.ts
@@ -1,0 +1,57 @@
+import { resolve } from 'path'
+import { flow, commonChecks, ECS_PATH, BUILD_ECS_PATH, DECENTRALAND_AMD_PATH, ROLLUP_CONFIG_PATH } from './common'
+import { itExecutes, patchJson, readJson } from './helpers'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+
+flow('build-all', () => {
+  ;``
+  commonChecks()
+
+  flow('pack every package', () => {
+    const rootPath = resolve(__dirname, '..')
+    const ecsPackageJsonPath = resolve(ECS_PATH, 'package.json')
+    const ecsPackageLockJsonPath = resolve(ECS_PATH, 'package-lock.json')
+
+    // This information can be found in `npm pack --json` output
+    let dclAmdTgzFilename = 'dcl-amd-0.0.0.tgz'
+    let dclBuildEcsTgzFilename = 'dcl-build-ecs-0.0.0.tgz'
+
+    itExecutes('npm pack', DECENTRALAND_AMD_PATH)
+    itExecutes('npm pack', ROLLUP_CONFIG_PATH)
+    itExecutes('npm pack', BUILD_ECS_PATH)
+
+    itExecutes(`cp ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename} ${ECS_PATH}`, rootPath)
+    itExecutes(`cp ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename} ${ECS_PATH}`, rootPath)
+
+    const backupPackageJson = readFileSync(ecsPackageJsonPath).toString()
+    const backupPackageLockJson = existsSync(ecsPackageLockJsonPath)
+      ? readFileSync(ecsPackageLockJsonPath).toString()
+      : ''
+
+    const redux = ($: any) => ({
+      ...$,
+      files: [...($.files || []), dclAmdTgzFilename, dclBuildEcsTgzFilename],
+      dependencies: {
+        ...($.dependencies || {}),
+        '@dcl/amd': `file:./${dclAmdTgzFilename}`,
+        '@dcl/build-ecs': `file:./${dclBuildEcsTgzFilename}`
+      }
+    })
+
+    patchJson('package.json', ECS_PATH, redux)
+    if (backupPackageLockJson.length > 0) {
+      patchJson('package-lock.json', ECS_PATH, redux)
+    }
+
+    itExecutes('npm pack', ECS_PATH)
+
+    // restore
+    itExecutes(`rm ${DECENTRALAND_AMD_PATH}/${dclAmdTgzFilename}`, rootPath)
+    itExecutes(`rm ${BUILD_ECS_PATH}/${dclBuildEcsTgzFilename}`, rootPath)
+
+    writeFileSync(ecsPackageJsonPath, backupPackageJson)
+    if (backupPackageJson.length > 0) {
+      writeFileSync(ecsPackageLockJsonPath, backupPackageLockJson)
+    }
+  })
+})

--- a/test/decentraland-ecs/local-build-test.spec.ts
+++ b/test/decentraland-ecs/local-build-test.spec.ts
@@ -1,10 +1,9 @@
 import { resolve } from 'path'
-import { readFileSync } from 'fs'
-import { runCommand, itExecutes, ensureFileExists, itDeletesFolder } from '../../scripts/helpers'
+import { runCommand, itExecutes, ensureFileExists } from '../../scripts/helpers'
 
 describe('setup local build of decentraland-ecs package', async () => {
   const workingDir = resolve(__dirname, '..', '..')
-  const generatedEcsTgzName = 'decentraland-ecs-0.0.0.tgz'
+  const generatedEcsTgzName = 'local-decentraland-ecs.tgz'
   const generatedEcsTgzPath = resolve(workingDir, 'packages', 'decentraland-ecs', generatedEcsTgzName)
 
   await runCommand('make prepare-pr', workingDir)

--- a/test/decentraland-ecs/local-build-test.spec.ts
+++ b/test/decentraland-ecs/local-build-test.spec.ts
@@ -1,0 +1,28 @@
+import { resolve } from 'path'
+import { readFileSync } from 'fs'
+import { itExecutes, ensureFileExists, itDeletesFolder } from '../../scripts/helpers'
+
+describe('setup local build of decentraland-ecs package', () => {
+  const workingDir = resolve(__dirname, '..', '..')
+  const generatedEcsTgzName = 'decentraland-ecs-0.0.0.tgz'
+  const generatedEcsTgzPath = resolve(workingDir, 'packages', 'decentraland-ecs', generatedEcsTgzName)
+
+  itExecutes('make prepare-pr', workingDir)
+
+  it('ensure files exist', () => {
+    ensureFileExists(generatedEcsTgzPath)
+  })
+
+  describe('install generated package', () => {
+    const testPackagePath = resolve(__dirname, `ecs-test-scene-${new Date().getTime()}`)
+    const testCommands = [
+        'mkdir',testPackagePath, '&&',
+        'cd', testPackagePath, '&&',
+        'cp',generatedEcsTgzPath,'./', '&&',
+        'tar -xvf', generatedEcsTgzName, '&&',
+        'npm init --yes && npm install ./package &&',
+        'cd .. && rm -r', testPackagePath
+    ]
+    itExecutes(testCommands.join(' '), workingDir)
+  })
+})

--- a/test/decentraland-ecs/local-build-test.spec.ts
+++ b/test/decentraland-ecs/local-build-test.spec.ts
@@ -1,27 +1,35 @@
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
-import { itExecutes, ensureFileExists, itDeletesFolder } from '../../scripts/helpers'
+import { runCommand, itExecutes, ensureFileExists, itDeletesFolder } from '../../scripts/helpers'
 
-describe('setup local build of decentraland-ecs package', () => {
+describe('setup local build of decentraland-ecs package', async () => {
   const workingDir = resolve(__dirname, '..', '..')
   const generatedEcsTgzName = 'decentraland-ecs-0.0.0.tgz'
   const generatedEcsTgzPath = resolve(workingDir, 'packages', 'decentraland-ecs', generatedEcsTgzName)
 
-  itExecutes('make prepare-pr', workingDir)
-
-  it('ensure files exist', () => {
-    ensureFileExists(generatedEcsTgzPath)
-  })
+  await runCommand('make prepare-pr', workingDir)
 
   describe('install generated package', () => {
+    expect(ensureFileExists(generatedEcsTgzPath)).toBe(true)
+
     const testPackagePath = resolve(__dirname, `ecs-test-scene-${new Date().getTime()}`)
     const testCommands = [
-        'mkdir',testPackagePath, '&&',
-        'cd', testPackagePath, '&&',
-        'cp',generatedEcsTgzPath,'./', '&&',
-        'tar -xvf', generatedEcsTgzName, '&&',
-        'npm init --yes && npm install ./package &&',
-        'cd .. && rm -r', testPackagePath
+      'mkdir',
+      testPackagePath,
+      '&&',
+      'cd',
+      testPackagePath,
+      '&&',
+      'cp',
+      generatedEcsTgzPath,
+      './',
+      '&&',
+      'tar -xvf',
+      generatedEcsTgzName,
+      '&&',
+      'npm init --yes && npm install ./package &&',
+      'cd .. && rm -r',
+      testPackagePath
     ]
     itExecutes(testCommands.join(' '), workingDir)
   })


### PR DESCRIPTION
# What?
Add a CI job and script which pack the decentraland-ecs package with local dependencies. 

# Why?
To make the PR tests easier, you can download artifacts and install them with one command.

# How to test it?
1. Go to 'Checks' tab and download the artifact **'local-decentraland-ecs.zip'** in your scene directory
2. Run `tar -xvf local-decentraland-ecs.zip && tar -xvf local-decentraland-ecs.tgz` to uncompress the artifact
3. Run `npm install ./package`
4. Test with `dcl start` if your CLI version is 3.7.0 or lower. Otherwise you can test with `dcl start --skip-version-checks`