### PR TITLE
fix: deprecated `Camera` `cameraMode` and default it to `ThirdPerson`

### DIFF
--- a/packages/@dcl/legacy-ecs/src/decentraland/Camera.ts
+++ b/packages/@dcl/legacy-ecs/src/decentraland/Camera.ts
@@ -31,7 +31,7 @@ export class Camera {
     return this._playerHeight
   }
 
-  /** Get Camera Mode. */
+  /** @deprecated Use onCameraModeChangedObservable Observable instead. */
   get cameraMode(): CameraMode {
     return this._cameraMode
   }
@@ -47,7 +47,7 @@ export class Camera {
   // @internal
   private _playerHeight: number = 1.6
   // @internal
-  private _cameraMode: CameraMode = CameraMode.FirstPerson
+  private _cameraMode: CameraMode = CameraMode.ThirdPerson
 
   constructor() {
     if (typeof dcl !== 'undefined') {

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -4077,7 +4077,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@dcl/legacy-ecs!Camera#cameraMode:member",
-              "docComment": "/**\n * Get Camera Mode.\n */\n",
+              "docComment": "/**\n * @deprecated\n *\n * Use onCameraModeChangedObservable Observable instead.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
@@ -286,6 +286,7 @@ export class BoxShape extends Shape {
 // @public (undocumented)
 export class Camera {
     constructor();
+    // @deprecated (undocumented)
     get cameraMode(): CameraMode;
     readonly feetPosition: Vector3;
     // (undocumented)

--- a/packages/decentraland-ecs/types/dcl/index-beta.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-beta.d.ts
@@ -454,7 +454,7 @@ export declare class Camera {
     readonly worldPosition: Vector3;
     /** Player height. */
     get playerHeight(): number;
-    /** Get Camera Mode. */
+    /** @deprecated Use onCameraModeChangedObservable Observable instead. */
     get cameraMode(): CameraMode;
     constructor();
 }

--- a/packages/decentraland-ecs/types/dcl/index-full.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-full.d.ts
@@ -454,7 +454,7 @@ export declare class Camera {
     readonly worldPosition: Vector3;
     /** Player height. */
     get playerHeight(): number;
-    /** Get Camera Mode. */
+    /** @deprecated Use onCameraModeChangedObservable Observable instead. */
     get cameraMode(): CameraMode;
     constructor();
 }

--- a/packages/decentraland-ecs/types/dcl/index.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index.d.ts
@@ -454,7 +454,7 @@ declare class Camera {
     readonly worldPosition: Vector3;
     /** Player height. */
     get playerHeight(): number;
-    /** Get Camera Mode. */
+    /** @deprecated Use onCameraModeChangedObservable Observable instead. */
     get cameraMode(): CameraMode;
     constructor();
 }


### PR DESCRIPTION
deprecated `Camera.instance.cameraMode` since there are multiple scenarios where it value could be outdated.
it use should be discouraged in favor of the observable `onCameraModeChangedObservable` 