### PR TITLE
fix: revert to getInputCommand without mandatory entity

### DIFF
--- a/packages/@dcl/ecs/src/engine/input.ts
+++ b/packages/@dcl/ecs/src/engine/input.ts
@@ -80,7 +80,7 @@ export type IInputSystem = {
   getInputCommand: (
     inputAction: InputAction,
     pointerEventType: PointerEventType,
-    entity: Entity
+    entity?: Entity
   ) => PBPointerEventsResult | null
 }
 
@@ -213,7 +213,7 @@ export function createInputSystem(engine: IEngine): IInputSystem {
     return null
   }
 
-  function getInputCommand(
+  function getInputCommandFromEntity(
     inputAction: InputAction,
     pointerEventType: PointerEventType,
     entity: Entity
@@ -227,6 +227,23 @@ export function createInputSystem(engine: IEngine): IInputSystem {
       if (cmd) return cmd
     }
     return null
+  }
+
+  function getInputCommand(
+    inputAction: InputAction,
+    pointerEventType: PointerEventType,
+    entity?: Entity
+  ): PBPointerEventsResult | null {
+    if (entity) {
+      return getInputCommandFromEntity(inputAction, pointerEventType, entity)
+    } else {
+      for (const command of globalState.thisFrameCommands) {
+        if (command.button === inputAction && command.state === pointerEventType) {
+          return command
+        }
+      }
+      return null
+    }
   }
 
   function findInputCommand(

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -917,7 +917,7 @@ export interface IEvents {
 export type IInputSystem = {
     isTriggered: (inputAction: InputAction, pointerEventType: PointerEventType, entity?: Entity) => boolean;
     isPressed: (inputAction: InputAction) => boolean;
-    getInputCommand: (inputAction: InputAction, pointerEventType: PointerEventType, entity: Entity) => PBPointerEventsResult | null;
+    getInputCommand: (inputAction: InputAction, pointerEventType: PointerEventType, entity?: Entity) => PBPointerEventsResult | null;
 };
 
 // @public

--- a/test/ecs/events/isPressed.spec.ts
+++ b/test/ecs/events/isPressed.spec.ts
@@ -73,7 +73,7 @@ describe('Events helpers isTriggered', () => {
   })
 })
 
-describe('Global Events helpers isTriggered', () => {
+describe('Global Events helpers isTriggered, getInputCommand', () => {
   it('should detect no events', () => {
     const newEngine = Engine()
     const { isTriggered } = createInputSystem(newEngine)
@@ -84,7 +84,7 @@ describe('Global Events helpers isTriggered', () => {
     const newEngine = Engine()
     const PointerEventsResult = components.PointerEventsResult(newEngine)
     const entity = newEngine.addEntity()
-    const { isTriggered } = createInputSystem(newEngine)
+    const { isTriggered, getInputCommand } = createInputSystem(newEngine)
     PointerEventsResult.addValue(entity, createTestPointerDownCommand(entity, 4, PointerEventType.PET_DOWN))
 
     // we must run the systems to update the internal inputSystem state
@@ -92,8 +92,12 @@ describe('Global Events helpers isTriggered', () => {
 
     // then assert
     expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN)).toBe(true)
+    expect(getInputCommand(InputAction.IA_POINTER, PointerEventType.PET_DOWN)).not.toBeNull()
+
     expect(isTriggered(InputAction.IA_POINTER, PointerEventType.PET_UP)).toBe(false)
+
     expect(isTriggered(InputAction.IA_ACTION_3, PointerEventType.PET_UP)).toBe(false)
+    expect(getInputCommand(InputAction.IA_ACTION_3, PointerEventType.PET_DOWN)).toBeNull()
   })
 
   it('dont detect pointerEventActive after update', async () => {

--- a/test/snapshots/append-value-crdt.ts.crdt
+++ b/test/snapshots/append-value-crdt.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/append-value-crdt.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 15k
-  MALLOC_COUNT = 9859
+  MALLOC_COUNT = 9867
   ALIVE_OBJS_DELTA ~= 1.95k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"origin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5}
@@ -53,4 +53,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 14k
   MALLOC_COUNT = 33
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1019.17k bytes
+  MEMORY_USAGE_COUNT ~= 1020.51k bytes

--- a/test/snapshots/billboard.ts.crdt
+++ b/test/snapshots/billboard.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/billboard.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 25k
-  MALLOC_COUNT = 12382
+  MALLOC_COUNT = 12390
   ALIVE_OBJS_DELTA ~= 2.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -75,4 +75,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 9k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1229.36k bytes
+  MEMORY_USAGE_COUNT ~= 1230.70k bytes

--- a/test/snapshots/cube-deleted.ts.crdt
+++ b/test/snapshots/cube-deleted.ts.crdt
@@ -7,8 +7,8 @@ EVAL test/snapshots/cube-deleted.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 10k
-  MALLOC_COUNT = 6074
-  ALIVE_OBJS_DELTA ~= 1.01k
+  MALLOC_COUNT = 6082
+  ALIVE_OBJS_DELTA ~= 1.02k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -40,4 +40,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 811.12k bytes
+  MEMORY_USAGE_COUNT ~= 812.46k bytes

--- a/test/snapshots/cube.ts.crdt
+++ b/test/snapshots/cube.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/cube.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 10k
-  MALLOC_COUNT = 6046
+  MALLOC_COUNT = 6054
   ALIVE_OBJS_DELTA ~= 1.01k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 800.41k bytes
+  MEMORY_USAGE_COUNT ~= 801.75k bytes

--- a/test/snapshots/cubes.ts.crdt
+++ b/test/snapshots/cubes.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/cubes.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 57k
-  MALLOC_COUNT = 13770
+  MALLOC_COUNT = 13778
   ALIVE_OBJS_DELTA ~= 3.36k
 CALL onStart()
   OPCODES ~= 0k
@@ -1650,4 +1650,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 615k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1184.60k bytes
+  MEMORY_USAGE_COUNT ~= 1185.93k bytes

--- a/test/snapshots/pointer-events.ts.crdt
+++ b/test/snapshots/pointer-events.ts.crdt
@@ -7,8 +7,8 @@ EVAL test/snapshots/pointer-events.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 16k
-  MALLOC_COUNT = 9580
-  ALIVE_OBJS_DELTA ~= 1.88k
+  MALLOC_COUNT = 9588
+  ALIVE_OBJS_DELTA ~= 1.89k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1000.28k bytes
+  MEMORY_USAGE_COUNT ~= 1001.62k bytes

--- a/test/snapshots/schema-components.ts.crdt
+++ b/test/snapshots/schema-components.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/schema-components.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 13k
-  MALLOC_COUNT = 5078
+  MALLOC_COUNT = 5086
   ALIVE_OBJS_DELTA ~= 0.81k
 CALL onStart()
   OPCODES ~= 0k
@@ -29,4 +29,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 706.86k bytes
+  MEMORY_USAGE_COUNT ~= 708.20k bytes

--- a/test/snapshots/two-way-crdt.ts.crdt
+++ b/test/snapshots/two-way-crdt.ts.crdt
@@ -7,8 +7,8 @@ EVAL test/snapshots/two-way-crdt.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 11k
-  MALLOC_COUNT = 6411
-  ALIVE_OBJS_DELTA ~= 1.10k
+  MALLOC_COUNT = 6419
+  ALIVE_OBJS_DELTA ~= 1.11k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -47,4 +47,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 814.44k bytes
+  MEMORY_USAGE_COUNT ~= 815.78k bytes

--- a/test/snapshots/ui.ts.crdt
+++ b/test/snapshots/ui.ts.crdt
@@ -7,7 +7,7 @@ EVAL test/snapshots/ui.js
   REQUIRE: buffer
   REQUIRE: long
   OPCODES ~= 24k
-  MALLOC_COUNT = 23098
+  MALLOC_COUNT = 23106
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -50,4 +50,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 51k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 4542.76k bytes
+  MEMORY_USAGE_COUNT ~= 4544.10k bytes


### PR DESCRIPTION
Same as https://github.com/decentraland/js-sdk-toolchain/pull/427