### PR TITLE
feat: transform with optionals

### DIFF
--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -8,32 +8,32 @@
 // Warning: (ae-forgotten-export) The symbol "PBAnimator" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Animator: ComponentDefinition<ISchema<PBAnimator>>;
+export const Animator: ComponentDefinition<ISchema<PBAnimator>, PBAnimator>;
 
 // Warning: (ae-forgotten-export) The symbol "PBAudioSource" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+export const AudioSource: ComponentDefinition<ISchema<PBAudioSource>, PBAudioSource>;
 
 // Warning: (ae-forgotten-export) The symbol "PBAvatarAttach" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+export const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>, PBAvatarAttach>;
 
 // Warning: (ae-forgotten-export) The symbol "PBAvatarShape" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+export const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>, PBAvatarShape>;
 
 // Warning: (ae-forgotten-export) The symbol "PBBillboard" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+export const Billboard: ComponentDefinition<ISchema<PBBillboard>, PBBillboard>;
 
 // Warning: (ae-forgotten-export) The symbol "PBBoxShape" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+export const BoxShape: ComponentDefinition<ISchema<PBBoxShape>, PBBoxShape>;
 
 // Warning: (ae-forgotten-export) The symbol "createByteBuffer" needs to be exported by the entry point index.d.ts
 //
@@ -43,22 +43,22 @@ export type ByteBuffer = ReturnType<typeof createByteBuffer>;
 // Warning: (ae-forgotten-export) The symbol "PBCameraMode" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+export const CameraMode: ComponentDefinition<ISchema<PBCameraMode>, PBCameraMode>;
 
 // Warning: (ae-forgotten-export) The symbol "PBCameraModeArea" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+export const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>, PBCameraModeArea>;
 
 // @public (undocumented)
