### PR TITLE
fix: move `AttachToAvatarAnchorPointId` to ecs

### DIFF
--- a/packages/@dcl/amd/package-lock.json
+++ b/packages/@dcl/amd/package-lock.json
@@ -9,21 +9,21 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@dcl/posix": "^1.0.4-20211220185734.commit-366afb4"
+        "@dcl/posix": "^1.0.3"
       }
     },
     "node_modules/@dcl/posix": {
-      "version": "1.0.4-20211220185734.commit-366afb4",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.4-20211220185734.commit-366afb4.tgz",
-      "integrity": "sha512-N/tvO/r5YbQ4uj7DSMHQeFYgo77JKun0u0cFxKhIJpb91I/P8WdXSzvKuidRDQJ/HTuVQYhkGIWIq7uOuxAxfg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3.tgz",
+      "integrity": "sha512-oY0MAPxnaws95u/G0jJoQq5GLz2viUXT8G9qiB1Bwai01PrML5GCTvOfZK+jfUE/HW0DEocAGjtz8aNbgh6xIA==",
       "dev": true
     }
   },
   "dependencies": {
     "@dcl/posix": {
-      "version": "1.0.4-20211220185734.commit-366afb4",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.4-20211220185734.commit-366afb4.tgz",
-      "integrity": "sha512-N/tvO/r5YbQ4uj7DSMHQeFYgo77JKun0u0cFxKhIJpb91I/P8WdXSzvKuidRDQJ/HTuVQYhkGIWIq7uOuxAxfg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3.tgz",
+      "integrity": "sha512-oY0MAPxnaws95u/G0jJoQq5GLz2viUXT8G9qiB1Bwai01PrML5GCTvOfZK+jfUE/HW0DEocAGjtz8aNbgh6xIA==",
       "dev": true
     }
   }

--- a/packages/@dcl/amd/package.json
+++ b/packages/@dcl/amd/package.json
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@dcl/posix": "^1.0.4-20211220185734.commit-366afb4"
+    "@dcl/posix": "^1.0.3"
   }
 }

--- a/packages/@dcl/legacy-ecs/package-lock.json
+++ b/packages/@dcl/legacy-ecs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs-math": "^1.0.1-20211130194043.commit-c994f71",
-        "@dcl/posix": "^1.0.4-20211220185734.commit-366afb4"
+        "@dcl/posix": "^1.0.3"
       }
     },
     "node_modules/@dcl/ecs-math": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-eTWiJzXlcTSjIHP67hJoumrzV5PUwGpqwgpJjPkvTwaini3/ZLmIricTG7Yn8OP9WEBNpYrKYY4CrImZ1b+w5Q=="
     },
     "node_modules/@dcl/posix": {
-      "version": "1.0.4-20211220185734.commit-366afb4",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.4-20211220185734.commit-366afb4.tgz",
-      "integrity": "sha512-N/tvO/r5YbQ4uj7DSMHQeFYgo77JKun0u0cFxKhIJpb91I/P8WdXSzvKuidRDQJ/HTuVQYhkGIWIq7uOuxAxfg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3.tgz",
+      "integrity": "sha512-oY0MAPxnaws95u/G0jJoQq5GLz2viUXT8G9qiB1Bwai01PrML5GCTvOfZK+jfUE/HW0DEocAGjtz8aNbgh6xIA=="
     }
   },
   "dependencies": {
@@ -31,9 +31,9 @@
       "integrity": "sha512-eTWiJzXlcTSjIHP67hJoumrzV5PUwGpqwgpJjPkvTwaini3/ZLmIricTG7Yn8OP9WEBNpYrKYY4CrImZ1b+w5Q=="
     },
     "@dcl/posix": {
-      "version": "1.0.4-20211220185734.commit-366afb4",
-      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.4-20211220185734.commit-366afb4.tgz",
-      "integrity": "sha512-N/tvO/r5YbQ4uj7DSMHQeFYgo77JKun0u0cFxKhIJpb91I/P8WdXSzvKuidRDQJ/HTuVQYhkGIWIq7uOuxAxfg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dcl/posix/-/posix-1.0.3.tgz",
+      "integrity": "sha512-oY0MAPxnaws95u/G0jJoQq5GLz2viUXT8G9qiB1Bwai01PrML5GCTvOfZK+jfUE/HW0DEocAGjtz8aNbgh6xIA=="
     }
   }
 }

--- a/packages/@dcl/legacy-ecs/package.json
+++ b/packages/@dcl/legacy-ecs/package.json
@@ -17,6 +17,6 @@
   ],
   "dependencies": {
     "@dcl/ecs-math": "^1.0.1-20211130194043.commit-c994f71",
-    "@dcl/posix": "^1.0.4-20211220185734.commit-366afb4"
+    "@dcl/posix": "^1.0.3"
   }
 }

