### PR TITLE
Fix playground/react types

### DIFF
--- a/packages/@dcl/ecs/src/runtime/MessageBus.ts
+++ b/packages/@dcl/ecs/src/runtime/MessageBus.ts
@@ -107,7 +107,7 @@ export class MessageBus {
         this.flushing = false
         this.flush()
       },
-      (e) => {
+      (_) => {
         this.flushing = false
       }
     )

--- a/packages/@dcl/react-ecs/etc/react-ecs.api.md
+++ b/packages/@dcl/react-ecs/etc/react-ecs.api.md
@@ -238,21 +238,23 @@ export type Position = {
 // Warning: (ae-missing-release-tag) "ReactEcs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export namespace ReactEcs {
+namespace ReactEcs {
     // (undocumented)
-    export namespace JSX {
+    namespace JSX {
         // (undocumented)
-        export interface Component {
+        interface Component {
         }
         // (undocumented)
-        export interface Element {
+        interface Element {
         }
         // (undocumented)
-        export type IntrinsicElements = EcsElements;
+        type IntrinsicElements = EcsElements;
     }
     const // (undocumented)
     createElement: any;
 }
+export { ReactEcs }
+export default ReactEcs;
 
 // Warning: (ae-missing-release-tag) "removeUi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/@dcl/react-ecs/src/index.ts
+++ b/packages/@dcl/react-ecs/src/index.ts
@@ -1,7 +1,7 @@
 import { ReactEcs } from './react-ecs'
-;(globalThis as any).ReactEcs = ReactEcs
 
 export * from './components'
 export * from './system'
 export * from './react-ecs'
 
+export default ReactEcs

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -1,11 +1,5 @@
 import { readFileSync, writeFileSync } from 'fs'
-import {
-  copyFileSync,
-  copySync,
-  existsSync,
-  mkdirSync,
-  removeSync
-} from 'fs-extra'
+import { copySync, mkdirSync, removeSync } from 'fs-extra'
 
 import {
   BUILD_ECS_PATH,
@@ -26,8 +20,7 @@ import {
   itDeletesFolder,
   itDeletesGlob,
   itExecutes,
-  runCommand,
-  waitForFileExist
+  runCommand
 } from './helpers'
 import { compileEcsComponents } from './protocol-buffer-generation'
 
@@ -243,7 +236,7 @@ flow('build-all', () => {
           fileName: 'index.min.js'
         },
         {
-          from: path.resolve(SDK_PATH, 'dist', 'ecs7', 'index.d.ts'),
+          from: path.resolve(SDK_PATH, 'types', 'ecs7', 'index.d.ts'),
           fileName: 'index.d.ts'
         },
         {
@@ -255,27 +248,11 @@ flow('build-all', () => {
           fileName: 'react-ecs.index.d.ts'
         }
       ]
-
-      // Wait until ecs is built
-      const timeoutExists = 180 * 1000
-      const result = await Promise.all(
-        filesToCopy.map((filePath) =>
-          waitForFileExist(filePath.from, timeoutExists)
-        )
-      )
-
-      if (result.some((item) => item === true)) {
-        throw new Error(
-          'Timeout waiting for the files in the playground folder build.'
-        )
-      }
-
       const distPlaygroundSdkPath = path.resolve(playgroundDistPath, 'sdk')
-      mkdirSync(distPlaygroundSdkPath)
       for (const file of filesToCopy) {
         const filePath = ensureFileExists(file.from)
         const destPath = path.resolve(distPlaygroundSdkPath, file.fileName)
-        copyFileSync(filePath, destPath)
+        copyFile(filePath, destPath)
       }
     })
   })

--- a/test/build-ecs/fixtures/ecs7-scene/package-lock.json
+++ b/test/build-ecs/fixtures/ecs7-scene/package-lock.json
@@ -17,8 +17,8 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/amd": "0.0.0",
-        "@dcl/build-ecs": "0.0.0",
+        "@dcl/amd": "file:../amd",
+        "@dcl/build-ecs": "file:../build-ecs",
         "@dcl/kernel": "1.0.0-2994874542.commit-c3ae489",
         "@dcl/posix": "^1.0.4",
         "@dcl/schemas": "4.8.0",
@@ -37,8 +37,8 @@
     "@dcl/sdk": {
       "version": "file:../../../../packages/@dcl/sdk",
       "requires": {
-        "@dcl/amd": "0.0.0",
-        "@dcl/build-ecs": "0.0.0",
+        "@dcl/amd": "file:../amd",
+        "@dcl/build-ecs": "file:../build-ecs",
         "@dcl/kernel": "1.0.0-2994874542.commit-c3ae489",
         "@dcl/posix": "^1.0.4",
         "@dcl/schemas": "4.8.0",


### PR DESCRIPTION
## What  ??
Fix ecs & react types generated for the playground

## Why ??
We were bundling the incorrect file for ecs7 types.
Also there were some errors on the react-ecs typings, with some missing exports.