### PR TITLE
feat: renaming and docs methods 

### DIFF
--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -59,8 +59,8 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
-    getModifiable(entity: Entity): ComponentType<T>;
-    getModifiableOrNull(entity: Entity): ComponentType<T> | null;
+    getMutable(entity: Entity): ComponentType<T>;
+    getMutableOrNull(entity: Entity): ComponentType<T> | null;
     upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     toBinary(entity: Entity): ByteBuffer;
@@ -157,7 +157,7 @@ export namespace Components {
 
 // @public (undocumented)
 export type ComponentSchema<T extends [ComponentDefinition, ...ComponentDefinition[]]> = {
-    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getModifiable']> : never;
+    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getMutable']> : never;
 };
 
 // Warning: (ae-forgotten-export) The symbol "EcsResult" needs to be exported by the entry point index.d.ts

--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -54,12 +54,13 @@ export const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
 export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     _id: number;
     has(entity: Entity): boolean;
-    getFrom(entity: Entity): DeepReadonly<ComponentType<T>>;
+    get(entity: Entity): DeepReadonly<ComponentType<T>>;
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
     create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
-    mutable(entity: Entity): ComponentType<T>;
     createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
+    getModifiable(entity: Entity): ComponentType<T>;
+    getModifiableOrNull(entity: Entity): ComponentType<T> | null;
     upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     toBinary(entity: Entity): ByteBuffer;
@@ -156,7 +157,7 @@ export namespace Components {
 
 // @public (undocumented)
 export type ComponentSchema<T extends [ComponentDefinition, ...ComponentDefinition[]]> = {
-    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['mutable']> : never;
+    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getModifiable']> : never;
 };
 
 // Warning: (ae-forgotten-export) The symbol "EcsResult" needs to be exported by the entry point index.d.ts
@@ -193,6 +194,9 @@ export type Entity = number & {
 export const Epsilon = 0.000001;
 
 // @public (undocumented)
+export const error: (message: string | Error, data?: any) => void;
+
+// @public (undocumented)
 export type float = number;
 
 // @public (undocumented)
@@ -208,10 +212,10 @@ export type IEngine = {
     removeEntity(entity: Entity): void;
     addSystem(system: Update, priority?: number, name?: string): void;
     removeSystem(selector: string | Update): boolean;
-    defineComponent<T extends ISchema>(componentId: number, spec: T): ComponentDefinition<T>;
-    mutableGroupOf<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...ComponentSchema<T>]>;
-    groupOf<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
+    defineComponent<T extends Spec>(spec: Spec, componentId?: number): ComponentDefinition<ISchema<Result<T>>>;
+    defineComponentFromSchema<T extends ISchema>(spec: T, componentId?: number): ComponentDefinition<T>;
     getComponent<T extends ISchema>(componentId: number): ComponentDefinition<T>;
+    getEntitiesWith<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
     update(dt: number): void;
     baseComponents: SdkComponents;
 };
@@ -226,6 +230,9 @@ export interface ISize {
     height: number;
     width: number;
 }
+
+// @public (undocumented)
+export const log: (...a: any[]) => void;
 
 // @public (undocumented)
 export const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
@@ -430,9 +437,11 @@ export namespace Vector3 {
 
 // Warnings were encountered during analysis:
 //
-// dist/engine/types.d.ts:25:5 - (ae-forgotten-export) The symbol "Update" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:32:5 - (ae-forgotten-export) The symbol "SdkComponents" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:38:5 - (ae-forgotten-export) The symbol "Transport" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:26:5 - (ae-forgotten-export) The symbol "Update" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:28:5 - (ae-forgotten-export) The symbol "Spec" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:28:5 - (ae-forgotten-export) The symbol "Result" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:33:5 - (ae-forgotten-export) The symbol "SdkComponents" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:39:5 - (ae-forgotten-export) The symbol "Transport" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -301,6 +301,13 @@ export namespace Quaternion {
 // @public
 export const RAD2DEG: number;
 
+// Warning: (ae-forgotten-export) The symbol "ToOptional" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type Result<T extends Spec> = ToOptional<{
+    [K in keyof T]: T[K] extends ISchema ? ReturnType<T[K]['deserialize']> : T[K] extends Spec ? Result<T[K]> : never;
+}>;
+
 // @public (undocumented)
 export namespace Schemas {
     // (undocumented)
@@ -341,11 +348,22 @@ export namespace Schemas {
     Optional: typeof IOptional;
 }
 
+// Warning: (ae-forgotten-export) The symbol "defineLibraryComponents" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type SdkComponents = ReturnType<typeof defineLibraryComponents>;
+
 // @public
 export enum Space {
     BONE = 2,
     LOCAL = 0,
     WORLD = 1
+}
+
+// @public (undocumented)
+export interface Spec {
+    // (undocumented)
+    [key: string]: ISchema;
 }
 
 // @public (undocumented)
@@ -382,7 +400,23 @@ parent?: Entity | undefined;
 }>>;
 
 // @public (undocumented)
+export type Transport = {
+    type: string;
+    send(message: Uint8Array): void;
+    onmessage?(message: Uint8Array): void;
+    filter(message: Omit<TransportMessage, 'messageBuffer'>): boolean;
+};
+
+// Warning: (ae-forgotten-export) The symbol "ReceiveMessage" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type TransportMessage = Omit<ReceiveMessage, 'data'>;
+
+// @public (undocumented)
 export type Unpacked<T> = T extends (infer U)[] ? U : T;
+
+// @public (undocumented)
+export type Update = (dt: number) => void;
 
 // @public (undocumented)
 export namespace Vector3 {
@@ -427,14 +461,6 @@ export namespace Vector3 {
     export function Up(): MutableVector3;
     export function Zero(): MutableVector3;
 }
-
-// Warnings were encountered during analysis:
-//
-// dist/engine/types.d.ts:55:5 - (ae-forgotten-export) The symbol "Update" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:77:5 - (ae-forgotten-export) The symbol "Spec" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:77:5 - (ae-forgotten-export) The symbol "Result" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:113:5 - (ae-forgotten-export) The symbol "SdkComponents" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:119:5 - (ae-forgotten-export) The symbol "Transport" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -53,6 +53,7 @@ export const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
 // @public (undocumented)
 export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     _id: number;
+    default(): DeepReadonly<ComponentType<T>>;
     has(entity: Entity): boolean;
     get(entity: Entity): DeepReadonly<ComponentType<T>>;
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
@@ -61,14 +62,7 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     deleteFrom(entity: Entity): ComponentType<T> | null;
     getMutable(entity: Entity): ComponentType<T>;
     getMutableOrNull(entity: Entity): ComponentType<T> | null;
-    upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
-    updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
-    toBinary(entity: Entity): ByteBuffer;
     writeToByteBuffer(entity: Entity, buffer: ByteBuffer): void;
-    iterator(): Iterable<[Entity, ComponentType<T>]>;
-    dirtyIterator(): Iterable<Entity>;
-    clearDirty(): void;
-    isDirty(entity: Entity): boolean;
 };
 
 // @public (undocumented)
@@ -212,11 +206,10 @@ export type IEngine = {
     removeEntity(entity: Entity): void;
     addSystem(system: Update, priority?: number, name?: string): void;
     removeSystem(selector: string | Update): boolean;
-    defineComponent<T extends Spec>(spec: Spec, componentId?: number): ComponentDefinition<ISchema<Result<T>>>;
-    defineComponentFromSchema<T extends ISchema>(spec: T, componentId?: number): ComponentDefinition<T>;
+    defineComponent<T extends Spec>(spec: Spec, componentId: number): ComponentDefinition<ISchema<Result<T>>>;
+    defineComponentFromSchema<T extends ISchema>(spec: T, componentId: number): ComponentDefinition<T>;
     getComponent<T extends ISchema>(componentId: number): ComponentDefinition<T>;
     getEntitiesWith<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
-    update(dt: number): void;
     baseComponents: SdkComponents;
 };
 
@@ -437,11 +430,11 @@ export namespace Vector3 {
 
 // Warnings were encountered during analysis:
 //
-// dist/engine/types.d.ts:26:5 - (ae-forgotten-export) The symbol "Update" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:28:5 - (ae-forgotten-export) The symbol "Spec" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:28:5 - (ae-forgotten-export) The symbol "Result" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:33:5 - (ae-forgotten-export) The symbol "SdkComponents" needs to be exported by the entry point index.d.ts
-// dist/engine/types.d.ts:39:5 - (ae-forgotten-export) The symbol "Transport" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:55:5 - (ae-forgotten-export) The symbol "Update" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:77:5 - (ae-forgotten-export) The symbol "Spec" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:77:5 - (ae-forgotten-export) The symbol "Result" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:113:5 - (ae-forgotten-export) The symbol "SdkComponents" needs to be exported by the entry point index.d.ts
+// dist/engine/types.d.ts:119:5 - (ae-forgotten-export) The symbol "Transport" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -61,23 +61,10 @@ function preEngine() {
     return entityContainer.removeEntity(entity)
   }
 
-  function ensureComponentId(componentId?: number) {
-    if (!componentId) {
-      const CUSTOM_COMPONENTS_START_AT = 10e3
-      let i = CUSTOM_COMPONENTS_START_AT
-      while (componentsDefinition.get(i)) {
-        i++
-      }
-      return i
-    }
-    return componentId
-  }
-
   function defineComponentFromSchema<T extends ISchema>(
     spec: T,
-    componentIdDefined?: number
+    componentId: number
   ): ComponentDefinition<T> {
-    const componentId = ensureComponentId(componentIdDefined)
     if (componentsDefinition.get(componentId)) {
       throw new Error(`Component ${componentId} already declared`)
     }
@@ -88,9 +75,9 @@ function preEngine() {
 
   function defineComponent<T extends Spec>(
     spec: Spec,
-    componentIdDefined?: number
+    componentId: number
   ): ComponentDefinition<ISchema<Result<T>>> {
-    return defineComponentFromSchema(Schemas.Map(spec), componentIdDefined)
+    return defineComponentFromSchema(Schemas.Map(spec), componentId)
   }
 
   function getComponent<T extends ISchema>(

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -118,9 +118,8 @@ export type IEngine = {
    * Get a iterator of entities that has all the component requested.
    * @param components a list of component definitions
    * @return An iterator of an array with the [entity, component1, component2, ...]
-   * ```ts
-   * const StateComponentId = 10023
-   * const StateComponent = engine.getComponent(StateComponentId)
+   *
+   * Example:
    * ```ts
    * for (const [entity, boxShape, transform] of engine.getEntitiesWith(BoxShape, Transform)) {
    * // the properties of boxShape and transform are read only

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -16,37 +16,126 @@ export type Unpacked<T> = T extends (infer U)[] ? U : T
  * @public
  */
 export type ComponentSchema<T extends [CompDef, ...CompDef[]]> = {
-  [K in keyof T]: T[K] extends CompDef
-    ? ReturnType<T[K]['getModifiable']>
-    : never
+  [K in keyof T]: T[K] extends CompDef ? ReturnType<T[K]['getMutable']> : never
 }
 
 /**
  * @public
  */
 export type IEngine = {
+  /**
+   * Increment the used entity counter and return the next one.
+   * @param dynamic
+   * @return the next entity unused
+   */
   addEntity(dynamic?: boolean): Entity
+
+  /**
+   * An alias of engine.addEntity(true)
+   */
   addDynamicEntity(): Entity
+
+  /**
+   * Remove all components of an entity
+   * @param entity
+   */
   removeEntity(entity: Entity): void
 
+  /**
+   * Add the system to the engine. It will be called every tick updated.
+   * @param system function that receives the delta time between last tick and current one.
+   * @param priority a number with the priority, big number are called before smaller ones
+   * @param name optional: a unique name to identify it
+   *
+   * Example:
+   * ```ts
+   * function mySystem(dt: number) {
+   *   const entitiesWithBoxShapes = engine.getEntitiesWith(BoxShape, Transform)
+   *   for (const [entity, _boxShape, _transform] of engine.getEntitiesWith(BoxShape, Transform)) {
+   *     // do stuffs
+   *   }
+   * }
+   * engine.addSystem(mySystem, 10)
+   * ```
+   */
   addSystem(system: Update, priority?: number, name?: string): void
+
+  /**
+   * Remove a system from the engine.
+   * @param selector the function or the unique name to identify
+   * @returns if it was found and removed
+   */
   removeSystem(selector: string | Update): boolean
 
+  /**
+   * Define a component and add it to the engine.
+   * @param spec An object with schema fields
+   * @param componentId unique id to identify the component, if the component id already exist, it will fail.
+   * @return The component definition
+   *
+   * ```ts
+   * const DoorComponentId = 10017
+   * const Door = engine.defineComponent({
+   *   id: Schemas.Int,
+   *   name: Schemas.String
+   * }, DoorComponentId)
+   *
+   * ```
+   */
   defineComponent<T extends Spec>(
     spec: Spec,
-    componentId?: number
+    componentId: number
   ): CompDef<ISchema<Result<T>>>
+
+  /**
+   * Define a component and add it to the engine.
+   * @param spec An object with schema fields
+   * @param componentId unique id to identify the component, if the component id already exist, it will fail.
+   * @return The component definition
+   *
+   * ```ts
+   * const StateComponentId = 10023
+   * const StateComponent = engine.defineComponent(Schemas.Bool, VisibleComponentId)
+   * ```
+   */
   defineComponentFromSchema<T extends ISchema>(
     spec: T,
-    componentId?: number
+    componentId: number
   ): CompDef<T>
 
+  /**
+   * Get the component definition from the component id.
+   * @param componentId
+   * @return the component definition, throw an error if it doesn't exist
+   * ```ts
+   * const StateComponentId = 10023
+   * const StateComponent = engine.getComponent(StateComponentId)
+   * ```
+   */
   getComponent<T extends ISchema>(componentId: number): CompDef<T>
 
+  /**
+   * Get a iterator of entities that has all the component requested.
+   * @param components a list of component definitions
+   * @return An iterator of an array with the [entity, component1, component2, ...]
+   * ```ts
+   * const StateComponentId = 10023
+   * const StateComponent = engine.getComponent(StateComponentId)
+   * ```ts
+   * for (const [entity, boxShape, transform] of engine.getEntitiesWith(BoxShape, Transform)) {
+   * // the properties of boxShape and transform are read only
+   * }
+   * ```
+   */
   getEntitiesWith<T extends [CompDef, ...CompDef[]]>(
     ...components: T
   ): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>
 
+  /**
+   * @internal
+   *
+   * @param dt
+   */
   update(dt: number): void
 
   baseComponents: SdkComponents

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -1,5 +1,6 @@
 import { SdkComponents } from '../components/types'
 import type { ISchema } from '../schemas/ISchema'
+import { Result, Spec } from '../schemas/Map'
 import { Transport } from '../systems/crdt/transports/types'
 import { ComponentDefinition as CompDef } from './component'
 import { Entity } from './entity'
@@ -15,7 +16,9 @@ export type Unpacked<T> = T extends (infer U)[] ? U : T
  * @public
  */
 export type ComponentSchema<T extends [CompDef, ...CompDef[]]> = {
-  [K in keyof T]: T[K] extends CompDef ? ReturnType<T[K]['mutable']> : never
+  [K in keyof T]: T[K] extends CompDef
+    ? ReturnType<T[K]['getModifiable']>
+    : never
 }
 
 /**
@@ -25,17 +28,27 @@ export type IEngine = {
   addEntity(dynamic?: boolean): Entity
   addDynamicEntity(): Entity
   removeEntity(entity: Entity): void
+
   addSystem(system: Update, priority?: number, name?: string): void
   removeSystem(selector: string | Update): boolean
-  defineComponent<T extends ISchema>(componentId: number, spec: T): CompDef<T>
-  mutableGroupOf<T extends [CompDef, ...CompDef[]]>(
-    ...components: T
-  ): Iterable<[Entity, ...ComponentSchema<T>]>
-  groupOf<T extends [CompDef, ...CompDef[]]>(
+
+  defineComponent<T extends Spec>(
+    spec: Spec,
+    componentId?: number
+  ): CompDef<ISchema<Result<T>>>
+  defineComponentFromSchema<T extends ISchema>(
+    spec: T,
+    componentId?: number
+  ): CompDef<T>
+
+  getComponent<T extends ISchema>(componentId: number): CompDef<T>
+
+  getEntitiesWith<T extends [CompDef, ...CompDef[]]>(
     ...components: T
   ): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>
-  getComponent<T extends ISchema>(componentId: number): CompDef<T>
+
   update(dt: number): void
+
   baseComponents: SdkComponents
 }
 

--- a/packages/@dcl/ecs/src/index.ts
+++ b/packages/@dcl/ecs/src/index.ts
@@ -5,3 +5,5 @@ export * from './initialization'
 
 export * from './components/generated/global.gen'
 export * from './components/generated/global.namespace.gen'
+
+export * from './types'

--- a/packages/@dcl/ecs/src/initialization.ts
+++ b/packages/@dcl/ecs/src/initialization.ts
@@ -37,3 +37,6 @@ if (dcl) {
       .finally(() => engine.update(dt))
   })
 }
+
+export const log = dcl.log
+export const error = dcl.error

--- a/packages/@dcl/ecs/src/types.ts
+++ b/packages/@dcl/ecs/src/types.ts
@@ -1,0 +1,7 @@
+import { SdkComponents } from './components/types'
+import { Update } from './engine/systems'
+import { Result, Spec } from './schemas/Map'
+import { Transport } from './systems/crdt/transports/types'
+import { TransportMessage } from './systems/crdt/types'
+
+export type { Spec, Update, Result, SdkComponents, Transport, TransportMessage }

--- a/packages/@dcl/ecs/test/components/Animator.spec.ts
+++ b/packages/@dcl/ecs/test/components/Animator.spec.ts
@@ -37,6 +37,6 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = Animator.toBinary(entity)
     Animator.updateFromBinary(entityB, buffer)
 
-    expect(_animator).toEqual({ ...Animator.getModifiable(entityB) })
+    expect(_animator).toEqual({ ...Animator.getMutable(entityB) })
   })
 })

--- a/packages/@dcl/ecs/test/components/Animator.spec.ts
+++ b/packages/@dcl/ecs/test/components/Animator.spec.ts
@@ -37,6 +37,6 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = Animator.toBinary(entity)
     Animator.updateFromBinary(entityB, buffer)
 
-    expect(_animator).toEqual({ ...Animator.mutable(entityB) })
+    expect(_animator).toEqual({ ...Animator.getModifiable(entityB) })
   })
 })

--- a/packages/@dcl/ecs/test/components/AudioSource.spec.ts
+++ b/packages/@dcl/ecs/test/components/AudioSource.spec.ts
@@ -25,10 +25,12 @@ describe('Generated AudioSource ProtoBuf', () => {
     const buffer = AudioSource.toBinary(entity)
     AudioSource.updateFromBinary(entityB, buffer)
 
-    expect(_audioSource).toBeDeepCloseTo({ ...AudioSource.mutable(entityB) })
+    expect(_audioSource).toBeDeepCloseTo({
+      ...AudioSource.getModifiable(entityB)
+    })
 
     expect(AudioSource.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AudioSource.mutable(entity)
+      ...AudioSource.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AudioSource.spec.ts
+++ b/packages/@dcl/ecs/test/components/AudioSource.spec.ts
@@ -26,11 +26,11 @@ describe('Generated AudioSource ProtoBuf', () => {
     AudioSource.updateFromBinary(entityB, buffer)
 
     expect(_audioSource).toBeDeepCloseTo({
-      ...AudioSource.getModifiable(entityB)
+      ...AudioSource.getMutable(entityB)
     })
 
     expect(AudioSource.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AudioSource.getModifiable(entity)
+      ...AudioSource.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AudioStream.spec.ts.ignore
+++ b/packages/@dcl/ecs/test/components/AudioStream.spec.ts.ignore
@@ -21,10 +21,10 @@ describe.skip('Generated AudioStream ProtoBuf', () => {
     const buffer = AudioStream.toBinary(entity)
     AudioStream.updateFromBinary(entityB, buffer)
 
-    expect(_audioStream).toBeDeepCloseTo({ ...AudioStream.mutable(entityB) })
+    expect(_audioStream).toBeDeepCloseTo({ ...AudioStream.getModifiable(entityB) })
 
     expect(AudioStream.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AudioStream.mutable(entity)
+      ...AudioStream.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AudioStream.spec.ts.ignore
+++ b/packages/@dcl/ecs/test/components/AudioStream.spec.ts.ignore
@@ -21,10 +21,10 @@ describe.skip('Generated AudioStream ProtoBuf', () => {
     const buffer = AudioStream.toBinary(entity)
     AudioStream.updateFromBinary(entityB, buffer)
 
-    expect(_audioStream).toBeDeepCloseTo({ ...AudioStream.getModifiable(entityB) })
+    expect(_audioStream).toBeDeepCloseTo({ ...AudioStream.getMutable(entityB) })
 
     expect(AudioStream.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AudioStream.getModifiable(entity)
+      ...AudioStream.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AvatarAttach.spec.ts
+++ b/packages/@dcl/ecs/test/components/AvatarAttach.spec.ts
@@ -21,11 +21,11 @@ describe('Generated BoxShape ProtoBuf', () => {
     AvatarAttach.updateFromBinary(entityB, buffer)
 
     expect(avatarAttach).toBeDeepCloseTo({
-      ...AvatarAttach.getModifiable(entityB)
+      ...AvatarAttach.getMutable(entityB)
     })
 
     expect(AvatarAttach.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AvatarAttach.getModifiable(entity)
+      ...AvatarAttach.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AvatarAttach.spec.ts
+++ b/packages/@dcl/ecs/test/components/AvatarAttach.spec.ts
@@ -20,10 +20,12 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = AvatarAttach.toBinary(entity)
     AvatarAttach.updateFromBinary(entityB, buffer)
 
-    expect(avatarAttach).toBeDeepCloseTo({ ...AvatarAttach.mutable(entityB) })
+    expect(avatarAttach).toBeDeepCloseTo({
+      ...AvatarAttach.getModifiable(entityB)
+    })
 
     expect(AvatarAttach.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...AvatarAttach.mutable(entity)
+      ...AvatarAttach.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AvatarModifierArea.spec.ts.ignore
+++ b/packages/@dcl/ecs/test/components/AvatarModifierArea.spec.ts.ignore
@@ -26,11 +26,11 @@ describe.skip('Generated Avatar ModifierArea ProtoBuf', () => {
     AvatarModifierArea.updateFromBinary(entityB, buffer)
 
     expect(avatarModifierArea).toEqual({
-      ...AvatarModifierArea.getModifiable(entityB)
+      ...AvatarModifierArea.getMutable(entityB)
     })
 
     expect(AvatarModifierArea.createOrReplace(entityB)).not.toEqual({
-      ...AvatarModifierArea.getModifiable(entity)
+      ...AvatarModifierArea.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AvatarModifierArea.spec.ts.ignore
+++ b/packages/@dcl/ecs/test/components/AvatarModifierArea.spec.ts.ignore
@@ -26,11 +26,11 @@ describe.skip('Generated Avatar ModifierArea ProtoBuf', () => {
     AvatarModifierArea.updateFromBinary(entityB, buffer)
 
     expect(avatarModifierArea).toEqual({
-      ...AvatarModifierArea.mutable(entityB)
+      ...AvatarModifierArea.getModifiable(entityB)
     })
 
     expect(AvatarModifierArea.createOrReplace(entityB)).not.toEqual({
-      ...AvatarModifierArea.mutable(entity)
+      ...AvatarModifierArea.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/AvatarShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/AvatarShape.spec.ts
@@ -39,9 +39,9 @@ describe('Generated AvatarShape ProtoBuf', () => {
     const buffer = AvatarShape.toBinary(entity)
     AvatarShape.updateFromBinary(entityB, buffer)
 
-    expect(avatarShape).toEqual({ ...AvatarShape.getFrom(entityB) })
+    expect(avatarShape).toEqual({ ...AvatarShape.get(entityB) })
     expect(AvatarShape.createOrReplace(entityB)).not.toEqual({
-      ...AvatarShape.getFrom(entity)
+      ...AvatarShape.get(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/Billboard.spec.ts
+++ b/packages/@dcl/ecs/test/components/Billboard.spec.ts
@@ -21,10 +21,10 @@ describe('Generated Billboard ProtoBuf', () => {
     const buffer = Billboard.toBinary(entity)
     Billboard.updateFromBinary(entityB, buffer)
 
-    expect(billboard).toBeDeepCloseTo({ ...Billboard.getModifiable(entityB) })
+    expect(billboard).toBeDeepCloseTo({ ...Billboard.getMutable(entityB) })
 
     expect(Billboard.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...Billboard.getModifiable(entity)
+      ...Billboard.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/Billboard.spec.ts
+++ b/packages/@dcl/ecs/test/components/Billboard.spec.ts
@@ -21,10 +21,10 @@ describe('Generated Billboard ProtoBuf', () => {
     const buffer = Billboard.toBinary(entity)
     Billboard.updateFromBinary(entityB, buffer)
 
-    expect(billboard).toBeDeepCloseTo({ ...Billboard.mutable(entityB) })
+    expect(billboard).toBeDeepCloseTo({ ...Billboard.getModifiable(entityB) })
 
     expect(Billboard.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...Billboard.mutable(entity)
+      ...Billboard.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/BoxShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/BoxShape.spec.ts
@@ -23,10 +23,10 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = BoxShape.toBinary(entity)
     BoxShape.updateFromBinary(entityB, buffer)
 
-    expect(_boxShape).toBeDeepCloseTo({ ...BoxShape.mutable(entityB) })
+    expect(_boxShape).toBeDeepCloseTo({ ...BoxShape.getModifiable(entityB) })
 
     expect(BoxShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...BoxShape.mutable(entity)
+      ...BoxShape.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/BoxShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/BoxShape.spec.ts
@@ -23,10 +23,10 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = BoxShape.toBinary(entity)
     BoxShape.updateFromBinary(entityB, buffer)
 
-    expect(_boxShape).toBeDeepCloseTo({ ...BoxShape.getModifiable(entityB) })
+    expect(_boxShape).toBeDeepCloseTo({ ...BoxShape.getMutable(entityB) })
 
     expect(BoxShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...BoxShape.getModifiable(entity)
+      ...BoxShape.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CameraMode.spec.ts
+++ b/packages/@dcl/ecs/test/components/CameraMode.spec.ts
@@ -18,10 +18,12 @@ describe('Generated CameraMode ProtoBuf', () => {
     const buffer = CameraMode.toBinary(entity)
     CameraMode.updateFromBinary(entityB, buffer)
 
-    expect(_cameraMode).toBeDeepCloseTo({ ...CameraMode.mutable(entityB) })
+    expect(_cameraMode).toBeDeepCloseTo({
+      ...CameraMode.getModifiable(entityB)
+    })
 
     expect(CameraMode.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...CameraMode.mutable(entity)
+      ...CameraMode.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CameraMode.spec.ts
+++ b/packages/@dcl/ecs/test/components/CameraMode.spec.ts
@@ -19,11 +19,11 @@ describe('Generated CameraMode ProtoBuf', () => {
     CameraMode.updateFromBinary(entityB, buffer)
 
     expect(_cameraMode).toBeDeepCloseTo({
-      ...CameraMode.getModifiable(entityB)
+      ...CameraMode.getMutable(entityB)
     })
 
     expect(CameraMode.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...CameraMode.getModifiable(entity)
+      ...CameraMode.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CameraModeArea.spec.ts
+++ b/packages/@dcl/ecs/test/components/CameraModeArea.spec.ts
@@ -21,11 +21,11 @@ describe('Generated CameraModifierArea ProtoBuf', () => {
     CameraModeArea.updateFromBinary(entityB, buffer)
 
     expect(avatarModifierArea).toEqual({
-      ...CameraModeArea.mutable(entityB)
+      ...CameraModeArea.getModifiable(entityB)
     })
 
     expect(CameraModeArea.createOrReplace(entityB)).not.toEqual({
-      ...CameraModeArea.mutable(entity)
+      ...CameraModeArea.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CameraModeArea.spec.ts
+++ b/packages/@dcl/ecs/test/components/CameraModeArea.spec.ts
@@ -21,11 +21,11 @@ describe('Generated CameraModifierArea ProtoBuf', () => {
     CameraModeArea.updateFromBinary(entityB, buffer)
 
     expect(avatarModifierArea).toEqual({
-      ...CameraModeArea.getModifiable(entityB)
+      ...CameraModeArea.getMutable(entityB)
     })
 
     expect(CameraModeArea.createOrReplace(entityB)).not.toEqual({
-      ...CameraModeArea.getModifiable(entity)
+      ...CameraModeArea.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CylinderShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/CylinderShape.spec.ts
@@ -25,10 +25,10 @@ describe('Generated Cylinder ProtoBuf', () => {
     const buffer = CylinderShape.toBinary(entity)
     CylinderShape.updateFromBinary(entityB, buffer)
 
-    expect(_shape).toBeDeepCloseTo({ ...CylinderShape.mutable(entityB) })
+    expect(_shape).toBeDeepCloseTo({ ...CylinderShape.getModifiable(entityB) })
 
     expect(CylinderShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...CylinderShape.mutable(entity)
+      ...CylinderShape.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/CylinderShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/CylinderShape.spec.ts
@@ -25,10 +25,10 @@ describe('Generated Cylinder ProtoBuf', () => {
     const buffer = CylinderShape.toBinary(entity)
     CylinderShape.updateFromBinary(entityB, buffer)
 
-    expect(_shape).toBeDeepCloseTo({ ...CylinderShape.getModifiable(entityB) })
+    expect(_shape).toBeDeepCloseTo({ ...CylinderShape.getMutable(entityB) })
 
     expect(CylinderShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...CylinderShape.getModifiable(entity)
+      ...CylinderShape.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/GLTFShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/GLTFShape.spec.ts
@@ -23,10 +23,10 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = GLTFShape.toBinary(entity)
     GLTFShape.updateFromBinary(entityB, buffer)
 
-    expect(_shape).toBeDeepCloseTo({ ...GLTFShape.mutable(entityB) })
+    expect(_shape).toBeDeepCloseTo({ ...GLTFShape.getModifiable(entityB) })
 
     expect(GLTFShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...GLTFShape.mutable(entity)
+      ...GLTFShape.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/GLTFShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/GLTFShape.spec.ts
@@ -23,10 +23,10 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = GLTFShape.toBinary(entity)
     GLTFShape.updateFromBinary(entityB, buffer)
 
-    expect(_shape).toBeDeepCloseTo({ ...GLTFShape.getModifiable(entityB) })
+    expect(_shape).toBeDeepCloseTo({ ...GLTFShape.getMutable(entityB) })
 
     expect(GLTFShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...GLTFShape.getModifiable(entity)
+      ...GLTFShape.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/NFTShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/NFTShape.spec.ts
@@ -29,9 +29,9 @@ describe('Generated NFTShape ProtoBuf', () => {
     const buffer = NFTShape.toBinary(entity)
     NFTShape.updateFromBinary(entityB, buffer)
 
-    expect(_nftShape).toBeDeepCloseTo({ ...NFTShape.getFrom(entityB) })
+    expect(_nftShape).toBeDeepCloseTo({ ...NFTShape.get(entityB) })
     expect(NFTShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...NFTShape.getFrom(entity)
+      ...NFTShape.get(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/OnPointerDown.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerDown.spec.ts
@@ -24,7 +24,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerDown.toBinary(entity)
     OnPointerDown.updateFromBinary(entityB, buffer)
 
-    expect(onPointerDown).toEqual({ ...OnPointerDown.mutable(entityB) })
+    expect(onPointerDown).toEqual({ ...OnPointerDown.getModifiable(entityB) })
   })
 
   it('should receive OnPointerResult', () => {

--- a/packages/@dcl/ecs/test/components/OnPointerDown.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerDown.spec.ts
@@ -24,7 +24,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerDown.toBinary(entity)
     OnPointerDown.updateFromBinary(entityB, buffer)
 
-    expect(onPointerDown).toEqual({ ...OnPointerDown.getModifiable(entityB) })
+    expect(onPointerDown).toEqual({ ...OnPointerDown.getMutable(entityB) })
   })
 
   it('should receive OnPointerResult', () => {

--- a/packages/@dcl/ecs/test/components/OnPointerDownResult.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerDownResult.spec.ts
@@ -31,7 +31,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerDownResult.toBinary(entity)
     OnPointerDownResult.updateFromBinary(entityB, buffer)
 
-    const result = { ...OnPointerDownResult.mutable(entityB) }
+    const result = { ...OnPointerDownResult.getModifiable(entityB) }
 
     expect(onPointerResult).toEqual(result)
   })

--- a/packages/@dcl/ecs/test/components/OnPointerDownResult.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerDownResult.spec.ts
@@ -31,7 +31,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerDownResult.toBinary(entity)
     OnPointerDownResult.updateFromBinary(entityB, buffer)
 
-    const result = { ...OnPointerDownResult.getModifiable(entityB) }
+    const result = { ...OnPointerDownResult.getMutable(entityB) }
 
     expect(onPointerResult).toEqual(result)
   })

--- a/packages/@dcl/ecs/test/components/OnPointerUp.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerUp.spec.ts
@@ -23,7 +23,9 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerUp.toBinary(entity)
     OnPointerUp.updateFromBinary(entityB, buffer)
 
-    expect(onPointerUp).toBeDeepCloseTo({ ...OnPointerUp.mutable(entityB) })
+    expect(onPointerUp).toBeDeepCloseTo({
+      ...OnPointerUp.getModifiable(entityB)
+    })
   })
 
   it('should receive OnPointerResult', () => {

--- a/packages/@dcl/ecs/test/components/OnPointerUp.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerUp.spec.ts
@@ -24,7 +24,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     OnPointerUp.updateFromBinary(entityB, buffer)
 
     expect(onPointerUp).toBeDeepCloseTo({
-      ...OnPointerUp.getModifiable(entityB)
+      ...OnPointerUp.getMutable(entityB)
     })
   })
 

--- a/packages/@dcl/ecs/test/components/OnPointerUpResult.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerUpResult.spec.ts
@@ -31,7 +31,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerUpResult.toBinary(entity)
     OnPointerUpResult.updateFromBinary(entityB, buffer)
 
-    const result = { ...OnPointerUpResult.getModifiable(entityB) }
+    const result = { ...OnPointerUpResult.getMutable(entityB) }
 
     expect(onPointerResult).toEqual(result)
   })

--- a/packages/@dcl/ecs/test/components/OnPointerUpResult.spec.ts
+++ b/packages/@dcl/ecs/test/components/OnPointerUpResult.spec.ts
@@ -31,7 +31,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
     const buffer = OnPointerUpResult.toBinary(entity)
     OnPointerUpResult.updateFromBinary(entityB, buffer)
 
-    const result = { ...OnPointerUpResult.mutable(entityB) }
+    const result = { ...OnPointerUpResult.getModifiable(entityB) }
 
     expect(onPointerResult).toEqual(result)
   })

--- a/packages/@dcl/ecs/test/components/PlaneShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/PlaneShape.spec.ts
@@ -23,10 +23,12 @@ describe('Generated PlaneShape ProtoBuf', () => {
     const buffer = PlaneShape.toBinary(entity)
     PlaneShape.updateFromBinary(entityB, buffer)
 
-    expect(_planeShape).toBeDeepCloseTo({ ...PlaneShape.mutable(entityB) })
+    expect(_planeShape).toBeDeepCloseTo({
+      ...PlaneShape.getModifiable(entityB)
+    })
 
     expect(PlaneShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...PlaneShape.mutable(entity)
+      ...PlaneShape.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/PlaneShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/PlaneShape.spec.ts
@@ -24,11 +24,11 @@ describe('Generated PlaneShape ProtoBuf', () => {
     PlaneShape.updateFromBinary(entityB, buffer)
 
     expect(_planeShape).toBeDeepCloseTo({
-      ...PlaneShape.getModifiable(entityB)
+      ...PlaneShape.getMutable(entityB)
     })
 
     expect(PlaneShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...PlaneShape.getModifiable(entity)
+      ...PlaneShape.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/PointerLock.spec.ts
+++ b/packages/@dcl/ecs/test/components/PointerLock.spec.ts
@@ -18,11 +18,11 @@ describe('Generated PointerLock ProtoBuf', () => {
     PointerLock.updateFromBinary(entityB, buffer)
 
     expect(_pointerLock).toBeDeepCloseTo({
-      ...PointerLock.getModifiable(entityB)
+      ...PointerLock.getMutable(entityB)
     })
 
     expect(PointerLock.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...PointerLock.getModifiable(entity)
+      ...PointerLock.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/PointerLock.spec.ts
+++ b/packages/@dcl/ecs/test/components/PointerLock.spec.ts
@@ -17,10 +17,12 @@ describe('Generated PointerLock ProtoBuf', () => {
     const buffer = PointerLock.toBinary(entity)
     PointerLock.updateFromBinary(entityB, buffer)
 
-    expect(_pointerLock).toBeDeepCloseTo({ ...PointerLock.mutable(entityB) })
+    expect(_pointerLock).toBeDeepCloseTo({
+      ...PointerLock.getModifiable(entityB)
+    })
 
     expect(PointerLock.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...PointerLock.mutable(entity)
+      ...PointerLock.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/SphereShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/SphereShape.spec.ts
@@ -21,9 +21,11 @@ describe('Generated SphereShape ProtoBuf', () => {
     const buffer = SphereShape.toBinary(entity)
     SphereShape.updateFromBinary(entityB, buffer)
 
-    expect(_sphereShape).toBeDeepCloseTo({ ...SphereShape.mutable(entityB) })
+    expect(_sphereShape).toBeDeepCloseTo({
+      ...SphereShape.getModifiable(entityB)
+    })
     expect(SphereShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...SphereShape.mutable(entity)
+      ...SphereShape.getModifiable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/SphereShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/SphereShape.spec.ts
@@ -22,10 +22,10 @@ describe('Generated SphereShape ProtoBuf', () => {
     SphereShape.updateFromBinary(entityB, buffer)
 
     expect(_sphereShape).toBeDeepCloseTo({
-      ...SphereShape.getModifiable(entityB)
+      ...SphereShape.getMutable(entityB)
     })
     expect(SphereShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...SphereShape.getModifiable(entity)
+      ...SphereShape.getMutable(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/TextShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/TextShape.spec.ts
@@ -63,7 +63,7 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = TextShape.toBinary(entity)
     TextShape.updateFromBinary(entityB, buffer)
 
-    const otherTextShape = TextShape.getModifiable(entityB)
+    const otherTextShape = TextShape.getMutable(entityB)
     expect(_textShape).toBeDeepCloseTo({
       ...(otherTextShape as any)
     })

--- a/packages/@dcl/ecs/test/components/TextShape.spec.ts
+++ b/packages/@dcl/ecs/test/components/TextShape.spec.ts
@@ -63,13 +63,13 @@ describe('Generated BoxShape ProtoBuf', () => {
     const buffer = TextShape.toBinary(entity)
     TextShape.updateFromBinary(entityB, buffer)
 
-    const otherTextShape = TextShape.mutable(entityB)
+    const otherTextShape = TextShape.getModifiable(entityB)
     expect(_textShape).toBeDeepCloseTo({
       ...(otherTextShape as any)
     })
 
     expect(TextShape.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...TextShape.getFrom(entity)
+      ...TextShape.get(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/Transform.spec.ts
+++ b/packages/@dcl/ecs/test/components/Transform.spec.ts
@@ -52,7 +52,7 @@ describe('Transform component', () => {
     const buffer = Transform.toBinary(entity)
     Transform.updateFromBinary(entityB, buffer)
 
-    expect(t1).toBeDeepCloseTo(Transform.getFrom(entityB) as any)
+    expect(t1).toBeDeepCloseTo(Transform.get(entityB) as any)
   })
 
   it('should serialize/deserialize Transform without parent', () => {
@@ -77,11 +77,9 @@ describe('Transform component', () => {
     const buffer = Transform.toBinary(entity)
     Transform.updateFromBinary(entityB, buffer)
 
-    expect({ ...t1, parent: 0 }).toBeDeepCloseTo(
-      Transform.getFrom(entityB) as any
-    )
+    expect({ ...t1, parent: 0 }).toBeDeepCloseTo(Transform.get(entityB) as any)
     // optional parent serialize as 0
-    expect(Transform.getFrom(entityB).parent).toBe(0)
+    expect(Transform.get(entityB).parent).toBe(0)
   })
 
   it('should create a valid empty transform component if no value argument is passed', () => {

--- a/packages/@dcl/ecs/test/components/UiComponent.spec.ts.ignore
+++ b/packages/@dcl/ecs/test/components/UiComponent.spec.ts.ignore
@@ -79,7 +79,7 @@ describe.skip('UiTransform component', () => {
     UiTransform.upsertFromBinary(entity, buffer)
     const entityB = newEngine.addEntity()
     expect(UiTransform.createOrReplace(entityB)).not.toBeDeepCloseTo({
-      ...UiTransform.getFrom(entity)
+      ...UiTransform.get(entity)
     })
   })
 })

--- a/packages/@dcl/ecs/test/components/components.spec.ts
+++ b/packages/@dcl/ecs/test/components/components.spec.ts
@@ -1,4 +1,5 @@
 import { Quaternion, Vector3 } from '@dcl/ecs-math'
+import { PBBoxShape } from '../../src/components/generated/pb/BoxShape.gen'
 import { Engine } from '../../src/engine'
 import { Entity } from '../../src/engine/entity'
 
@@ -28,7 +29,7 @@ describe('Legacy component tests', () => {
     }
 
     function rotatorSystem(dt: number) {
-      const group = engine.mutableGroupOf(sdk.Transform)
+      const group = engine.getEntitiesWith(sdk.Transform)
       for (const [entity, component] of group) {
         Quaternion.multiplyToRef(
           component.rotation,
@@ -45,10 +46,11 @@ describe('Legacy component tests', () => {
         expect(transformReceveid).toBeDeepCloseTo(transformOriginal)
       }
 
-      const groupBoxShape = engine.mutableGroupOf(sdk.BoxShape)
+      const groupBoxShape = engine.getEntitiesWith(sdk.BoxShape)
       for (const [entity, component] of groupBoxShape) {
         const boxShapeData = sdk.BoxShape.toBinary(entity)
-        const boxShapeOriginal = { ...component }
+        // TODO: see this
+        const boxShapeOriginal = { ...component } as any 
         const boxShapeReceveid = sdk.BoxShape.updateFromBinary(
           entity,
           boxShapeData

--- a/packages/@dcl/ecs/test/components/components.spec.ts
+++ b/packages/@dcl/ecs/test/components/components.spec.ts
@@ -1,5 +1,4 @@
 import { Quaternion, Vector3 } from '@dcl/ecs-math'
-import { PBBoxShape } from '../../src/components/generated/pb/BoxShape.gen'
 import { Engine } from '../../src/engine'
 import { Entity } from '../../src/engine/entity'
 
@@ -50,7 +49,7 @@ describe('Legacy component tests', () => {
       for (const [entity, component] of groupBoxShape) {
         const boxShapeData = sdk.BoxShape.toBinary(entity)
         // TODO: see this
-        const boxShapeOriginal = { ...component } as any 
+        const boxShapeOriginal = { ...component } as any
         const boxShapeReceveid = sdk.BoxShape.updateFromBinary(
           entity,
           boxShapeData

--- a/packages/@dcl/ecs/test/crdt.spec.ts
+++ b/packages/@dcl/ecs/test/crdt.spec.ts
@@ -29,7 +29,7 @@ describe('CRDT tests', () => {
     // Reset ws.send called times
     jest.resetAllMocks()
 
-    Transform.getModifiable(entityA).position.x = 10
+    Transform.getMutable(entityA).position.x = 10
     engine.update(1 / 30)
     expect(spySend).toBeCalledTimes(1)
   })
@@ -52,7 +52,7 @@ describe('CRDT tests', () => {
     jest.resetAllMocks()
 
     // Update a component and verify that's being sent through the crdt system
-    Transform.getModifiable(entityA).position.x = 10
+    Transform.getMutable(entityA).position.x = 10
     engine.update(1 / 30)
     expect(spySend).toBeCalledTimes(1)
 
@@ -120,7 +120,7 @@ describe('CRDT tests', () => {
     const DoorComponent = clientA.components.Door
     // Upate Transform from static entity
     const entity = (clientA.engine.addEntity() - 1) as Entity
-    Transform.getModifiable(entity).position.x = 10
+    Transform.getMutable(entity).position.x = 10
 
     // Create a dynamic entity
     const dynamicEntity = clientA.engine.addDynamicEntity()
@@ -135,7 +135,7 @@ describe('CRDT tests', () => {
           DoorComponent
         )) {
           if (EntityUtils.isStaticEntity(entity)) continue
-          DoorComponent.getModifiable(entity).open = isRandomGuy
+          DoorComponent.getMutable(entity).open = isRandomGuy
             ? DOOR_VALUE
             : Math.max(Math.random(), DOOR_VALUE) // Some random value < DOOR_VALUE
         }
@@ -158,7 +158,7 @@ describe('CRDT tests', () => {
     const entity = engine.addEntity()
     engine.baseComponents.Transform.create(entity, SandBox.DEFAULT_POSITION)
     engine.update(1)
-    engine.baseComponents.Transform.getModifiable(entity).position.x = 8
+    engine.baseComponents.Transform.getMutable(entity).position.x = 8
     engine.update(1)
     const buffer = createByteBuffer()
     ComponentOperation.write(

--- a/packages/@dcl/ecs/test/engine.spec.ts
+++ b/packages/@dcl/ecs/test/engine.spec.ts
@@ -5,6 +5,7 @@ import EntityUtils from '../src/engine/entity-utils'
 import { createByteBuffer } from '../src/serialization/ByteBuffer'
 import { createRendererTransport } from '../src/systems/crdt/transports/rendererTransport'
 import { Schemas } from '../src/schemas'
+import { TransformSchema } from '../src/components/legacy/Transform'
 
 const PositionSchema = {
   x: Schemas.Float
@@ -55,12 +56,12 @@ describe('Engine tests', () => {
 
   it('should fail when trying to add the same system twice', () => {
     const engine = Engine()
-    const system = () => { }
+    const system = () => {}
     engine.addSystem(system)
     expect(() => engine.addSystem(system)).toThrowError()
 
-    const systemA = () => { }
-    const systemA2 = () => { }
+    const systemA = () => {}
+    const systemA2 = () => {}
     engine.addSystem(systemA, SYSTEMS_REGULAR_PRIORITY, 'systemA')
     expect(() =>
       engine.addSystem(systemA2, SYSTEMS_REGULAR_PRIORITY, 'systemA')
@@ -124,8 +125,8 @@ describe('Engine tests', () => {
   it('define two custom components multiple components without ids', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(PositionSchema)
-    const Velocity = engine.defineComponent(VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, 123)
+    const Velocity = engine.defineComponent(VelocitySchema, 124)
     const posComponent = Position.create(entity, { x: 10 })
     const velComponent = Velocity.create(entity, { y: 20 })
 
@@ -519,5 +520,12 @@ describe('Engine tests', () => {
     engine.baseComponents.OnPointerDownResult.create(entity)
     engine.update(1 / 30)
     expect(engine.baseComponents.OnPointerDownResult.has(entity)).toBe(false)
+  })
+
+  it('should return the default component of the transform', () => {
+    const engine = Engine()
+    expect(TransformSchema.create()).toBeDeepCloseTo(
+      engine.baseComponents.Transform.default()
+    )
   })
 })

--- a/packages/@dcl/ecs/test/engine.spec.ts
+++ b/packages/@dcl/ecs/test/engine.spec.ts
@@ -36,7 +36,7 @@ describe('Engine tests', () => {
     const Position = engine.defineComponent(PositionSchema, 888)
     const entity = engine.addEntity()
     const entityB = engine.addEntity()
-    expect(() => Position.getModifiable(entity)).toThrowError()
+    expect(() => Position.getMutable(entity)).toThrowError()
     expect(() => Position.toBinary(entity)).toThrowError()
     Position.create(entityB, { x: 10 })
     const binary = Position.toBinary(entityB)
@@ -55,12 +55,12 @@ describe('Engine tests', () => {
 
   it('should fail when trying to add the same system twice', () => {
     const engine = Engine()
-    const system = () => {}
+    const system = () => { }
     engine.addSystem(system)
     expect(() => engine.addSystem(system)).toThrowError()
 
-    const systemA = () => {}
-    const systemA2 = () => {}
+    const systemA = () => { }
+    const systemA2 = () => { }
     engine.addSystem(systemA, SYSTEMS_REGULAR_PRIORITY, 'systemA')
     expect(() =>
       engine.addSystem(systemA2, SYSTEMS_REGULAR_PRIORITY, 'systemA')
@@ -89,7 +89,7 @@ describe('Engine tests', () => {
     }
 
     for (const [ent, _readOnlyPosition] of engine.getEntitiesWith(Position)) {
-      const position = Position.getModifiable(ent)
+      const position = Position.getMutable(ent)
       expect(ent).toBe(entity)
       expect(position).toStrictEqual({ x: 10 })
       position.x = 80
@@ -202,13 +202,13 @@ describe('Engine tests', () => {
     expect(Velocity).toThrowError()
   })
 
-  it('should return mutable obj if use component.getModifiable()', () => {
+  it('should return mutable obj if use component.getMutable()', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
     const COMPONENT_ID = 888
     const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
     Position.create(entity, { x: 10 })
-    Position.getModifiable(entity).x = 8888
+    Position.getMutable(entity).x = 8888
     expect(Position.get(entity)).toStrictEqual({ x: 8888 })
   })
 
@@ -276,7 +276,7 @@ describe('Engine tests', () => {
     for (const [entity, _readonlyPosition] of engine.getEntitiesWith(
       Position
     )) {
-      const position = Position.getModifiable(entity)
+      const position = Position.getMutable(entity)
       expect(entity).toBe(entityA)
       expect(position).toStrictEqual({ x: 0 })
       expect(Velocity.get(entity)).toStrictEqual({ y: 1 })
@@ -306,8 +306,8 @@ describe('Engine tests', () => {
       engine.getEntitiesWith(Position, Velocity)
     ).map(([entity]) => [
       entity,
-      Position.getModifiable(entity),
-      Velocity.getModifiable(entity)
+      Position.getMutable(entity),
+      Velocity.getMutable(entity)
     ])
 
     expect(component1).toStrictEqual([entityA, { x: 0 }, { y: 0 }])
@@ -356,7 +356,7 @@ describe('Engine tests', () => {
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(true)
     engine.update(1)
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(false)
-    engine.baseComponents.BoxShape.getModifiable(entityA)
+    engine.baseComponents.BoxShape.getMutable(entityA)
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(true)
   })
 
@@ -387,9 +387,9 @@ describe('Engine tests', () => {
       for (const [entity, _readonlyMove] of engine.getEntitiesWith(
         MoveTransformComponent
       )) {
-        const move = MoveTransformComponent.getModifiable(entity)
+        const move = MoveTransformComponent.getMutable(entity)
         move.speed += 1
-        engine.baseComponents.Transform.getModifiable(entity).position =
+        engine.baseComponents.Transform.getMutable(entity).position =
           Vector3.Zero()
         if (moves === 2) {
           MoveTransformComponent.deleteFrom(entity)
@@ -433,7 +433,7 @@ describe('Engine tests', () => {
     function moveSystem(_dt: number) {
       moves++
       for (const [ent] of engine.getEntitiesWith(Transform)) {
-        Transform.getModifiable(ent).position.x += 1
+        Transform.getMutable(ent).position.x += 1
         if (moves === 2) {
           Transform.deleteFrom(ent)
         }

--- a/packages/@dcl/ecs/test/engine.spec.ts
+++ b/packages/@dcl/ecs/test/engine.spec.ts
@@ -6,13 +6,13 @@ import { createByteBuffer } from '../src/serialization/ByteBuffer'
 import { createRendererTransport } from '../src/systems/crdt/transports/rendererTransport'
 import { Schemas } from '../src/schemas'
 
-const PositionSchema = Schemas.Map({
+const PositionSchema = {
   x: Schemas.Float
-})
+}
 
-const VelocitySchema = Schemas.Map({
+const VelocitySchema = {
   y: Schemas.Float
-})
+}
 
 describe('Engine tests', () => {
   it('generates new entities', () => {
@@ -26,17 +26,17 @@ describe('Engine tests', () => {
   it('should not allow u to create same component to an existing entitiy', () => {
     const engine = Engine()
     const entity = engine.addEntity()
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     Position.create(entity, { x: 1 })
     expect(() => Position.create(entity, { x: 10 })).toThrowError()
   })
 
   it('should throw an error if the component doesnt exist', () => {
     const engine = Engine()
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     const entity = engine.addEntity()
     const entityB = engine.addEntity()
-    expect(() => Position.mutable(entity)).toThrowError()
+    expect(() => Position.getModifiable(entity)).toThrowError()
     expect(() => Position.toBinary(entity)).toThrowError()
     Position.create(entityB, { x: 10 })
     const binary = Position.toBinary(entityB)
@@ -45,7 +45,7 @@ describe('Engine tests', () => {
 
   it('should delete component if exists or not', () => {
     const engine = Engine()
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     const entity = engine.addEntity()
     const entity2 = engine.addEntity()
     Position.create(entity, { x: 10 })
@@ -69,31 +69,32 @@ describe('Engine tests', () => {
 
   it('should replace existing component with the new one', () => {
     const engine = Engine()
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     const entity = engine.addEntity()
     Position.create(entity, { x: 1 })
     Position.createOrReplace(entity, { x: 10 })
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 10 })
+    expect(Position.get(entity)).toStrictEqual({ x: 10 })
   })
 
   it('define component and creates new entity', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     const posComponent = Position.create(entity, { x: 10 })
     expect(posComponent).toStrictEqual({ x: 10 })
 
-    for (const [ent, position] of engine.groupOf(Position)) {
+    for (const [ent, position] of engine.getEntitiesWith(Position)) {
       expect(ent).toBe(entity)
       expect(position).toStrictEqual({ x: 10 })
     }
 
-    for (const [ent, position] of engine.mutableGroupOf(Position)) {
+    for (const [ent, readOnlyPosition] of engine.getEntitiesWith(Position)) {
+      const position = Position.getModifiable(ent)
       expect(ent).toBe(entity)
       expect(position).toStrictEqual({ x: 10 })
       position.x = 80
     }
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 80 })
+    expect(Position.get(entity)).toStrictEqual({ x: 80 })
   })
 
   it('should fail if we try to fetch a component not deifned', () => {
@@ -104,16 +105,35 @@ describe('Engine tests', () => {
   it('iterate multiple components', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
-    const Velocity = engine.defineComponent(222, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
+    const Velocity = engine.defineComponent(VelocitySchema, 222)
     const posComponent = Position.create(entity, { x: 10 })
     const velComponent = Velocity.create(entity, { y: 20 })
 
     expect(posComponent).toStrictEqual({ x: 10 })
     expect(velComponent).toStrictEqual({ y: 20 })
 
-    for (const [ent, position] of engine.groupOf(Position)) {
-      const velocity = Velocity.getFrom(ent)
+    for (const [ent, position] of engine.getEntitiesWith(Position)) {
+      const velocity = Velocity.get(ent)
+      expect(ent).toBe(entity)
+      expect(velocity).toStrictEqual({ y: 20 })
+      expect(position).toStrictEqual({ x: 10 })
+    }
+  })
+
+  it('define two custom components multiple components without ids', () => {
+    const engine = Engine()
+    const entity = engine.addEntity() // 0
+    const Position = engine.defineComponent(PositionSchema)
+    const Velocity = engine.defineComponent(VelocitySchema)
+    const posComponent = Position.create(entity, { x: 10 })
+    const velComponent = Velocity.create(entity, { y: 20 })
+
+    expect(posComponent).toStrictEqual({ x: 10 })
+    expect(velComponent).toStrictEqual({ y: 20 })
+
+    for (const [ent, position] of engine.getEntitiesWith(Position)) {
+      const velocity = Velocity.get(ent)
       expect(ent).toBe(entity)
       expect(velocity).toStrictEqual({ y: 20 })
       expect(position).toStrictEqual({ x: 10 })
@@ -123,53 +143,53 @@ describe('Engine tests', () => {
   it('should not update a readonly prop', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     expect(Array.from(Position.dirtyIterator())).toEqual([])
     const posComponent = Position.create(entity, { x: 10 })
     posComponent.x = 1000000000000
     expect(Array.from(Position.dirtyIterator())).toEqual([entity])
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 1000000000000 })
+    expect(Position.get(entity)).toStrictEqual({ x: 1000000000000 })
   })
 
   it('should not update a readonly prop groupOf', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     const _posComponent = Position.create(entity, { x: 10 })
-    for (const [_entity, position] of engine.groupOf(Position)) {
+    for (const [_entity, position] of engine.getEntitiesWith(Position)) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       expect(() => (position.x = 1000000000000)).toThrowError()
     }
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 10 })
+    expect(Position.get(entity)).toStrictEqual({ x: 10 })
   })
 
   it('should not update a readonly prop getFrom(entity)', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
     Position.create(entity, { x: 10 })
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const assignError = () => (Position.getFrom(entity).x = 1000000000000)
+    const assignError = () => (Position.get(entity).x = 1000000000000)
     expect(assignError).toThrowError()
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 10 })
+    expect(Position.get(entity)).toStrictEqual({ x: 10 })
   })
 
   it('should fail if we fetch a component that doesnt exists on an entity', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
-    const Velocity = engine.defineComponent(222, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
+    const Velocity = engine.defineComponent(VelocitySchema, 222)
     Position.create(entity, { x: 10 })
-    expect(() => Velocity.getFrom(entity)).toThrowError()
+    expect(() => Velocity.get(entity)).toThrowError()
   })
 
   it('should return null if the component not exists on the entity.', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
-    const Position = engine.defineComponent(888, PositionSchema)
-    const Velocity = engine.defineComponent(222, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, 888)
+    const Velocity = engine.defineComponent(VelocitySchema, 222)
     Position.create(entity, { x: 10 })
     expect(Velocity.getOrNull(entity)).toBe(null)
   })
@@ -177,19 +197,19 @@ describe('Engine tests', () => {
   it('should throw an error if the component class id already exists', () => {
     const engine = Engine()
     const COMPONENT_ID = 888
-    engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Velocity = () => engine.defineComponent(COMPONENT_ID, VelocitySchema)
+    engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Velocity = () => engine.defineComponent(VelocitySchema, COMPONENT_ID)
     expect(Velocity).toThrowError()
   })
 
-  it('should return mutable obj if use component.mutable()', () => {
+  it('should return mutable obj if use component.getModifiable()', () => {
     const engine = Engine()
     const entity = engine.addEntity() // 0
     const COMPONENT_ID = 888
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
     Position.create(entity, { x: 10 })
-    Position.mutable(entity).x = 8888
-    expect(Position.getFrom(entity)).toStrictEqual({ x: 8888 })
+    Position.getModifiable(entity).x = 8888
+    expect(Position.get(entity)).toStrictEqual({ x: 8888 })
   })
 
   it('should destroy an entity', () => {
@@ -197,8 +217,8 @@ describe('Engine tests', () => {
     const entity = engine.addEntity() // 0
     const entityB = engine.addEntity() // 0
     const COMPONENT_ID = 888
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Velocity = engine.defineComponent(COMPONENT_ID + 1, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Velocity = engine.defineComponent(VelocitySchema, COMPONENT_ID + 1)
     Position.create(entity, { x: 10 })
     Position.create(entityB, { x: 20 })
     Velocity.create(entity, { y: 20 })
@@ -213,28 +233,29 @@ describe('Engine tests', () => {
     expect(Position.getOrNull(entityB)).toStrictEqual({ x: 20 })
   })
 
-  it('should return mutableGroupOf multiples components', () => {
+  it('should return get entities with multiples components', () => {
     const engine = Engine()
     const entityA = engine.addEntity()
     const entityB = engine.addEntity()
     const COMPONENT_ID = 888
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Position2 = engine.defineComponent(COMPONENT_ID + 1, PositionSchema)
-    const Velocity = engine.defineComponent(COMPONENT_ID + 2, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Position2 = engine.defineComponent(PositionSchema, COMPONENT_ID + 1)
+    const Velocity = engine.defineComponent(VelocitySchema, COMPONENT_ID + 2)
     Position.create(entityA, { x: 0 })
     Position2.create(entityA, { x: 8 })
     Velocity.create(entityA, { y: 1 })
     Velocity.create(entityB, { y: 1 })
 
-    for (const [entity, velocity, position, position2] of engine.mutableGroupOf(
-      Velocity,
-      Position,
-      Position2
-    )) {
+    for (const [
+      entity,
+      readonlyVelocity,
+      readonlyPosition,
+      readonlyPosition2
+    ] of engine.getEntitiesWith(Velocity, Position, Position2)) {
       expect(entity).toBe(entityA)
-      expect(velocity).toStrictEqual({ y: 1 })
-      expect(position).toStrictEqual({ x: 0 })
-      expect(position2).toStrictEqual({ x: 8 })
+      expect(readonlyVelocity).toStrictEqual({ y: 1 })
+      expect(readonlyPosition).toStrictEqual({ x: 0 })
+      expect(readonlyPosition2).toStrictEqual({ x: 8 })
     }
   })
 
@@ -243,8 +264,8 @@ describe('Engine tests', () => {
     const entityA = engine.addEntity()
     const entityB = engine.addEntity()
     const COMPONENT_ID = Math.random() | 0
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Velocity = engine.defineComponent(COMPONENT_ID + 2, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Velocity = engine.defineComponent(VelocitySchema, COMPONENT_ID + 2)
     Position.create(entityA, { x: 0 })
     Velocity.create(entityA, { y: 1 })
     Velocity.create(entityB, { y: 10 })
@@ -252,10 +273,11 @@ describe('Engine tests', () => {
     // avoid dirty iterators
     engine.update(0)
 
-    for (const [entity, position] of engine.mutableGroupOf(Position)) {
+    for (const [entity, readonlyPosition] of engine.getEntitiesWith(Position)) {
+      const position = Position.getModifiable(entity)
       expect(entity).toBe(entityA)
       expect(position).toStrictEqual({ x: 0 })
-      expect(Velocity.getFrom(entity)).toStrictEqual({ y: 1 })
+      expect(Velocity.get(entity)).toStrictEqual({ y: 1 })
     }
     expect(Array.from(Velocity.dirtyIterator())).toEqual([])
     expect(Array.from(Position.dirtyIterator())).toEqual([entityA])
@@ -267,8 +289,8 @@ describe('Engine tests', () => {
     const entityB = engine.addEntity()
     const entityC = engine.addEntity()
     const COMPONENT_ID = Math.random() | 0
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Velocity = engine.defineComponent(COMPONENT_ID + 2, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Velocity = engine.defineComponent(VelocitySchema, COMPONENT_ID + 2)
     Position.create(entityA, { x: 0 })
     Position.create(entityB, { x: 1 })
     Position.create(entityC, { x: 2 })
@@ -279,8 +301,13 @@ describe('Engine tests', () => {
     engine.update(0)
 
     const [component1, component2, component3] = Array.from(
-      engine.mutableGroupOf(Position, Velocity)
-    )
+      engine.getEntitiesWith(Position, Velocity)
+    ).map(([entity]) => [
+      entity,
+      Position.getModifiable(entity),
+      Velocity.getModifiable(entity)
+    ])
+
     expect(component1).toStrictEqual([entityA, { x: 0 }, { y: 0 }])
     expect(component2).toStrictEqual([entityB, { x: 1 }, { y: 1 }])
     expect(component3).toBe(undefined)
@@ -294,8 +321,8 @@ describe('Engine tests', () => {
     const entityB = engine.addEntity()
     const entityC = engine.addEntity()
     const COMPONENT_ID = Math.random() | 0
-    const Position = engine.defineComponent(COMPONENT_ID, PositionSchema)
-    const Velocity = engine.defineComponent(COMPONENT_ID + 2, VelocitySchema)
+    const Position = engine.defineComponent(PositionSchema, COMPONENT_ID)
+    const Velocity = engine.defineComponent(VelocitySchema, COMPONENT_ID + 2)
     Position.create(entityA, { x: 0 })
     Position.create(entityB, { x: 1 })
     Position.create(entityC, { x: 2 })
@@ -306,7 +333,7 @@ describe('Engine tests', () => {
     engine.update(0)
 
     const [component1, component2, component3] = Array.from(
-      engine.groupOf(Position, Velocity)
+      engine.getEntitiesWith(Position, Velocity)
     )
     expect(component1).toStrictEqual([entityA, { x: 0 }, { y: 0 }])
     expect(component2).toStrictEqual([entityB, { x: 1 }, { y: 1 }])
@@ -327,7 +354,7 @@ describe('Engine tests', () => {
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(true)
     engine.update(1)
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(false)
-    engine.baseComponents.BoxShape.mutable(entityA)
+    engine.baseComponents.BoxShape.getModifiable(entityA)
     expect(engine.baseComponents.BoxShape.isDirty(entityA)).toBe(true)
   })
 
@@ -342,24 +369,25 @@ describe('Engine tests', () => {
 
   it('should remove component when using deleteFrom', () => {
     const engine = Engine()
-    const MoveTransportData = Schemas.Map({
+    const MoveTransportData = {
       duration: Schemas.Float,
       speed: Schemas.Float
-    })
-    engine.defineComponent(888, MoveTransportData)
+    }
+    engine.defineComponent(MoveTransportData, 888)
     const zombie = engine.addEntity()
 
-    const MoveTransformComponent = engine.defineComponent(46, MoveTransportData)
+    const MoveTransformComponent = engine.defineComponent(MoveTransportData, 46)
 
     let moves = 0
 
     function moveSystem(_dt: number) {
       moves++
-      for (const [entity, move] of engine.mutableGroupOf(
+      for (const [entity, readonlyMove] of engine.getEntitiesWith(
         MoveTransformComponent
       )) {
+        const move = MoveTransformComponent.getModifiable(entity)
         move.speed += 1
-        engine.baseComponents.Transform.mutable(entity).position =
+        engine.baseComponents.Transform.getModifiable(entity).position =
           Vector3.Zero()
         if (moves === 2) {
           MoveTransformComponent.deleteFrom(entity)
@@ -380,12 +408,12 @@ describe('Engine tests', () => {
 
     engine.addSystem(moveSystem)
 
-    expect(MoveTransformComponent.getFrom(zombie)).toStrictEqual({
+    expect(MoveTransformComponent.get(zombie)).toStrictEqual({
       duration: 10,
       speed: 1
     })
     engine.update(1)
-    expect(MoveTransformComponent.getFrom(zombie)).toStrictEqual({
+    expect(MoveTransformComponent.get(zombie)).toStrictEqual({
       speed: 2,
       duration: 10
     })
@@ -402,8 +430,8 @@ describe('Engine tests', () => {
 
     function moveSystem(_dt: number) {
       moves++
-      for (const [ent, transform] of engine.mutableGroupOf(Transform)) {
-        transform.position.x += 1
+      for (const [ent] of engine.getEntitiesWith(Transform)) {
+        Transform.getModifiable(ent).position.x += 1
         if (moves === 2) {
           Transform.deleteFrom(ent)
         }
@@ -418,13 +446,13 @@ describe('Engine tests', () => {
 
     engine.addSystem(moveSystem)
 
-    expect(Transform.getFrom(entity)).toStrictEqual({
+    expect(Transform.get(entity)).toStrictEqual({
       position: { x: 12, y: 1, z: 3 },
       scale: { x: 1, y: 1, z: 1 },
       rotation: { x: 0, y: 0, z: 0, w: 1 }
     })
     engine.update(1)
-    expect(Transform.getFrom(entity).position.x).toStrictEqual(13)
+    expect(Transform.get(entity).position.x).toStrictEqual(13)
     engine.update(1)
     expect(Transform.getOrNull(entity)).toStrictEqual(null)
   })

--- a/packages/@dcl/ecs/test/engine.spec.ts
+++ b/packages/@dcl/ecs/test/engine.spec.ts
@@ -88,7 +88,7 @@ describe('Engine tests', () => {
       expect(position).toStrictEqual({ x: 10 })
     }
 
-    for (const [ent, readOnlyPosition] of engine.getEntitiesWith(Position)) {
+    for (const [ent, _readOnlyPosition] of engine.getEntitiesWith(Position)) {
       const position = Position.getModifiable(ent)
       expect(ent).toBe(entity)
       expect(position).toStrictEqual({ x: 10 })
@@ -273,7 +273,9 @@ describe('Engine tests', () => {
     // avoid dirty iterators
     engine.update(0)
 
-    for (const [entity, readonlyPosition] of engine.getEntitiesWith(Position)) {
+    for (const [entity, _readonlyPosition] of engine.getEntitiesWith(
+      Position
+    )) {
       const position = Position.getModifiable(entity)
       expect(entity).toBe(entityA)
       expect(position).toStrictEqual({ x: 0 })
@@ -382,7 +384,7 @@ describe('Engine tests', () => {
 
     function moveSystem(_dt: number) {
       moves++
-      for (const [entity, readonlyMove] of engine.getEntitiesWith(
+      for (const [entity, _readonlyMove] of engine.getEntitiesWith(
         MoveTransformComponent
       )) {
         const move = MoveTransformComponent.getModifiable(entity)

--- a/packages/@dcl/ecs/test/performance.spec.ts
+++ b/packages/@dcl/ecs/test/performance.spec.ts
@@ -31,18 +31,22 @@ describe('Performance.', () => {
     )
 
     function doorSystem() {
-      for (const [_entity, door] of engine.mutableGroupOf(components.Door)) {
-        door.open = Math.random() * 10
+      for (const [entity] of engine.getEntitiesWith(components.Door)) {
+        components.Door.getModifiable(entity).open = Math.random() * 10
       }
     }
 
     function transformSystem() {
-      for (const [_entity, position, transform] of engine.mutableGroupOf(
-        components.Position,
-        Transform
-      )) {
-        transform.position.x = position.x + Math.random() * 10
-        position.y = transform.position.y + Math.random() * 10
+      for (const [
+        entity,
+        readonlyPosition,
+        readonlyTransform
+      ] of engine.getEntitiesWith(components.Position, Transform)) {
+        // TODO: see this
+        Transform.getModifiable(entity).position.x =
+          (readonlyPosition.x as any as number) + Math.random() * 10
+        components.Position.getModifiable(entity).y =
+          readonlyTransform.position.y + Math.random() * 10
       }
     }
 

--- a/packages/@dcl/ecs/test/performance.spec.ts
+++ b/packages/@dcl/ecs/test/performance.spec.ts
@@ -32,7 +32,7 @@ describe('Performance.', () => {
 
     function doorSystem() {
       for (const [entity] of engine.getEntitiesWith(components.Door)) {
-        components.Door.getModifiable(entity).open = Math.random() * 10
+        components.Door.getMutable(entity).open = Math.random() * 10
       }
     }
 
@@ -43,9 +43,9 @@ describe('Performance.', () => {
         readonlyTransform
       ] of engine.getEntitiesWith(components.Position, Transform)) {
         // TODO: see this
-        Transform.getModifiable(entity).position.x =
+        Transform.getMutable(entity).position.x =
           (readonlyPosition.x as any as number) + Math.random() * 10
-        components.Position.getModifiable(entity).y =
+        components.Position.getMutable(entity).y =
           readonlyTransform.position.y + Math.random() * 10
       }
     }

--- a/packages/@dcl/ecs/test/transports.spec.ts
+++ b/packages/@dcl/ecs/test/transports.spec.ts
@@ -33,8 +33,9 @@ describe('Transport tests', () => {
     const engine = Engine({ transports })
     const entity = engine.addDynamicEntity()
     const UserComponent = engine.defineComponent(
-      8888,
-      Schemas.Map({ x: Schemas.Byte })
+      { x: Schemas.Byte },
+
+      8888
     )
 
     // Transform component should be sent to renderer transport

--- a/packages/@dcl/ecs/test/utils.ts
+++ b/packages/@dcl/ecs/test/utils.ts
@@ -13,9 +13,9 @@ export namespace SandBox {
   export const WS_SEND_DELAY = 30
   export const Position = {
     id: 88,
-    type: Schemas.Map({ x: Schemas.Float, y: Schemas.Float })
+    type: { x: Schemas.Float, y: Schemas.Float }
   }
-  export const Door = { id: 888, type: Schemas.Map({ open: Schemas.Byte }) }
+  export const Door = { id: 888, type: { open: Schemas.Byte } }
 
   export const DEFAULT_POSITION = {
     position: Vector3.create(0, 1, 2),
@@ -33,10 +33,10 @@ export namespace SandBox {
       const clientTransport = transport.createNetworkTransport()
       const engine = Engine({ transports: [clientTransport] })
       const Position = engine.defineComponent(
-        SandBox.Position.id,
-        SandBox.Position.type
+        SandBox.Position.type,
+        SandBox.Position.id
       )
-      const Door = engine.defineComponent(SandBox.Door.id, SandBox.Door.type)
+      const Door = engine.defineComponent(SandBox.Door.type, SandBox.Door.id)
 
       return {
         id: index,

--- a/packages/@dcl/ecs/tools/protocol-buffer-generation/generateIndex.ts
+++ b/packages/@dcl/ecs/tools/protocol-buffer-generation/generateIndex.ts
@@ -11,7 +11,7 @@ function importComponent(component: Component) {
 }
 
 function defineComponent(component: Component) {
-  return `\t\t${component.componentName}: defineComponent(${component.componentName}Schema.COMPONENT_ID, ${component.componentName}Schema.${component.componentName}Schema),`
+  return `\t\t${component.componentName}: defineComponentFromSchema(${component.componentName}Schema.${component.componentName}Schema, ${component.componentName}Schema.COMPONENT_ID),`
 }
 
 function useDefinedComponent(component: Component) {
@@ -31,8 +31,8 @@ $componentImports
 declare const engine: IEngine
 
 export function defineLibraryComponents({
-  defineComponent
-}: Pick<IEngine, 'defineComponent'>) {
+  defineComponentFromSchema
+}: Pick<IEngine, 'defineComponentFromSchema'>) {
   return {
 ${defineComponent(TransformComponent)}
 $componentReturns

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -1,20 +1,46 @@
-/** @public */
-declare const Animator: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const enum ActionButton {
+    POINTER = 0,
+    PRIMARY = 1,
+    SECONDARY = 2,
+    ANY = 3,
+    FORWARD = 4,
+    BACKWARD = 5,
+    RIGHT = 6,
+    LEFT = 7,
+    JUMP = 8,
+    WALK = 9,
+    ACTION_3 = 10,
+    ACTION_4 = 11,
+    ACTION_5 = 12,
+    ACTION_6 = 13,
+    UNRECOGNIZED = -1
+}
 
 /** @public */
-declare const AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const Animator: ComponentDefinition<ISchema<PBAnimator>>;
 
 /** @public */
-declare const AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+
+declare const enum AvatarAnchorPoint {
+    POSITION = 0,
+    NAME_TAG = 1,
+    LEFT_HAND = 2,
+    RIGHT_HAND = 3,
+    UNRECOGNIZED = -1
+}
 
 /** @public */
-declare const AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
 
 /** @public */
-declare const Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
 
 /** @public */
-declare const BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+
+/** @public */
+declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
 
 /**
  * @public
@@ -22,10 +48,22 @@ declare const BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
 declare type ByteBuffer = ReturnType<typeof createByteBuffer>;
 
 /** @public */
-declare const CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
 
 /** @public */
-declare const CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+
+declare const enum CameraModeValue {
+    FIRST_PERSON = 0,
+    THIRD_PERSON = 1,
+    UNRECOGNIZED = -1
+}
+
+declare interface Color3 {
+    r: number;
+    g: number;
+    b: number;
+}
 
 /**
  * @public
@@ -53,45 +91,64 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: ComponentDefinition<ISchema<Result<Spec>>>;
+    const Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
     /** @public */
-    const Animator: ComponentDefinition<ISchema<Result<Spec>>>;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>>;
     /** @public */
-    const AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
+    const Animator: ComponentDefinition<ISchema<PBAnimator>>;
     /** @public */
-    const AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
+    const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
     /** @public */
-    const AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
     /** @public */
-    const Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
+    const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
     /** @public */
-    const BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
     /** @public */
-    const CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
+    const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
     /** @public */
-    const CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
+    const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
     /** @public */
-    const CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
     /** @public */
-    const GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
     /** @public */
-    const NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
     /** @public */
-    const OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
+    const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
     /** @public */
-    const OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
+    const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
     /** @public */
-    const OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
+    const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
     /** @public */
-    const OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
+    const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
     /** @public */
-    const PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
     /** @public */
-    const PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
+    const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
     /** @public */
-    const SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
     /** @public */
-    const TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+    /** @public */
+    const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
 }
 
 /**
@@ -245,7 +302,7 @@ declare interface CreateByteBufferOptions {
 }
 
 /** @public */
-declare const CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
 
 /**
  * Make each field readonly deeply
@@ -255,27 +312,45 @@ declare type DeepReadonly<T> = {
     readonly [P in keyof T]: DeepReadonly<T[P]>;
 };
 
-declare function defineLibraryComponents({ defineComponent }: Pick<IEngine, 'defineComponent'>): {
-    Transform: ComponentDefinition<ISchema<Result<Spec>>>;
-    Animator: ComponentDefinition<ISchema<Result<Spec>>>;
-    AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
-    AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
-    AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
-    BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
-    CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
-    CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
-    OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
-    OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
-    OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
-    PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
-    SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
-    TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare function defineLibraryComponents({ defineComponentFromSchema }: Pick<IEngine, 'defineComponentFromSchema'>): {
+    Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>>;
+    Animator: ComponentDefinition<ISchema<PBAnimator>>;
+    AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+    Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+    BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+    CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+    NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+    PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+    SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+    TextShape: ComponentDefinition<ISchema<PBTextShape>>;
 };
 
 /**
@@ -318,6 +393,8 @@ declare const entitySymbol: unique symbol;
  */
 declare const Epsilon = 0.000001;
 
+declare const error: (message: string | Error, data?: any) => void;
+
 /** Excludes property keys from T where the property is assignable to U */
 declare type ExcludeUndefined<T> = {
     [P in keyof T]: undefined extends T[P] ? never : P;
@@ -330,7 +407,7 @@ declare type float = number;
 declare type FloatArray = number[];
 
 /** @public */
-declare const GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
 
 /**
  * @public
@@ -1127,7 +1204,7 @@ declare namespace Matrix {
 }
 
 /** @public */
-declare const NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
 
 /** @public */
 declare type Nullable<T> = T | null;
@@ -1141,16 +1218,16 @@ declare type OnlyOptionalUndefinedTypes<T> = {
 };
 
 /** @public */
-declare const OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
 
 /** @public */
-declare const OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
 
 /** @public */
-declare const OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
 
 /** @public */
-declare const OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
 
 /**
  * Defines potential orientation for back face culling
@@ -1163,6 +1240,221 @@ declare enum Orientation {
     CW = 0,
     /** Counter clockwise */
     CCW = 1
+}
+
+declare interface PBAnimationState {
+    name: string;
+    clip: string;
+    playing?: boolean | undefined;
+    /** default=1.0s */
+    weight?: number | undefined;
+    /** default=1.0 */
+    speed?: number | undefined;
+    /** default=true */
+    loop?: boolean | undefined;
+    shouldReset?: boolean | undefined;
+}
+
+declare interface PBAnimator {
+    states: PBAnimationState[];
+}
+
+declare interface PBAudioSource {
+    playing?: boolean | undefined;
+    /** default=1.0f */
+    volume?: number | undefined;
+    loop?: boolean | undefined;
+    /** default=1.0f */
+    pitch?: number | undefined;
+    audioClipUrl: string;
+}
+
+declare interface PBAvatarAttach {
+    avatarId: string;
+    anchorPointId: AvatarAnchorPoint;
+}
+
+declare interface PBAvatarShape {
+    id: string;
+    name?: string | undefined;
+    bodyShape?: string | undefined;
+    skinColor?: Color3 | undefined;
+    hairColor?: Color3 | undefined;
+    eyeColor?: Color3 | undefined;
+    wearables: string[];
+    expressionTriggerId?: string | undefined;
+    expressionTriggerTimestamp?: number | undefined;
+    stickerTriggerId?: string | undefined;
+    stickerTriggerTimestamp?: number | undefined;
+    talking?: boolean | undefined;
+}
+
+declare interface PBBillboard {
+    /** default=true */
+    x?: boolean | undefined;
+    /** default=true */
+    y?: boolean | undefined;
+    /** default=true */
+    z?: boolean | undefined;
+}
+
+declare interface PBBoxShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    uvs: number[];
+}
+
+declare interface PBCameraMode {
+    mode: CameraModeValue;
+}
+
+declare interface PBCameraModeArea {
+    area: Vector3_2 | undefined;
+    mode: CameraModeValue;
+}
+
+declare interface PBCylinderShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    /** default=1.0 */
+    radiusTop?: number | undefined;
+    /** default=1.0 */
+    radiusBottom?: number | undefined;
+}
+
+declare interface PBGLTFShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    src: string;
+}
+
+declare interface PBNFTShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    src: string;
+    assetId?: string | undefined;
+    style?: number | undefined;
+    color?: Color3 | undefined;
+}
+
+declare interface PBOnPointerDown {
+    /** default=ActionButton.ANY */
+    button?: ActionButton | undefined;
+    /** default='Interact' */
+    hoverText?: string | undefined;
+    /** default=10 */
+    maxDistance?: number | undefined;
+    /** default=true */
+    showFeedback?: boolean | undefined;
+}
+
+declare interface PBOnPointerDownResult {
+    button: ActionButton;
+    meshName: string;
+    origin: Vector3_2 | undefined;
+    direction: Vector3_2 | undefined;
+    point: Vector3_2 | undefined;
+    normal: Vector3_2 | undefined;
+    distance: number;
+    timestamp: number;
+}
+
+declare interface PBOnPointerUp {
+    /** default=ActionButton.ANY */
+    button?: ActionButton | undefined;
+    /** default='Interact' */
+    hoverText?: string | undefined;
+    /** default=10 */
+    maxDistance?: number | undefined;
+    /** default=true */
+    showFeedback?: boolean | undefined;
+}
+
+declare interface PBOnPointerUpResult {
+    button: ActionButton;
+    meshName: string;
+    origin: Vector3_2 | undefined;
+    direction: Vector3_2 | undefined;
+    point: Vector3_2 | undefined;
+    normal: Vector3_2 | undefined;
+    distance: number;
+    timestamp: number;
+}
+
+declare interface PBPlaneShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    uvs: number[];
+}
+
+declare interface PBPointerLock {
+    isPointerLocked: boolean;
+}
+
+declare interface PBSphereShape {
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    withCollisions?: boolean | undefined;
+    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
+    isPointerBlocker?: boolean | undefined;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+}
+
+declare interface PBTextShape {
+    text: string;
+    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
+    visible?: boolean | undefined;
+    font?: string | undefined;
+    /** default=1.0f */
+    opacity?: number | undefined;
+    /** default=10 */
+    fontSize?: number | undefined;
+    fontAutoSize?: boolean | undefined;
+    /** default='center' */
+    hTextAlign?: string | undefined;
+    /** default='center' */
+    vTextAlign?: string | undefined;
+    /** default=1 */
+    width?: number | undefined;
+    /** default=1 */
+    height?: number | undefined;
+    paddingTop?: number | undefined;
+    paddingRight?: number | undefined;
+    paddingBottom?: number | undefined;
+    paddingLeft?: number | undefined;
+    lineSpacing?: number | undefined;
+    lineCount?: number | undefined;
+    textWrapping?: boolean | undefined;
+    shadowBlur?: number | undefined;
+    shadowOffsetX?: number | undefined;
+    shadowOffsetY?: number | undefined;
+    outlineWidth?: number | undefined;
+    /** default=(1.0,1.0,1.0) */
+    shadowColor?: Color3 | undefined;
+    /** default=(1.0,1.0,1.0) */
+    outlineColor?: Color3 | undefined;
+    /** default=(1.0,1.0,1.0) */
+    textColor?: Color3 | undefined;
 }
 
 /**
@@ -1275,10 +1567,10 @@ declare namespace Plane {
 }
 
 /** @public */
-declare const PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
 
 /** @public */
-declare const PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
 
 /**
  * @public
@@ -1513,10 +1805,10 @@ declare interface Spec {
 }
 
 /** @public */
-declare const SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
 
 /** @public */
-declare const TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
 
 /**
  * Constant used to convert a value to gamma space
@@ -1533,7 +1825,25 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: ComponentDefinition<ISchema<Result<Spec>>>;
+declare const Transform: ComponentDefinition<ISchema<    {
+position: {
+x: number;
+y: number;
+z: number;
+};
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
+}>>;
 
 declare type Transport = {
     type: string;
@@ -1757,6 +2067,12 @@ declare namespace Vector3 {
      * @returns a new left Vector3
      */
     export function Left(): MutableVector3;
+}
+
+declare interface Vector3_2 {
+    x: number;
+    y: number;
+    z: number;
 }
 
 declare namespace WireMessage {

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -70,46 +70,149 @@ declare interface Color3 {
  */
 declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     _id: number;
+    /**
+     * Return the default value of the current component
+     */
+    default(): DeepReadonly<ComponentType<T>>;
+    /**
+     * Get if the entity has this component
+     * @param entity
+     *
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.has(myEntity) // return false
+     * Transform.create(myEntity)
+     * Transform.has(myEntity) // return true
+     * ```
+     */
     has(entity: Entity): boolean;
+    /**
+     * Get the readonly component of the entity (to mutate it, use getMutable instead), throw an error if the entity doesn't have the component.
+     * @param entity
+     * @return
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.create(myEntity)
+     * const transform = Transform.get(myEntity) // return true
+     * log(transform.position.x === 0) // log 'true'
+     *
+     * transform.position.y = 10 // illegal statement, to mutate the component use getMutable
+     * ```
+     *
+     * ```ts
+     * const otherEntity = engine.addEntity()
+     * Transform.get(otherEntity) // throw an error!!
+     * ```
+     */
     get(entity: Entity): DeepReadonly<ComponentType<T>>;
+    /**
+     * Get the readonly component of the entity (to mutate it, use getMutable instead), or null if the entity doesn't have the component.
+     * @param entity
+     * @return
+     *
+     * Example:
+     * ```ts
+     * const otherEntity = engine.addEntity()
+     * log(Transform.get(otherEntity) === null) // log 'true'
+     * ```
+     */
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
+    /**
+     * Add the current component to an entity, throw an error if the component already exists (use `createOrReplace` instead).
+     * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
+     * @param entity
+     * @param val The initial value
+     *
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.create(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
+     * Transform.create(myEntity) // throw an error, the `Transform` component already exists in `myEntity`
+     * ````
+     */
     create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    /**
+     * Add the current component to an entity or replace the content if the entity already has the component
+     * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
+     * @param entity
+     * @param val The initial or new value
+     *
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.create(myEntity) // ok!
+     * Transform.createOrReplace(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
+     * ````
+     */
     createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    /**
+     * Delete the current component to an entity, return null if the entity doesn't have the current component.
+     * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
+     * @param entity
+     *
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.create(myEntity) // ok!
+     * Transform.deleteFrom(myEntity) // return the component
+     * Transform.deleteFrom(myEntity) // return null
+     * ````
+     */
     deleteFrom(entity: Entity): ComponentType<T> | null;
+    /**
+     * Get the mutable component of the entity, throw an error if the entity doesn't have the component.
+     * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
+     * @param entity
+     *
+     * Example:
+     * ```ts
+     * const myEntity = engine.addEntity()
+     * Transform.create(myEntity)
+     * Transform.getMutable(myEntity).position = {x: 4, y: 0, z: 4}
+     * ````
+     */
     getMutable(entity: Entity): ComponentType<T>;
+    /**
+     * Get the mutable component of the entity, return null if the entity doesn't have the component.
+     * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
+     * @param entity
+     *
+     * Example:
+     * ```ts
+     * const transform = Transform.getMutableOrNull(myEntity)
+     * if (transform) {
+     *   transform.position = {x: 4, y: 0, z: 4}
+     * }
+     * ````
+     */
     getMutableOrNull(entity: Entity): ComponentType<T> | null;
-    upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
-    updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
-    toBinary(entity: Entity): ByteBuffer;
     writeToByteBuffer(entity: Entity, buffer: ByteBuffer): void;
-    iterator(): Iterable<[Entity, ComponentType<T>]>;
-    dirtyIterator(): Iterable<Entity>;
-    clearDirty(): void;
-    isDirty(entity: Entity): boolean;
 };
 
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: ComponentDefinition<ISchema<{
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            /** @public */
-            z: number;
-        };
-        parent?: Entity | undefined;
+    const Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    /** @public */
+    z: number;
+    };
+    parent?: Entity | undefined;
     }>>;
     /** @public */
     const Animator: ComponentDefinition<ISchema<PBAnimator>>;
