### PR TITLE
fix: recursive export, now it ignores the files specified in .dclignore

### DIFF
--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -32,7 +32,8 @@
     "@dcl/posix": "^1.0.0-20210529225617.commit-f7f0ee9",
     "@dcl/unity-renderer": "latest",
     "glob": "^7.1.7",
-    "http-proxy-middleware": "^2.0.1"
+    "http-proxy-middleware": "^2.0.1",
+    "ignore": "^5.1.8"
   },
   "minCliVersion": "3.7.0"
 }

--- a/packages/decentraland-ecs/src/setupExport.ts
+++ b/packages/decentraland-ecs/src/setupExport.ts
@@ -91,7 +91,6 @@ const setupExport = async ({
     )
 
     await ensureWriteFile(path.resolve(lambdasPath, 'profiles'), JSON.stringify([]))
-    await copyWearables({ exportDir })
 
     let ignoreFileContent = ''
     if (fs.existsSync(dclIgnorePath)) {
@@ -136,6 +135,8 @@ const setupExport = async ({
         )
       }
     }
+    
+    await copyWearables({ exportDir })
   } catch (err) {
     console.error('Export failed.', err)
     throw err

--- a/packages/decentraland-ecs/src/setupExport.ts
+++ b/packages/decentraland-ecs/src/setupExport.ts
@@ -27,6 +27,7 @@ const setupExport = async ({
         paths: [workDir, __dirname + '/../../', __dirname + '/../']
       })
     )
+    const dclIgnorePath = path.resolve(workDir, '.dclignore')
     const dclKernelPath = path.dirname(require.resolve('@dcl/kernel/package.json', { paths: [workDir, ecsPath] }))
     const dclKernelDefaultProfilePath = path.resolve(dclKernelPath, 'default-profile')
     const dclKernelLoaderPath = path.resolve(dclKernelPath, 'loader')
@@ -92,7 +93,10 @@ const setupExport = async ({
     await ensureWriteFile(path.resolve(lambdasPath, 'profiles'), JSON.stringify([]))
     await copyWearables({ exportDir })
 
-    const ignoreFileContent = await fs.promises.readFile(path.resolve(workDir, '.dclignore'), 'utf-8')
+    let ignoreFileContent = ''
+    if (fs.existsSync(dclIgnorePath)) {
+      ignoreFileContent = fs.readFileSync(path.resolve(workDir, '.dclignore'), 'utf-8')
+    }
     const contentStatic = entityV3FromFolder({
       folder: workDir,
       addOriginalPath: true,

--- a/packages/decentraland-ecs/src/setupUtils.ts
+++ b/packages/decentraland-ecs/src/setupUtils.ts
@@ -106,6 +106,8 @@ export function getSceneJson({
     let ignoreFileContent = ''
     if (fs.existsSync(dclIgnorePath)) {
       ignoreFileContent = fs.readFileSync(path.resolve(folder, '.dclignore'), 'utf-8')
+    } else {
+      ignoreFileContent = defaultDclIgnore()
     }
 
     return entityV3FromFolder({
@@ -175,3 +177,25 @@ export const downloadFile = async (url: string, path: string) => {
 }
 
 export const shaHashMaker = (str: string) => crypto.createHash('sha1').update(str).digest('hex')
+
+export const defaultDclIgnore = () =>
+  [
+    '.*',
+    'package.json',
+    'package-lock.json',
+    'yarn-lock.json',
+    'build.json',
+    'export',
+    'tsconfig.json',
+    'tslint.json',
+    'node_modules',
+    '*.ts',
+    '*.tsx',
+    'Dockerfile',
+    'dist',
+    'README.md',
+    '*.blend',
+    '*.fbx',
+    '*.zip',
+    '*.rar'
+  ].join('\n')

--- a/packages/decentraland-ecs/src/setupUtils.ts
+++ b/packages/decentraland-ecs/src/setupUtils.ts
@@ -59,7 +59,8 @@ export function entityV3FromFolder({
       })
       .filter(($) => !!$) as string[]
 
-    const ig = ignore().add(ignorePattern || '')
+    const ensureIgnorePattern = (ignorePattern && ignorePattern !== '') ? ignorePattern : defaultDclIgnore()
+    const ig = ignore().add(ensureIgnorePattern)
     const filteredFiles = ig.filter(allFiles)
 
     const mappedFiles = filteredFiles
@@ -106,8 +107,6 @@ export function getSceneJson({
     let ignoreFileContent = ''
     if (fs.existsSync(dclIgnorePath)) {
       ignoreFileContent = fs.readFileSync(path.resolve(folder, '.dclignore'), 'utf-8')
-    } else {
-      ignoreFileContent = defaultDclIgnore()
     }
 
     return entityV3FromFolder({


### PR DESCRIPTION
# Whats ?
Now it reads the .dclignore file to exclude the paths specified there from `dcl export` and `dcl start`.
Also, it changes the base64 hash to sha1 in export to no expose the path where the export is done.

# Why?
As of the preview and export were added, the .dclignore hasn't been considered to this jobs, so the export can be recursively self-added and in the same way preview include export dir. This causes that the export directory non stop increasement  