### PR TITLE
fix deploy command

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/deploy/linker-dapp/api.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/linker-dapp/api.ts
@@ -58,7 +58,7 @@ export function runLinkerApp(
 
         const https = isHttps ? await getCredentials(cliComponents) : undefined
 
-        const server = await createServerComponent({ ...cliComponents, logs }, { https })
+        const server = await createServerComponent({ ...cliComponents, config, logs }, { https })
 
         return { ...cliComponents, config, logs, server }
       },

--- a/packages/@dcl/sdk-commands/src/commands/deploy/linker-dapp/api.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/linker-dapp/api.ts
@@ -96,7 +96,7 @@ async function browse({ logger }: Pick<CliComponents, 'logger'>, url: string, pa
     }
   }, 5000)
 
-  logger.info(`Signing app ready at ${url}`)
+  logger.info(`Signing app ready at ${url}?${params}`)
 }
 
 async function getCredentials({ fs }: Pick<CliComponents, 'fs' | 'logger'>) {

--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -1,0 +1,47 @@
+import { Scene } from '@dcl/schemas'
+import { Lifecycle } from '@well-known-components/interfaces'
+import { CatalystClient, ContentClient } from 'dcl-catalyst-client'
+import { hexToBytes } from 'eth-connect'
+import { ethSign } from '@dcl/crypto/dist/crypto'
+
+import { CliComponents } from '../../components'
+import { IFile } from '../../logic/scene-validations'
+import { runLinkerApp, LinkerResponse } from './linker-dapp/api'
+import { createWallet } from '../../logic/account'
+
+export async function getCatalyst(target?: string, targetContent?: string) {
+  if (target) {
+    return new CatalystClient({ catalystUrl: target.endsWith('/') ? target.slice(0, -1) : target })
+  }
+
+  if (targetContent) {
+    return new ContentClient({ contentUrl: targetContent })
+  }
+
+  return CatalystClient.connectedToCatalystIn({ network: 'mainnet' })
+}
+
+interface LinkOptions {
+  openBrowser: boolean
+  linkerPort?: number
+  isHttps: boolean
+  skipValidations: boolean
+}
+
+export async function getAddressAndSignature(
+  components: CliComponents,
+  messageToSign: string,
+  scene: Scene,
+  files: IFile[],
+  linkOptions: LinkOptions
+): Promise<{ linkerResponse: Promise<LinkerResponse>; program?: Lifecycle.ComponentBasedProgram<unknown> }> {
+  if (process.env.DCL_PRIVATE_KEY) {
+    const wallet = createWallet(process.env.DCL_PRIVATE_KEY)
+    const signature = ethSign(hexToBytes(wallet.privateKey), messageToSign)
+    const linkerResponse = Promise.resolve({ signature, address: wallet.address })
+    return { linkerResponse }
+  }
+
+  const { linkerPort, ...opts } = linkOptions
+  return runLinkerApp(components, scene, files, linkerPort!, messageToSign, opts)
+}

--- a/packages/@dcl/sdk-commands/src/logic/config.ts
+++ b/packages/@dcl/sdk-commands/src/logic/config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { CliComponents } from '../components'
-import { readStringConfig, requireStringConfig } from '../components/config'
+import { readStringConfig } from '../components/config'
 import { readJson } from './fs'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -61,10 +61,10 @@ export function getSegmentKey() {
 
 /* istanbul ignore next */
 export async function getLandRegistry(components: Pick<CliComponents, 'config'>) {
-  return requireStringConfig(components, 'DCL_LAND_REGISTRY_ADDRESS')
+  return readStringConfig(components, 'DCL_LAND_REGISTRY_ADDRESS')
 }
 
 /* istanbul ignore next */
 export async function getEstateRegistry(components: Pick<CliComponents, 'config'>) {
-  return requireStringConfig(components, 'DCL_ESTATE_REGISTRY_ADDRESS')
+  return readStringConfig(components, 'DCL_ESTATE_REGISTRY_ADDRESS')
 }

--- a/test/sdk-commands/commands/deploy/index.spec.ts
+++ b/test/sdk-commands/commands/deploy/index.spec.ts
@@ -1,0 +1,43 @@
+import { Router } from '../../../../packages/@dcl/sdk-commands/node_modules/@well-known-components/http-server'
+import { Authenticator } from '../../../../packages/@dcl/sdk-commands/node_modules/@dcl/crypto'
+
+import * as sceneValidations from '../../../../packages/@dcl/sdk-commands/src/logic/scene-validations'
+import * as projectFiles from '../../../../packages/@dcl/sdk-commands/src/logic/project-files'
+import * as deployUtils from '../../../../packages/@dcl/sdk-commands/src/commands/deploy/utils'
+import { main as deploy } from '../../../../packages/@dcl/sdk-commands/src/commands/deploy'
+import { initComponents } from '../../../../packages/@dcl/sdk-commands/src/components'
+import * as routes from '../../../../packages/@dcl/sdk-commands/src/commands/deploy/linker-dapp/routes'
+import { sceneJson } from './scene.json'
+
+afterEach(() => {
+  jest.clearAllMocks()
+  jest.restoreAllMocks()
+})
+describe('deploy command', () => {
+  it('happy path. Should open the linker-dapp', async () => {
+    const components = await initComponents()
+    jest.spyOn(sceneValidations, 'getValidSceneJson').mockResolvedValue(sceneJson)
+    jest.spyOn(projectFiles, 'getPackageJson').mockResolvedValue({ dependencies: {}, devDependencies: {} })
+    jest
+      .spyOn(sceneValidations, 'getFiles')
+      .mockResolvedValue([{ path: 'boedo/path', content: Buffer.from('casla'), size: 150 }])
+    jest
+      .spyOn(routes, 'setRoutes')
+      .mockReturnValue({ router: new Router(), futureSignature: Promise.resolve({}) as any })
+
+    jest.spyOn(deployUtils, 'getCatalyst').mockResolvedValue({
+      deploy: async () => Promise.resolve({}),
+      getContentUrl: () => 'boedo.casla.content'
+    } as any)
+    jest.spyOn(Authenticator, 'createSimpleAuthChain').mockReturnValue([])
+
+    const spyResponse = jest.spyOn(deployUtils, 'getAddressAndSignature')
+
+    await deploy({
+      args: { _: [], '--skip-build': true, '--no-browser': true },
+      components
+    })
+
+    expect(spyResponse).toReturn()
+  })
+})

--- a/test/sdk-commands/commands/deploy/scene.json.ts
+++ b/test/sdk-commands/commands/deploy/scene.json.ts
@@ -1,0 +1,39 @@
+export const sceneJson = {
+  ecs7: true,
+  runtimeVersion: '7',
+  display: {
+    title: 'SDK7 Decentraland - Cube Spawner Scene',
+    description: 'First scene with SDK7',
+    navmapThumbnail: 'images/scene-thumbnail.png',
+    favicon: 'favicon_asset'
+  },
+  owner: '',
+  contact: {
+    name: 'SDK',
+    email: ''
+  },
+  main: 'bin/index.js',
+  tags: [],
+  scene: {
+    parcels: ['0,0'],
+    base: '0,0'
+  },
+  spawnPoints: [
+    {
+      name: 'spawn1',
+      default: true,
+      position: {
+        x: [0, 3],
+        y: [0, 0],
+        z: [0, 3]
+      },
+      cameraTarget: {
+        x: 8,
+        y: 1,
+        z: 8
+      }
+    }
+  ],
+  requiredPermissions: ['ALLOW_TO_TRIGGER_AVATAR_EMOTE', 'ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE'],
+  featureToggles: {}
+}

--- a/test/sdk-commands/utils/validations.spec.ts
+++ b/test/sdk-commands/utils/validations.spec.ts
@@ -1,7 +1,7 @@
-import * as projectValidation from '../../../../packages/@dcl/sdk-commands/src/logic/project-validations'
-import * as sceneValidation from '../../../../packages/@dcl/sdk-commands/src/logic/scene-validations'
-import { Scene } from '../../../../packages/@dcl/sdk-commands/node_modules/@dcl/schemas'
-import { initComponents } from '../../../../packages/@dcl/sdk-commands/src/components'
+import * as projectValidation from '../../../packages/@dcl/sdk-commands/src/logic/project-validations'
+import * as sceneValidation from '../../../packages/@dcl/sdk-commands/src/logic/scene-validations'
+import { Scene } from '../../../packages/@dcl/sdk-commands/node_modules/@dcl/schemas/dist'
+import { initComponents } from '../../../packages/@dcl/sdk-commands/src/components'
 import path from 'path'
 
 afterEach(() => {


### PR DESCRIPTION
- ServerComponent was being intialized with the wrong config component
- config component was expecting to have LANDRegistry string always declared.
So when you run sdk-commands deploy if failes because there was no config.LANDRegistry value, and since the default values are already hardcoded on the linker-dapp, we can ommit the requiredString to a readString 

