### PR TITLE
add missing predefined emote enums

### DIFF
--- a/packages/decentraland-ecs/types/@decentraland/RestrictedActions/index.d.ts
+++ b/packages/decentraland-ecs/types/@decentraland/RestrictedActions/index.d.ts
@@ -28,5 +28,14 @@ declare module '@decentraland/RestrictedActions' {
     CLAP = 'clap',
     MONEY = 'money',
     KISS = 'kiss',
+    TIK = 'tik',
+    HAMMER = 'hammer',
+    TEKTONIK = 'tektonik',
+    DONT_SEE = 'dontsee',
+    HANDS_AIR = 'handsair',
+    SHRUG = 'shrug',
+    DISCO = 'disco',
+    DAB = 'dab',
+    HEAD_EXPLODDE = 'headexplode'
   }
 }


### PR DESCRIPTION
https://github.com/decentraland/sdk/issues/82

This seems that has been resolved at https://github.com/decentraland/explorer/pull/2496, but somehow we lost that commit.
