### PR TITLE
feat: scene component should only be visible for root entity

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -12,7 +12,7 @@ export const EntityInspector: React.FC = () => {
     <div className="EntityInspector" key={entity}>
       {entity && <TransformInspector entity={entity} />}
       {entity && <GltfInspector entity={entity} />}
-      <SceneInspector entity={ROOT} />
+      {!entity && <SceneInspector entity={ROOT} />}
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -1,13 +1,14 @@
-import React from 'react'
+import React, { useCallback } from 'react'
+import { Entity } from '@dcl/ecs'
 import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io'
 import { FiHexagon } from 'react-icons/fi'
 
-import { useTree } from '../../hooks/sdk/useTree'
 import { ROOT } from '../../lib/sdk/tree'
+import { useSelectedEntity } from '../../hooks/sdk/useSelectedEntity'
+import { useTree } from '../../hooks/sdk/useTree'
+import { Container } from '../Container'
 import { Tree } from '../Tree'
 import { ContextMenu } from './ContextMenu'
-import { Container } from '../Container'
-import { Entity } from '@dcl/ecs'
 
 const Hierarchy: React.FC = () => {
   const {
@@ -20,11 +21,18 @@ const Hierarchy: React.FC = () => {
     getChildren,
     getLabel,
     isOpen,
-    isSelected,
     canRename,
     canRemove,
     canToggle
   } = useTree()
+  const selectedEntity = useSelectedEntity()
+
+  const isSelected = useCallback((entity: Entity) => {
+      if (entity === ROOT) return !selectedEntity
+      return selectedEntity === entity
+    },
+    [selectedEntity]
+  )
 
   return (
     <Container>

--- a/packages/@dcl/inspector/src/hooks/sdk/useEntitiesWith.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useEntitiesWith.ts
@@ -6,7 +6,7 @@ import { useChange } from './useChange'
 import { useSdk } from './useSdk'
 
 function getEntities(engine: IEngine, component: Component) {
-  return Array.from(engine.getEntitiesWith(component)).map(([entity]) => entity)
+  return Array.from(engine.getEntitiesWith(component), ([entity]) => entity)
 }
 
 export const useEntitiesWith = (getComponent: (components: SdkContextValue['components']) => Component) => {

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { getEmptyTree, getTreeFromEngine, ROOT } from '../../lib/sdk/tree'
 import { useChange } from './useChange'
 import { useSdk } from './useSdk'
-import { changeSelectedEntity } from '../../lib/utils/gizmo'
+import { changeSelectedEntity, removeSelectedEntities } from '../../lib/utils/gizmo'
 import { isLastWriteWinComponent } from './useComponentValue'
 
 /**
@@ -44,7 +44,7 @@ export const useTree = () => {
 
   const getLabel = useCallback(
     (entity: Entity) => {
-      if (entity === ROOT) return 'Root'
+      if (entity === ROOT) return 'Scene'
       if (!sdk) return entity.toString()
       const { EntityNode } = sdk.components
       return EntityNode.has(entity) ? EntityNode.get(entity).label : entity.toString()
@@ -58,16 +58,6 @@ export const useTree = () => {
       if (!sdk) return false
       const { Toggle } = sdk.components
       return Toggle.has(entity)
-    },
-    [sdk]
-  )
-
-  const isSelected = useCallback(
-    (entity: Entity) => {
-      if (entity === ROOT) return false
-      if (!sdk) return false
-      const { Selection } = sdk.components
-      return Selection.has(entity)
     },
     [sdk]
   )
@@ -132,9 +122,10 @@ export const useTree = () => {
 
   const toggle = useCallback(
     (entity: Entity, open: boolean) => {
-      if (entity === ROOT || !sdk) return
-      const { Toggle } = sdk.components
+      if (!sdk) return
+      if (entity === ROOT) return removeSelectedEntities(sdk.engine)
 
+      const { Toggle } = sdk.components
       changeSelectedEntity(entity, sdk.engine)
 
       if (open) {
@@ -151,7 +142,7 @@ export const useTree = () => {
   const isNotRoot = useCallback((entity: Entity) => entity !== ROOT, [])
   const canRename = isNotRoot
   const canRemove = isNotRoot
-  const canToggle = isNotRoot
+  const canToggle = useCallback(() => true, [])
 
   return {
     tree,
@@ -164,7 +155,6 @@ export const useTree = () => {
     getChildren,
     getLabel,
     isOpen,
-    isSelected,
     canRename,
     canRemove,
     canToggle

--- a/packages/@dcl/inspector/src/lib/utils/gizmo.ts
+++ b/packages/@dcl/inspector/src/lib/utils/gizmo.ts
@@ -7,6 +7,13 @@ export enum GizmoType {
   SCALE = 2
 }
 
+export function removeSelectedEntities(engine: IEngine) {
+  const Selection = engine.getComponent(EditorComponentIds.Selection) as EditorComponents['Selection']
+  for (const [entity] of engine.getEntitiesWith(Selection)) {
+    Selection.deleteFrom(entity)
+  }
+}
+
 export function changeSelectedEntity(entity: Entity, engine: IEngine) {
   let gizmo = GizmoType.TRANSLATE
 


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/714

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fc8678</samp>

This pull request improves the hierarchy component in the inspector by adding more functionality and simplifying the code. It allows the user to toggle and remove the root entity and the selected entities, and shows the scene properties only when no entity is selected. It also refactors the hierarchy and entity inspector components to share the same hooks and logic, and moves some functions to the `gizmo` file.