### PR TITLE
fix: inputs

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "@dcl/inspector",
       "version": "0.1.0",
-      "dependencies": {
-        "classnames": "^2.3.2"
-      },
       "devDependencies": {
         "@babylonjs/core": "^5.48.0",
         "@babylonjs/gui": "^5.48.0",
@@ -26,6 +23,7 @@
         "@types/react-dom": "^18.0.10",
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "@well-known-components/pushable-channel": "^1.0.3",
+        "classnames": "^2.3.2",
         "decentraland-ui": "^3.87.2",
         "esbuild": "^0.17.12",
         "fp-future": "^1.0.1",
@@ -990,7 +988,8 @@
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+      "dev": true
     },
     "node_modules/clsx": {
       "version": "1.2.1",
@@ -3341,7 +3340,8 @@
     "classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+      "dev": true
     },
     "clsx": {
       "version": "1.2.1",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.0.10",
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@well-known-components/pushable-channel": "^1.0.3",
+    "classnames": "^2.3.2",
     "decentraland-ui": "^3.87.2",
     "esbuild": "^0.17.12",
     "fp-future": "^1.0.1",

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -23,7 +23,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
         <TextField label="" {...getInputProps('layout.base')} />
       </Block>
       <Block label="Parcels">
-        <TextField label="" {...getInputProps('layout.base')} />
+        <TextField label="" {...getInputProps('layout.parcels')} />
       </Block>
     </Container>
   )

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
@@ -12,13 +12,13 @@
   border-color: var(--border-focused);
 }
 
