### PR TITLE
feat: add `excludeIds` field to `AvatarModifierArea`

### DIFF
--- a/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
+++ b/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
@@ -113,10 +113,18 @@ export class AvatarModifierArea extends ObservableComponent {
   @ObservableComponent.field
   modifiers!: AvatarModifiers[]
 
-  constructor(args: { area: Area; modifiers: AvatarModifiers[] }) {
+  @ObservableComponent.field
+  excludeIds?: string[]
+
+  constructor(args: {
+    area: Area
+    modifiers: AvatarModifiers[]
+    excludeIds?: string[]
+  }) {
     super()
     this.area = args.area
     this.modifiers = args.modifiers
+    this.excludeIds = args.excludeIds
   }
 }
 

--- a/packages/decentraland-ecs/package.json
+++ b/packages/decentraland-ecs/package.json
@@ -32,7 +32,7 @@
     "@dcl/kernel": "^1.0.0-1876297332.commit-9804de6",
     "@dcl/posix": "^1.0.4",
     "@dcl/schemas": "^3.8.0",
-    "@dcl/unity-renderer": "^1.0.28231-20220218195314.commit-01ad746",
+    "@dcl/unity-renderer": "^1.0.28548-20220301152044.commit-c70047e",
     "glob": "^7.1.7",
     "http-proxy-middleware": "^2.0.3",
     "ignore": "^5.1.8"

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -2828,7 +2828,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "[];\n    }"
+                  "text": "[];\n        excludeIds?: string[];\n    }"
                 },
                 {
                   "kind": "Content",
@@ -2869,6 +2869,33 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "area",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@dcl/legacy-ecs!AvatarModifierArea#excludeIds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "excludeIds?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "excludeIds",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
@@ -186,9 +186,12 @@ export class AvatarModifierArea extends ObservableComponent {
     constructor(args: {
         area: Area;
         modifiers: AvatarModifiers[];
+        excludeIds?: string[];
     });
     // (undocumented)
     area: Area;
+    // (undocumented)
+    excludeIds?: string[];
     // (undocumented)
     modifiers: AvatarModifiers[];
 }

--- a/packages/decentraland-ecs/types/dcl/index-beta.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-beta.d.ts
@@ -319,9 +319,11 @@ export declare type AvatarForRenderer = {
 export declare class AvatarModifierArea extends ObservableComponent {
     area: Area;
     modifiers: AvatarModifiers[];
+    excludeIds?: string[];
     constructor(args: {
         area: Area;
         modifiers: AvatarModifiers[];
+        excludeIds?: string[];
     });
 }
 

--- a/packages/decentraland-ecs/types/dcl/index-full.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-full.d.ts
@@ -319,9 +319,11 @@ export declare type AvatarForRenderer = {
 export declare class AvatarModifierArea extends ObservableComponent {
     area: Area;
     modifiers: AvatarModifiers[];
+    excludeIds?: string[];
     constructor(args: {
         area: Area;
         modifiers: AvatarModifiers[];
+        excludeIds?: string[];
     });
 }
 

--- a/packages/decentraland-ecs/types/dcl/index.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index.d.ts
@@ -319,9 +319,11 @@ declare type AvatarForRenderer = {
 declare class AvatarModifierArea extends ObservableComponent {
     area: Area;
     modifiers: AvatarModifiers[];
+    excludeIds?: string[];
     constructor(args: {
         area: Area;
         modifiers: AvatarModifiers[];
+        excludeIds?: string[];
     });
 }
 

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -62,6 +62,7 @@ flow('build-all', () => {
   flow('decentraland-ecs', () => {
     itDeletesFolder('dist', ECS_PATH)
     itExecutes(`npm i --quiet`, ECS_PATH)
+    itExecutes(`npm link @dcl/posix`, LEGACY_ECS_PATH)
 
     itDeletesGlob('types/dcl/*.d.ts', ECS_PATH)
 
@@ -83,6 +84,7 @@ flow('build-all', () => {
     // And then we build legacy-ecs with TS and publish it to npm so we can use it like a normal module.
 
     itExecutes(`npm ci --quiet`, LEGACY_ECS_PATH)
+    itExecutes(`npm link @dcl/posix`, LEGACY_ECS_PATH)
     itDeletesFolder('dist', LEGACY_ECS_PATH)
     itExecutes(`${TSC} -p tsconfig.json`, LEGACY_ECS_PATH)
   })

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -62,7 +62,6 @@ flow('build-all', () => {
   flow('decentraland-ecs', () => {
     itDeletesFolder('dist', ECS_PATH)
     itExecutes(`npm i --quiet`, ECS_PATH)
-    itExecutes(`npm link @dcl/posix`, LEGACY_ECS_PATH)
 
     itDeletesGlob('types/dcl/*.d.ts', ECS_PATH)
 
@@ -84,7 +83,6 @@ flow('build-all', () => {
     // And then we build legacy-ecs with TS and publish it to npm so we can use it like a normal module.
 
     itExecutes(`npm ci --quiet`, LEGACY_ECS_PATH)
-    itExecutes(`npm link @dcl/posix`, LEGACY_ECS_PATH)
     itDeletesFolder('dist', LEGACY_ECS_PATH)
     itExecutes(`${TSC} -p tsconfig.json`, LEGACY_ECS_PATH)
   })


### PR DESCRIPTION
add `excludeIds` field to `AvatarModifierArea` component.
Note: Modifiers won't affect avatars for users which id are contained in `excludeIds`

Can be merged after this PR: https://github.com/decentraland/unity-renderer/pull/1853