### PR TITLE
fix: undo issues

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -1,21 +1,39 @@
 import { ComponentType } from '@dcl/ecs'
+import { EcsEntity } from '../EcsEntity'
 import type { ComponentOperation } from '../component-operations'
 import { getGizmoManager } from '../gizmo-manager'
 
 export const putEntitySelectedComponent: ComponentOperation = (entity, component) => {
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
-    const enabled = component.getOrNull(entity.entityId) as { gizmo: number } | null
+    const componentValue = component.getOrNull(entity.entityId) as { gizmo: number } | null
     if (entity.meshRenderer) {
-      entity.meshRenderer.showBoundingBox = !!enabled
+      entity.meshRenderer.showBoundingBox = !!componentValue
     }
-    const context = entity.context.deref()!
 
-    const gm = getGizmoManager(context.scene)
+    updateGizmoManager(entity, componentValue)
+  }
+}
 
-    gm.setEntity(entity)
+const updateGizmoManager = (entity: EcsEntity, value: { gizmo: number } | null) => {
+  const context = entity.context.deref()!
+  const gm = getGizmoManager(context.scene)
+  let atLeastOne = 0
 
-    gm.gizmoManager.positionGizmoEnabled = enabled?.gizmo === 0
-    gm.gizmoManager.rotationGizmoEnabled = enabled?.gizmo === 1
-    gm.gizmoManager.scaleGizmoEnabled = enabled?.gizmo === 2
+  for (const [_entity] of context.engine.getEntitiesWith(context.editorComponents.Selection)) {
+    atLeastOne++
+    if (entity.entityId === _entity) {
+        gm.setEntity(entity)
+        gm.gizmoManager.positionGizmoEnabled = value?.gizmo === 0
+        gm.gizmoManager.rotationGizmoEnabled = value?.gizmo === 1
+        gm.gizmoManager.scaleGizmoEnabled = value?.gizmo === 2
+        return
+    }
+  }
+
+  if (atLeastOne === 0) {
+    gm.unsetEntity()
+    gm.gizmoManager.positionGizmoEnabled = false
+    gm.gizmoManager.rotationGizmoEnabled = false
+    gm.gizmoManager.scaleGizmoEnabled = false
   }
 }

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -17,20 +17,20 @@ export const putEntitySelectedComponent: ComponentOperation = (entity, component
 const updateGizmoManager = (entity: EcsEntity, value: { gizmo: number } | null) => {
   const context = entity.context.deref()!
   const gm = getGizmoManager(context.scene)
-  let atLeastOne = 0
+  let processedSomeEntity = false
 
   for (const [_entity] of context.engine.getEntitiesWith(context.editorComponents.Selection)) {
-    atLeastOne++
+    processedSomeEntity = true
     if (entity.entityId === _entity) {
-        gm.setEntity(entity)
-        gm.gizmoManager.positionGizmoEnabled = value?.gizmo === 0
-        gm.gizmoManager.rotationGizmoEnabled = value?.gizmo === 1
-        gm.gizmoManager.scaleGizmoEnabled = value?.gizmo === 2
-        return
+      gm.setEntity(entity)
+      gm.gizmoManager.positionGizmoEnabled = value?.gizmo === 0
+      gm.gizmoManager.rotationGizmoEnabled = value?.gizmo === 1
+      gm.gizmoManager.scaleGizmoEnabled = value?.gizmo === 2
+      return
     }
   }
 
-  if (atLeastOne === 0) {
+  if (!processedSomeEntity) {
     gm.unsetEntity()
     gm.gizmoManager.positionGizmoEnabled = false
     gm.gizmoManager.rotationGizmoEnabled = false

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -75,6 +75,7 @@ export const getGizmoManager = memoize((scene: Scene) => {
     },
     unsetEntity() {
       lastEntity = null
+      gizmoManager.attachToNode(lastEntity)
     }
   }
 })

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -69,6 +69,12 @@ export const getGizmoManager = memoize((scene: Scene) => {
       if (entity === lastEntity) return
       gizmoManager.attachToNode(entity)
       lastEntity = entity
+    },
+    getEntity() {
+      return lastEntity
+    },
+    unsetEntity() {
+      lastEntity = null
     }
   }
 })

--- a/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
@@ -38,7 +38,7 @@ export function stream(
     if (!queue.closed) queue.close()
   }
 
-  // and lastly wire the new messages from the iterator to the
+  // and lastly wire the new messages from the renderer engine
   consumeAllMessagesInto(stream, processMessage, closeCallback).catch((err) => {
     console.error('consumeAllMessagesInto failed: ', err)
   })

--- a/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
@@ -45,13 +45,14 @@ export function initUndoRedo(fs: FileSystemInterface, engine: IEngine, getCompos
     component: ComponentDefinition<unknown> | undefined,
     _componentValue: unknown
   ) {
-    if (!getComposite()) {
+    const composite = getComposite()
+    if (!composite) {
       return
     }
 
     // TODO: selection doesn't exists on composite
     if (operation === CrdtMessageType.PUT_COMPONENT || operation === CrdtMessageType.DELETE_COMPONENT) {
-      const prevValue = findPrevValue(getComposite(), component!.componentName, entity)
+      const prevValue = findPrevValue(composite, component!.componentName, entity)
       crdtAcc.push({
         entity,
         operation,

--- a/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
@@ -118,7 +118,7 @@ export function initUndoRedo(fs: FileSystemInterface, engine: IEngine, getCompos
       undoList.push({ $case: 'file', operations })
     },
     addUndoCrdt() {
-      // TODO: when we delete an entity it's sending a delete EntityNdoe that idk from where its comming
+      // TODO: when we delete an entity it's sending a delete EntityNode that idk from where its comming
       // and its breaking the whole undo/redo logic.
       const lostEntityNodeBug = crdtAcc.length === 1 && crdtAcc[0].componentName === 'editor::EntityNode'
       const changes = getAndCleanArray(crdtAcc)


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/691
closes https://github.com/decentraland/sdk/issues/743

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 912bdfe</samp>

This pull request enhances the inspector tool by improving the undo/redo functionality, the selection logic, the gizmo manager handling, and the data layer documentation. It mainly affects the files `useTree.ts`, `selection.ts`, `undo-redo.ts`, `gizmo-manager.ts`, and `stream.ts`.