@@ -313,24 +416,24 @@ declare type DeepReadonly<T> = {
 };
 
 declare function defineLibraryComponents({ defineComponentFromSchema }: Pick<IEngine, 'defineComponentFromSchema'>): {
-    Transform: ComponentDefinition<ISchema<{
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
+    Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
     }>>;
     Animator: ComponentDefinition<ISchema<PBAnimator>>;
     AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
@@ -418,16 +521,96 @@ declare function IArray<T>(type: ISchema<T>): ISchema<Array<T>>;
  * @public
  */
 declare type IEngine = {
+    /**
+     * Increment the used entity counter and return the next one.
+     * @param dynamic
+     * @return the next entity unused
+     */
     addEntity(dynamic?: boolean): Entity;
+    /**
+     * An alias of engine.addEntity(true)
+     */
     addDynamicEntity(): Entity;
+    /**
+     * Remove all components of an entity
+     * @param entity
+     */
     removeEntity(entity: Entity): void;
+    /**
+     * Add the system to the engine. It will be called every tick updated.
+     * @param system function that receives the delta time between last tick and current one.
+     * @param priority a number with the priority, big number are called before smaller ones
+     * @param name optional: a unique name to identify it
+     *
+     * Example:
+     * ```ts
+     * function mySystem(dt: number) {
+     *   const entitiesWithBoxShapes = engine.getEntitiesWith(BoxShape, Transform)
+     *   for (const [entity, _boxShape, _transform] of engine.getEntitiesWith(BoxShape, Transform)) {
+     *     // do stuffs
+     *   }
+     * }
+     * engine.addSystem(mySystem, 10)
+     * ```
+     */
     addSystem(system: Update, priority?: number, name?: string): void;
+    /**
+     * Remove a system from the engine.
+     * @param selector the function or the unique name to identify
+     * @returns if it was found and removed
+     */
     removeSystem(selector: string | Update): boolean;
-    defineComponent<T extends Spec>(spec: Spec, componentId?: number): ComponentDefinition<ISchema<Result<T>>>;
-    defineComponentFromSchema<T extends ISchema>(spec: T, componentId?: number): ComponentDefinition<T>;
+    /**
+     * Define a component and add it to the engine.
+     * @param spec An object with schema fields
+     * @param componentId unique id to identify the component, if the component id already exist, it will fail.
+     * @return The component definition
+     *
+     * ```ts
+     * const DoorComponentId = 10017
+     * const Door = engine.defineComponent({
+     *   id: Schemas.Int,
+     *   name: Schemas.String
+     * }, DoorComponentId)
+     *
+     * ```
+     */
+    defineComponent<T extends Spec>(spec: Spec, componentId: number): ComponentDefinition<ISchema<Result<T>>>;
+    /**
+     * Define a component and add it to the engine.
+     * @param spec An object with schema fields
+     * @param componentId unique id to identify the component, if the component id already exist, it will fail.
+     * @return The component definition
+     *
+     * ```ts
+     * const StateComponentId = 10023
+     * const StateComponent = engine.defineComponent(Schemas.Bool, VisibleComponentId)
+     * ```
+     */
+    defineComponentFromSchema<T extends ISchema>(spec: T, componentId: number): ComponentDefinition<T>;
+    /**
+     * Get the component definition from the component id.
+     * @param componentId
+     * @return the component definition, throw an error if it doesn't exist
+     * ```ts
+     * const StateComponentId = 10023
+     * const StateComponent = engine.getComponent(StateComponentId)
+     * ```
+     */
     getComponent<T extends ISchema>(componentId: number): ComponentDefinition<T>;
+    /**
+     * Get a iterator of entities that has all the component requested.
+     * @param components a list of component definitions
+     * @return An iterator of an array with the [entity, component1, component2, ...]
+     *
+     * Example:
+     * ```ts
+     * for (const [entity, boxShape, transform] of engine.getEntitiesWith(BoxShape, Transform)) {
+     * // the properties of boxShape and transform are read only
+     * }
+     * ```
+     */
     getEntitiesWith<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
-    update(dt: number): void;
     baseComponents: SdkComponents;
 };
 
@@ -490,22 +673,22 @@ declare const log: (...a: any[]) => void;
  */
 declare namespace Matrix {
     type Matrix4x4 = [
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number,
-        number
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number
     ];
     type MutableMatrix = {
         /**
@@ -1597,14 +1780,14 @@ declare namespace Quaternion {
      * @param w - defines the fourth component (1.0 by default)
      */
     export function create(
-        /** defines the first component (0 by default) */
-        x?: number,
-        /** defines the second component (0 by default) */
-        y?: number,
-        /** defines the third component (0 by default) */
-        z?: number,
-        /** defines the fourth component (1.0 by default) */
-        w?: number): MutableQuaternion;
+    /** defines the first component (0 by default) */
+    x?: number, 
+    /** defines the second component (0 by default) */
+    y?: number, 
+    /** defines the third component (0 by default) */
+    z?: number, 
+    /** defines the fourth component (1.0 by default) */
+    w?: number): MutableQuaternion;
     /**
      * Returns a new Quaternion as the result of the addition of the two given quaternions.
      * @param q1 - the first quaternion
@@ -1825,24 +2008,24 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: ComponentDefinition<ISchema<{
-    position: {
-        x: number;
-        y: number;
-        z: number;
-    };
-    rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-    };
-    scale: {
-        x: number;
-        y: number;
-        z: number;
-    };
-    parent?: Entity | undefined;
+declare const Transform: ComponentDefinition<ISchema<    {
+position: {
+x: number;
+y: number;
+z: number;
+};
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
 }>>;
 
 declare type Transport = {
@@ -1889,18 +2072,18 @@ declare namespace Vector3 {
      * @param z - defines the third coordinates (on Z axis)
      */
     export function create(
-        /**
-         * Defines the first coordinates (on X axis)
-         */
-        x?: number,
-        /**
-         * Defines the second coordinates (on Y axis)
-         */
-        y?: number,
-        /**
-         * Defines the third coordinates (on Z axis)
-         */
-        z?: number): MutableVector3;
+    /**
+     * Defines the first coordinates (on X axis)
+     */
+    x?: number, 
+    /**
+     * Defines the second coordinates (on Y axis)
+     */
+    y?: number, 
+    /**
+     * Defines the third coordinates (on Z axis)
+     */
+    z?: number): MutableVector3;
     /**
      * Returns a new Vector3 as the result of the addition of the two given vectors.
      * @param vector1 - the first vector

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -1,46 +1,20 @@
-declare const enum ActionButton {
-    POINTER = 0,
-    PRIMARY = 1,
-    SECONDARY = 2,
-    ANY = 3,
-    FORWARD = 4,
-    BACKWARD = 5,
-    RIGHT = 6,
-    LEFT = 7,
-    JUMP = 8,
-    WALK = 9,
-    ACTION_3 = 10,
-    ACTION_4 = 11,
-    ACTION_5 = 12,
-    ACTION_6 = 13,
-    UNRECOGNIZED = -1
-}
+/** @public */
+declare const Animator: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const Animator: ComponentDefinition<ISchema<PBAnimator>>;
+declare const AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
-
-declare const enum AvatarAnchorPoint {
-    POSITION = 0,
-    NAME_TAG = 1,
-    LEFT_HAND = 2,
-    RIGHT_HAND = 3,
-    UNRECOGNIZED = -1
-}
+declare const AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+declare const AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+declare const Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
-
-/** @public */
-declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+declare const BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * @public
@@ -48,22 +22,10 @@ declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
 declare type ByteBuffer = ReturnType<typeof createByteBuffer>;
 
 /** @public */
-declare const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+declare const CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
-
-declare const enum CameraModeValue {
-    FIRST_PERSON = 0,
-    THIRD_PERSON = 1,
-    UNRECOGNIZED = -1
-}
-
-declare interface Color3 {
-    r: number;
-    g: number;
-    b: number;
-}
+declare const CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * @public
@@ -71,12 +33,13 @@ declare interface Color3 {
 declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     _id: number;
     has(entity: Entity): boolean;
-    getFrom(entity: Entity): DeepReadonly<ComponentType<T>>;
+    get(entity: Entity): DeepReadonly<ComponentType<T>>;
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
     create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
-    mutable(entity: Entity): ComponentType<T>;
     createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
+    getModifiable(entity: Entity): ComponentType<T>;
+    getModifiableOrNull(entity: Entity): ComponentType<T> | null;
     upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     toBinary(entity: Entity): ByteBuffer;
@@ -90,71 +53,52 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
+    const Transform: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>>;
+    const Animator: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const Animator: ComponentDefinition<ISchema<PBAnimator>>;
+    const AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+    const AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+    const AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+    const Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+    const BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+    const CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+    const CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+    const CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+    const GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+    const NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+    const OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+    const OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+    const OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+    const OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+    const PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+    const PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+    const SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
     /** @public */
-    const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
-    /** @public */
-    const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+    const TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
 }
 
 /**
  * @public
  */
 declare type ComponentSchema<T extends [ComponentDefinition, ...ComponentDefinition[]]> = {
-    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['mutable']> : never;
+    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getModifiable']> : never;
 };
 
 /**
@@ -301,7 +245,7 @@ declare interface CreateByteBufferOptions {
 }
 
 /** @public */
-declare const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+declare const CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * Make each field readonly deeply
@@ -312,44 +256,26 @@ declare type DeepReadonly<T> = {
 };
 
 declare function defineLibraryComponents({ defineComponent }: Pick<IEngine, 'defineComponent'>): {
-    Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>>;
-    Animator: ComponentDefinition<ISchema<PBAnimator>>;
-    AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
-    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
-    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
-    Billboard: ComponentDefinition<ISchema<PBBillboard>>;
-    BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
-    CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
-    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
-    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
-    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
-    NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
-    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
-    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
-    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
-    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
-    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
-    PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
-    SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
-    TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+    Transform: ComponentDefinition<ISchema<Result<Spec>>>;
+    Animator: ComponentDefinition<ISchema<Result<Spec>>>;
+    AudioSource: ComponentDefinition<ISchema<Result<Spec>>>;
+    AvatarAttach: ComponentDefinition<ISchema<Result<Spec>>>;
+    AvatarShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    Billboard: ComponentDefinition<ISchema<Result<Spec>>>;
+    BoxShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    CameraMode: ComponentDefinition<ISchema<Result<Spec>>>;
+    CameraModeArea: ComponentDefinition<ISchema<Result<Spec>>>;
+    CylinderShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
+    OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
+    OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
+    OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
+    PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
+    SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
+    TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
 };
 
 /**
@@ -404,7 +330,7 @@ declare type float = number;
 declare type FloatArray = number[];
 
 /** @public */
-declare const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+declare const GLTFShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * @public
@@ -420,10 +346,10 @@ declare type IEngine = {
     removeEntity(entity: Entity): void;
     addSystem(system: Update, priority?: number, name?: string): void;
     removeSystem(selector: string | Update): boolean;
-    defineComponent<T extends ISchema>(componentId: number, spec: T): ComponentDefinition<T>;
-    mutableGroupOf<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...ComponentSchema<T>]>;
-    groupOf<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
+    defineComponent<T extends Spec>(spec: Spec, componentId?: number): ComponentDefinition<ISchema<Result<T>>>;
+    defineComponentFromSchema<T extends ISchema>(spec: T, componentId?: number): ComponentDefinition<T>;
     getComponent<T extends ISchema>(componentId: number): ComponentDefinition<T>;
+    getEntitiesWith<T extends [ComponentDefinition, ...ComponentDefinition[]]>(...components: T): Iterable<[Entity, ...DeepReadonly<ComponentSchema<T>>]>;
     update(dt: number): void;
     baseComponents: SdkComponents;
 };
