### PR TITLE
update: editor sidebar to allow vertical resizement

### DIFF
--- a/packages/@dcl/inspector/src/components/App/App.css
+++ b/packages/@dcl/inspector/src/components/App/App.css
@@ -74,6 +74,7 @@ code {
   align-items: center;
   padding: 8px;
   cursor: pointer;
+  user-select: none;
 }
 
 .footer .footer-buttons > div > svg {

--- a/packages/@dcl/inspector/src/components/App/App.tsx
+++ b/packages/@dcl/inspector/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { MdImageSearch } from 'react-icons/md'
 import { AiFillFolder } from 'react-icons/ai'
 
@@ -23,22 +23,21 @@ const App = () => {
   const [catalog] = useCatalog()
   const [tab, setTab] = useState<Tab | undefined>(undefined)
 
-  function handleTabClick(value: Tab) {
-    if (tab === value) {
-      return setTab(undefined)
-    }
-    setTab(value)
-  }
+  const handleTabClick = useCallback((value: Tab) => () => {
+    setTab(tab === value ? undefined : value)
+  }, [tab])
 
   return (
-    <Resizable minWidth={220} initialWidth={250} >
+    <Resizable type="horizontal" min={280} initial={280}>
       <Box>
         <div
           className="sidebar"
           data-vscode-context='{"webviewSection": "sidebar", "preventDefaultContextMenuItems": true}'
         >
-          <Hierarchy />
-          <EntityInspector />
+          <Resizable type="vertical" min={130} initial={130} max={730}>
+            <Hierarchy />
+            <EntityInspector />
+          </Resizable>
         </div>
       </Box>
       <div className="editor">
@@ -54,11 +53,11 @@ const App = () => {
             </div>
           )}
           <div className="footer-buttons">
-            <div onClick={() => handleTabClick(Tab.FileSystem)}>
+            <div onClick={handleTabClick(Tab.FileSystem)}>
               <AiFillFolder />
               <span>Asset Catalog</span>
             </div>
-            <div onClick={() => handleTabClick(Tab.AssetsPack)}>
+            <div onClick={handleTabClick(Tab.AssetsPack)}>
               <MdImageSearch />
               <span>World Assets Pack</span>
             </div>

--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -5,6 +5,8 @@
   background-color: var(--modal);
   border-radius: 8px;
   margin: 12px;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .Container.hover {

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -27,7 +27,7 @@ const Hierarchy: React.FC = () => {
   } = useTree()
 
   return (
-    <Container label="">
+    <Container>
       <Tree
         value={ROOT}
         getExtraContextMenu={ContextMenu}

--- a/packages/@dcl/inspector/src/components/Resizable/Resizable.css
+++ b/packages/@dcl/inspector/src/components/Resizable/Resizable.css
@@ -2,10 +2,29 @@
   display: flex;
 }
 
-/* TODO: Maybe position absolute ? */
 .Resizable .resize-handle {
   position: absolute;
   width: 10px;
   height: 100%;
   cursor: col-resize;
+}
+
+.Resizable.vertical {
+  display: flex;
+  flex-direction: column;
+}
+
+.Resizable.vertical .resize-handle {
+  width: 100%;
+  height: 10px;
+  cursor: row-resize;
+}
+
+.Resizable.vertical > div:first-child {
+  display: flex;
+  flex-direction: column;
+}
+
+.Resizable.vertical > div:nth-child(3) {
+  overflow-y: auto;
 }

--- a/packages/@dcl/inspector/src/components/Resizable/types.ts
+++ b/packages/@dcl/inspector/src/components/Resizable/types.ts
@@ -1,5 +1,34 @@
 export interface PropTypes {
-  minWidth?: 'initial' | number
-  initialWidth?: number
+  type: 'horizontal' | 'vertical'
+  min?: 'initial' | number
+  initial?: number
+  max?: number
   onChange?(value: [number, number]): void
+}
+
+export interface TypeProps {
+  offsetValue: 'offsetWidth' | 'offsetHeight'
+  eventClientValue: 'clientX' | 'clientY'
+  css: {
+    childs: 'width' | 'height'
+    handle: 'left' | 'top'
+  }
+}
+
+export const HORIZONTAL_PROPS: TypeProps = {
+  offsetValue: 'offsetWidth',
+  eventClientValue: 'clientX',
+  css: {
+    childs: 'width',
+    handle: 'left'
+  }
+}
+
+export const VERTICAL_PROPS: TypeProps = {
+  offsetValue: 'offsetHeight',
+  eventClientValue: 'clientY',
+  css: {
+    childs: 'height',
+    handle: 'top'
+  }
 }

--- a/packages/@dcl/inspector/src/components/Tree/Tree.css
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.css
@@ -1,6 +1,5 @@
 .Tree {
   font-size: 14px;
-  background-color: var(--tree-bg-color);
   color: var(--white);
   width: 100%;
 }


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/722

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3b0bac</samp>

This pull request enhances the inspector tool by adding a resizeable hierarchy panel, a memoized tab switching function, and vertical scrolling for the inspector panel. It also fixes a CSS syntax error, disables text selection, and refactors some code for readability and performance. The changes affect the `App`, `Resizable`, `Container`, `Hierarchy`, and `Tree` components and their corresponding CSS and types files.