### PR TITLE
Fix remove component

### DIFF
--- a/packages/@dcl/ecs/package-lock.json
+++ b/packages/@dcl/ecs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/crdt": "^1.0.0-20220412150438.commit-965dc72",
+        "@dcl/crdt": "^1.0.0-20220628173122.commit-5581606",
         "@dcl/ecs-math": "^2.0.1-20220526123120.commit-dab2aff",
         "@dcl/posix": "^1.0.4"
       },
@@ -606,9 +606,9 @@
       "dev": true
     },
     "node_modules/@dcl/crdt": {
-      "version": "1.0.0-20220422154142.commit-0126c3c",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-1.0.0-20220422154142.commit-0126c3c.tgz",
-      "integrity": "sha512-no6PlET0izybv7plIQOeXt6A/CJtBCzvHhSQXlMpySnLfg4d++cNIpNxPOVBHaz6H6oFdiYA6TRO3MH6VpJ9BQ=="
+      "version": "1.0.0-20220628173122.commit-5581606",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-1.0.0-20220628173122.commit-5581606.tgz",
+      "integrity": "sha512-zbpJ0e7Bm9w/hU7chNRCEbhJB+tpiBZu46ySMZHsmKcH8nNSUoDuA37zxOrc2w9Erznd77m+v8RfeOH08bRt0g=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.1-20220526123120.commit-dab2aff",
@@ -5198,9 +5198,9 @@
       "dev": true
     },
     "@dcl/crdt": {
-      "version": "1.0.0-20220422154142.commit-0126c3c",
-      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-1.0.0-20220422154142.commit-0126c3c.tgz",
-      "integrity": "sha512-no6PlET0izybv7plIQOeXt6A/CJtBCzvHhSQXlMpySnLfg4d++cNIpNxPOVBHaz6H6oFdiYA6TRO3MH6VpJ9BQ=="
+      "version": "1.0.0-20220628173122.commit-5581606",
+      "resolved": "https://registry.npmjs.org/@dcl/crdt/-/crdt-1.0.0-20220628173122.commit-5581606.tgz",
+      "integrity": "sha512-zbpJ0e7Bm9w/hU7chNRCEbhJB+tpiBZu46ySMZHsmKcH8nNSUoDuA37zxOrc2w9Erznd77m+v8RfeOH08bRt0g=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.1-20220526123120.commit-dab2aff",

--- a/packages/@dcl/ecs/package.json
+++ b/packages/@dcl/ecs/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@dcl/crdt": "^1.0.0-20220412150438.commit-965dc72",
+    "@dcl/crdt": "^1.0.0-20220628173122.commit-5581606",
     "@dcl/ecs-math": "^2.0.1-20220526123120.commit-dab2aff",
     "@dcl/posix": "^1.0.4"
   },