@@ -478,6 +404,8 @@ declare interface ISize {
      */
     height: number;
 }
+
+declare const log: (...a: any[]) => void;
 
 /**
  * Class used to store matrix data (4x4)
@@ -1199,7 +1127,7 @@ declare namespace Matrix {
 }
 
 /** @public */
-declare const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+declare const NFTShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
 declare type Nullable<T> = T | null;
@@ -1213,16 +1141,16 @@ declare type OnlyOptionalUndefinedTypes<T> = {
 };
 
 /** @public */
-declare const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+declare const OnPointerDown: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+declare const OnPointerDownResult: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+declare const OnPointerUp: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+declare const OnPointerUpResult: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * Defines potential orientation for back face culling
@@ -1235,221 +1163,6 @@ declare enum Orientation {
     CW = 0,
     /** Counter clockwise */
     CCW = 1
-}
-
-declare interface PBAnimationState {
-    name: string;
-    clip: string;
-    playing?: boolean | undefined;
-    /** default=1.0s */
-    weight?: number | undefined;
-    /** default=1.0 */
-    speed?: number | undefined;
-    /** default=true */
-    loop?: boolean | undefined;
-    shouldReset?: boolean | undefined;
-}
-
-declare interface PBAnimator {
-    states: PBAnimationState[];
-}
-
-declare interface PBAudioSource {
-    playing?: boolean | undefined;
-    /** default=1.0f */
-    volume?: number | undefined;
-    loop?: boolean | undefined;
-    /** default=1.0f */
-    pitch?: number | undefined;
-    audioClipUrl: string;
-}
-
-declare interface PBAvatarAttach {
-    avatarId: string;
-    anchorPointId: AvatarAnchorPoint;
-}
-
-declare interface PBAvatarShape {
-    id: string;
-    name?: string | undefined;
-    bodyShape?: string | undefined;
-    skinColor?: Color3 | undefined;
-    hairColor?: Color3 | undefined;
-    eyeColor?: Color3 | undefined;
-    wearables: string[];
-    expressionTriggerId?: string | undefined;
-    expressionTriggerTimestamp?: number | undefined;
-    stickerTriggerId?: string | undefined;
-    stickerTriggerTimestamp?: number | undefined;
-    talking?: boolean | undefined;
-}
-
-declare interface PBBillboard {
-    /** default=true */
-    x?: boolean | undefined;
-    /** default=true */
-    y?: boolean | undefined;
-    /** default=true */
-    z?: boolean | undefined;
-}
-
-declare interface PBBoxShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    uvs: number[];
-}
-
-declare interface PBCameraMode {
-    mode: CameraModeValue;
-}
-
-declare interface PBCameraModeArea {
-    area: Vector3_2 | undefined;
-    mode: CameraModeValue;
-}
-
-declare interface PBCylinderShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    /** default=1.0 */
-    radiusTop?: number | undefined;
-    /** default=1.0 */
-    radiusBottom?: number | undefined;
-}
-
-declare interface PBGLTFShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    src: string;
-}
-
-declare interface PBNFTShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    src: string;
-    assetId?: string | undefined;
-    style?: number | undefined;
-    color?: Color3 | undefined;
-}
-
-declare interface PBOnPointerDown {
-    /** default=ActionButton.ANY */
-    button?: ActionButton | undefined;
-    /** default='Interact' */
-    hoverText?: string | undefined;
-    /** default=10 */
-    maxDistance?: number | undefined;
-    /** default=true */
-    showFeedback?: boolean | undefined;
-}
-
-declare interface PBOnPointerDownResult {
-    button: ActionButton;
-    meshName: string;
-    origin: Vector3_2 | undefined;
-    direction: Vector3_2 | undefined;
-    point: Vector3_2 | undefined;
-    normal: Vector3_2 | undefined;
-    distance: number;
-    timestamp: number;
-}
-
-declare interface PBOnPointerUp {
-    /** default=ActionButton.ANY */
-    button?: ActionButton | undefined;
-    /** default='Interact' */
-    hoverText?: string | undefined;
-    /** default=10 */
-    maxDistance?: number | undefined;
-    /** default=true */
-    showFeedback?: boolean | undefined;
-}
-
-declare interface PBOnPointerUpResult {
-    button: ActionButton;
-    meshName: string;
-    origin: Vector3_2 | undefined;
-    direction: Vector3_2 | undefined;
-    point: Vector3_2 | undefined;
-    normal: Vector3_2 | undefined;
-    distance: number;
-    timestamp: number;
-}
-
-declare interface PBPlaneShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    uvs: number[];
-}
-
-declare interface PBPointerLock {
-    isPointerLocked: boolean;
-}
-
-declare interface PBSphereShape {
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    withCollisions?: boolean | undefined;
-    /** @deprecated use MeshCollider instead https://github.com/decentraland/sdk/issues/366 */
-    isPointerBlocker?: boolean | undefined;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-}
-
-declare interface PBTextShape {
-    text: string;
-    /** @deprecated use HiddenComponent instead https://github.com/decentraland/sdk/issues/353 */
-    visible?: boolean | undefined;
-    font?: string | undefined;
-    /** default=1.0f */
-    opacity?: number | undefined;
-    /** default=10 */
-    fontSize?: number | undefined;
-    fontAutoSize?: boolean | undefined;
-    /** default='center' */
-    hTextAlign?: string | undefined;
-    /** default='center' */
-    vTextAlign?: string | undefined;
-    /** default=1 */
-    width?: number | undefined;
-    /** default=1 */
-    height?: number | undefined;
-    paddingTop?: number | undefined;
-    paddingRight?: number | undefined;
-    paddingBottom?: number | undefined;
-    paddingLeft?: number | undefined;
-    lineSpacing?: number | undefined;
-    lineCount?: number | undefined;
-    textWrapping?: boolean | undefined;
-    shadowBlur?: number | undefined;
-    shadowOffsetX?: number | undefined;
-    shadowOffsetY?: number | undefined;
-    outlineWidth?: number | undefined;
-    /** default=(1.0,1.0,1.0) */
-    shadowColor?: Color3 | undefined;
-    /** default=(1.0,1.0,1.0) */
-    outlineColor?: Color3 | undefined;
-    /** default=(1.0,1.0,1.0) */
-    textColor?: Color3 | undefined;
 }
 
 /**
@@ -1562,10 +1275,10 @@ declare namespace Plane {
 }
 
 /** @public */
