### PR TITLE
fix: adding/removing Transform component crashing the app

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -19,13 +19,12 @@ export default withSdk<Props>(
     const { Transform } = sdk.components
 
     const hasTransform = useHasComponent(entity, Transform)
-    const getInputProps =
-      hasTransform && useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
+    const getInputProps = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
     const { handleAction } = useContextMenu()
 
     const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])
 
-    if (!getInputProps) {
+    if (!hasTransform) {
       return null
     }
 


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/715

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86eed1b</samp>

Fix a bug and simplify the code for rendering the transform inspector component. Check if the entity has the `transform` component instead of relying on the `getInputProps` function in `TransformInspector.tsx`.