### PR TITLE
fix: send to transport a copied array instead of a reference array. 

### DIFF
--- a/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
+++ b/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
@@ -201,11 +201,25 @@ export function createByteBuffer(options: CreateByteBufferOptions = {}) {
       return woffset
     },
     /**
-     * @returns The subarray from 0 to offset.
+     * Take care using this function, if you modify the data after, the
+     * returned subarray will change too. If you'll modify the content of the
+     * bytebuffer, maybe you want to use toCopiedBinary()
+     *
+     * @returns The subarray from 0 to offset as reference.
      */
     toBinary() {
       return buffer.subarray(0, woffset)
     },
+
+    /**
+     * Safe copied buffer of the current data of ByteBuffer
+     *
+     * @returns The subarray from 0 to offset.
+     */
+    toCopiedBinary() {
+      return new Uint8Array(this.toBinary())
+    },
+
     writeBuffer(value: Uint8Array, writeLength: boolean = true) {
       if (writeLength) {
         this.writeUint32(value.byteLength)

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -118,7 +118,7 @@ export function crdtSceneSystem({
       }
 
       if (buffer.size()) {
-        transport.send(buffer.toBinary())
+        transport.send(buffer.toCopiedBinary())
       }
     }
   }
@@ -174,7 +174,7 @@ export function crdtSceneSystem({
         }
       }
       if (transportBuffer.size()) {
-        transport.send(transportBuffer.toBinary())
+        transport.send(transportBuffer.toCopiedBinary())
       }
     }
   }

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -118,7 +118,7 @@ export function crdtSceneSystem({
       }
 
       if (buffer.size()) {
-        transport.send(buffer.toCopiedBinary())
+        transport.send(buffer.toBinary())
       }
     }
   }
@@ -174,7 +174,7 @@ export function crdtSceneSystem({
         }
       }
       if (transportBuffer.size()) {
-        transport.send(transportBuffer.toCopiedBinary())
+        transport.send(transportBuffer.toBinary())
       }
     }
   }

--- a/packages/@dcl/ecs/src/systems/crdt/transports/rendererTransport.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/transports/rendererTransport.ts
@@ -16,7 +16,7 @@ export function createRendererTransport(): Transport {
       // TODO: replace with new rpc
       dcl
         .callRpc('@decentraland/ExperimentalAPI', 'sendToRenderer', [
-          { data: message }
+          { data: new Uint8Array(message) }
         ])
         .catch(dcl.error)
     },

--- a/packages/@dcl/ecs/test/byteBuffer.spec.ts
+++ b/packages/@dcl/ecs/test/byteBuffer.spec.ts
@@ -149,5 +149,30 @@ describe('ByteBuffer tests', () => {
     expect(position.getUint64(readOffset + 34)).toBe(18446744073709551615n)
     expect(position.currentReadOffset()).toBe(12)
   })
+
+  it('should change toBinary() buffer and not change toCopiedBinary()', () => {
+    const testValueA = [123, 123, 123, 123, 123]
+    const testValueB = [77, 77, 77, 77, 77]
+
+    const bb = createByteBuffer()
+
+    for (const value of testValueA) {
+      bb.writeUint8(value)
+    }
+
+    const copiedBuffer = bb.toCopiedBinary()
+    const referenceBuffer = bb.toBinary()
+
+    expect(copiedBuffer[0]).toBe(testValueA[0])
+    expect(referenceBuffer[0]).toBe(testValueA[0])
+
+    bb.resetBuffer()
+    for (const value of testValueB) {
+      bb.writeUint8(value)
+    }
+
+    expect(copiedBuffer[0]).toBe(testValueA[0])
+    expect(referenceBuffer[0]).toBe(testValueB[0])
+  })
 })
 // getInt64


### PR DESCRIPTION
# What?
Add the method `toBinaryCopied()` to ByteBuffer and use it in the transport sending.

# Why?
If we have more than a `transport`, the data will be changed before being sent.