### PR TITLE
Allow `types` field in package.json as well as `typings`

### DIFF
--- a/packages/@dcl/build-ecs/index.ts
+++ b/packages/@dcl/build-ecs/index.ts
@@ -10,6 +10,7 @@ type PackageJson = {
 
   // only package.json
   typings?: string
+  types?: string
 
   bundledDependencies: string[]
   bundleDependencies: string[]
@@ -627,12 +628,15 @@ function getConfiguration(
           }
         }
 
-        if (!libPackageJson.typings) {
-          throw new Error(`field "typings" is missing in package.json`)
+        if (!libPackageJson.typings && !libPackageJson.types) {
+          throw new Error(`field "typings" or "types" is missing in package.json`)
         } else {
           typings = resolve(
             dirname(resolved),
-            decentralandLibrary.typings || libPackageJson.typings
+            decentralandLibrary.typings
+              || decentralandLibrary.types
+              || libPackageJson.typings
+              || libPackageJson.types
           )
           if (!ts.sys.fileExists(typings)) {
             throw new Error(`typings file ${typings} not found`)
@@ -824,14 +828,16 @@ function validatePackageJsonForLibrary(
     }
   }
 
-  if (!packageJson.typings) {
-    throw new Error(`field "typings" in package.json is missing.`)
+  if (!packageJson.typings && !packageJson.types) {
+    throw new Error(`field "typings" or "types" in package.json is missing.`)
   } else {
-    const typingsFile = ts.sys.resolvePath(packageJson.typings)
+    const typingsFile = ts.sys.resolvePath(
+      (packageJson.typings || packageJson.types) as string
+    )
 
     if (!typingsFile) {
       throw new Error(
-        `! Error: field "typings" in package.json cannot be resolved.`
+        `! Error: field "typings" or "types" in package.json cannot be resolved.`
       )
     }
 
@@ -842,7 +848,7 @@ function validatePackageJsonForLibrary(
         ''
       )} != ${typingsFile.replace(ts.sys.getCurrentDirectory(), '')})`
       throw new Error(
-        `! Error: package.json .typings does not match the emited file\n       ${help}`
+        `! Error: package.json .typings or .types does not match the emitted file\n       ${help}`
       )
     }
   }

--- a/packages/@dcl/dcl-rollup/api-extractor.ts
+++ b/packages/@dcl/dcl-rollup/api-extractor.ts
@@ -14,8 +14,11 @@ export async function apiExtractor(
 ) {
   const cwd = path.dirname(packageJsonPath)
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString())
-  console.assert(packageJson.typings, 'package.json#typings is not valid')
-  const typingsFullPath = path.resolve(packageJson.typings)
+  console.assert(
+    packageJson.typings || packageJson.types,
+    'package.json#typings or package.json#types is not valid'
+  )
+  const typingsFullPath = path.resolve(packageJson.typings || packageJson.types)
 
   const prepareOptions: IExtractorConfigPrepareOptions =
     ExtractorConfig.tryLoadForFolder({ startingFolder: cwd }) || {

--- a/packages/@dcl/dcl-rollup/ecs.config.ts
+++ b/packages/@dcl/dcl-rollup/ecs.config.ts
@@ -14,7 +14,10 @@ const packageJson = JSON.parse(sys.readFile(packageJsonPath)!)
 
 console.assert(packageJson.name, 'package.json .name must be present')
 console.assert(packageJson.main, 'package.json .main must be present')
-console.assert(packageJson.typings, 'package.json .typings must be present')
+console.assert(
+  packageJson.typings || packageJson.types,
+  'package.json .typings or .types must be present'
+)
 
 const plugins = [
   typescript({

--- a/packages/@dcl/dcl-rollup/libs.config.ts
+++ b/packages/@dcl/dcl-rollup/libs.config.ts
@@ -18,7 +18,10 @@ console.assert(
   'package.json .decentralandLibrary must be an object'
 )
 console.assert(packageJson.main, 'package.json .main must be present')
-console.assert(packageJson.typings, 'package.json .typings must be present')
+console.assert(
+  packageJson.typings || packageJson.types,
+  'package.json .typings or .types must be present'
+)
 
 const plugins = [
   typescript({


### PR DESCRIPTION
The TypeScript docs seem to prefer `types` as opposed to `typings`:

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

And there are many packages that use `types` instead of `typings`. So this PR allows the toolchain to support both! 💯 