### PR TITLE
fix: revert isTriggered `entity` param to optional

### DIFF
--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -915,7 +915,7 @@ export interface IEvents {
 
 // @public (undocumented)
 export type IInputSystem = {
-    isTriggered: (inputAction: InputAction, pointerEventType: PointerEventType, entity: Entity) => boolean;
+    isTriggered: (inputAction: InputAction, pointerEventType: PointerEventType, entity?: Entity) => boolean;
     isPressed: (inputAction: InputAction) => boolean;
     getInputCommand: (inputAction: InputAction, pointerEventType: PointerEventType, entity: Entity) => PBPointerEventsResult | null;
 };

--- a/test/ecs/events/isPressed.spec.ts
+++ b/test/ecs/events/isPressed.spec.ts
@@ -73,6 +73,45 @@ describe('Events helpers isTriggered', () => {
   })
 })
 
+describe('Global Events helpers isTriggered', () => {
+  it('should detect no events', () => {
+    const newEngine = Engine()
+    const { isTriggered } = createInputSystem(newEngine)
+    expect(isTriggered(InputAction.IA_ANY, PointerEventType.PET_DOWN)).toBe(false)
+  })
+
+  it('detect pointerEvent', async () => {
+    const newEngine = Engine()
+    const PointerEventsResult = components.PointerEventsResult(newEngine)
+    const entity = newEngine.addEntity()
+    const { isTriggered } = createInputSystem(newEngine)
+    PointerEventsResult.addValue(entity, createTestPointerDownCommand(entity, 4, PointerEventType.PET_DOWN))
+
+    // we must run the systems to update the internal inputSystem state
+    await newEngine.update(1)
+
+    // then assert
+    expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN)).toBe(true)
+    expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_UP)).toBe(false)
+    expect(isTriggered(InputAction.IA_ACTION_3, PointerEventType.PET_UP)).toBe(false)
+  })
+
+  it('dont detect pointerEventActive after update', async () => {
+    const newEngine = Engine()
+    const PointerEventsResult = components.PointerEventsResult(newEngine)
+    const entity = newEngine.addEntity()
+    const { isTriggered } = createInputSystem(newEngine)
+    PointerEventsResult.addValue(entity, createTestPointerDownCommand(entity, 4, PointerEventType.PET_DOWN))
+
+    // we must run the systems to update the internal inputSystem state
+    await newEngine.update(1)
+    expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN)).toBe(true)
+
+    // in the next tick we will no-longer see the entity bing triggered==true
+    await newEngine.update(0)
+    expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN)).toBe(false)
+  })
+})
 function createTestPointerDownCommand(
   entity: Entity,
   timestamp: number,

--- a/test/snapshots/append-value-crdt.ts.crdt
+++ b/test/snapshots/append-value-crdt.ts.crdt
@@ -7,8 +7,8 @@ EVAL test/snapshots/append-value-crdt.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 15k
-  MALLOC_COUNT = 9850
-  ALIVE_OBJS_DELTA ~= 1.94k
+  MALLOC_COUNT = 9853
+  ALIVE_OBJS_DELTA ~= 1.95k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"origin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5}
   OPCODES ~= 8k
@@ -22,7 +22,7 @@ CALL onUpdate(0.0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"origin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5}
   OPCODES ~= 16k
-  MALLOC_COUNT = 81
+  MALLOC_COUNT = 82
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   LOG: ["PointerEventsResult",[{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"origin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5},{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"origin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5}]]
@@ -53,4 +53,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 14k
   MALLOC_COUNT = 33
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1017.49k bytes
+  MEMORY_USAGE_COUNT ~= 1018.97k bytes

--- a/test/snapshots/billboard.ts.crdt
+++ b/test/snapshots/billboard.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/billboard.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 25k
-  MALLOC_COUNT = 12373
+  MALLOC_COUNT = 12376
   ALIVE_OBJS_DELTA ~= 2.32k
 CALL onStart()
   OPCODES ~= 0k
@@ -75,4 +75,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 9k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1227.69k bytes
+  MEMORY_USAGE_COUNT ~= 1229.16k bytes

--- a/test/snapshots/cube-deleted.ts.crdt
+++ b/test/snapshots/cube-deleted.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/cube-deleted.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 10k
-  MALLOC_COUNT = 6065
+  MALLOC_COUNT = 6068
   ALIVE_OBJS_DELTA ~= 1.01k
 CALL onStart()
   OPCODES ~= 0k
@@ -40,4 +40,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 809.44k bytes
+  MEMORY_USAGE_COUNT ~= 810.92k bytes

--- a/test/snapshots/cube.ts.crdt
+++ b/test/snapshots/cube.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/cube.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 10k
-  MALLOC_COUNT = 6037
+  MALLOC_COUNT = 6040
   ALIVE_OBJS_DELTA ~= 1.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 798.74k bytes
+  MEMORY_USAGE_COUNT ~= 800.21k bytes

--- a/test/snapshots/cubes.ts.crdt
+++ b/test/snapshots/cubes.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/cubes.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 57k
-  MALLOC_COUNT = 13761
+  MALLOC_COUNT = 13764
   ALIVE_OBJS_DELTA ~= 3.36k
 CALL onStart()
   OPCODES ~= 0k
@@ -1650,4 +1650,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 615k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1182.92k bytes
+  MEMORY_USAGE_COUNT ~= 1184.40k bytes

--- a/test/snapshots/pointer-events.ts.crdt
+++ b/test/snapshots/pointer-events.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/pointer-events.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 16k
-  MALLOC_COUNT = 9571
+  MALLOC_COUNT = 9574
   ALIVE_OBJS_DELTA ~= 1.88k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 998.60k bytes
+  MEMORY_USAGE_COUNT ~= 1000.08k bytes

--- a/test/snapshots/schema-components.ts.crdt
+++ b/test/snapshots/schema-components.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/schema-components.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 13k
-  MALLOC_COUNT = 5069
+  MALLOC_COUNT = 5072
   ALIVE_OBJS_DELTA ~= 0.81k
 CALL onStart()
   OPCODES ~= 0k
@@ -29,4 +29,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 705.19k bytes
+  MEMORY_USAGE_COUNT ~= 706.66k bytes

--- a/test/snapshots/two-way-crdt.ts.crdt
+++ b/test/snapshots/two-way-crdt.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/two-way-crdt.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 11k
-  MALLOC_COUNT = 6402
+  MALLOC_COUNT = 6405
   ALIVE_OBJS_DELTA ~= 1.10k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -47,4 +47,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 812.77k bytes
+  MEMORY_USAGE_COUNT ~= 814.24k bytes

--- a/test/snapshots/ui.ts.crdt
+++ b/test/snapshots/ui.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/ui.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 24k
-  MALLOC_COUNT = 23089
+  MALLOC_COUNT = 23092
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -50,4 +50,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 51k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 4541.09k bytes
+  MEMORY_USAGE_COUNT ~= 4542.56k bytes


### PR DESCRIPTION
# What?
Fix the most of scene with `isTriggered` usage in the [`sdk7-goerli-plaza`](https://github.com/decentraland-scenes/sdk7-goerli-plaza/actions/runs/4183957143/jobs/7248978072).

# Why?
This avoids a small breaking change that would need a fix in those scenes and a change of the documentation. 
Until the `Input` API is well defined, the keeps [the known implementation.](https://docs.decentraland.org/creator/development-guide/sdk7/system-based-events/)

@param entity - the entity to query, **ignore for global**
isTriggered: (inputAction: InputAction, pointerEventType: PointerEventType, entity?: Entity) => boolean
