### PR TITLE
feat: add event for peer's avatar connected or disconnected

### DIFF
--- a/packages/@dcl/amd/package-lock.json
+++ b/packages/@dcl/amd/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dcl/posix": {
-      "version": "1.0.3-20211108141117.commit-fb3dffe",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3-20211108141117.commit-fb3dffe.tgz",
-      "integrity": "sha512-HnpWYfBIudjRyywkKMIemisHB9cyQOZfJBAR5rmUNnGhM1Fhnr1uDHlOcyO9jhfHmHDNZGvKBDKJNj76LrIWXw==",
+      "version": "1.0.3-20211118190143.commit-0989fa3",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3-20211118190143.commit-0989fa3.tgz",
+      "integrity": "sha512-dXDlhrdHKsHe4enTGtaqTFHSb0Kni1N4HGlXwtuLTmqeTbCUpSVqc/KNPmqXD4X+UQKhoDSCo6cGdC1hk/ZQrw==",
       "dev": true
     }
   }

--- a/packages/@dcl/amd/package-lock.json
+++ b/packages/@dcl/amd/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dcl/posix": {
-      "version": "1.0.3-20211118190143.commit-0989fa3",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3-20211118190143.commit-0989fa3.tgz",
-      "integrity": "sha512-dXDlhrdHKsHe4enTGtaqTFHSb0Kni1N4HGlXwtuLTmqeTbCUpSVqc/KNPmqXD4X+UQKhoDSCo6cGdC1hk/ZQrw==",
+      "version": "1.0.3-20211119173339.commit-c94b391",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3-20211119173339.commit-c94b391.tgz",
+      "integrity": "sha512-ZG/74ziM8u/pDxruCqJa/qd9025IX8jfoLHKZE74WAmNrMZL75G3e9ik4TrAfPZHRwjFXWVaMRlGlGqILGaNfQ==",
       "dev": true
     }
   }

--- a/packages/@dcl/amd/package.json
+++ b/packages/@dcl/amd/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@dcl/posix": "1.0.3-20211108141117.commit-fb3dffe"
+    "@dcl/posix": "1.0.3-20211118190143.commit-0989fa3"
   }
 }

--- a/packages/@dcl/amd/package.json
+++ b/packages/@dcl/amd/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@dcl/posix": "1.0.3-20211118190143.commit-0989fa3"
+    "@dcl/posix": "1.0.3-20211119173339.commit-c94b391"
   }
 }

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -29,7 +29,7 @@
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
     "@dcl/kernel": "^1.0.0-1435962399.commit-67d3765",
-    "@dcl/posix": "1.0.3-20211118190143.commit-0989fa3",
+    "@dcl/posix": "1.0.3-20211119173339.commit-c94b391",
     "@dcl/unity-renderer": "1.0.18126-20211029133620.commit-42454bc",
     "glob": "^7.1.7",
     "http-proxy-middleware": "^2.0.1",

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -29,7 +29,7 @@
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
     "@dcl/kernel": "^1.0.0-1435962399.commit-67d3765",
-    "@dcl/posix": "1.0.3-20211108141117.commit-fb3dffe",
+    "@dcl/posix": "1.0.3-20211118190143.commit-0989fa3",
     "@dcl/unity-renderer": "1.0.18126-20211029133620.commit-42454bc",
     "glob": "^7.1.7",
     "http-proxy-middleware": "^2.0.1",

