### PR TITLE
fix: asset drop inside renderer

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.spec.ts
@@ -1,4 +1,6 @@
 import * as utils from './utils'
+import { TreeNode } from '../../ProjectAssetExplorer/ProjectView'
+import { AssetNodeItem } from '../../ProjectAssetExplorer/types'
 
 describe('GltfInspector/utils', () => {
   describe('fromGltf', () => {
@@ -35,6 +37,69 @@ describe('GltfInspector/utils', () => {
         ]
       }
       expect(utils.isValidInput(assets, 'root/other-path')).toBe(false)
+    })
+  })
+  describe('isAsset', () => {
+    it('should return true if value has ".gltf" or ".glb" extension', () => {
+      expect(utils.isAsset('test.gltf')).toBe(true)
+      expect(utils.isAsset('test.glb')).toBe(true)
+      expect(utils.isAsset('test.dll')).toBe(false)
+      expect(utils.isAsset('test.gltff')).toBe(false)
+    })
+  })
+  describe('isModel', () => {
+    it('should return true if value is an "AssetNodeItem"', () => {
+      const validNodeItem: AssetNodeItem = {
+        type: 'asset',
+        name: 'balloon.glb',
+        parent: null,
+        asset: { type: 'gltf', src: 'some/path' }
+      }
+      const invalidNodeItem = { ...validNodeItem, type: 'wrong' } as any
+      expect(utils.isModel(validNodeItem)).toBe(true)
+      expect(utils.isModel(invalidNodeItem)).toBe(false)
+    })
+  })
+  describe('getModel', () => {
+    it('should get the model from a tree when found', () => {
+      const buildAssetNode = (name: string, parent?: TreeNode): TreeNode => {
+        if (parent?.children) parent.children.push(name)
+        const path = `${name}.gltf`
+        return {
+          name: path,
+          parent: parent ?? null,
+          type: 'asset',
+          asset: { src: path, type: 'gltf' }
+        } as TreeNode
+      }
+      const buildFolderNode = (name: string, parent?: TreeNode): TreeNode => {
+        if (parent?.children) parent.children.push(name)
+        return {
+          name,
+          parent: parent ?? null,
+          type: 'folder',
+          children: []
+        } as TreeNode
+      }
+
+      const root = buildFolderNode('root')
+      const folder = buildFolderNode('folder', root)
+      const asset = buildAssetNode('asset', folder)
+      const tree: Map<string, TreeNode> = new Map([
+        ['root', root],
+        ['folder', folder],
+        ['asset', asset]
+      ])
+      const incompleteTree: Map<string, TreeNode> = new Map([
+        ['root', root],
+        ['folder', folder]
+      ])
+
+      expect(utils.getModel(root, tree)).toBe(null)
+      expect(utils.getModel(folder, tree)).toBe(asset)
+      expect(utils.getModel(asset, tree)).toBe(asset)
+      // need to create a new object since we are memoizing this function...
+      expect(utils.getModel({ ...folder }, incompleteTree)).toBe(null)
     })
   })
 })

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
@@ -1,5 +1,9 @@
 import { PBGltfContainer } from '@dcl/ecs'
 
+import { memoize } from '../../../lib/logic/once'
+import { TreeNode } from '../../ProjectAssetExplorer/ProjectView'
+import { isAssetNode } from '../../ProjectAssetExplorer/utils'
+import { AssetNodeItem } from '../../ProjectAssetExplorer/types'
 import { AssetCatalogResponse } from '../../../tooling-entrypoint'
 
 export function fromGltf(value: PBGltfContainer) {
@@ -11,3 +15,18 @@ export const toGltf = fromGltf
 export function isValidInput({ assets }: AssetCatalogResponse, src: string): boolean {
   return !!assets.find(($) => $.path === src)
 }
+
+export const isModel = (node: TreeNode): node is AssetNodeItem =>
+  isAssetNode(node) && (node.name.endsWith('.gltf') || node.name.endsWith('.glb'))
+
+export const getModel = memoize((node: TreeNode, tree: Map<string, TreeNode>): AssetNodeItem | null => {
+  if (isModel(node)) return node
+
+  const children = node.children || []
+  for (const child of children) {
+    const childNode = tree.get(child)!
+    if (isModel(childNode)) return childNode
+  }
+
+  return null
+})

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
@@ -16,8 +16,9 @@ export function isValidInput({ assets }: AssetCatalogResponse, src: string): boo
   return !!assets.find(($) => $.path === src)
 }
 