-declare const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+declare const PlaneShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+declare const PointerLock: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * @public
@@ -1800,10 +1513,10 @@ declare interface Spec {
 }
 
 /** @public */
-declare const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+declare const SphereShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /** @public */
-declare const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+declare const TextShape: ComponentDefinition<ISchema<Result<Spec>>>;
 
 /**
  * Constant used to convert a value to gamma space
@@ -1820,25 +1533,7 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: ComponentDefinition<ISchema<    {
-position: {
-x: number;
-y: number;
-z: number;
-};
-rotation: {
-x: number;
-y: number;
-z: number;
-w: number;
-};
-scale: {
-x: number;
-y: number;
-z: number;
-};
-parent?: Entity | undefined;
-}>>;
+declare const Transform: ComponentDefinition<ISchema<Result<Spec>>>;
 
 declare type Transport = {
     type: string;
@@ -2062,12 +1757,6 @@ declare namespace Vector3 {
      * @returns a new left Vector3
      */
     export function Left(): MutableVector3;
-}
-
-declare interface Vector3_2 {
-    x: number;
-    y: number;
-    z: number;
 }
 
 declare namespace WireMessage {

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -76,8 +76,8 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
     create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
-    getModifiable(entity: Entity): ComponentType<T>;
-    getModifiableOrNull(entity: Entity): ComponentType<T> | null;
+    getMutable(entity: Entity): ComponentType<T>;
+    getMutableOrNull(entity: Entity): ComponentType<T> | null;
     upsertFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     updateFromBinary(entity: Entity, data: ByteBuffer): ComponentType<T> | null;
     toBinary(entity: Entity): ByteBuffer;
@@ -91,25 +91,25 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    /** @public */
-    z: number;
-    };
-    parent?: Entity | undefined;
+    const Transform: ComponentDefinition<ISchema<{
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            /** @public */
+            z: number;
+        };
+        parent?: Entity | undefined;
     }>>;
     /** @public */
     const Animator: ComponentDefinition<ISchema<PBAnimator>>;
