### PR TITLE
feat: add math schemas to global namespace Schemas

### DIFF
--- a/packages/@dcl/ecs/etc/ecs.api.md
+++ b/packages/@dcl/ecs/etc/ecs.api.md
@@ -693,6 +693,22 @@ export namespace Schemas {
     Int64: ISchema<number>;
     const // (undocumented)
     Number: ISchema<number>;
+    const // Warning: (ae-forgotten-export) The symbol "Vector3Type" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    Vector3: ISchema<Vector3Type>;
+    const // Warning: (ae-forgotten-export) The symbol "QuaternionType" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    Quaternion: ISchema<QuaternionType>;
+    const // Warning: (ae-forgotten-export) The symbol "Color3Type" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    Color3: ISchema<Color3Type>;
+    const // Warning: (ae-forgotten-export) The symbol "Color4Type" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    Color4: ISchema<Color4Type>;
     const // Warning: (ae-forgotten-export) The symbol "IEnum" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/@dcl/ecs/src/schemas/custom/Color3.ts
+++ b/packages/@dcl/ecs/src/schemas/custom/Color3.ts
@@ -1,0 +1,28 @@
+import { ByteBuffer } from '../../serialization/ByteBuffer'
+import { ISchema } from '../ISchema'
+
+/**
+ * @public
+ */
+export type Color3Type = { r: number; g: number; b: number }
+
+/**
+ * @public
+ */
+export const Color3Schema: ISchema<Color3Type> = {
+  serialize(value: Color3Type, builder: ByteBuffer): void {
+    builder.writeFloat32(value.r)
+    builder.writeFloat32(value.g)
+    builder.writeFloat32(value.b)
+  },
+  deserialize(reader: ByteBuffer): Color3Type {
+    return {
+      r: reader.readFloat32(),
+      g: reader.readFloat32(),
+      b: reader.readFloat32()
+    }
+  },
+  create() {
+    return { r: 0, g: 0, b: 0 }
+  }
+}

--- a/packages/@dcl/ecs/src/schemas/custom/Color4.ts
+++ b/packages/@dcl/ecs/src/schemas/custom/Color4.ts
@@ -1,0 +1,30 @@
+import { ByteBuffer } from '../../serialization/ByteBuffer'
+import { ISchema } from '../ISchema'
+
+/**
+ * @public
+ */
+export type Color4Type = { r: number; g: number; b: number; a: number }
+
+/**
+ * @public
+ */
+export const Color4Schema: ISchema<Color4Type> = {
+  serialize(value: Color4Type, builder: ByteBuffer): void {
+    builder.writeFloat32(value.r)
+    builder.writeFloat32(value.g)
+    builder.writeFloat32(value.b)
+    builder.writeFloat32(value.a)
+  },
+  deserialize(reader: ByteBuffer): Color4Type {
+    return {
+      r: reader.readFloat32(),
+      g: reader.readFloat32(),
+      b: reader.readFloat32(),
+      a: reader.readFloat32()
+    }
+  },
+  create() {
+    return { r: 0, g: 0, b: 0, a: 0 }
+  }
+}

--- a/packages/@dcl/ecs/src/schemas/custom/Quaternion.ts
+++ b/packages/@dcl/ecs/src/schemas/custom/Quaternion.ts
@@ -1,0 +1,30 @@
+import { ByteBuffer } from '../../serialization/ByteBuffer'
+import { ISchema } from '../ISchema'
+
+/**
+ * @public
+ */
+export type QuaternionType = { x: number; y: number; z: number; w: number }
+
+/**
+ * @public
+ */
+export const QuaternionSchema: ISchema<QuaternionType> = {
+  serialize(value: QuaternionType, builder: ByteBuffer): void {
+    builder.writeFloat32(value.x)
+    builder.writeFloat32(value.y)
+    builder.writeFloat32(value.z)
+    builder.writeFloat32(value.w)
+  },
+  deserialize(reader: ByteBuffer): QuaternionType {
+    return {
+      x: reader.readFloat32(),
+      y: reader.readFloat32(),
+      z: reader.readFloat32(),
+      w: reader.readFloat32()
+    }
+  },
+  create() {
+    return { x: 0, y: 0, z: 0, w: 0 }
+  }
+}

--- a/packages/@dcl/ecs/src/schemas/custom/Vector3.ts
+++ b/packages/@dcl/ecs/src/schemas/custom/Vector3.ts
@@ -1,0 +1,28 @@
+import { ByteBuffer } from '../../serialization/ByteBuffer'
+import { ISchema } from '../ISchema'
+
+/**
+ * @public
+ */
+export type Vector3Type = { x: number; y: number; z: number }
+
+/**
+ * @public
+ */
+export const Vector3Schema: ISchema<Vector3Type> = {
+  serialize(value: Vector3Type, builder: ByteBuffer): void {
+    builder.writeFloat32(value.x)
+    builder.writeFloat32(value.y)
+    builder.writeFloat32(value.z)
+  },
+  deserialize(reader: ByteBuffer): Vector3Type {
+    return {
+      x: reader.readFloat32(),
+      y: reader.readFloat32(),
+      z: reader.readFloat32()
+    }
+  },
+  create() {
+    return { x: 0, y: 0, z: 0 }
+  }
+}

--- a/packages/@dcl/ecs/src/schemas/index.ts
+++ b/packages/@dcl/ecs/src/schemas/index.ts
@@ -4,6 +4,10 @@ import { IEnum } from './basic/Enum'
 import { Float32, Float64 } from './basic/Float'
 import { Int16, Int32, Int8, Int64 as iInt64 } from './basic/Integer'
 import { EcsString } from './basic/String'
+import { Color3Schema } from './custom/Color3'
+import { Color4Schema } from './custom/Color4'
+import { QuaternionSchema } from './custom/Quaternion'
+import { Vector3Schema } from './custom/Vector3'
 import { ISchema } from './ISchema'
 import { IMap } from './Map'
 import { IOptional } from './Optional'
@@ -27,6 +31,11 @@ export namespace Schemas {
   export const Int64 = iInt64
 
   export const Number = Float32
+
+  export const Vector3 = Vector3Schema
+  export const Quaternion = QuaternionSchema
+  export const Color3 = Color3Schema
+  export const Color4 = Color4Schema
 
   export const Enum = IEnum
   export const Array = IArray

--- a/packages/@dcl/sdk/types/ecs7/index.d.ts
+++ b/packages/@dcl/sdk/types/ecs7/index.d.ts
@@ -416,6 +416,15 @@ declare interface Color3_2 {
 
 /**
  * @public
+ */
+declare type Color3Type = {
+    r: number;
+    g: number;
+    b: number;
+};
+
+/**
+ * @public
  * Color4 is a type and a namespace.
  * - The namespace contains all types and functions to operates with Color4
  * - The type Color4 is an alias to Color4.ReadonlyColor4
@@ -758,6 +767,16 @@ declare interface Color4_2 {
     b: number;
     a: number;
 }
+
+/**
+ * @public
+ */
+declare type Color4Type = {
+    r: number;
+    g: number;
+    b: number;
+    a: number;
+};
 
 /**
  * @public
@@ -3274,6 +3293,16 @@ declare namespace Quaternion {
 }
 
 /**
+ * @public
+ */
+declare type QuaternionType = {
+    x: number;
+    y: number;
+    z: number;
+    w: number;
+};
+
+/**
  * Constant used to convert from radians to Euler degrees
  * @public
  */
@@ -3536,6 +3565,10 @@ declare namespace Schemas {
     const Int: ISchema<number>;
     const Int64: ISchema<number>;
     const Number: ISchema<number>;
+    const Vector3: ISchema<Vector3Type>;
+    const Quaternion: ISchema<QuaternionType>;
+    const Color3: ISchema<Color3Type>;
+    const Color4: ISchema<Color4Type>;
     const Enum: typeof IEnum;
     const Array: typeof IArray;
     const Map: typeof IMap;
@@ -4241,6 +4274,15 @@ declare interface Vector3_2 {
     y: number;
     z: number;
 }
+
+/**
+ * @public
+ */
+declare type Vector3Type = {
+    x: number;
+    y: number;
+    z: number;
+};
 
 /** @public */
 declare const VisibilityComponent: ComponentDefinition<ISchema<PBVisibilityComponent>, PBVisibilityComponent>;

--- a/test/ecs/serialization.spec.ts
+++ b/test/ecs/serialization.spec.ts
@@ -426,4 +426,31 @@ describe('Serialization Types', () => {
       d: 12
     })
   })
+
+  it('should serialize and deserialize math schemas', () => {
+    const engine = Engine()
+    const entity = engine.addEntity()
+    const MixComponent = engine.defineComponent(
+      {
+        v3: Schemas.Vector3,
+        q: Schemas.Quaternion,
+        c3: Schemas.Color3,
+        c4: Schemas.Color4
+      },
+      1222
+    )
+
+    const originalValue = MixComponent.create(entity, {
+      c3: { r: 0.1, g: 0.2, b: 0.3 },
+      c4: { r: 0.4, g: 0.5, b: 0.6, a: 0.7 },
+      q: { x: 0.8, y: 0.9, z: 1.0, w: 1.1 },
+      v3: { x: 1.2, y: 1.3, z: 1.4 }
+    })
+
+    const entityB = engine.addEntity()
+    const buf = MixComponent.toBinary(entity)
+    const value = MixComponent.upsertFromBinary(entityB, buf)
+
+    expect(value).toBeDeepCloseTo(originalValue)
+  })
 })


### PR DESCRIPTION
# What?
Add `Vector3`, `Quaternion`, `Color3` and `Color4` schemas to namespace `Schemas`

