### PR TITLE
fix: preview mode

### DIFF
--- a/packages/@dcl/sdk/src/cli/mock-catalyst/index.ts
+++ b/packages/@dcl/sdk/src/cli/mock-catalyst/index.ts
@@ -130,22 +130,30 @@ const serveFolders = (app: express.Application, baseFolders: string[]) => {
     }
   })
 
-  app.get('/content/entities/scene', (req, res) => {
-    if (!req.query.pointer) {
-      res.json([])
-      return
+  function pointerRequestHandler(pointers: unknown) {
+    if (!pointers) {
+      return []
     }
 
     const requestedPointers = new Set<string>(
-      req.query.pointer && typeof req.query.pointer === 'string'
-        ? [req.query.pointer as string]
-        : (req.query.pointer as string[])
+      pointers && typeof pointers === 'string'
+        ? [pointers as string]
+        : (pointers as string[])
     )
 
     const resultEntities = getSceneJson({
       baseFolders,
       pointers: Array.from(requestedPointers)
     })
-    res.json(resultEntities).end()
+
+    return resultEntities
+  }
+
+  app.get('/content/entities/scene', (req, res) => {
+    return res.json(pointerRequestHandler(req.query.pointer)).end()
+  })
+
+  app.post('/content/entities/active', (req, res) => {
+    return res.json(pointerRequestHandler(req.body.pointers)).end()
   })
 }

--- a/packages/@dcl/sdk/src/setupProxy.ts
+++ b/packages/@dcl/sdk/src/setupProxy.ts
@@ -78,6 +78,8 @@ const setupProxy = (dcl: any, app: express.Application) => {
     }
   }
 
+  app.use(express.json())
+
   try {
     mockCatalyst(app, [...baseSceneFolders, ...baseWearableFolders])
   } catch (err) {


### PR DESCRIPTION
# What?
Add the request /active for entities fetching.

# Why?
Today, kernel uses this new request to fetch scene ids.
https://github.com/decentraland/kernel/pull/349/files#diff-90cd3cdfb62415b9ba7ebe5619ede1358524bfd7387fae63a0fda769f24e895eR43
