### PR TITLE
fix: createOrReplace constructor type

### DIFF
--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -64,7 +64,7 @@ export type ComponentDefinition<T extends ISchema = ISchema<any>, ConstructorTyp
     get(entity: Entity): DeepReadonly<ComponentType<T>>;
     getOrNull(entity: Entity): DeepReadonly<ComponentType<T>> | null;
     create(entity: Entity, val?: ConstructorType): ComponentType<T>;
-    createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>;
     deleteFrom(entity: Entity): ComponentType<T> | null;
     getMutable(entity: Entity): ComponentType<T>;
     getMutableOrNull(entity: Entity): ComponentType<T> | null;

--- a/packages/@dcl/ecs/src/engine/component.ts
+++ b/packages/@dcl/ecs/src/engine/component.ts
@@ -104,7 +104,7 @@ export type ComponentDefinition<
    * Transform.createOrReplace(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
    * ````
    */
-  createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>
+  createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>
 
   /**
    * Delete the current component to an entity, return null if the entity doesn't have the current component.

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -164,7 +164,7 @@ declare type ComponentDefinition<T extends ISchema = ISchema<any>, ConstructorTy
      * Transform.createOrReplace(myEntity, { ...Transform.default(), position: {x: 4, y: 0, z: 4} }) // ok!
      * ````
      */
-    createOrReplace(entity: Entity, val?: ComponentType<T>): ComponentType<T>;
+    createOrReplace(entity: Entity, val?: ConstructorType): ComponentType<T>;
     /**
      * Delete the current component to an entity, return null if the entity doesn't have the current component.
      * - Internal comment: This method adds the <entity,component> to the list to be reviewed next frame


### PR DESCRIPTION
Fix the types mismatch between `create` and `createOrReplace`.

Example:
![image](https://user-images.githubusercontent.com/8042536/193804220-3f600023-e5f7-4ac8-9035-faea37b47f6a.png)