-export const isModel = (node: TreeNode): node is AssetNodeItem =>
-  isAssetNode(node) && (node.name.endsWith('.gltf') || node.name.endsWith('.glb'))
+export const isAsset = (value: string): boolean => (value.endsWith('.gltf') || value.endsWith('.glb'))
+
+export const isModel = (node: TreeNode): node is AssetNodeItem => isAssetNode(node) && isAsset(node.name)
 
 export const getModel = memoize((node: TreeNode, tree: Map<string, TreeNode>): AssetNodeItem | null => {
   if (isModel(node)) return node

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
@@ -16,7 +16,7 @@ export function isValidInput({ assets }: AssetCatalogResponse, src: string): boo
   return !!assets.find(($) => $.path === src)
 }
 
-export const isAsset = (value: string): boolean => (value.endsWith('.gltf') || value.endsWith('.glb'))
+export const isAsset = (value: string): boolean => value.endsWith('.gltf') || value.endsWith('.glb')
 
 export const isModel = (node: TreeNode): node is AssetNodeItem => isAssetNode(node) && isAsset(node.name)
 
@@ -25,8 +25,8 @@ export const getModel = memoize((node: TreeNode, tree: Map<string, TreeNode>): A
 
   const children = node.children || []
   for (const child of children) {
-    const childNode = tree.get(child)!
-    if (isModel(childNode)) return childNode
+    const childNode = tree.get(child)
+    if (childNode && isModel(childNode)) return childNode
   }
 
   return null

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { useDrop } from 'react-dnd'
 
+import { BuilderAsset, DROP_TYPES, IDrop, ProjectAssetDrop, isDropType } from '../../lib/sdk/drag-drop'
 import { useRenderer } from '../../hooks/sdk/useRenderer'
 import { useSdk } from '../../hooks/sdk/useSdk'
 import { getPointerCoords } from '../../lib/babylon/decentraland/mouse-utils'
 import { ROOT } from '../../lib/sdk/tree'
 import { AssetNodeItem } from '../ProjectAssetExplorer/types'
 import { IAsset } from '../AssetsCatalog/types'
+import { getModel } from '../EntityInspector/GltfInspector/utils'
 
 import './Renderer.css'
 
@@ -56,14 +58,21 @@ const Renderer: React.FC = () => {
 
   const [, drop] = useDrop(
     () => ({
-      accept: ['project-asset-gltf', 'builder-asset'],
-      drop: ({ value }: { value: AssetNodeItem | IAsset }, monitor) => {
-        if (monitor.getItemType() === 'builder-asset') {
-          void importBuilderAsset(value as IAsset)
+      accept: DROP_TYPES,
+      drop: (item: IDrop, monitor) => {
+        if (monitor.didDrop()) return
+        const itemType = monitor.getItemType()
+
+        if (isDropType<BuilderAsset>(item, itemType, 'builder-asset')) {
+          void importBuilderAsset(item.value)
           return
         }
-        if (monitor.didDrop()) return
-        void addAsset(value as AssetNodeItem)
+
+        if (isDropType<ProjectAssetDrop>(item, itemType, 'project-asset-gltf')) {
+          const node = item.context.tree.get(item.value)!
+          const model = getModel(node, item.context.tree)
+          if (model) void addAsset(model)
+        }
       }
     }),
     [addAsset]

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.spec.ts
@@ -1,0 +1,12 @@
+import * as dnd from './drag-drop'
+
+describe('sdk drag and drop', () => {
+  it('should return true when identifier equals type', () => {
+    const drop = { value: 'project-asset-gltf', context: { tree: new Map() } }
+    expect(dnd.isDropType(drop, 'project-asset-gltf', 'project-asset-gltf')).toBe(true)
+    expect(dnd.isDropType(drop, 'invalid', 'project-asset-gltf')).toBe(false)
+  })
+  it('should return all drop types list', () => {
+    expect(dnd.DROP_TYPES).toStrictEqual(expect.arrayContaining(Object.values(dnd.DropTypesEnum)))
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
@@ -13,7 +13,7 @@ export type BuilderAsset = Drop<IAsset>
 
 export type IDrop = ProjectAssetDrop | BuilderAsset
 
-enum DropTypesEnum {
+export enum DropTypesEnum {
   ProjectAsset = 'project-asset-gltf',
   BuilderAsset = 'builder-asset'
 }

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
@@ -1,0 +1,27 @@
+import { Identifier } from 'dnd-core'
+
+import { IAsset } from '../../components/AssetsCatalog/types'
+import { TreeNode } from '../../components/ProjectAssetExplorer/ProjectView'
+
+interface Drop<T, K = object> {
+  value: T
+  context: K
+}
+
+export type ProjectAssetDrop = Drop<string, { tree: Map<string, TreeNode> }>
+export type BuilderAsset = Drop<IAsset>
+
+export type IDrop = ProjectAssetDrop | BuilderAsset
+
+enum DropTypesEnum {
+  ProjectAsset = 'project-asset-gltf',
+  BuilderAsset = 'builder-asset'
+}
+
+export type DropTypes = `${DropTypesEnum}`
+
+export function isDropType<T extends IDrop>(_: IDrop, identifier: Identifier | null, type: DropTypes): _ is T {
+  return identifier === type
+}
+
+export const DROP_TYPES = Object.values(DropTypesEnum)


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/730

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c3b1c6</samp>

Refactored and added utility functions and types for the GLTF inspector and the drag and drop events in the SDK. Improved the drop function in the renderer component to handle different asset types. Created a new `drag-drop.ts` file to export the common types and functions for the drag and drop feature.