-export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
+export type ComponentDefinition<T extends ISchema = ISchema<any>, ConstructorType = ComponentType<T>> = {
     _id: number;
     default(): DeepReadonly<ComponentType<T>>;
     has(entity: Entity): boolean;
     get(entity: Entity): DeepReadonly<ComponentType<T>>;
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
-    create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
-    createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    create(entity: Entity, val?: ConstructorType): ComponentType<T>;
+    createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
     getMutable(entity: Entity): ComponentType<T>;
     getMutableOrNull(entity: Entity): ComponentType<T> | null;
@@ -68,536 +68,103 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 // @public (undocumented)
 export namespace Components {
     const // (undocumented)
-    Transform: {
-        create(entity: Entity, val?: {
-            position?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            rotation?: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            } | undefined;
-            scale?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        _id: number;
-        default(): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        has(entity: Entity): boolean;
-        get(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        getOrNull(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }> | null;
-        createOrReplace(entity: Entity, val?: {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        deleteFrom(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        getMutable(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        getMutableOrNull(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        upsertFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        updateFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        toBinary(entity: Entity): {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        };
-        writeToByteBuffer(entity: Entity, buffer: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): void;
-        iterator(): Iterable<[Entity, {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        }]>;
-        dirtyIterator(): Iterable<Entity>;
-        clearDirty(): void;
-        isDirty(entity: Entity): boolean;
+    Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
     };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined; /** @public */
+    }>, Partial<{
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined; /** @public */
+    }>>;
     const // (undocumented)
-    Animator: ComponentDefinition<ISchema<PBAnimator>>;
+    Animator: ComponentDefinition<ISchema<PBAnimator>, PBAnimator>;
     const // (undocumented)
-    AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+    AudioSource: ComponentDefinition<ISchema<PBAudioSource>, PBAudioSource>;
     const // (undocumented)
-    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>, PBAvatarAttach>;
     const // (undocumented)
-    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>, PBAvatarShape>;
     const // (undocumented)
-    Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+    Billboard: ComponentDefinition<ISchema<PBBillboard>, PBBillboard>;
     const // (undocumented)
-    BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+    BoxShape: ComponentDefinition<ISchema<PBBoxShape>, PBBoxShape>;
     const // (undocumented)
-    CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+    CameraMode: ComponentDefinition<ISchema<PBCameraMode>, PBCameraMode>;
     const // (undocumented)
-    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>, PBCameraModeArea>;
     const // Warning: (ae-forgotten-export) The symbol "PBCylinderShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>, PBCylinderShape>;
     const // Warning: (ae-forgotten-export) The symbol "PBGLTFShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>, PBGLTFShape>;
     const // Warning: (ae-forgotten-export) The symbol "PBNFTShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+    NFTShape: ComponentDefinition<ISchema<PBNFTShape>, PBNFTShape>;
     const // Warning: (ae-forgotten-export) The symbol "PBOnPointerDown" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>, PBOnPointerDown>;
     const // Warning: (ae-forgotten-export) The symbol "PBOnPointerDownResult" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>, PBOnPointerDownResult>;
     const // Warning: (ae-forgotten-export) The symbol "PBOnPointerUp" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>, PBOnPointerUp>;
     const // Warning: (ae-forgotten-export) The symbol "PBOnPointerUpResult" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>, PBOnPointerUpResult>;
     const // Warning: (ae-forgotten-export) The symbol "PBPlaneShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>, PBPlaneShape>;
     const // Warning: (ae-forgotten-export) The symbol "PBPointerLock" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+    PointerLock: ComponentDefinition<ISchema<PBPointerLock>, PBPointerLock>;
     const // Warning: (ae-forgotten-export) The symbol "PBSphereShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+    SphereShape: ComponentDefinition<ISchema<PBSphereShape>, PBSphereShape>;
     const // Warning: (ae-forgotten-export) The symbol "PBTextShape" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+    TextShape: ComponentDefinition<ISchema<PBTextShape>, PBTextShape>;
 }
 
 // @public (undocumented)
@@ -611,7 +178,7 @@ export type ComponentSchema<T extends [ComponentDefinition, ...ComponentDefiniti
 export type ComponentType<T extends ISchema> = EcsResult<T>;
 
 // @public (undocumented)
-export const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+export const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>, PBCylinderShape>;
 
 // @public
 export type DeepReadonly<T> = {
@@ -648,7 +215,7 @@ export type float = number;
 export type FloatArray = number[];
 
 // @public (undocumented)
-export const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+export const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>, PBGLTFShape>;
 
 // @public (undocumented)
 export type IEngine = {
@@ -679,22 +246,22 @@ export interface ISize {
 export const log: (...a: any[]) => void;
 
 // @public (undocumented)
-export const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+export const NFTShape: ComponentDefinition<ISchema<PBNFTShape>, PBNFTShape>;
 
 // @public (undocumented)
 export type Nullable<T> = T | null;
 
 // @public (undocumented)
-export const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+export const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>, PBOnPointerDown>;
 
 // @public (undocumented)
-export const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+export const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>, PBOnPointerDownResult>;
 
 // @public (undocumented)
-export const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+export const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>, PBOnPointerUp>;
 
 // @public (undocumented)
-export const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+export const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>, PBOnPointerUpResult>;
 
 // @public
 export enum Orientation {
@@ -703,10 +270,10 @@ export enum Orientation {
 }
 
 // @public (undocumented)
-export const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+export const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>, PBPlaneShape>;
 
 // @public (undocumented)
-export const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+export const PointerLock: ComponentDefinition<ISchema<PBPointerLock>, PBPointerLock>;
 
 // @public (undocumented)
 export namespace Quaternion {
@@ -818,10 +385,10 @@ export interface Spec {
 }
 
 // @public (undocumented)
-export const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+export const SphereShape: ComponentDefinition<ISchema<PBSphereShape>, PBSphereShape>;
 
 // @public (undocumented)
-export const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+export const TextShape: ComponentDefinition<ISchema<PBTextShape>, PBTextShape>;
 
 // @public
 export const ToGammaSpace: number;
@@ -830,476 +397,43 @@ export const ToGammaSpace: number;
 export const ToLinearSpace = 2.2;
 
 // @public (undocumented)
-export const Transform: {
-    create(entity: Entity, val?: {
-        position?: {
-            x: number;
-            y: number;
-            z: number;
-        } | undefined;
-        rotation?: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        } | undefined;
-        scale?: {
-            x: number;
-            y: number;
-            z: number;
-        } | undefined;
-        parent?: Entity | undefined;
-    } | undefined): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    _id: number;
-    default(): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>;
-    has(entity: Entity): boolean;
-    get(entity: Entity): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>;
-    getOrNull(entity: Entity): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }> | null;
-    createOrReplace(entity: Entity, val?: {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | undefined): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    deleteFrom(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    getMutable(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    getMutableOrNull(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    upsertFromBinary(entity: Entity, data: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    updateFromBinary(entity: Entity, data: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    toBinary(entity: Entity): {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    };
-    writeToByteBuffer(entity: Entity, buffer: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): void;
-    iterator(): Iterable<[Entity, {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    }]>;
-    dirtyIterator(): Iterable<Entity>;
-    clearDirty(): void;
-    isDirty(entity: Entity): boolean;
+export const Transform: ComponentDefinition<ISchema<    {
+position: {
+x: number;
+y: number;
+z: number;
 };
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
+}>, Partial<{
+position: {
+x: number;
+y: number;
+z: number;
+};
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
+}>>;
 
 // @public (undocumented)
 export type Transport = {

--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -68,25 +68,476 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 // @public (undocumented)
 export namespace Components {
     const // (undocumented)
-    Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
+    Transform: {
+        create(entity: Entity, val?: {
+            position?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            rotation?: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            } | undefined;
+            scale?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        _id: number;
+        default(): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        has(entity: Entity): boolean;
+        get(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        getOrNull(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }> | null;
+        createOrReplace(entity: Entity, val?: {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        deleteFrom(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        getMutable(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        getMutableOrNull(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        upsertFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        updateFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        toBinary(entity: Entity): {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        };
+        writeToByteBuffer(entity: Entity, buffer: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): void;
+        iterator(): Iterable<[Entity, {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        }]>;
+        dirtyIterator(): Iterable<Entity>;
+        clearDirty(): void;
+        isDirty(entity: Entity): boolean;
     };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>>;
     const // (undocumented)
     Animator: ComponentDefinition<ISchema<PBAnimator>>;
     const // (undocumented)
@@ -379,25 +830,476 @@ export const ToGammaSpace: number;
 export const ToLinearSpace = 2.2;
 
 // @public (undocumented)
-export const Transform: ComponentDefinition<ISchema<    {
-position: {
-x: number;
-y: number;
-z: number;
+export const Transform: {
+    create(entity: Entity, val?: {
+        position?: {
+            x: number;
+            y: number;
+            z: number;
+        } | undefined;
+        rotation?: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        } | undefined;
+        scale?: {
+            x: number;
+            y: number;
+            z: number;
+        } | undefined;
+        parent?: Entity | undefined;
+    } | undefined): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    _id: number;
+    default(): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>;
+    has(entity: Entity): boolean;
+    get(entity: Entity): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>;
+    getOrNull(entity: Entity): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }> | null;
+    createOrReplace(entity: Entity, val?: {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | undefined): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    deleteFrom(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    getMutable(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    getMutableOrNull(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    upsertFromBinary(entity: Entity, data: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    updateFromBinary(entity: Entity, data: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    toBinary(entity: Entity): {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    };
+    writeToByteBuffer(entity: Entity, buffer: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): void;
+    iterator(): Iterable<[Entity, {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    }]>;
+    dirtyIterator(): Iterable<Entity>;
+    clearDirty(): void;
+    isDirty(entity: Entity): boolean;
 };
-rotation: {
-x: number;
-y: number;
-z: number;
-w: number;
-};
-scale: {
-x: number;
-y: number;
-z: number;
-};
-parent?: Entity | undefined;
-}>>;
 
 // @public (undocumented)
 export type Transport = {

--- a/packages/@dcl/ecs/src/components/legacy/Transform.ts
+++ b/packages/@dcl/ecs/src/components/legacy/Transform.ts
@@ -1,6 +1,7 @@
 import type { ISchema } from '../../schemas/ISchema'
 import { Entity } from '../../engine/entity'
 import { ByteBuffer } from '../../serialization/ByteBuffer'
+import { ComponentDefinition } from '../../engine'
 
 /**
  * @internal
@@ -62,8 +63,31 @@ export const TransformSchema: ISchema<TransformType> = {
     return {
       position: { x: 0, y: 0, z: 0 },
       scale: { x: 1, y: 1, z: 1 },
-      rotation: { x: 0, y: 0, z: 0, w: 1 },
-      parent: undefined
+      rotation: { x: 0, y: 0, z: 0, w: 1 }
+    }
+  }
+}
+
+/**
+ * @internal
+ */
+type TransformTypeWithOptionals = {
+  position?: { x: number; y: number; z: number }
+  rotation?: { x: number; y: number; z: number; w: number }
+  scale?: { x: number; y: number; z: number }
+  parent?: Entity
+}
+
+export function wrapTransformDefinition(
+  def: ComponentDefinition<ISchema<TransformType>>
+) {
+  return {
+    ...def,
+
+    create(entity: Entity, val?: TransformTypeWithOptionals): TransformType {
+      const defaultTransform = { ...def.default() } as TransformType
+      const value = { ...defaultTransform, ...(val || {}) }
+      return def.create(entity, value)
     }
   }
 }

--- a/packages/@dcl/ecs/src/components/legacy/Transform.ts
+++ b/packages/@dcl/ecs/src/components/legacy/Transform.ts
@@ -9,7 +9,7 @@ import { ComponentDefinition } from '../../engine'
 export const COMPONENT_ID = 1
 
 /**
- * @internal
+ * @public
  */
 type TransformType = {
   position: { x: number; y: number; z: number }
@@ -68,23 +68,12 @@ export const TransformSchema: ISchema<TransformType> = {
   }
 }
 
-/**
- * @internal
- */
-type TransformTypeWithOptionals = {
-  position?: { x: number; y: number; z: number }
-  rotation?: { x: number; y: number; z: number; w: number }
-  scale?: { x: number; y: number; z: number }
-  parent?: Entity
-}
-
 export function wrapTransformDefinition(
   def: ComponentDefinition<ISchema<TransformType>>
-) {
+): ComponentDefinition<ISchema<TransformType>, Partial<TransformType>> {
   return {
     ...def,
-
-    create(entity: Entity, val?: TransformTypeWithOptionals): TransformType {
+    create(entity: Entity, val?: Partial<TransformType>): TransformType {
       const defaultTransform = { ...def.default() } as TransformType
       const value = { ...defaultTransform, ...(val || {}) }
       return def.create(entity, value)

--- a/packages/@dcl/ecs/src/engine/component.ts
+++ b/packages/@dcl/ecs/src/engine/component.ts
@@ -18,7 +18,10 @@ export type ComponentType<T extends ISchema> = EcsResult<T>
 /**
  * @public
  */
-export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
+export type ComponentDefinition<
+  T extends ISchema = ISchema<any>,
+  ConstructorType = ComponentType<T>
+> = {
   _id: number
 
   /**
@@ -87,7 +90,7 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
    * Transform.create(myEntity) // throw an error, the `Transform` component already exists in `myEntity`
    * ````
    */
-  create(entity: Entity, val?: ComponentType<T>): ComponentType<T>
+  create(entity: Entity, val?: ConstructorType): ComponentType<T>
   /**
    * Add the current component to an entity or replace the content if the entity already has the component
    * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
@@ -101,7 +104,7 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
    * Transform.createOrReplace(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
    * ````
    */
-  createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>
+  createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>
 
   /**
    * Delete the current component to an entity, return null if the entity doesn't have the current component.
@@ -191,7 +194,10 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>> = {
   isDirty(entity: Entity): boolean
 }
 
-export function defineComponent<T extends ISchema>(
+export function defineComponent<
+  T extends ISchema,
+  ConstructorType = ComponentType<T>
+>(
   componentId: number,
   spec: T
   // meta: { syncFlags }
@@ -233,7 +239,7 @@ export function defineComponent<T extends ISchema>(
     },
     create: function (
       entity: Entity,
-      value?: ComponentType<T>
+      value?: ConstructorType
     ): ComponentType<T> {
       const component = data.get(entity)
       if (component) {
@@ -248,7 +254,7 @@ export function defineComponent<T extends ISchema>(
     },
     createOrReplace: function (
       entity: Entity,
-      value?: ComponentType<T>
+      value?: ConstructorType
     ): ComponentType<T> {
       const usedValue = value === undefined ? spec.create() : value
       data.set(entity, usedValue!)

--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -61,10 +61,10 @@ function preEngine() {
     return entityContainer.removeEntity(entity)
   }
 
-  function defineComponentFromSchema<T extends ISchema>(
-    spec: T,
-    componentId: number
-  ): ComponentDefinition<T> {
+  function defineComponentFromSchema<
+    T extends ISchema,
+    ConstructorType = ComponentType<T>
+  >(spec: T, componentId: number): ComponentDefinition<T, ConstructorType> {
     if (componentsDefinition.get(componentId)) {
       throw new Error(`Component ${componentId} already declared`)
     }
@@ -73,10 +73,10 @@ function preEngine() {
     return newComponent
   }
 
-  function defineComponent<T extends Spec>(
+  function defineComponent<T extends Spec, ConstructorType = Result<T>>(
     spec: Spec,
     componentId: number
-  ): ComponentDefinition<ISchema<Result<T>>> {
+  ): ComponentDefinition<ISchema<Result<T>>, ConstructorType> {
     return defineComponentFromSchema(Schemas.Map(spec), componentId)
   }
 

--- a/packages/@dcl/ecs/test/components/Transform.spec.ts
+++ b/packages/@dcl/ecs/test/components/Transform.spec.ts
@@ -117,4 +117,18 @@ describe('Transform component', () => {
       parent: undefined
     })
   })
+
+  it('should create a prefilled empty transform component if only the position argument is passed', () => {
+    const newEngine = Engine()
+    const { Transform } = newEngine.baseComponents
+    const entity = newEngine.addEntity()
+
+    const t1 = Transform.create(entity, { position: { x: 22, y: 23, z: 24 } })
+
+    expect(t1).toEqual({
+      position: { x: 22, y: 23, z: 24 },
+      scale: { x: 1, y: 1, z: 1 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 }
+    })
+  })
 })

--- a/packages/@dcl/ecs/tools/protocol-buffer-generation/generateIndex.ts
+++ b/packages/@dcl/ecs/tools/protocol-buffer-generation/generateIndex.ts
@@ -2,6 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import { Component } from './generateComponent'
 
+const TransformComponent = { componentId: 1, componentName: 'Transform' }
+
 function enumTemplate({ componentName, componentId }: Component) {
   return `\t${componentName} = ${componentId},`
 }
@@ -11,6 +13,9 @@ function importComponent(component: Component) {
 }
 
 function defineComponent(component: Component) {
+  if (component.componentId === TransformComponent.componentId) {
+    return `\t\t${component.componentName}: TransformSchema.wrapTransformDefinition(defineComponentFromSchema(${component.componentName}Schema.${component.componentName}Schema, ${component.componentName}Schema.COMPONENT_ID)),`
+  }
   return `\t\t${component.componentName}: defineComponentFromSchema(${component.componentName}Schema.${component.componentName}Schema, ${component.componentName}Schema.COMPONENT_ID),`
 }
 
@@ -21,8 +26,6 @@ function useDefinedComponent(component: Component) {
 function namespaceComponent(component: Component) {
   return `\t/** @public */\n\texport const ${component.componentName} = engine.baseComponents.${component.componentName}`
 }
-
-const TransformComponent = { componentId: 1, componentName: 'Transform' }
 
 const indexTemplate = `import type { IEngine } from '../../engine/types'
 import * as TransformSchema from './../legacy/Transform'

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -17,10 +17,10 @@ declare const enum ActionButton {
 }
 
 /** @public */
-declare const Animator: ComponentDefinition<ISchema<PBAnimator>>;
+declare const Animator: ComponentDefinition<ISchema<PBAnimator>, PBAnimator>;
 
 /** @public */
-declare const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+declare const AudioSource: ComponentDefinition<ISchema<PBAudioSource>, PBAudioSource>;
 
 declare const enum AvatarAnchorPoint {
     POSITION = 0,
@@ -31,16 +31,16 @@ declare const enum AvatarAnchorPoint {
 }
 
 /** @public */
-declare const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+declare const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>, PBAvatarAttach>;
 
 /** @public */
-declare const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+declare const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>, PBAvatarShape>;
 
 /** @public */
-declare const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+declare const Billboard: ComponentDefinition<ISchema<PBBillboard>, PBBillboard>;
 
 /** @public */
-declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>, PBBoxShape>;
 
 /**
  * @public
@@ -48,10 +48,10 @@ declare const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
 declare type ByteBuffer = ReturnType<typeof createByteBuffer>;
 
 /** @public */
-declare const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+declare const CameraMode: ComponentDefinition<ISchema<PBCameraMode>, PBCameraMode>;
 
 /** @public */
-declare const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+declare const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>, PBCameraModeArea>;
 
 declare const enum CameraModeValue {
     FIRST_PERSON = 0,
@@ -68,7 +68,7 @@ declare interface Color3 {
 /**
  * @public
  */
-declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
+declare type ComponentDefinition<T extends ISchema = ISchema<any>, ConstructorType = ComponentType<T>> = {
     _id: number;
     /**
      * Return the default value of the current component
@@ -132,7 +132,7 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
      * Transform.create(myEntity) // throw an error, the `Transform` component already exists in `myEntity`
      * ````
      */
-    create(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    create(entity: Entity, val?: ConstructorType): ComponentType<T>;
     /**
      * Add the current component to an entity or replace the content if the entity already has the component
      * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
@@ -146,7 +146,7 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
      * Transform.createOrReplace(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
      * ````
      */
-    createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>;
     /**
      * Delete the current component to an entity, return null if the entity doesn't have the current component.
      * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame
@@ -194,514 +194,81 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: {
-        create(entity: Entity, val?: {
-            position?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            rotation?: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            } | undefined;
-            scale?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        _id: number;
-        default(): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        has(entity: Entity): boolean;
-        get(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        getOrNull(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }> | null;
-        createOrReplace(entity: Entity, val?: {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        deleteFrom(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        getMutable(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        getMutableOrNull(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        upsertFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        updateFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        toBinary(entity: Entity): {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        };
-        writeToByteBuffer(entity: Entity, buffer: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): void;
-        iterator(): Iterable<[Entity, {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        }]>;
-        dirtyIterator(): Iterable<Entity>;
-        clearDirty(): void;
-        isDirty(entity: Entity): boolean;
+    const Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
     };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined; /** @public */
+    }>, Partial<{
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined; /** @public */
+    }>>;
     /** @public */
-    const Animator: ComponentDefinition<ISchema<PBAnimator>>;
+    const Animator: ComponentDefinition<ISchema<PBAnimator>, PBAnimator>;
     /** @public */
-    const AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
+    const AudioSource: ComponentDefinition<ISchema<PBAudioSource>, PBAudioSource>;
     /** @public */
-    const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
+    const AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>, PBAvatarAttach>;
     /** @public */
-    const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
+    const AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>, PBAvatarShape>;
     /** @public */
-    const Billboard: ComponentDefinition<ISchema<PBBillboard>>;
+    const Billboard: ComponentDefinition<ISchema<PBBillboard>, PBBillboard>;
     /** @public */
-    const BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
+    const BoxShape: ComponentDefinition<ISchema<PBBoxShape>, PBBoxShape>;
     /** @public */
-    const CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
+    const CameraMode: ComponentDefinition<ISchema<PBCameraMode>, PBCameraMode>;
     /** @public */
-    const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
+    const CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>, PBCameraModeArea>;
     /** @public */
-    const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+    const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>, PBCylinderShape>;
     /** @public */
-    const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+    const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>, PBGLTFShape>;
     /** @public */
-    const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+    const NFTShape: ComponentDefinition<ISchema<PBNFTShape>, PBNFTShape>;
     /** @public */
-    const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+    const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>, PBOnPointerDown>;
     /** @public */
-    const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+    const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>, PBOnPointerDownResult>;
     /** @public */
-    const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+    const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>, PBOnPointerUp>;
     /** @public */
-    const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+    const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>, PBOnPointerUpResult>;
     /** @public */
-    const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+    const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>, PBPlaneShape>;
     /** @public */
-    const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+    const PointerLock: ComponentDefinition<ISchema<PBPointerLock>, PBPointerLock>;
     /** @public */
-    const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+    const SphereShape: ComponentDefinition<ISchema<PBSphereShape>, PBSphereShape>;
     /** @public */
-    const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+    const TextShape: ComponentDefinition<ISchema<PBTextShape>, PBTextShape>;
 }
 
 /**
@@ -855,7 +422,7 @@ declare interface CreateByteBufferOptions {
 }
 
 /** @public */
-declare const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
+declare const CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>, PBCylinderShape>;
 
 /**
  * Make each field readonly deeply
@@ -866,495 +433,62 @@ declare type DeepReadonly<T> = {
 };
 
 declare function defineLibraryComponents({ defineComponentFromSchema }: Pick<IEngine, 'defineComponentFromSchema'>): {
-    Transform: {
-        create(entity: Entity, val?: {
-            position?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            rotation?: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            } | undefined;
-            scale?: {
-                x: number;
-                y: number;
-                z: number;
-            } | undefined;
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        _id: number;
-        default(): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        has(entity: Entity): boolean;
-        get(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }>;
-        getOrNull(entity: Entity): DeepReadonly<    {
-        position: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        rotation: {
-        x: number;
-        y: number;
-        z: number;
-        w: number;
-        };
-        scale: {
-        x: number;
-        y: number;
-        z: number;
-        };
-        parent?: Entity | undefined;
-        }> | null;
-        createOrReplace(entity: Entity, val?: {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | undefined): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        deleteFrom(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        getMutable(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        };
-        getMutableOrNull(entity: Entity): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        upsertFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        updateFromBinary(entity: Entity, data: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        } | null;
-        toBinary(entity: Entity): {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        };
-        writeToByteBuffer(entity: Entity, buffer: {
-            buffer(): Uint8Array;
-            bufferLength(): number;
-            resetBuffer(): void;
-            currentReadOffset(): number;
-            currentWriteOffset(): number;
-            incrementReadOffset(amount: number): number;
-            remainingBytes(): number;
-            readFloat32(): number;
-            readFloat64(): number;
-            readInt8(): number;
-            readInt16(): number;
-            readInt32(): number;
-            readInt64(): bigint;
-            readUint8(): number;
-            readUint16(): number;
-            readUint32(): number;
-            readUint64(): bigint;
-            readBuffer(): Uint8Array;
-            incrementWriteOffset(amount: number): number;
-            size(): number;
-            toBinary(): Uint8Array;
-            toCopiedBinary(): Uint8Array;
-            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-            writeFloat32(value: number): void;
-            writeFloat64(value: number): void;
-            writeInt8(value: number): void;
-            writeInt16(value: number): void;
-            writeInt32(value: number): void;
-            writeInt64(value: bigint): void;
-            writeUint8(value: number): void;
-            writeUint16(value: number): void;
-            writeUint32(value: number): void;
-            writeUint64(value: bigint): void;
-            getFloat32(offset: number): number;
-            getFloat64(offset: number): number;
-            getInt8(offset: number): number;
-            getInt16(offset: number): number;
-            getInt32(offset: number): number;
-            getInt64(offset: number): bigint;
-            getUint8(offset: number): number;
-            getUint16(offset: number): number;
-            getUint32(offset: number): number;
-            getUint64(offset: number): bigint;
-            setFloat32(offset: number, value: number): void;
-            setFloat64(offset: number, value: number): void;
-            setInt8(offset: number, value: number): void;
-            setInt16(offset: number, value: number): void;
-            setInt32(offset: number, value: number): void;
-            setInt64(offset: number, value: bigint): void;
-            setUint8(offset: number, value: number): void;
-            setUint16(offset: number, value: number): void;
-            setUint32(offset: number, value: number): void;
-            setUint64(offset: number, value: bigint): void;
-        }): void;
-        iterator(): Iterable<[Entity, {
-            position: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            rotation: {
-                x: number;
-                y: number;
-                z: number;
-                w: number;
-            };
-            scale: {
-                x: number;
-                y: number;
-                z: number;
-            };
-            parent?: Entity | undefined;
-        }]>;
-        dirtyIterator(): Iterable<Entity>;
-        clearDirty(): void;
-        isDirty(entity: Entity): boolean;
+    Transform: ComponentDefinition<ISchema<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
     };
-    Animator: ComponentDefinition<ISchema<PBAnimator>>;
-    AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
-    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
-    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>>;
-    Billboard: ComponentDefinition<ISchema<PBBillboard>>;
-    BoxShape: ComponentDefinition<ISchema<PBBoxShape>>;
-    CameraMode: ComponentDefinition<ISchema<PBCameraMode>>;
-    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>>;
-    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>>;
-    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
-    NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
-    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
-    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
-    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
-    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
-    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
-    PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
-    SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
-    TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>, Partial<{
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>>;
+    Animator: ComponentDefinition<ISchema<PBAnimator>, PBAnimator>;
+    AudioSource: ComponentDefinition<ISchema<PBAudioSource>, PBAudioSource>;
+    AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>, PBAvatarAttach>;
+    AvatarShape: ComponentDefinition<ISchema<PBAvatarShape>, PBAvatarShape>;
+    Billboard: ComponentDefinition<ISchema<PBBillboard>, PBBillboard>;
+    BoxShape: ComponentDefinition<ISchema<PBBoxShape>, PBBoxShape>;
+    CameraMode: ComponentDefinition<ISchema<PBCameraMode>, PBCameraMode>;
+    CameraModeArea: ComponentDefinition<ISchema<PBCameraModeArea>, PBCameraModeArea>;
+    CylinderShape: ComponentDefinition<ISchema<PBCylinderShape>, PBCylinderShape>;
+    GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>, PBGLTFShape>;
+    NFTShape: ComponentDefinition<ISchema<PBNFTShape>, PBNFTShape>;
+    OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>, PBOnPointerDown>;
+    OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>, PBOnPointerDownResult>;
+    OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>, PBOnPointerUp>;
+    OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>, PBOnPointerUpResult>;
+    PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>, PBPlaneShape>;
+    PointerLock: ComponentDefinition<ISchema<PBPointerLock>, PBPointerLock>;
+    SphereShape: ComponentDefinition<ISchema<PBSphereShape>, PBSphereShape>;
+    TextShape: ComponentDefinition<ISchema<PBTextShape>, PBTextShape>;
 };
 
 /**
@@ -1411,7 +545,7 @@ declare type float = number;
 declare type FloatArray = number[];
 
 /** @public */
-declare const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>>;
+declare const GLTFShape: ComponentDefinition<ISchema<PBGLTFShape>, PBGLTFShape>;
 
 /**
  * @public
@@ -2288,7 +1422,7 @@ declare namespace Matrix {
 }
 
 /** @public */
-declare const NFTShape: ComponentDefinition<ISchema<PBNFTShape>>;
+declare const NFTShape: ComponentDefinition<ISchema<PBNFTShape>, PBNFTShape>;
 
 /** @public */
 declare type Nullable<T> = T | null;
@@ -2302,16 +1436,16 @@ declare type OnlyOptionalUndefinedTypes<T> = {
 };
 
 /** @public */
-declare const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>>;
+declare const OnPointerDown: ComponentDefinition<ISchema<PBOnPointerDown>, PBOnPointerDown>;
 
 /** @public */
-declare const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>>;
+declare const OnPointerDownResult: ComponentDefinition<ISchema<PBOnPointerDownResult>, PBOnPointerDownResult>;
 
 /** @public */
-declare const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>>;
+declare const OnPointerUp: ComponentDefinition<ISchema<PBOnPointerUp>, PBOnPointerUp>;
 
 /** @public */
-declare const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>>;
+declare const OnPointerUpResult: ComponentDefinition<ISchema<PBOnPointerUpResult>, PBOnPointerUpResult>;
 
 /**
  * Defines potential orientation for back face culling
@@ -2651,10 +1785,10 @@ declare namespace Plane {
 }
 
 /** @public */
-declare const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>>;
+declare const PlaneShape: ComponentDefinition<ISchema<PBPlaneShape>, PBPlaneShape>;
 
 /** @public */
-declare const PointerLock: ComponentDefinition<ISchema<PBPointerLock>>;
+declare const PointerLock: ComponentDefinition<ISchema<PBPointerLock>, PBPointerLock>;
 
 /**
  * @public
@@ -2889,10 +2023,10 @@ declare interface Spec {
 }
 
 /** @public */
-declare const SphereShape: ComponentDefinition<ISchema<PBSphereShape>>;
+declare const SphereShape: ComponentDefinition<ISchema<PBSphereShape>, PBSphereShape>;
 
 /** @public */
-declare const TextShape: ComponentDefinition<ISchema<PBTextShape>>;
+declare const TextShape: ComponentDefinition<ISchema<PBTextShape>, PBTextShape>;
 
 /**
  * Constant used to convert a value to gamma space
@@ -2909,476 +2043,43 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: {
-    create(entity: Entity, val?: {
-        position?: {
-            x: number;
-            y: number;
-            z: number;
-        } | undefined;
-        rotation?: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        } | undefined;
-        scale?: {
-            x: number;
-            y: number;
-            z: number;
-        } | undefined;
-        parent?: Entity | undefined;
-    } | undefined): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    _id: number;
-    default(): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>;
-    has(entity: Entity): boolean;
-    get(entity: Entity): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>;
-    getOrNull(entity: Entity): DeepReadonly<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }> | null;
-    createOrReplace(entity: Entity, val?: {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | undefined): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    deleteFrom(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    getMutable(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    };
-    getMutableOrNull(entity: Entity): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    upsertFromBinary(entity: Entity, data: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    updateFromBinary(entity: Entity, data: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    } | null;
-    toBinary(entity: Entity): {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    };
-    writeToByteBuffer(entity: Entity, buffer: {
-        buffer(): Uint8Array;
-        bufferLength(): number;
-        resetBuffer(): void;
-        currentReadOffset(): number;
-        currentWriteOffset(): number;
-        incrementReadOffset(amount: number): number;
-        remainingBytes(): number;
-        readFloat32(): number;
-        readFloat64(): number;
-        readInt8(): number;
-        readInt16(): number;
-        readInt32(): number;
-        readInt64(): bigint;
-        readUint8(): number;
-        readUint16(): number;
-        readUint32(): number;
-        readUint64(): bigint;
-        readBuffer(): Uint8Array;
-        incrementWriteOffset(amount: number): number;
-        size(): number;
-        toBinary(): Uint8Array;
-        toCopiedBinary(): Uint8Array;
-        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
-        writeFloat32(value: number): void;
-        writeFloat64(value: number): void;
-        writeInt8(value: number): void;
-        writeInt16(value: number): void;
-        writeInt32(value: number): void;
-        writeInt64(value: bigint): void;
-        writeUint8(value: number): void;
-        writeUint16(value: number): void;
-        writeUint32(value: number): void;
-        writeUint64(value: bigint): void;
-        getFloat32(offset: number): number;
-        getFloat64(offset: number): number;
-        getInt8(offset: number): number;
-        getInt16(offset: number): number;
-        getInt32(offset: number): number;
-        getInt64(offset: number): bigint;
-        getUint8(offset: number): number;
-        getUint16(offset: number): number;
-        getUint32(offset: number): number;
-        getUint64(offset: number): bigint;
-        setFloat32(offset: number, value: number): void;
-        setFloat64(offset: number, value: number): void;
-        setInt8(offset: number, value: number): void;
-        setInt16(offset: number, value: number): void;
-        setInt32(offset: number, value: number): void;
-        setInt64(offset: number, value: bigint): void;
-        setUint8(offset: number, value: number): void;
-        setUint16(offset: number, value: number): void;
-        setUint32(offset: number, value: number): void;
-        setUint64(offset: number, value: bigint): void;
-    }): void;
-    iterator(): Iterable<[Entity, {
-        position: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        rotation: {
-            x: number;
-            y: number;
-            z: number;
-            w: number;
-        };
-        scale: {
-            x: number;
-            y: number;
-            z: number;
-        };
-        parent?: Entity | undefined;
-    }]>;
-    dirtyIterator(): Iterable<Entity>;
-    clearDirty(): void;
-    isDirty(entity: Entity): boolean;
+declare const Transform: ComponentDefinition<ISchema<    {
+position: {
+x: number;
+y: number;
+z: number;
 };
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
+}>, Partial<{
+position: {
+x: number;
+y: number;
+z: number;
+};
+rotation: {
+x: number;
+y: number;
+z: number;
+w: number;
+};
+scale: {
+x: number;
+y: number;
+z: number;
+};
+parent?: Entity | undefined;
+}>>;
 
 declare type Transport = {
     type: string;

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -194,26 +194,476 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>> = {
 /** @public */
 declare namespace Components {
     /** @public */
-    const Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
+    const Transform: {
+        create(entity: Entity, val?: {
+            position?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            rotation?: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            } | undefined;
+            scale?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        _id: number;
+        default(): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        has(entity: Entity): boolean;
+        get(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        getOrNull(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }> | null;
+        createOrReplace(entity: Entity, val?: {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        deleteFrom(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        getMutable(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        getMutableOrNull(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        upsertFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        updateFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        toBinary(entity: Entity): {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        };
+        writeToByteBuffer(entity: Entity, buffer: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): void;
+        iterator(): Iterable<[Entity, {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        }]>;
+        dirtyIterator(): Iterable<Entity>;
+        clearDirty(): void;
+        isDirty(entity: Entity): boolean;
     };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    /** @public */
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>>;
     /** @public */
     const Animator: ComponentDefinition<ISchema<PBAnimator>>;
     /** @public */
@@ -416,25 +866,476 @@ declare type DeepReadonly<T> = {
 };
 
 declare function defineLibraryComponents({ defineComponentFromSchema }: Pick<IEngine, 'defineComponentFromSchema'>): {
-    Transform: ComponentDefinition<ISchema<    {
-    position: {
-    x: number;
-    y: number;
-    z: number;
+    Transform: {
+        create(entity: Entity, val?: {
+            position?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            rotation?: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            } | undefined;
+            scale?: {
+                x: number;
+                y: number;
+                z: number;
+            } | undefined;
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        _id: number;
+        default(): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        has(entity: Entity): boolean;
+        get(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }>;
+        getOrNull(entity: Entity): DeepReadonly<    {
+        position: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        rotation: {
+        x: number;
+        y: number;
+        z: number;
+        w: number;
+        };
+        scale: {
+        x: number;
+        y: number;
+        z: number;
+        };
+        parent?: Entity | undefined;
+        }> | null;
+        createOrReplace(entity: Entity, val?: {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | undefined): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        deleteFrom(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        getMutable(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        };
+        getMutableOrNull(entity: Entity): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        upsertFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        updateFromBinary(entity: Entity, data: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        } | null;
+        toBinary(entity: Entity): {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        };
+        writeToByteBuffer(entity: Entity, buffer: {
+            buffer(): Uint8Array;
+            bufferLength(): number;
+            resetBuffer(): void;
+            currentReadOffset(): number;
+            currentWriteOffset(): number;
+            incrementReadOffset(amount: number): number;
+            remainingBytes(): number;
+            readFloat32(): number;
+            readFloat64(): number;
+            readInt8(): number;
+            readInt16(): number;
+            readInt32(): number;
+            readInt64(): bigint;
+            readUint8(): number;
+            readUint16(): number;
+            readUint32(): number;
+            readUint64(): bigint;
+            readBuffer(): Uint8Array;
+            incrementWriteOffset(amount: number): number;
+            size(): number;
+            toBinary(): Uint8Array;
+            toCopiedBinary(): Uint8Array;
+            writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+            writeFloat32(value: number): void;
+            writeFloat64(value: number): void;
+            writeInt8(value: number): void;
+            writeInt16(value: number): void;
+            writeInt32(value: number): void;
+            writeInt64(value: bigint): void;
+            writeUint8(value: number): void;
+            writeUint16(value: number): void;
+            writeUint32(value: number): void;
+            writeUint64(value: bigint): void;
+            getFloat32(offset: number): number;
+            getFloat64(offset: number): number;
+            getInt8(offset: number): number;
+            getInt16(offset: number): number;
+            getInt32(offset: number): number;
+            getInt64(offset: number): bigint;
+            getUint8(offset: number): number;
+            getUint16(offset: number): number;
+            getUint32(offset: number): number;
+            getUint64(offset: number): bigint;
+            setFloat32(offset: number, value: number): void;
+            setFloat64(offset: number, value: number): void;
+            setInt8(offset: number, value: number): void;
+            setInt16(offset: number, value: number): void;
+            setInt32(offset: number, value: number): void;
+            setInt64(offset: number, value: bigint): void;
+            setUint8(offset: number, value: number): void;
+            setUint16(offset: number, value: number): void;
+            setUint32(offset: number, value: number): void;
+            setUint64(offset: number, value: bigint): void;
+        }): void;
+        iterator(): Iterable<[Entity, {
+            position: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            rotation: {
+                x: number;
+                y: number;
+                z: number;
+                w: number;
+            };
+            scale: {
+                x: number;
+                y: number;
+                z: number;
+            };
+            parent?: Entity | undefined;
+        }]>;
+        dirtyIterator(): Iterable<Entity>;
+        clearDirty(): void;
+        isDirty(entity: Entity): boolean;
     };
-    rotation: {
-    x: number;
-    y: number;
-    z: number;
-    w: number;
-    };
-    scale: {
-    x: number;
-    y: number;
-    z: number;
-    };
-    parent?: Entity | undefined;
-    }>>;
     Animator: ComponentDefinition<ISchema<PBAnimator>>;
     AudioSource: ComponentDefinition<ISchema<PBAudioSource>>;
     AvatarAttach: ComponentDefinition<ISchema<PBAvatarAttach>>;
@@ -2008,25 +2909,476 @@ declare const ToLinearSpace = 2.2;
 declare type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
 /** @public */
-declare const Transform: ComponentDefinition<ISchema<    {
-position: {
-x: number;
-y: number;
-z: number;
+declare const Transform: {
+    create(entity: Entity, val?: {
+        position?: {
+            x: number;
+            y: number;
+            z: number;
+        } | undefined;
+        rotation?: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        } | undefined;
+        scale?: {
+            x: number;
+            y: number;
+            z: number;
+        } | undefined;
+        parent?: Entity | undefined;
+    } | undefined): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    _id: number;
+    default(): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>;
+    has(entity: Entity): boolean;
+    get(entity: Entity): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }>;
+    getOrNull(entity: Entity): DeepReadonly<    {
+    position: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    rotation: {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+    };
+    scale: {
+    x: number;
+    y: number;
+    z: number;
+    };
+    parent?: Entity | undefined;
+    }> | null;
+    createOrReplace(entity: Entity, val?: {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | undefined): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    deleteFrom(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    getMutable(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    };
+    getMutableOrNull(entity: Entity): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    upsertFromBinary(entity: Entity, data: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    updateFromBinary(entity: Entity, data: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    } | null;
+    toBinary(entity: Entity): {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    };
+    writeToByteBuffer(entity: Entity, buffer: {
+        buffer(): Uint8Array;
+        bufferLength(): number;
+        resetBuffer(): void;
+        currentReadOffset(): number;
+        currentWriteOffset(): number;
+        incrementReadOffset(amount: number): number;
+        remainingBytes(): number;
+        readFloat32(): number;
+        readFloat64(): number;
+        readInt8(): number;
+        readInt16(): number;
+        readInt32(): number;
+        readInt64(): bigint;
+        readUint8(): number;
+        readUint16(): number;
+        readUint32(): number;
+        readUint64(): bigint;
+        readBuffer(): Uint8Array;
+        incrementWriteOffset(amount: number): number;
+        size(): number;
+        toBinary(): Uint8Array;
+        toCopiedBinary(): Uint8Array;
+        writeBuffer(value: Uint8Array, writeLength?: boolean): void;
+        writeFloat32(value: number): void;
+        writeFloat64(value: number): void;
+        writeInt8(value: number): void;
+        writeInt16(value: number): void;
+        writeInt32(value: number): void;
+        writeInt64(value: bigint): void;
+        writeUint8(value: number): void;
+        writeUint16(value: number): void;
+        writeUint32(value: number): void;
+        writeUint64(value: bigint): void;
+        getFloat32(offset: number): number;
+        getFloat64(offset: number): number;
+        getInt8(offset: number): number;
+        getInt16(offset: number): number;
+        getInt32(offset: number): number;
+        getInt64(offset: number): bigint;
+        getUint8(offset: number): number;
+        getUint16(offset: number): number;
+        getUint32(offset: number): number;
+        getUint64(offset: number): bigint;
+        setFloat32(offset: number, value: number): void;
+        setFloat64(offset: number, value: number): void;
+        setInt8(offset: number, value: number): void;
+        setInt16(offset: number, value: number): void;
+        setInt32(offset: number, value: number): void;
+        setInt64(offset: number, value: bigint): void;
+        setUint8(offset: number, value: number): void;
+        setUint16(offset: number, value: number): void;
+        setUint32(offset: number, value: number): void;
+        setUint64(offset: number, value: bigint): void;
+    }): void;
+    iterator(): Iterable<[Entity, {
+        position: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        rotation: {
+            x: number;
+            y: number;
+            z: number;
+            w: number;
+        };
+        scale: {
+            x: number;
+            y: number;
+            z: number;
+        };
+        parent?: Entity | undefined;
+    }]>;
+    dirtyIterator(): Iterable<Entity>;
+    clearDirty(): void;
+    isDirty(entity: Entity): boolean;
 };
-rotation: {
-x: number;
-y: number;
-z: number;
-w: number;
-};
-scale: {
-x: number;
-y: number;
-z: number;
-};
-parent?: Entity | undefined;
-}>>;
 
 declare type Transport = {
     type: string;

--- a/test/build-ecs/fixtures/ecs7-scene/game.ts
+++ b/test/build-ecs/fixtures/ecs7-scene/game.ts
@@ -18,9 +18,7 @@ function createCube(x: number, y: number, z: number) {
   const myEntity = engine.addEntity()
 
   Transform.create(myEntity, {
-    position: { x, y, z },
-    scale: { x: 1, y: 1, z: 1 },
-    rotation: { x: 0, y: 0, z: 0, w: 1 }
+    position: { x, y, z }
   })
 
   BoxShape.create(myEntity, {


### PR DESCRIPTION
# What?
Create a wrapper for the Transform definition. Now, the fields are optional and you can pass only the position if you wish.

```ts
// now
Transform.create(entity) // ok => create the default transform
Transform.create(entity, { position: { x: 1, y: 2, z: 3} }) // wrong, all fields are mandatory (even if the value that I'd put them are the defaults)
 
// now
Transform.create(entity, { position: { x: 1, y: 2, z: 3} }) => ok, the other fields are filled within default ones

```