### PR TITLE
Add '--move-out' parametet to init command

### DIFF
--- a/packages/@dcl/sdk/cli/commands/init/repos.ts
+++ b/packages/@dcl/sdk/cli/commands/init/repos.ts
@@ -1,5 +1,17 @@
-export const REPOS = {
-  'scene-template': 'https://github.com/decentraland/sdk7-scene-template/archive/refs/heads/main.zip'
+type Scene = 'scene-template'
+
+type Repos = {
+  [key in Scene]: {
+    url: string
+    contentFolders: string[]
+  }
 }
 
-export const get = (repo: keyof typeof REPOS) => REPOS[repo]
+const REPOS: Repos = {
+  'scene-template': {
+    url: 'https://github.com/decentraland/sdk7-scene-template/archive/refs/heads/main.zip',
+    contentFolders: ['sdk7-scene-template-main']
+  }
+}
+
+export const get = (scene: Scene): Repos[Scene] => REPOS[scene]

--- a/packages/@dcl/sdk/cli/components/fs.ts
+++ b/packages/@dcl/sdk/cli/components/fs.ts
@@ -8,7 +8,10 @@ import * as fsPromises from 'fs/promises'
  */
 export type IFileSystemComponent = Pick<typeof fs, 'createReadStream'> &
   Pick<typeof fs, 'createWriteStream'> &
-  Pick<typeof fsPromises, 'access' | 'opendir' | 'stat' | 'unlink' | 'mkdir' | 'readFile' | 'writeFile'> & {
+  Pick<
+    typeof fsPromises,
+    'access' | 'opendir' | 'stat' | 'unlink' | 'mkdir' | 'readFile' | 'writeFile' | 'rename' | 'rmdir'
+  > & {
     constants: Pick<typeof fs.constants, 'F_OK' | 'R_OK'>
   } & {
     existPath(path: string): Promise<boolean>
@@ -37,12 +40,14 @@ export function createFsComponent(): IFileSystemComponent {
     stat: fsPromises.stat,
     unlink: fsPromises.unlink,
     mkdir: fsPromises.mkdir,
+    rmdir: fsPromises.rmdir,
     readdir: fsPromises.readdir,
     readFile: fsPromises.readFile,
     constants: {
       F_OK: fs.constants.F_OK,
       R_OK: fs.constants.R_OK
     },
+    rename: fsPromises.rename,
     existPath
   }
 }

--- a/packages/@dcl/sdk/cli/index.ts
+++ b/packages/@dcl/sdk/cli/index.ts
@@ -48,7 +48,7 @@ const commandFnsAreValid = (fns: FileExports): fns is Required<FileExports> => {
 }
 
 const args = getArgs()
-const helpMessage = (commands: string[]) => `Here is the list of commands: ${listCommandsStr(commands)}`
+const helpMessage = (commands: string[]) => `Here is the list of commands:\n${listCommandsStr(commands)}`
 
 ;(async () => {
   const command = process.argv[2]

--- a/packages/@dcl/sdk/cli/utils/fs.ts
+++ b/packages/@dcl/sdk/cli/utils/fs.ts
@@ -36,6 +36,6 @@ export async function download(
  */
 export async function extract(path: string, dest: string): Promise<string> {
   const destPath = resolve(dest)
-  await extractZip(path, { dir: destPath })
+  await extractZip(resolve(path), { dir: destPath })
   return destPath
 }

--- a/test/sdk/cli/commands/init/index.spec.ts
+++ b/test/sdk/cli/commands/init/index.spec.ts
@@ -39,6 +39,9 @@ describe('init command', () => {
     const downloadSpy = jest.spyOn(fsUtils, 'download').mockResolvedValue('1')
     const extractSpy = jest.spyOn(fsUtils, 'extract').mockImplementation()
     const removeSpy = jest.spyOn(components.fs, 'unlink').mockImplementation()
+    jest.spyOn(components.fs, 'readdir').mockResolvedValue(['test'])
+    jest.spyOn(components.fs, 'rename').mockImplementation()
+    jest.spyOn(components.fs, 'rmdir').mockImplementation()
 
     await init.main({ args: { _: [] }, components })
 
@@ -54,6 +57,9 @@ describe('init command', () => {
     const downloadSpy = jest.spyOn(fsUtils, 'download').mockImplementation()
     const extractSpy = jest.spyOn(fsUtils, 'extract').mockImplementation()
     const removeSpy = jest.spyOn(components.fs, 'unlink').mockImplementation()
+    jest.spyOn(components.fs, 'readdir').mockResolvedValue(['test'])
+    jest.spyOn(components.fs, 'rename').mockImplementation()
+    jest.spyOn(components.fs, 'rmdir').mockImplementation()
 
     await init.main({ args: { _: [], '--yes': true }, components })
 
@@ -61,6 +67,27 @@ describe('init command', () => {
     expect(downloadSpy).toBeCalled()
     expect(extractSpy).toBeCalled()
     expect(removeSpy).toBeCalled()
+  })
+
+  it('main: should move files out of dirs', async () => {
+    const components = initComponents()
+    const confirmSpy = jest.spyOn(prompt, 'confirm')
+    const downloadSpy = jest.spyOn(fsUtils, 'download').mockImplementation()
+    const extractSpy = jest.spyOn(fsUtils, 'extract').mockImplementation()
+    const removeSpy = jest.spyOn(components.fs, 'unlink').mockImplementation()
+    const readdirSpy = jest.spyOn(components.fs, 'readdir').mockResolvedValue(['test'])
+    const renameSpy = jest.spyOn(components.fs, 'rename').mockImplementation()
+    const rmdirSpy = jest.spyOn(components.fs, 'rmdir').mockImplementation()
+
+    await init.main({ args: { _: [], '--yes': true }, components })
+
+    expect(confirmSpy).not.toBeCalled()
+    expect(downloadSpy).toBeCalled()
+    expect(extractSpy).toBeCalled()
+    expect(removeSpy).toBeCalled()
+    expect(readdirSpy).toBeCalled()
+    expect(renameSpy).toBeCalled()
+    expect(rmdirSpy).toBeCalled()
   })
 
   it('main: should throw if something wrong happens', async () => {

--- a/test/sdk/cli/utils/fs.spec.ts
+++ b/test/sdk/cli/utils/fs.spec.ts
@@ -3,7 +3,7 @@ import * as extractZip from '../../../../packages/@dcl/sdk/node_modules/extract-
 import * as fsUtils from '../../../../packages/@dcl/sdk/cli/utils/fs'
 import { createFsComponent } from '../../../../packages/@dcl/sdk/cli/components/fs'
 import { createFetchComponent } from '../../../../packages/@dcl/sdk/cli/components/fetch'
-import path from 'path'
+import path, { resolve } from 'path'
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -40,8 +40,8 @@ describe('utils/fs', () => {
     const dist = await fsUtils.extract('some/path', './other/path')
 
     expect(dist).toBe(path.resolve('./other/path'))
-    expect(extractSpy).toBeCalledWith('some/path', {
-      dir: dist
+    expect(extractSpy).toBeCalledWith(resolve('some/path'), {
+      dir: resolve(dist)
     })
   })
 })


### PR DESCRIPTION
New `--move-out` parameter for init command to move files out of the templates folders.

EX: 
1. Clone `https://github.com/decentraland/sdk7-scene-template/archive/refs/heads/main.zip`
2. Extract
3. You will now have a folder with the scene files inside (folder name doesn't matter)

If the user provides the `--move-out` parameter, it will move those files out of that folder, if the user doesn't provide it, it will leave the directory structure as it is.