-.TextField > label {
+.TextField>label {
   color: var(--secondary-text);
   display: block;
   margin-right: 8px;
 }
 
-.TextField > input {
+.TextField>input {
   width: 100%;
   color: var(--text);
   background-color: var(--transparent-color);
@@ -26,9 +26,13 @@
   border: none;
 }
 
+.TextField:last-child {
+  margin-right: 0px;
+}
+
 /* Chrome, Safari, Edge, Opera */
-.TextField > input::-webkit-outer-spin-button,
-.TextField > input::-webkit-inner-spin-button {
+.TextField>input::-webkit-outer-spin-button,
+.TextField>input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.tsx
@@ -3,12 +3,11 @@ import { Props } from './types'
 import './TextField.css'
 
 const Input: React.FC<Props> = (props) => {
-  const { label, fractionDigits, ...rest } = props
-  const value = props.type === 'number' && fractionDigits ? Number(rest.value).toFixed(fractionDigits) : rest.value
+  const { label, ...rest } = props
   return (
     <div className="TextField">
       {label && <label>{label}</label>}
-      <input {...rest} value={value} />
+      <input {...rest} />
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/types.ts
@@ -2,6 +2,4 @@ import React from 'react'
 
 export type Props = React.InputHTMLAttributes<HTMLElement> & {
   label?: string
-  // Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
-  fractionDigits?: number
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -9,7 +9,7 @@ import { withContextMenu } from '../../../hoc/withContextMenu'
 import { useContextMenu } from '../../../hooks/sdk/useContextMenu'
 
 import { Props } from './types'
-import { fromTranform, toTransform } from './utils'
+import { fromTransform, toTransform } from './utils'
 import { Block } from '../../Block'
 import { Container } from '../../Container'
 import { TextField } from '../TextField'
@@ -20,7 +20,7 @@ export default withSdk<Props>(
 
     const hasTransform = useHasComponent(entity, Transform)
     const getInputProps =
-      hasTransform && useComponentInput(entity, Transform, fromTranform, toTransform, isValidNumericInput)
+      hasTransform && useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
     const { handleAction } = useContextMenu()
 
     const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -1,52 +1,57 @@
 import { useCallback } from 'react'
-import { Menu, Item } from 'react-contexify';
-import { AiFillDelete as DeleteIcon} from 'react-icons/ai'
+import { Menu, Item } from 'react-contexify'
+import { AiFillDelete as DeleteIcon } from 'react-icons/ai'
 
 import { isValidNumericInput, useComponentInput } from '../../../hooks/sdk/useComponentInput'
 import { useHasComponent } from '../../../hooks/sdk/useHasComponent'
 import { WithSdkProps, withSdk } from '../../../hoc/withSdk'
+import { withContextMenu } from '../../../hoc/withContextMenu'
+import { useContextMenu } from '../../../hooks/sdk/useContextMenu'
 
 import { Props } from './types'
 import { fromTranform, toTransform } from './utils'
 import { Block } from '../../Block'
 import { Container } from '../../Container'
 import { TextField } from '../TextField'
-import { withContextMenu } from '../../../hoc/withContextMenu'
-import { useContextMenu } from '../../../hooks/sdk/useContextMenu';
 
-export default withSdk<Props>(withContextMenu<WithSdkProps & Props>(({ sdk, entity, contextMenuId }) => {
-  const { Transform } = sdk.components
+export default withSdk<Props>(
+  withContextMenu<WithSdkProps & Props>(({ sdk, entity, contextMenuId }) => {
+    const { Transform } = sdk.components
 
-  const hasTransform = useHasComponent(entity, Transform)
-  const getInputProps = hasTransform && useComponentInput(entity, Transform, fromTranform, toTransform, isValidNumericInput)
-  const { handleAction } = useContextMenu()
+    const hasTransform = useHasComponent(entity, Transform)
+    const getInputProps =
+      hasTransform && useComponentInput(entity, Transform, fromTranform, toTransform, isValidNumericInput)
+    const { handleAction } = useContextMenu()
 
-  const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])
+    const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])
 
-  if (!getInputProps) {
-    return null
-  }
+    if (!getInputProps) {
+      return null
+    }
 
-  return (
-    <Container label="Transform" className="Transform">
-      <Menu id={contextMenuId}>
-        <Item id="delete" onClick={handleAction(handleRemove)}><DeleteIcon /> Delete</Item>
-      </Menu>
-      <Block label="Position">
-        <TextField label="X" type="number" fractionDigits={2} {...getInputProps('position.x')} />
-        <TextField label="Y" type="number" fractionDigits={2} {...getInputProps('position.y')} />
-        <TextField label="Z" type="number" fractionDigits={2} {...getInputProps('position.z')} />
-      </Block>
-      <Block label="Scale">
-        <TextField label="X" type="number" fractionDigits={2} {...getInputProps('scale.x')} />
-        <TextField label="Y" type="number" fractionDigits={2} {...getInputProps('scale.y')} />
-        <TextField label="Z" type="number" fractionDigits={2} {...getInputProps('scale.z')} />
-      </Block>
-      <Block label="Rotation">
-        <TextField label="X" type="number" fractionDigits={2} {...getInputProps('rotation.x')} />
-        <TextField label="Y" type="number" fractionDigits={2} {...getInputProps('rotation.y')} />
-        <TextField label="Z" type="number" fractionDigits={2} {...getInputProps('rotation.z')} />
-      </Block>
-    </Container>
-  )
-}))
+    return (
+      <Container label="Transform" className="Transform">
+        <Menu id={contextMenuId}>
+          <Item id="delete" onClick={handleAction(handleRemove)}>
+            <DeleteIcon /> Delete
+          </Item>
+        </Menu>
+        <Block label="Position">
+          <TextField label="X" type="number" {...getInputProps('position.x')} />
+          <TextField label="Y" type="number" {...getInputProps('position.y')} />
+          <TextField label="Z" type="number" {...getInputProps('position.z')} />
+        </Block>
+        <Block label="Scale">
+          <TextField label="X" type="number" {...getInputProps('scale.x')} />
+          <TextField label="Y" type="number" {...getInputProps('scale.y')} />
+          <TextField label="Z" type="number" {...getInputProps('scale.z')} />
+        </Block>
+        <Block label="Rotation">
+          <TextField label="X" type="number" {...getInputProps('rotation.x')} />
+          <TextField label="Y" type="number" {...getInputProps('rotation.y')} />
+          <TextField label="Z" type="number" {...getInputProps('rotation.z')} />
+        </Block>
+      </Container>
+    )
+  })
+)

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
@@ -1,0 +1,34 @@
+import { TransformType } from '@dcl/ecs'
+import { fromTransform } from './utils'
+
+describe('TransformInspector utils', () => {
+  let transform: TransformType
+
+  beforeEach(() => {
+    transform = {
+      position: { x: 8, y: 0, z: 8 },
+      scale: { x: 1, y: 1, z: 1 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 }
+    }
+  })
+  describe('when converting the TransformType into a TransformInput', () => {
+    it('should convert position values to strings with two decimals', () => {
+      const input = fromTransform(transform)
+      expect(input.position.x).toBe('8.00')
+      expect(input.position.y).toBe('0.00')
+      expect(input.position.z).toBe('8.00')
+    })
+    it('should convert scale values to strings with two decimals', () => {
+      const input = fromTransform(transform)
+      expect(input.scale.x).toBe('1.00')
+      expect(input.scale.y).toBe('1.00')
+      expect(input.scale.z).toBe('1.00')
+    })
+    it('should convert rotation values from quaterion to euler angles, as strings with two decimals', () => {
+      const input = fromTransform(transform)
+      expect(input.rotation.x).toBe('0.00')
+      expect(input.rotation.y).toBe('0.00')
+      expect(input.rotation.z).toBe('0.00')
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
@@ -1,17 +1,17 @@
 import { TransformType } from '@dcl/ecs'
-import { fromTransform } from './utils'
+import { fromTransform, toTransform } from './utils'
+import { TransformInput } from './types'
 
 describe('TransformInspector utils', () => {
-  let transform: TransformType
-
-  beforeEach(() => {
-    transform = {
-      position: { x: 8, y: 0, z: 8 },
-      scale: { x: 1, y: 1, z: 1 },
-      rotation: { x: 0, y: 0, z: 0, w: 1 }
-    }
-  })
   describe('when converting the TransformType into a TransformInput', () => {
+    let transform: TransformType
+    beforeEach(() => {
+      transform = {
+        position: { x: 8, y: 0, z: 8 },
+        scale: { x: 1, y: 1, z: 1 },
+        rotation: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    })
     it('should convert position values to strings with two decimals', () => {
       const input = fromTransform(transform)
       expect(input.position.x).toBe('8.00')
@@ -29,6 +29,35 @@ describe('TransformInspector utils', () => {
       expect(input.rotation.x).toBe('0.00')
       expect(input.rotation.y).toBe('0.00')
       expect(input.rotation.z).toBe('0.00')
+    })
+  })
+  describe('when converting the TransformInput into a TransformType', () => {
+    let input: TransformInput
+    beforeEach(() => {
+      input = {
+        position: { x: '8.00', y: '0.00', z: '8.00' },
+        scale: { x: '1.00', y: '1.00', z: '1.00' },
+        rotation: { x: '0.00', y: '0.00', z: '0.00' }
+      }
+    })
+    it('should convert position string values into numbers', () => {
+      const transform = toTransform(input)
+      expect(transform.position.x).toBe(8)
+      expect(transform.position.y).toBe(0)
+      expect(transform.position.z).toBe(8)
+    })
+    it('should convert scale string values into numbers', () => {
+      const transform = toTransform(input)
+      expect(transform.scale.x).toBe(1)
+      expect(transform.scale.y).toBe(1)
+      expect(transform.scale.z).toBe(1)
+    })
+    it('should convert rotation euler angles into a quaternion', () => {
+      const tranform = toTransform(input)
+      expect(tranform.rotation.x).toBe(0)
+      expect(tranform.rotation.y).toBe(0)
+      expect(tranform.rotation.z).toBe(0)
+      expect(tranform.rotation.w).toBe(1)
     })
   })
 })

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
@@ -2,7 +2,7 @@ import { TransformType } from '@dcl/ecs'
 import { Quaternion } from '@dcl/ecs-math'
 import { TransformInput } from './types'
 
-export function fromTranform(value: TransformType): TransformInput {
+export function fromTransform(value: TransformType): TransformInput {
   const angles = Quaternion.toEulerAngles(value.rotation)
   return {
     position: {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
@@ -6,14 +6,14 @@ export function fromTranform(value: TransformType): TransformInput {
   const angles = Quaternion.toEulerAngles(value.rotation)
   return {
     position: {
-      x: value.position.x.toString(),
-      y: value.position.y.toString(),
-      z: value.position.z.toString()
+      x: value.position.x.toFixed(2),
+      y: value.position.y.toFixed(2),
+      z: value.position.z.toFixed(2)
     },
     scale: {
-      x: value.scale.x.toString(),
-      y: value.scale.y.toString(),
-      z: value.scale.z.toString()
+      x: value.scale.x.toFixed(2),
+      y: value.scale.y.toFixed(2),
+      z: value.scale.z.toFixed(2)
     },
     rotation: {
       x: formatAngle(angles.x),
@@ -24,7 +24,7 @@ export function fromTranform(value: TransformType): TransformInput {
 }
 
 function formatAngle(angle: number) {
-  const value = angle.toString()
+  const value = angle.toFixed(2)
   return value === '360.00' ? '0.00' : value
 }
 

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.ts
@@ -1,9 +1,9 @@
 import { TransformType } from '@dcl/ecs'
-import { Quaternion } from '@dcl/ecs-math'
+import { Quaternion } from '@babylonjs/core'
 import { TransformInput } from './types'
 
 export function fromTransform(value: TransformType): TransformInput {
-  const angles = Quaternion.toEulerAngles(value.rotation)
+  const angles = new Quaternion(value.rotation.x, value.rotation.y, value.rotation.z, value.rotation.w).toEulerAngles()
   return {
     position: {
       x: value.position.x.toFixed(2),
@@ -16,9 +16,9 @@ export function fromTransform(value: TransformType): TransformInput {
       z: value.scale.z.toFixed(2)
     },
     rotation: {
-      x: formatAngle(angles.x),
-      y: formatAngle(angles.y),
-      z: formatAngle(angles.z)
+      x: formatAngle((angles.x * 180) / Math.PI),
+      y: formatAngle((angles.y * 180) / Math.PI),
+      z: formatAngle((angles.z * 180) / Math.PI)
     }
   }
 }
@@ -29,10 +29,10 @@ function formatAngle(angle: number) {
 }
 
 export function toTransform(inputs: TransformInput): TransformType {
-  const rotation = Quaternion.fromEulerDegrees(
-    Number(inputs.rotation.x),
-    Number(inputs.rotation.y),
-    Number(inputs.rotation.z)
+  const quaternion = Quaternion.RotationYawPitchRoll(
+    (Number(inputs.rotation.y) * Math.PI) / 180,
+    (Number(inputs.rotation.x) * Math.PI) / 180,
+    (Number(inputs.rotation.z) * Math.PI) / 180
   )
   return {
     position: {
@@ -45,6 +45,11 @@ export function toTransform(inputs: TransformInput): TransformType {
       y: Number(inputs.scale.y),
       z: Number(inputs.scale.z)
     },
-    rotation
+    rotation: {
+      x: quaternion.x,
+      y: quaternion.y,
+      z: quaternion.z,
+      w: quaternion.w
+    }
   }
 }

--- a/packages/@dcl/inspector/test/data-layer/utils.ts
+++ b/packages/@dcl/inspector/test/data-layer/utils.ts
@@ -1,11 +1,11 @@
 import * as BABYLON from '@babylonjs/core'
+import { IEngine } from '@dcl/ecs'
 import { SceneContext, LoadableScene } from '../../src/lib/babylon/decentraland/SceneContext'
 import { SdkContextValue } from '../../src/lib/sdk/context'
 import { createInspectorEngine } from '../../src/lib/sdk/inspector-engine'
 import { createLocalDataLayerRpcClient } from '../../src/lib/data-layer/client/local-data-layer'
 import { feededFileSystem } from '../../src/lib/data-layer/client/feeded-local-fs'
 import { DataLayerRpcClient } from '../../src/lib/data-layer/types'
-import { IEngine } from '@dcl/ecs'
 
 export function initTestEngine(loadableScene: Readonly<LoadableScene>) {
   let sceneCtx: SceneContext


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/703

The issue was formatting the input value within the render of the react component. The conversion from component value into input value should be done within the `fromComponentValueToInput` function provided to the `useComponentInput` hook:

```ts
fromComponentValueToInput(componentValue: ComponentValueType) => InputType
``` 

Otherwise the hook fails to compare the values and fires unnecessary syncs.

I also fixed an issue with the `Scene > Parcels` input which was bound to the wrong value
