### PR TITLE
fix: crop work directory to works in window

### DIFF
--- a/packages/decentraland-ecs/src/setupProxy.ts
+++ b/packages/decentraland-ecs/src/setupProxy.ts
@@ -159,7 +159,8 @@ const entityV3FromFolder = (folder: string) => {
         } catch (err) {
           return
         }
-        const key = file.replace(folder, '').replace(/^\/+/, '')
+        const _folder = folder.replace(/\\/gi, ‘/’)
+        const key = file.replace(_folder, '').replace(/^\/+/, '')
 
         return { file: key.toLowerCase(), hash: 'b64-' + Buffer.from(file).toString('base64') }
       })

--- a/packages/decentraland-ecs/src/setupProxy.ts
+++ b/packages/decentraland-ecs/src/setupProxy.ts
@@ -159,7 +159,7 @@ const entityV3FromFolder = (folder: string) => {
         } catch (err) {
           return
         }
-        const _folder = folder.replace(/\\/gi, ‘/’)
+        const _folder = folder.replace(/\\/gi, '/')
         const key = file.replace(_folder, '').replace(/^\/+/, '')
 
         return { file: key.toLowerCase(), hash: 'b64-' + Buffer.from(file).toString('base64') }


### PR DESCRIPTION
# Whats?
Replace folder string inverted slash to slash 

# Why?
path.resolve in windows returns inverted slash. This breaks the path processing 