--- a/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -101,6 +101,16 @@ export const onVideoEvent = new Observable<IEvents['videoEvent']>(createSubscrib
 export const onProfileChanged = new Observable<IEvents['profileChanged']>(createSubscriber('profileChanged'))
 
 /**
+* @public
+*/
+export const onPlayerConnectedObservable = new Observable<IEvents['avatarConnected']>(createSubscriber('avatarConnected'))
+
+/**
+* @public
+*/
+export const onPlayerDisconnectedObservable = new Observable<IEvents['avatarDisconnected']>(createSubscriber('avatarDisconnected'))
+
+/**
  * @internal
  * This function adds _one_ listener to the onEvent event of dcl interface.
  * Leveraging a switch to route events to the Observable handlers.
@@ -151,6 +161,14 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'onPointerLock': {
           onPointerLockedStateChange.notifyObservers(event.data as IEvents['onPointerLock'])
+          return
+        }
+        case 'avatarConnected': {
+          onPlayerConnectedObservable.notifyObservers(event.data as IEvents['avatarConnected'])
+          return
+        }
+        case 'avatarDisconnected': {
+          onPlayerConnectedObservable.notifyObservers(event.data as IEvents['avatarDisconnected'])
           return
         }
       }

--- a/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -103,12 +103,12 @@ export const onProfileChanged = new Observable<IEvents['profileChanged']>(create
 /**
 * @public
 */
-export const onPlayerConnectedObservable = new Observable<IEvents['avatarConnected']>(createSubscriber('avatarConnected'))
+export const onPlayerConnectedObservable = new Observable<IEvents['playerConnected']>(createSubscriber('playerConnected'))
 
 /**
 * @public
 */
-export const onPlayerDisconnectedObservable = new Observable<IEvents['avatarDisconnected']>(createSubscriber('avatarDisconnected'))
+export const onPlayerDisconnectedObservable = new Observable<IEvents['playerDisconnected']>(createSubscriber('playerDisconnected'))
 
 /**
  * @internal
@@ -163,12 +163,12 @@ export function _initEventObservables(dcl: DecentralandInterface) {
           onPointerLockedStateChange.notifyObservers(event.data as IEvents['onPointerLock'])
           return
         }
-        case 'avatarConnected': {
-          onPlayerConnectedObservable.notifyObservers(event.data as IEvents['avatarConnected'])
+        case 'playerConnected': {
+          onPlayerConnectedObservable.notifyObservers(event.data as IEvents['playerConnected'])
           return
         }
-        case 'avatarDisconnected': {
-          onPlayerDisconnectedObservable.notifyObservers(event.data as IEvents['avatarDisconnected'])
+        case 'playerDisconnected': {
+          onPlayerDisconnectedObservable.notifyObservers(event.data as IEvents['playerDisconnected'])
           return
         }
       }

--- a/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -168,7 +168,7 @@ export function _initEventObservables(dcl: DecentralandInterface) {
           return
         }
         case 'avatarDisconnected': {
-          onPlayerConnectedObservable.notifyObservers(event.data as IEvents['avatarDisconnected'])
+          onPlayerDisconnectedObservable.notifyObservers(event.data as IEvents['avatarDisconnected'])
           return
         }
       }

--- a/packages/decentraland-ecs/types/@decentraland/Players/index.d.ts
+++ b/packages/decentraland-ecs/types/@decentraland/Players/index.d.ts
@@ -30,4 +30,9 @@ declare module '@decentraland/Players' {
    * Return the players's data
    */
   export function getPlayerData(opt: { userId: string }): Promise<UserData | null>
+
+  /**
+   * Return array of connected players
+   */
+  export function getConnectedPlayers(): Promise<{ userId: string }[]>
 }

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -28922,6 +28922,58 @@
         },
         {
           "kind": "Variable",
+          "canonicalReference": "decentraland-ecs!onPlayerConnectedObservable:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "onPlayerConnectedObservable: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Observable",
+              "canonicalReference": "decentraland-ecs!Observable:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<{\n    userId: string;\n}>"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "onPlayerConnectedObservable",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          }
+        },
+        {
+          "kind": "Variable",
+          "canonicalReference": "decentraland-ecs!onPlayerDisconnectedObservable:var",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "onPlayerDisconnectedObservable: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Observable",
+              "canonicalReference": "decentraland-ecs!Observable:class"
+            },
+            {
+              "kind": "Content",
+              "text": "<{\n    userId: string;\n}>"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "onPlayerDisconnectedObservable",
+          "variableTypeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 3
+          }
+        },
+        {
+          "kind": "Variable",
           "canonicalReference": "decentraland-ecs!onPlayerExpressionObservable:var",
           "docComment": "/**\n * @public\n */\n",
           "excerptTokens": [

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
@@ -1259,6 +1259,16 @@ export const onLeaveSceneObservable: Observable<{
 }>;
 
 // @public (undocumented)
+export const onPlayerConnectedObservable: Observable<{
+    userId: string;
+}>;
+
+// @public (undocumented)
+export const onPlayerDisconnectedObservable: Observable<{
+    userId: string;
+}>;
+
+// @public (undocumented)
 export const onPlayerExpressionObservable: Observable<{
     expressionId: string;
 }>;

--- a/packages/decentraland-ecs/types/dcl/index-beta.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-beta.d.ts
@@ -3063,6 +3063,20 @@ export declare const onLeaveSceneObservable: Observable<{
 /**
  * @public
  */
+export declare const onPlayerConnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
+export declare const onPlayerDisconnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
 export declare const onPlayerExpressionObservable: Observable<{
     expressionId: string;
 }>;

--- a/packages/decentraland-ecs/types/dcl/index-full.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-full.d.ts
@@ -3063,6 +3063,20 @@ export declare const onLeaveSceneObservable: Observable<{
 /**
  * @public
  */
+export declare const onPlayerConnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
+export declare const onPlayerDisconnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
 export declare const onPlayerExpressionObservable: Observable<{
     expressionId: string;
 }>;

--- a/packages/decentraland-ecs/types/dcl/index.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index.d.ts
@@ -3063,6 +3063,20 @@ declare const onLeaveSceneObservable: Observable<{
 /**
  * @public
  */
+declare const onPlayerConnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
+declare const onPlayerDisconnectedObservable: Observable<{
+    userId: string;
+}>;
+
+/**
+ * @public
+ */
 declare const onPlayerExpressionObservable: Observable<{
     expressionId: string;
 }>;


### PR DESCRIPTION
+add `onPlayerConnectedObservable` triggered when an avatar spawns
+add `onPlayerDisconnectedObservable` triggered when peer disconnects or comms set avatar as not visible