--- a/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
+++ b/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
@@ -177,6 +177,14 @@ export class Transform extends ObservableComponent {
 }
 
 /** @public */
+export enum AttachToAvatarAnchorPointId {
+  Position = 0,
+  NameTag = 1,
+  LeftHand = 2,
+  RightHand = 3
+}
+
+/** @public */
 export type AttachToAvatarConstructorArgs = {
   avatarId?: string
   anchorPointId?: AttachToAvatarAnchorPointId

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -30,9 +30,9 @@
     "@dcl/amd": "file:../@dcl/amd",
     "@dcl/build-ecs": "file:../@dcl/build-ecs",
     "@dcl/kernel": "1.0.0-1527377120.commit-a94b988",
-    "@dcl/posix": "^1.0.4-20211220185734.commit-366afb4",
+    "@dcl/posix": "^1.0.3",
     "@dcl/schemas": "2.2.3-20211130152647.commit-cbda2b3",
-    "@dcl/unity-renderer": "1.0.22803-20211220192351.commit-e0005aa",
+    "@dcl/unity-renderer": "1.0.22898-20211221140621.commit-be45041",
     "glob": "^7.1.7",
     "http-proxy-middleware": "^2.0.1",
     "ignore": "^5.1.8"

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -1980,7 +1980,7 @@
                 {
                   "kind": "Reference",
                   "text": "AttachToAvatarAnchorPointId",
-                  "canonicalReference": "!AttachToAvatarAnchorPointId:enum"
+                  "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId:enum"
                 },
                 {
                   "kind": "Content",
@@ -2058,6 +2058,105 @@
           "implementsTokenRanges": []
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId:enum",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum AttachToAvatarAnchorPointId "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "AttachToAvatarAnchorPointId",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId.LeftHand:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LeftHand = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "2"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LeftHand",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId.NameTag:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NameTag = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "1"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NameTag",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId.Position:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Position = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "0"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Position",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId.RightHand:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RightHand = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "3"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RightHand",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarConstructorArgs:type",
           "docComment": "/**\n * @public\n */\n",
@@ -2073,7 +2172,7 @@
             {
               "kind": "Reference",
               "text": "AttachToAvatarAnchorPointId",
-              "canonicalReference": "!AttachToAvatarAnchorPointId:enum"
+              "canonicalReference": "@dcl/legacy-ecs!AttachToAvatarAnchorPointId:enum"
             },
             {
               "kind": "Content",

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
@@ -124,6 +124,18 @@ export class AttachToAvatar extends ObservableComponent {
 }
 
 // @public (undocumented)
+export enum AttachToAvatarAnchorPointId {
+    // (undocumented)
+    LeftHand = 2,
+    // (undocumented)
+    NameTag = 1,
+    // (undocumented)
+    Position = 0,
+    // (undocumented)
+    RightHand = 3
+}
+
+// @public (undocumented)
 export type AttachToAvatarConstructorArgs = {
     avatarId?: string;
     anchorPointId?: AttachToAvatarAnchorPointId;

--- a/packages/decentraland-ecs/types/dcl/index-beta.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-beta.d.ts
@@ -228,6 +228,14 @@ export declare class AttachToAvatar extends ObservableComponent {
 }
 
 /** @public */
+export declare enum AttachToAvatarAnchorPointId {
+    Position = 0,
+    NameTag = 1,
+    LeftHand = 2,
+    RightHand = 3
+}
+
+/** @public */
 export declare type AttachToAvatarConstructorArgs = {
     avatarId?: string;
     anchorPointId?: AttachToAvatarAnchorPointId;

--- a/packages/decentraland-ecs/types/dcl/index-full.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-full.d.ts
@@ -228,6 +228,14 @@ export declare class AttachToAvatar extends ObservableComponent {
 }
 
 /** @public */
+export declare enum AttachToAvatarAnchorPointId {
+    Position = 0,
+    NameTag = 1,
+    LeftHand = 2,
+    RightHand = 3
+}
+
+/** @public */
 export declare type AttachToAvatarConstructorArgs = {
     avatarId?: string;
     anchorPointId?: AttachToAvatarAnchorPointId;

--- a/packages/decentraland-ecs/types/dcl/index.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index.d.ts
@@ -228,6 +228,14 @@ declare class AttachToAvatar extends ObservableComponent {
 }
 
 /** @public */
+declare enum AttachToAvatarAnchorPointId {
+    Position = 0,
+    NameTag = 1,
+    LeftHand = 2,
+    RightHand = 3
+}
+
+/** @public */
 declare type AttachToAvatarConstructorArgs = {
     avatarId?: string;
     anchorPointId?: AttachToAvatarAnchorPointId;


### PR DESCRIPTION
having `AttachToAvatarAnchorPointId` in `posix` was throwing that that enum was `undefinied` while executing scene's script