### PR TITLE
fix: entity selected reparented

### DIFF
--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -67,7 +67,7 @@ function Tree<T>(props: Props<T>) {
   const quitInsertMode = () => setInsertMode(false)
 
   const handleToggleExpand = (_: React.MouseEvent) => {
-    onToggle(value, !open)
+    onToggle(value, !selected || !open)
   }
 
   const handleToggleEdit = (e: React.MouseEvent) => {

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -44,7 +44,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   // sync inputs -> engine
   useEffect(() => {
     if (isValidInput(input)) {
-      const newComponentValue = fromInputToComponentValue(input)
+      const newComponentValue = { ...componentValue, ...fromInputToComponentValue(input) }
       if (!isEqual(newComponentValue, componentValue)) {
         setComponentValue(newComponentValue)
       }


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/671

The issue was not related to the removal of the EntitySelected component, the issue was that at that same time, the EntityInspector would sync the inputs with the engine with the same value that the engine had, but it removed the `parent` property every time because it was not included when creating the new tranform from the values in the inputs.