@@ -155,7 +155,7 @@ declare namespace Components {
  * @public
  */
 declare type ComponentSchema<T extends [ComponentDefinition, ...ComponentDefinition[]]> = {
-    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getModifiable']> : never;
+    [K in keyof T]: T[K] extends ComponentDefinition ? ReturnType<T[K]['getMutable']> : never;
 };
 
 /**
@@ -313,24 +313,24 @@ declare type DeepReadonly<T> = {
 };
 
 declare function defineLibraryComponents({ defineComponentFromSchema }: Pick<IEngine, 'defineComponentFromSchema'>): {
-    Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
+    Transform: ComponentDefinition<ISchema<{
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
     }>>;
     Animator: ComponentDefinition<ISchema<PBAnimator>>;
     AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
@@ -490,22 +490,22 @@ declare const log: (...a: any[]) => void;
  */
 declare namespace Matrix {
     type Matrix4x4 = [
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+        number
     ];
     type MutableMatrix = {
         /**
@@ -1597,14 +1597,14 @@ declare namespace Quaternion {
      * @param w - defines the fourth component (1.0 by default)
      */
     export function create(
-    /** defines the first component (0 by default) */
-    x?: number, 
-    /** defines the second component (0 by default) */
-    y?: number, 
-    /** defines the third component (0 by default) */
-    z?: number, 
-    /** defines the fourth component (1.0 by default) */
-    w?: number): MutableQuaternion;
+        /** defines the first component (0 by default) */
+        x?: number,
+        /** defines the second component (0 by default) */
+        y?: number,
+        /** defines the third component (0 by default) */
+        z?: number,
+        /** defines the fourth component (1.0 by default) */
+        w?: number): MutableQuaternion;
     /**
      * Returns a new Quaternion as the result of the addition of the two given quaternions.
      * @param q1 - the first quaternion
@@ -1825,24 +1825,24 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: ComponentDefinition<ISchema<    {
-position: {
-x: number;
-y: number;
-z: number;
-};
-rotation: {
-x: number;
-y: number;
-z: number;
-w: number;
-};
-scale: {
-x: number;
-y: number;
-z: number;
-};
-parent?: Entity | undefined;
+declare const Transform: ComponentDefinition<ISchema<{
+    position: {
+        x: number;
+        y: number;
+        z: number;
+    };
+    rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+    };
+    scale: {
+        x: number;
+        y: number;
+        z: number;
+    };
+    parent?: Entity | undefined;
 }>>;
 
 declare type Transport = {
@@ -1889,18 +1889,18 @@ declare namespace Vector3 {
      * @param z - defines the third coordinates (on Z axis)
      */
     export function create(
-    /**
-     * Defines the first coordinates (on X axis)
-     */
-    x?: number, 
-    /**
-     * Defines the second coordinates (on Y axis)
-     */
-    y?: number, 
-    /**
-     * Defines the third coordinates (on Z axis)
-     */
-    z?: number): MutableVector3;
+        /**
+         * Defines the first coordinates (on X axis)
+         */
+        x?: number,
+        /**
+         * Defines the second coordinates (on Y axis)
+         */
+        y?: number,
+        /**
+         * Defines the third coordinates (on Z axis)
+         */
+        z?: number): MutableVector3;
     /**
      * Returns a new Vector3 as the result of the addition of the two given vectors.
      * @param vector1 - the first vector

--- a/test/build-ecs/fixtures/ecs7-scene/game.ts
+++ b/test/build-ecs/fixtures/ecs7-scene/game.ts
@@ -5,7 +5,7 @@ function circularSystem() {
 
     const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = Transform.getModifiableOrNull(entity)
+      const transform = Transform.getMutableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)

--- a/test/build-ecs/fixtures/ecs7-scene/game.ts
+++ b/test/build-ecs/fixtures/ecs7-scene/game.ts
@@ -1,12 +1,11 @@
 function circularSystem() {
   let t = 0.0
-  const sdk = engine.baseComponents
   return (dt: number) => {
     t += 2 * Math.PI * dt
 
-    const group = engine.groupOf(sdk.BoxShape)
+    const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = sdk.Transform.mutable(entity)
+      const transform = Transform.getModifiableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)
@@ -16,16 +15,15 @@ function circularSystem() {
 }
 
 function createCube(x: number, y: number, z: number) {
-  const sdk = engine.baseComponents
   const myEntity = engine.addEntity()
 
-  sdk.Transform.create(myEntity, {
+  Transform.create(myEntity, {
     position: { x, y, z },
     scale: { x: 1, y: 1, z: 1 },
     rotation: { x: 0, y: 0, z: 0, w: 1 }
   })
 
-  sdk.BoxShape.create(myEntity, {
+  BoxShape.create(myEntity, {
     withCollisions: true,
     isPointerBlocker: true,
     visible: true,

--- a/test/build-ecs/fixtures/simple-scene-without-installed-ecs/game.ts
+++ b/test/build-ecs/fixtures/simple-scene-without-installed-ecs/game.ts
@@ -5,7 +5,7 @@ function circularSystem() {
 
     const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = Transform.getModifiableOrNull(entity)
+      const transform = Transform.getMutableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)

--- a/test/build-ecs/fixtures/simple-scene-without-installed-ecs/game.ts
+++ b/test/build-ecs/fixtures/simple-scene-without-installed-ecs/game.ts
@@ -1,12 +1,11 @@
 function circularSystem() {
   let t = 0.0
-  const sdk = engine.baseComponents
   return (dt: number) => {
     t += 2 * Math.PI * dt
 
-    const group = engine.groupOf(sdk.BoxShape)
+    const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = sdk.Transform.mutable(entity)
+      const transform = Transform.getModifiableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)
@@ -16,16 +15,15 @@ function circularSystem() {
 }
 
 function createCube(x: number, y: number, z: number) {
-  const sdk = engine.baseComponents
   const myEntity = engine.addEntity()
 
-  sdk.Transform.create(myEntity, {
+  Transform.create(myEntity, {
     position: { x, y, z },
     scale: { x: 1, y: 1, z: 1 },
     rotation: { x: 0, y: 0, z: 0, w: 1 }
   })
 
-  sdk.BoxShape.create(myEntity, {
+  BoxShape.create(myEntity, {
     withCollisions: true,
     isPointerBlocker: true,
     visible: true,

--- a/test/build-ecs/fixtures/simple-scene/game.ts
+++ b/test/build-ecs/fixtures/simple-scene/game.ts
@@ -1,13 +1,12 @@
 import { testSubfolder } from './subfolder/subfoldergame'
 function circularSystem() {
   let t = 0.0
-  const sdk = engine.baseComponents
   return (dt: number) => {
     t += 2 * Math.PI * dt
 
-    const group = engine.groupOf(sdk.BoxShape)
+    const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = sdk.Transform.mutable(entity)
+      const transform = Transform.getModifiableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)
@@ -17,16 +16,15 @@ function circularSystem() {
 }
 
 function createCube(x: number, y: number, z: number) {
-  const sdk = engine.baseComponents
   const myEntity = engine.addEntity()
 
-  sdk.Transform.create(myEntity, {
+  Transform.create(myEntity, {
     position: { x, y, z },
     scale: { x: 1, y: 1, z: 1 },
     rotation: { x: 0, y: 0, z: 0, w: 1 }
   })
 
-  sdk.BoxShape.create(myEntity, {
+  BoxShape.create(myEntity, {
     withCollisions: true,
     isPointerBlocker: true,
     visible: true,

--- a/test/build-ecs/fixtures/simple-scene/game.ts
+++ b/test/build-ecs/fixtures/simple-scene/game.ts
@@ -6,7 +6,7 @@ function circularSystem() {
 
     const group = engine.getEntitiesWith(BoxShape)
     for (const [entity] of group) {
-      const transform = Transform.getModifiableOrNull(entity)
+      const transform = Transform.getMutableOrNull(entity)
       if (transform) {
         transform.position.x = 8 + 2 * Math.cos(t)
         transform.position.z = 8 + 2 * Math.sin(t)


### PR DESCRIPTION
# What?
## Log and Error
- Expose globally log and error
```ts
// Now
log('Hello world!')

error('Can not fetch the wearable')

```

## Component definitions
The order of the params is now first the definition, then the ID.
To define a component from a generic schema (using `ISchema<T>`), it's available the function `engine.defineComponentFromSchema`.
```ts
// Before
const COMPONENT_ID = 3000 // a value that doesn't matter actually
const CountableId = engine.defineComponent(COMPONENT_ID, Schemas.Map({
  id: Schemas.String,
  count: Schemas.Int
}))

// Now
const CountableId = engine.defineComponent({
  id: Schemas.String,
  count: Schemas.Int
}, COMPONENT_ID)
```
```ts
// Before
const VisibleComponent = engine.defineComponent(2311, Schemas.Bool)

// Now
const VisibleComponent = engine.defineComponentFromSchema(Schemas.Bool, 2311)
```

## Renaming some methods
- Change `ComponentDefinition.getFrom(entity)` to `ComponentDefinition.get(entity)`
- Change `ComponentDefinition.mutable(entity)` to `ComponentDefinition.getMutable(entity)`
- Add `ComponentDefinition.getMutableOrNull(entity)`
- Change `engine.groupOf(ComponentDefinition)` to `engine.getEntitiesWith(ComponentDefinition)`
- Remove `mutableGroupOf`, because it's an opened door to non-performance practices. 
```ts
// Before
for (const [entity, transform] of engine.mutableGroupOf(Transform)) {
  transform.position.x += 1
}

// Now
for (const [entity] of engine.getEntitiesWith(Transform)) {
  Transform.getModifiable(entity).position.x += 1
}

```


  


# Why?
https://github.com/decentraland/sdk/issues/347
