### PR TITLE
feat: add warning message when proxy errors

### DIFF
--- a/packages/decentraland-ecs/src/cli/mock-catalyst/index.ts
+++ b/packages/decentraland-ecs/src/cli/mock-catalyst/index.ts
@@ -67,7 +67,14 @@ export const mockCatalyst = (
     '/lambdas',
     createProxyMiddleware({
       target: 'https://peer-lb.decentraland.org/',
-      changeOrigin: true
+      changeOrigin: true,
+      timeout: 25 * 1000,
+      proxyTimeout: 25 * 1000,
+      onError: (err, req_, res) => {
+        console.warn(`Oops, it seems the catalyst isn't working well.`)
+        res.writeHead(500)
+        res.end('')
+      }
     })
   )
 
@@ -76,7 +83,14 @@ export const mockCatalyst = (
     '/content',
     createProxyMiddleware({
       target: 'https://peer-lb.decentraland.org/',
-      changeOrigin: true
+      changeOrigin: true,
+      timeout: 25 * 1000,
+      proxyTimeout: 25 * 1000,
+      onError: (err, req_, res) => {
+        console.warn(`Oops, it seems the content server isn't working well.`)
+        res.writeHead(500)
+        res.end('')
+      }
     })
   )
 }


### PR DESCRIPTION
# What ?
Add custom timeouts

Note:
It'd be great if we could catch this proxy error in another middleware, but the libary `http-proxy-middleware` stops the propagation of request even if it fails.

# Why?
It improves the information and it avoids the browser cancels the requests.