--- a/packages/@dcl/ecs/src/engine/component.ts
+++ b/packages/@dcl/ecs/src/engine/component.ts
@@ -132,7 +132,9 @@ export function defineComponent<T extends EcsType>(
     toBinary(entity: Entity): ByteBuffer {
       const component = data.get(entity)
       if (!component) {
-        throw new Error(`Component ${componentId} for ${entity} not found`)
+        throw new Error(
+          `[toBinary] Component ${componentId} for ${entity} not found`
+        )
       }
 
       const writeBuffer = createByteBuffer()
@@ -141,9 +143,10 @@ export function defineComponent<T extends EcsType>(
     },
     writeToByteBuffer(entity: Entity, buffer: ByteBuffer): void {
       const component = data.get(entity)
+      // TODO: if the component not exists, then its a delete. We should send null maybe?
       if (!component) {
         throw new Error(
-          `[toBinary] Component ${componentId} for ${entity} not found`
+          `[writeToByteBuffer] Component ${componentId} for ${entity} not found`
         )
       }
 

--- a/packages/@dcl/ecs/src/engine/component.ts
+++ b/packages/@dcl/ecs/src/engine/component.ts
@@ -143,7 +143,6 @@ export function defineComponent<T extends EcsType>(
     },
     writeToByteBuffer(entity: Entity, buffer: ByteBuffer): void {
       const component = data.get(entity)
-      // TODO: if the component not exists, then its a delete. We should send null maybe?
       if (!component) {
         throw new Error(
           `[writeToByteBuffer] Component ${componentId} for ${entity} not found`

--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -50,13 +50,12 @@ function preEngine() {
   }
 
   function removeEntity(entity: Entity) {
-    // TODO: Remove all the components of that entity
     for (const [, component] of componentsDefinition) {
       if (component.has(entity)) {
         component.deleteFrom(entity)
       }
     }
-    // entitiesComponent.delete(entity)
+
     return entityContainer.removeEntity(entity)
   }
 

--- a/packages/@dcl/ecs/src/engine/utils.ts
+++ b/packages/@dcl/ecs/src/engine/utils.ts
@@ -1,10 +1,6 @@
 import type { DeepReadonly } from '../Math'
 export type { DeepReadonly }
 
-// TODO: process does not exist in scene env
-// const isProd = () => false
-// const isProd = () => !!process.env.PRODUCTION || false
-
 export function deepReadonly<T extends Record<string, unknown>>(
   val: T
 ): DeepReadonly<T> {

--- a/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
+++ b/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
@@ -211,7 +211,6 @@ export function createByteBuffer(options: CreateByteBufferOptions = {}) {
         this.writeUint32(value.byteLength)
       }
 
-      // TODO: lean
       const o = woAdd(value.byteLength)
       buffer.set(value, o)
     },

--- a/packages/@dcl/ecs/src/serialization/crdt/componentOperation.ts
+++ b/packages/@dcl/ecs/src/serialization/crdt/componentOperation.ts
@@ -85,6 +85,4 @@ export namespace ComponentOperation {
       data: buf.readBuffer()
     }
   }
-
-  // export function isPutMessage(message: IPutComponent | IDeleteComponent)
 }

--- a/packages/@dcl/ecs/src/serialization/crdt/componentOperation.ts
+++ b/packages/@dcl/ecs/src/serialization/crdt/componentOperation.ts
@@ -3,18 +3,24 @@ import { Entity } from '../../engine/entity'
 import { ByteBuffer } from '../ByteBuffer'
 import WireMessage from '../wireMessage'
 
-export namespace PutComponentOperation {
+export namespace ComponentOperation {
   /**
    * @param entity - Uint32 number of the entity
    * @param componentId - Uint32 number of id
    * @param timestamp - Uint64 Lamport timestamp
    * @param data - Uint8[] data of component
    */
-  export type Type = {
+  export type IPutComponent = {
     entity: Entity
     componentId: number
     timestamp: number
     data: Uint8Array
+  }
+  export type IDeleteComponent = {
+    entity: Entity
+    componentId: number
+    timestamp: number
+    data?: undefined
   }
 
   export const MESSAGE_HEADER_LENGTH = 20
@@ -23,6 +29,7 @@ export namespace PutComponentOperation {
    *  already allocated
    */
   export function write(
+    type: WireMessage.Enum,
     entity: Entity,
     timestamp: number,
     componentDefinition: ComponentDefinition,
@@ -34,12 +41,14 @@ export namespace PutComponentOperation {
     )
 
     // write body
-    componentDefinition.writeToByteBuffer(entity, buf)
+    if (type === WireMessage.Enum.PUT_COMPONENT) {
+      componentDefinition.writeToByteBuffer(entity, buf)
+    }
     const messageLength = buf.size() - startMessageOffset
 
     // Write WireMessage header
     buf.setUint32(startMessageOffset, messageLength)
-    buf.setUint32(startMessageOffset + 4, WireMessage.Enum.PUT_COMPONENT)
+    buf.setUint32(startMessageOffset + 4, type)
 
     // Write ComponentOperation header
     buf.setUint32(startMessageOffset + 8, entity)
@@ -51,19 +60,31 @@ export namespace PutComponentOperation {
     )
   }
 
-  export function read(buf: ByteBuffer): (WireMessage.Header & Type) | null {
+  export function read(
+    buf: ByteBuffer
+  ): (WireMessage.Header & (IPutComponent | IDeleteComponent)) | null {
     const header = WireMessage.readHeader(buf)
 
     if (!header) {
       return null
     }
 
-    return {
+    const common = {
       ...header,
       entity: buf.readUint32() as Entity,
       componentId: buf.readInt32(),
-      timestamp: Number(buf.readUint64()),
+      timestamp: Number(buf.readUint64())
+    }
+
+    if (header.type === WireMessage.Enum.DELETE_COMPONENT) {
+      return common
+    }
+
+    return {
+      ...common,
       data: buf.readBuffer()
     }
   }
+
+  // export function isPutMessage(message: IPutComponent | IDeleteComponent)
 }

--- a/packages/@dcl/ecs/src/serialization/wireMessage.ts
+++ b/packages/@dcl/ecs/src/serialization/wireMessage.ts
@@ -24,7 +24,6 @@ export namespace WireMessage {
     PUT_COMPONENT = 1,
     DELETE_COMPONENT = 2,
 
-    // TODO: ?
     MAX_MESSAGE_TYPE
   }
 

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -131,8 +131,7 @@ export function crdtSceneSystem({
         const component = engine.getComponent(componentId)
         const entityComponent = component.has(entity)
           ? component.toBinary(entity).toBinary()
-          : // TODO: If the component is not found, then it was deleted.
-            new Uint8Array()
+          : null
         const event = crdtClient.createEvent(
           CrdtUtils.getKey(entity, componentId),
           entityComponent
@@ -148,6 +147,8 @@ export function crdtSceneSystem({
             timestamp: event.timestamp
           }
           if (transports.some((t) => t.filter(transportMessage))) {
+            // TODO: If the component is not found, then it was deleted.
+            // This should be another message or just sent null data ?
             Message.write(entity, event.timestamp, component, buffer)
             crdtMessages.push({
               ...transportMessage,

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -4,7 +4,7 @@ import type { PreEngine } from '../../engine'
 import { Entity } from '../../engine/entity'
 import EntityUtils from '../../engine/entity-utils'
 import { createByteBuffer } from '../../serialization/ByteBuffer'
-import { PutComponentOperation as Message } from '../../serialization/crdt/componentOperation'
+import { ComponentOperation as Message } from '../../serialization/crdt/componentOperation'
 import WireMessage from '../../serialization/wireMessage'
 import { Transport } from './transports/types'
 import { ReceiveMessage, TransportMessage } from './types'
@@ -50,8 +50,9 @@ export function crdtSceneSystem({
         const offset = buffer.currentReadOffset()
         const message = Message.read(buffer)!
 
-        const { entity, componentId, data, timestamp } = message
+        const { type, entity, componentId, data, timestamp } = message
         receivedMessages.push({
+          type,
           entity,
           componentId,
           data,
@@ -84,28 +85,35 @@ export function crdtSceneSystem({
     for (const transport of transports) {
       const buffer = createByteBuffer()
       for (const message of messagesToProcess) {
-        const { data, timestamp, componentId, entity } = message
+        const { data, timestamp, componentId, entity, type } = message
         const crdtMessage: CrdtMessage<Uint8Array> = {
           key: CrdtUtils.getKey(entity, componentId),
-          data: data,
+          data: data || null,
           timestamp: timestamp
         }
         const component = engine.getComponent(componentId)
-        const currentMessage = crdtClient.processMessage(crdtMessage)
-
+        const current = crdtClient.processMessage(crdtMessage)
         // CRDT outdated message. Resend this message through the wire
         // TODO: perf transactor
-        if (crdtMessage !== currentMessage) {
+        if (crdtMessage !== current) {
           // CRDT outdated message. Resend this message through the wire
-          Message.write(entity, currentMessage.timestamp, component, buffer)
+          const type = component.has(entity)
+            ? WireMessage.Enum.PUT_COMPONENT
+            : WireMessage.Enum.DELETE_COMPONENT
+          Message.write(type, entity, current.timestamp, component, buffer)
         } else {
-          const opts = { reading: { buffer: message.data, currentOffset: 0 } }
-          const bb = createByteBuffer(opts)
+          if (type === WireMessage.Enum.DELETE_COMPONENT) {
+            component.deleteFrom(entity)
+          } else {
+            const opts = {
+              reading: { buffer: message.data!, currentOffset: 0 }
+            }
+            const bb = createByteBuffer(opts)
 
-          // Update engine component
-          component.upsertFromBinary(message.entity, bb)
-          component.clearDirty()
-
+            // Update engine component
+            component.upsertFromBinary(message.entity, bb)
+            component.clearDirty()
+          }
           // Add message to transport queue to be processed by others transports
           transportMessages.push(message)
         }
@@ -141,7 +149,11 @@ export function crdtSceneSystem({
         // There is no need to create messages for the static entities the first time they are created
         // They are part of the scene loading. Send only updates.
         if (!EntityUtils.isStaticEntity(entity) || crdtEntities.has(entity)) {
+          const type = component.has(entity)
+            ? WireMessage.Enum.PUT_COMPONENT
+            : WireMessage.Enum.DELETE_COMPONENT
           const transportMessage: Omit<TransportMessage, 'messageBuffer'> = {
+            type,
             componentId,
             entity,
             timestamp: event.timestamp
@@ -149,7 +161,7 @@ export function crdtSceneSystem({
           if (transports.some((t) => t.filter(transportMessage))) {
             // TODO: If the component is not found, then it was deleted.
             // This should be another message or just sent null data ?
-            Message.write(entity, event.timestamp, component, buffer)
+            Message.write(type, entity, event.timestamp, component, buffer)
             crdtMessages.push({
               ...transportMessage,
               messageBuffer: buffer

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -93,15 +93,15 @@ export function crdtSceneSystem({
         }
         const component = engine.getComponent(componentId)
         const current = crdtClient.processMessage(crdtMessage)
+
         // CRDT outdated message. Resend this message through the wire
-        // TODO: perf transactor
         if (crdtMessage !== current) {
-          // CRDT outdated message. Resend this message through the wire
           const type = component.has(entity)
             ? WireMessage.Enum.PUT_COMPONENT
             : WireMessage.Enum.DELETE_COMPONENT
           Message.write(type, entity, current.timestamp, component, buffer)
         } else {
+          // Process CRDT Message
           if (type === WireMessage.Enum.DELETE_COMPONENT) {
             component.deleteFrom(entity)
           } else {
@@ -159,8 +159,6 @@ export function crdtSceneSystem({
             timestamp: event.timestamp
           }
           if (transports.some((t) => t.filter(transportMessage))) {
-            // TODO: If the component is not found, then it was deleted.
-            // This should be another message or just sent null data ?
             Message.write(type, entity, event.timestamp, component, buffer)
             crdtMessages.push({
               ...transportMessage,

--- a/packages/@dcl/ecs/src/systems/crdt/transports/types.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/transports/types.ts
@@ -4,5 +4,5 @@ export type Transport = {
   type: string
   send(message: Uint8Array): void
   onmessage?(message: Uint8Array): void
-  filter(message: TransportMessage): boolean
+  filter(message: Omit<TransportMessage, 'messageBuffer'>): boolean
 }

--- a/packages/@dcl/ecs/src/systems/crdt/types.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/types.ts
@@ -1,11 +1,13 @@
 import { Entity } from '../../engine/entity'
+import WireMessage from '../../serialization/wireMessage'
 
 export type ReceiveMessage = {
+  type: WireMessage.Enum
   entity: Entity
   componentId: number
   timestamp: number
   transportType?: string
-  data: Uint8Array
+  data?: Uint8Array
   messageBuffer: Uint8Array
 }
 

--- a/packages/@dcl/ecs/src/systems/crdt/utils.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/utils.ts
@@ -4,15 +4,6 @@ import { Entity } from '../../engine/entity'
 export namespace CrdtUtils {
   export type ComponentID = ComponentDefinition['_id']
 
-  // TODO: use this again
-  // export function parseKey(key: string): [Entity, ComponentID] {
-  //   const [entity, componentId] = key.split('.').map(Number) as [
-  //     Entity,
-  //     ComponentID
-  //   ]
-  //   return [entity, componentId]
-  // }
-
   export function getKey(entity: Entity, componentId: ComponentID): string {
     return `${entity}.${componentId}`
   }
@@ -26,39 +17,3 @@ export namespace CrdtUtils {
 }
 
 export default CrdtUtils
-
-// TODO: next version split between diff types of transports/crdts.
-// 1. engine.receiveMessage(rawMessage "diff")
-// 2. engine checks CRDT "filter"
-//   2.1. If pass, then apply CRDT message to internal cache
-//   2.2. Update registered components "patch" (using rawMessage data & created components)
-//   2.3. Execute onUpdate callbacks "emit"
-
-// engine.onUpdate((rawMessage) => {
-//   rawMessage // { entity_id, data, com, time}
-//   if (component.meta.syncFlags & SynchronizedEntityType.ALL || component.meta.syncFlags & SynchronizedEntityType.RENDERER) {
-//     SENDTORENDERER()
-//   }
-// })
-
-// async function sendUpdates(message: crdt.Message) {
-//   return
-// }
-
-// function rendererStream() {
-//   const componentIds = getComponentIds()
-
-//   function filter(componentId: number) {
-//     return componentIds.includes(componentId)
-//   }
-
-//   function send() {
-//     console.log('send')
-//   }
-
-//   return { filter, send }
-// }
-
-// function sceneStream() {
-//   function filter(componentId: number) {}
-// }

--- a/packages/@dcl/ecs/test/componentOperation.spec.ts
+++ b/packages/@dcl/ecs/test/componentOperation.spec.ts
@@ -3,8 +3,10 @@ import { TRANSFORM_LENGTH } from '../src/components/legacy/Transform'
 import { Engine } from '../src/engine'
 import { Entity } from '../src/engine/entity'
 import { createByteBuffer } from '../src/serialization/ByteBuffer'
-import { PutComponentOperation } from '../src/serialization/crdt/componentOperation'
+import { ComponentOperation } from '../src/serialization/crdt/componentOperation'
 import WireMessage from '../src/serialization/wireMessage'
+
+const putType = WireMessage.Enum.PUT_COMPONENT
 
 describe('Component operation tests', () => {
   it('validate corrupt message', () => {
@@ -37,18 +39,24 @@ describe('Component operation tests', () => {
 
     const bb = createByteBuffer()
 
-    PutComponentOperation.write(entityA, timestamp, sdk.Transform, bb)
+    ComponentOperation.write(
+      WireMessage.Enum.PUT_COMPONENT,
+      entityA,
+      timestamp,
+      sdk.Transform,
+      bb
+    )
 
     mutableTransform.position.x = 31.3
     timestamp++
 
-    PutComponentOperation.write(entityA, timestamp, sdk.Transform, bb)
+    ComponentOperation.write(putType, entityA, timestamp, sdk.Transform, bb)
 
     while (WireMessage.validate(bb)) {
-      const msgOne = PutComponentOperation.read(bb)!
+      const msgOne = ComponentOperation.read(bb)!
       expect(msgOne.length).toBe(
         TRANSFORM_LENGTH +
-          PutComponentOperation.MESSAGE_HEADER_LENGTH +
+          ComponentOperation.MESSAGE_HEADER_LENGTH +
           WireMessage.HEADER_LENGTH
       )
       expect(msgOne.type).toBe(WireMessage.Enum.PUT_COMPONENT)
@@ -58,6 +66,6 @@ describe('Component operation tests', () => {
 
   it('should return null if it has an invalid header', () => {
     const buf = createByteBuffer()
-    expect(PutComponentOperation.read(buf)).toBe(null)
+    expect(ComponentOperation.read(buf)).toBe(null)
   })
 })

--- a/packages/@dcl/ecs/test/components/TextShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/TextShape.spec.ts
@@ -63,8 +63,6 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = TextShape.toBinary(entity)
     TextShape.updateFromBinary(entityB, buffer)
 
-    // TODO: toBeDeepCloseTo has a error type implementation, should make an own toBeDeepCloseTo
-    //  or fix with a PR this one
     const otherTextShape = TextShape.mutable(entityB)
     expect(_textShape).toBeDeepCloseTo({
       ...(otherTextShape as any)

--- a/packages/@dcl/ecs/test/crdt.spec.ts
+++ b/packages/@dcl/ecs/test/crdt.spec.ts
@@ -2,7 +2,8 @@ import { Vector3 } from '@dcl/ecs-math'
 import { Entity } from '../src/engine/entity'
 import EntityUtils from '../src/engine/entity-utils'
 import { createByteBuffer } from '../src/serialization/ByteBuffer'
-import { PutComponentOperation } from '../src/serialization/crdt/componentOperation'
+import { ComponentOperation } from '../src/serialization/crdt/componentOperation'
+import WireMessage from '../src/serialization/wireMessage'
 import { wait, SandBox } from './utils'
 
 describe('CRDT tests', () => {
@@ -160,18 +161,66 @@ describe('CRDT tests', () => {
     engine.baseComponents.Transform.mutable(entity).position.x = 8
     engine.update(1)
     const buffer = createByteBuffer()
-    PutComponentOperation.write(
+    ComponentOperation.write(
+      WireMessage.Enum.PUT_COMPONENT,
       entity,
       0,
       engine.baseComponents.Transform,
       buffer
     )
     jest.resetAllMocks()
-    const spyWrite = jest.spyOn(PutComponentOperation, 'write')
+    const spyWrite = jest.spyOn(ComponentOperation, 'write')
     transports[0].onmessage!(buffer.toBinary())
     engine.update(1)
 
     expect(spySend).toBeCalledTimes(1)
     expect(spyWrite).toBeCalledTimes(1)
+  })
+
+  it('should resend a crdt delete message if its outdated', () => {
+    const [{ engine, transports, spySend }] = SandBox.create({ length: 1 })
+    const entity = engine.addEntity()
+    const { Transform } = engine.baseComponents
+    Transform.create(entity, SandBox.DEFAULT_POSITION)
+    engine.update(1)
+    const buffer = createByteBuffer()
+    ComponentOperation.write(
+      WireMessage.Enum.PUT_COMPONENT,
+      entity,
+      0,
+      Transform,
+      buffer
+    )
+    Transform.deleteFrom(entity)
+    engine.update(1)
+    jest.resetAllMocks()
+    const spyWrite = jest.spyOn(ComponentOperation, 'write')
+    transports[0].onmessage!(buffer.toBinary())
+    engine.update(1)
+
+    expect(spySend).toBeCalledTimes(1)
+    expect(spyWrite).toBeCalledTimes(1)
+  })
+
+  it('should remove a component if we receive a DELETE_COMPONENT operation message', () => {
+    const [{ engine, transports }] = SandBox.create({ length: 1 })
+    const [transport] = transports
+    const entity = engine.addEntity()
+    const { Transform } = engine.baseComponents
+
+    Transform.create(entity, SandBox.DEFAULT_POSITION)
+    engine.update(1)
+
+    const buffer = createByteBuffer()
+    ComponentOperation.write(
+      WireMessage.Enum.DELETE_COMPONENT,
+      entity,
+      2,
+      engine.baseComponents.Transform,
+      buffer
+    )
+    transport.onmessage!(buffer.toBinary())
+    engine.update(1)
+    expect(Transform.getOrNull(entity)).toBe(null)
   })
 })

--- a/packages/@dcl/ecs/test/engine.spec.ts
+++ b/packages/@dcl/ecs/test/engine.spec.ts
@@ -384,7 +384,7 @@ describe('Engine tests', () => {
     expect(MoveTransformComponent.getOrNull(zombie)).toStrictEqual(null)
   })
 
-  it.only('should remove transofmr component and send throught the network', () => {
+  it('should remove Transform component and send it throught the network', () => {
     const engine = Engine({ transports: [createRendererTransport()] })
     const entity = engine.addEntity()
 

--- a/packages/@dcl/ecs/test/transports.spec.ts
+++ b/packages/@dcl/ecs/test/transports.spec.ts
@@ -1,5 +1,6 @@
 import { Int8, MapType } from '../src/built-in-types'
 import { Engine } from '../src/engine'
+import WireMessage from '../src/serialization/wireMessage'
 import { createNetworkTransport } from '../src/systems/crdt/transports/networkTransport'
 import { createRendererTransport } from '../src/systems/crdt/transports/rendererTransport'
 import { TransportMessage } from '../src/systems/crdt/types'
@@ -15,6 +16,7 @@ describe('Transport tests', () => {
     const engine = Engine({ transports: [transport] })
     const entity = engine.addEntity()
     const message: TransportMessage = {
+      type: WireMessage.Enum.PUT_COMPONENT,
       entity,
       componentId: engine.baseComponents.Transform._id,
       timestamp: Date.now(),


### PR DESCRIPTION
When you delete a component, the crdt system try to serialize that component but it doesn't exist anymore.
Now we send an empty Uint8Array if thats the case.

We store all the components into the crdt state, but if there is no transport that needs to send that component we avoid it.