### PR TITLE
Remove self-contained GLTF/GLB asset

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "@types/react-modal": "^3.16.0",
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "@well-known-components/pushable-channel": "^1.0.3",
         "classnames": "^2.3.2",
@@ -36,6 +37,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
         "react-icons": "^4.7.1",
+        "react-modal": "^3.16.1",
         "typescript": "^5.0.2"
       }
     },
@@ -1135,6 +1137,15 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
+      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -3245,6 +3256,25 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
+    "node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dev": true,
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
+    },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
@@ -4786,6 +4816,15 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-modal": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
+      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -6403,6 +6442,18 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
+    },
+    "react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dev": true,
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
     },
     "react-popper": {
       "version": "2.3.0",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/react-modal": "^3.16.0",
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@well-known-components/pushable-channel": "^1.0.3",
     "classnames": "^2.3.2",
@@ -30,6 +31,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",
+    "react-modal": "^3.16.1",
     "typescript": "^5.0.2"
   },
   "files": [

--- a/packages/@dcl/inspector/src/components/App/App.tsx
+++ b/packages/@dcl/inspector/src/components/App/App.tsx
@@ -15,6 +15,7 @@ import { Toolbar } from '../Toolbar'
 import './App.css'
 import { Resizable } from '../Resizable'
 import ImportAsset from '../ImportAsset'
+import { fileSystemEvent } from '../../hooks/catalog/useFileSystem'
 
 enum Tab {
   FileSystem = 'FileSystem',
@@ -32,6 +33,11 @@ const App = () => {
     },
     [tab]
   )
+
+  const handleSave = useCallback(() => {
+    setTab(Tab.FileSystem)
+    fileSystemEvent.emit('change')
+  }, [])
 
   return (
     <Resizable type="horizontal" min={300} initial={300}>
@@ -56,7 +62,7 @@ const App = () => {
             <div className="footer-content">
               {tab === Tab.AssetsPack && catalog && <AssetsCatalog value={catalog} />}
               {tab === Tab.FileSystem && <ProjectAssetExplorer onImportAsset={handleTabClick(Tab.Import)} />}
-              {tab === Tab.Import && <ImportAsset onSave={handleTabClick(Tab.FileSystem)} />}
+              {tab === Tab.Import && <ImportAsset onSave={handleSave} />}
             </div>
           )}
           <div className="footer-buttons">

--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -14,3 +14,9 @@
   flex-direction: row;
   flex-grow: 1;
 }
+
+.Block.broken {
+  border: 1px #d33c3c dashed;
+  padding: 0 5px 8px 5px;
+  border-radius: 2px;
+}

--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -16,7 +16,7 @@
 }
 
 .Block.broken {
-  border: 1px #d33c3c dashed;
+  border: 1px var(--primary) dashed;
   padding: 0 5px 8px 5px;
   border-radius: 2px;
 }

--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -15,7 +15,7 @@
   flex-grow: 1;
 }
 
-.Block.broken {
+.Block.error {
   border: 1px var(--primary) dashed;
   padding: 0 5px 8px 5px;
   border-radius: 2px;

--- a/packages/@dcl/inspector/src/components/Block/Block.tsx
+++ b/packages/@dcl/inspector/src/components/Block/Block.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
+import cx from 'classnames'
 
 import { Props } from './types'
 
 import './Block.css'
 
-const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, children }, ref) => {
+const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, broken, children }, ref) => {
   return (
-    <div ref={ref} className="Block">
+    <div ref={ref} className={cx("Block", { broken })}>
       {label && <label>{label}</label>}
       <div className="content">{children}</div>
     </div>

--- a/packages/@dcl/inspector/src/components/Block/Block.tsx
+++ b/packages/@dcl/inspector/src/components/Block/Block.tsx
@@ -5,9 +5,9 @@ import { Props } from './types'
 
 import './Block.css'
 
-const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, broken, children }, ref) => {
+const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, error, children }, ref) => {
   return (
-    <div ref={ref} className={cx("Block", { broken })}>
+    <div ref={ref} className={cx("Block", { error })}>
       {label && <label>{label}</label>}
       <div className="content">{children}</div>
     </div>

--- a/packages/@dcl/inspector/src/components/Block/types.ts
+++ b/packages/@dcl/inspector/src/components/Block/types.ts
@@ -1,3 +1,4 @@
 export type Props = {
   label?: string
+  broken?: boolean
 }

--- a/packages/@dcl/inspector/src/components/Block/types.ts
+++ b/packages/@dcl/inspector/src/components/Block/types.ts
@@ -1,4 +1,4 @@
 export type Props = {
   label?: string
-  broken?: boolean
+  error?: boolean
 }

--- a/packages/@dcl/inspector/src/components/Button/Button.css
+++ b/packages/@dcl/inspector/src/components/Button/Button.css
@@ -24,3 +24,17 @@
   width: 24px;
   height: 24px;
 }
+
+.Button.big {
+  padding: 16px;
+  font-size: 16px;
+}
+
+.Button.danger {
+  background-color: var(--primary);
+}
+
+.Button.danger:hover,
+.Button.danger.active {
+  background-color: var(--primary-darker)
+}

--- a/packages/@dcl/inspector/src/components/Button/Button.tsx
+++ b/packages/@dcl/inspector/src/components/Button/Button.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-import classNames from 'classnames'
+import cx from 'classnames'
 
 import { PropTypes } from './types'
 import './Button.css'
 
-function Button(props: PropTypes) {
+function Button({ size, type, ...props }: PropTypes) {
   return (
-    <button {...props} className={classNames('Button', props.className)}>
+    <button {...props} className={cx('Button', size, type, props.className)}>
       {props.children}
     </button>
   )

--- a/packages/@dcl/inspector/src/components/Button/types.ts
+++ b/packages/@dcl/inspector/src/components/Button/types.ts
@@ -1,1 +1,6 @@
-export type PropTypes = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+type Button = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+
+export type PropTypes = Omit<Button, 'type' | 'size'> & {
+  type?: 'danger' | 'etc'
+  size?: 'big' | 'etc'
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -27,11 +27,13 @@ export default withSdk<Props>(
 
     const hasGltf = useHasComponent(entity, GltfContainer)
     const handleInputValidation = useCallback(({ src }: { src: string }) => isValidInput(files, src), [files])
-    const { getInputProps, monitor } = useComponentInput(entity, GltfContainer, fromGltf, toGltf, handleInputValidation, [files])
+    const { getInputProps, isValid } = useComponentInput(entity, GltfContainer, fromGltf, toGltf, handleInputValidation, [files])
 
     const handleRemove = useCallback(() => GltfContainer.deleteFrom(entity), [])
-    const handleDrop = useCallback((src: string) => {
-      GltfContainer.createOrReplace(entity, { src })
+    const handleDrop = useCallback(async (src: string) => {
+      const { operations } = sdk
+      operations.updateValue(GltfContainer, entity, { src })
+      await operations.dispatch()
     }, [])
 
     const [{ isHover }, drop] = useDrop(
@@ -65,7 +67,7 @@ export default withSdk<Props>(
             <DeleteIcon /> Delete
           </Item>
         </Menu>
-        <Block label="Path" ref={drop} broken={init && !monitor.isValid}>
+        <Block label="Path" ref={drop} error={init && !isValid}>
           <TextField type="text" {...inputProps} />
         </Block>
       </Container>

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -21,13 +21,13 @@ const DROP_TYPES = ['project-asset-gltf']
 
 export default withSdk<Props>(
   withContextMenu<WithSdkProps & Props>(({ sdk, entity, contextMenuId }) => {
-    const [files] = useFileSystem()
+    const [files, init] = useFileSystem()
     const { handleAction } = useContextMenu()
     const { GltfContainer } = sdk.components
 
     const hasGltf = useHasComponent(entity, GltfContainer)
     const handleInputValidation = useCallback(({ src }: { src: string }) => isValidInput(files, src), [files])
-    const getInputProps = useComponentInput(entity, GltfContainer, fromGltf, toGltf, handleInputValidation)
+    const { getInputProps, monitor } = useComponentInput(entity, GltfContainer, fromGltf, toGltf, handleInputValidation, [files])
 
     const handleRemove = useCallback(() => GltfContainer.deleteFrom(entity), [])
     const handleDrop = useCallback((src: string) => {
@@ -56,6 +56,8 @@ export default withSdk<Props>(
 
     if (!hasGltf) return null
 
+    const inputProps = getInputProps('src')
+
     return (
       <Container label="Gltf" className={cx('Gltf', { hover: isHover })}>
         <Menu id={contextMenuId}>
@@ -63,8 +65,8 @@ export default withSdk<Props>(
             <DeleteIcon /> Delete
           </Item>
         </Menu>
-        <Block label="Path" ref={drop}>
-          <TextField type="text" {...getInputProps('src')} />
+        <Block label="Path" ref={drop} broken={init && !monitor.isValid}>
+          <TextField type="text" {...inputProps} />
         </Block>
       </Container>
     )

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -11,7 +11,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
   const { Scene } = sdk.components
 
   const hasScene = useHasComponent(entity, Scene)
-  const getInputProps = useComponentInput(entity, Scene, fromScene, toScene, isValidInput)
+  const { getInputProps } = useComponentInput(entity, Scene, fromScene, toScene, isValidInput)
 
   if (!hasScene) {
     return null

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
@@ -21,7 +21,7 @@
 .TextField>input {
   width: 100%;
   color: var(--text);
-  background-color: var(--transparent-color);
+  background-color: var(--transparent);
   outline: none;
   border: none;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -19,7 +19,7 @@ export default withSdk<Props>(
     const { Transform } = sdk.components
 
     const hasTransform = useHasComponent(entity, Transform)
-    const getInputProps = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
+    const { getInputProps } = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
     const { handleAction } = useContextMenu()
 
     const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])

--- a/packages/@dcl/inspector/src/components/Modal/Modal.css
+++ b/packages/@dcl/inspector/src/components/Modal/Modal.css
@@ -1,0 +1,24 @@
+.Modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-right: -50%;
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--modal-content-border-color);
+  background: var(--modal-content-bg-color);
+  overflow: auto;
+  border-radius: 3px;
+  outline: none;
+  padding: 20px;
+  min-width: 500px;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.ModalOverlay {
+  position: fixed;
+  inset: 0px;
+  background-color: var(--modal-overlay-bg-color);
+}

--- a/packages/@dcl/inspector/src/components/Modal/Modal.tsx
+++ b/packages/@dcl/inspector/src/components/Modal/Modal.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import _Modal from 'react-modal'
+
+import { Props } from './types'
+
+import './Modal.css'
+
+const Modal = ({
+  children,
+  className = '',
+  overlayClassName = '',
+  ...props
+}: Props) => {
+  return (
+    <_Modal
+      ariaHideApp={false}
+      className={`${className} Modal`}
+      overlayClassName={`${overlayClassName} ModalOverlay`}
+      {...props}
+    >
+      {children}
+    </_Modal>
+  )
+}
+
+export default React.memo(Modal)

--- a/packages/@dcl/inspector/src/components/Modal/index.ts
+++ b/packages/@dcl/inspector/src/components/Modal/index.ts
@@ -1,0 +1,2 @@
+import Modal from './Modal'
+export { Modal }

--- a/packages/@dcl/inspector/src/components/Modal/types.ts
+++ b/packages/@dcl/inspector/src/components/Modal/types.ts
@@ -1,0 +1,4 @@
+import React from 'react'
+import Modal from 'react-modal'
+
+export type Props = React.PropsWithChildren<Modal.Props>

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ContextMenu.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ContextMenu.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Item } from 'react-contexify'
 import { AiOutlineFileAdd } from 'react-icons/ai'
 import { IoIosImage } from 'react-icons/io'
@@ -6,12 +5,19 @@ import { IoIosImage } from 'react-icons/io'
 import { useContextMenu } from '../../hooks/sdk/useContextMenu'
 import { ROOT, TreeNode } from './ProjectView'
 
-function ContextMenu({ value, onImportAsset }: { value: TreeNode | undefined; onImportAsset(): void }) {
+interface Props {
+  value: TreeNode | undefined
+  onImportAsset(): void
+}
+
+function ContextMenu({ value, onImportAsset }: Props) {
   const { handleAction } = useContextMenu()
+
+  if (value?.type === 'asset') return null
 
   return (
     <>
-      <Item hidden={false} id="new-asset-pack" onClick={handleAction(onImportAsset)}>
+      <Item id="new-asset-pack" onClick={handleAction(onImportAsset)}>
         <AiOutlineFileAdd /> Import new asset
       </Item>
       <Item hidden={true || value?.name === ROOT} id="new-asset-texture" onClick={handleAction(onImportAsset)}>

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.css
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.css
@@ -19,3 +19,7 @@
 .ProjectView .with-context-menu {
   height: 100%;
 }
+
+.RemoveAsset.Modal > div button {
+  margin-right: 12px;
+}

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/utils.ts
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/utils.ts
@@ -48,7 +48,7 @@ export function buildAssetTree(paths: string[]): AssetNodeFolder {
 export function getFullNodePath(item: AssetNode | TreeNode): string {
   let path = ''
   let it: AssetNode | TreeNode | null = item
-  while (it) {
+  while (it && it.name) {
     path = '/' + it.name + path
     it = it.parent
   }

--- a/packages/@dcl/inspector/src/hooks/catalog/useFileSystem.ts
+++ b/packages/@dcl/inspector/src/hooks/catalog/useFileSystem.ts
@@ -8,8 +8,9 @@ type FileSystemEvent = { change: unknown }
 export const fileSystemEvent = mitt<FileSystemEvent>()
 
 /* istanbul ignore next */
-export const useFileSystem = () => {
+export const useFileSystem = (): [AssetCatalogResponse, boolean] => {
   const [files, setFiles] = useState<AssetCatalogResponse>({ basePath: '', assets: [] })
+  const [init, setInit] = useState(false)
   useSdk(async ({ dataLayer }) => {
     async function fetchFiles() {
       const assets = await dataLayer.getAssetCatalog({})
@@ -17,7 +18,8 @@ export const useFileSystem = () => {
     }
     fileSystemEvent.on('change', fetchFiles)
     await fetchFiles()
+    setInit(true)
   })
 
-  return [files]
+  return [files, init]
 }

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -29,7 +29,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   )
   const [isFocused, setIsFocused] = useState(false)
   const [skipSync, setSkipSync] = useState(false)
-  const [monitor, setMonitor] = useState({ isValid: false })
+  const [isValid, setIsValid] = useState(false)
 
   const updateInputs = useCallback((value: InputType | null, skipSync = false) => {
     setSkipSync(skipSync)
@@ -83,9 +83,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   }, [componentValue])
 
   useEffect(() => {
-    setMonitor({
-      isValid: validate(input)
-    })
+    setIsValid(validate(input))
   }, [input, ...deps])
 
   const getProps = useCallback(
@@ -104,5 +102,5 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     [handleUpdate, handleFocus, handleBlur, input]
   )
 
-  return { getInputProps: getProps, monitor }
+  return { getInputProps: getProps, isValid }
 }

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -52,7 +52,10 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     updateInputs(fromComponentValueToInput(componentValue))
   }, [componentValue])
 
-  const validate = useCallback((input: InputType | null): input is InputType => input !== null && validateInput(input), [input, ...deps])
+  const validate = useCallback(
+    (input: InputType | null): input is InputType => input !== null && validateInput(input),
+    [input, ...deps]
+  )
 
   // sync inputs -> engine
   useEffect(() => {

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -20,7 +20,8 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   component: Component<ComponentValueType>,
   fromComponentValueToInput: (componentValue: ComponentValueType) => InputType,
   fromInputToComponentValue: (input: InputType) => ComponentValueType,
-  isValidInput: (input: InputType) => boolean = () => true
+  validateInput: (input: InputType) => boolean = () => true,
+  deps: unknown[] = []
 ) => {
   const [componentValue, setComponentValue, isEqual] = useComponentValue<ComponentValueType>(entity, component)
   const [input, setInput] = useState<InputType | null>(
@@ -28,6 +29,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   )
   const [isFocused, setIsFocused] = useState(false)
   const [skipSync, setSkipSync] = useState(false)
+  const [monitor, setMonitor] = useState({ isValid: false })
 
   const updateInputs = useCallback((value: InputType | null, skipSync = false) => {
     setSkipSync(skipSync)
@@ -50,10 +52,12 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     updateInputs(fromComponentValueToInput(componentValue))
   }, [componentValue])
 
+  const validate = useCallback((input: InputType | null): input is InputType => input !== null && validateInput(input), [input, ...deps])
+
   // sync inputs -> engine
   useEffect(() => {
     if (skipSync) return
-    if (input !== null && isValidInput(input)) {
+    if (validate(input)) {
       const newComponentValue = { ...componentValue, ...fromInputToComponentValue(input) }
 
       if (isEqual(newComponentValue)) {
@@ -75,6 +79,12 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     updateInputs(newInputs, true)
   }, [componentValue])
 
+  useEffect(() => {
+    setMonitor({
+      isValid: validate(input)
+    })
+  }, [input, ...deps])
+
   const getProps = useCallback(
     (
       path: NestedKey<InputType>
@@ -91,5 +101,5 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     [handleUpdate, handleFocus, handleBlur, input]
   )
 
-  return getProps
+  return { getInputProps: getProps, monitor }
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
@@ -1,4 +1,4 @@
-import { Transform, Entity, EntityMappingMode, IEngine, Composite, OnChangeFunction, CompositeDefinition } from '@dcl/ecs'
+import { Entity, EntityMappingMode, IEngine, Composite, OnChangeFunction, CompositeDefinition } from '@dcl/ecs'
 
 import { DataLayerRpcServer, FileSystemInterface } from '../types'
 import { getFilesInDirectory } from './fs-utils'
@@ -121,8 +121,6 @@ export async function initRpcMethods(
         const prevValue = await fs.readFile(filePath)
         await fs.rm(filePath)
         undoRedo.addUndoFile([{ prevValue, newValue: null, path: filePath }])
-        const asd = engine.addEntity()
-        Transform.create(asd)
       }
       return {}
     }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityMappingMode, IEngine, Composite, OnChangeFunction, CompositeDefinition } from '@dcl/ecs'
+import { Transform, Entity, EntityMappingMode, IEngine, Composite, OnChangeFunction, CompositeDefinition } from '@dcl/ecs'
 
 import { DataLayerRpcServer, FileSystemInterface } from '../types'
 import { getFilesInDirectory } from './fs-utils'
@@ -100,7 +100,7 @@ export async function initRpcMethods(
     },
     /**
      * Import asset into the file system.
-     * It generates an undo opreation.
+     * It generates an undo operation.
      */
     async importAsset(req) {
       const baseFolder = (req.basePath.length ? req.basePath + '/' : '') + req.assetPackageName + '/'
@@ -112,6 +112,18 @@ export async function initRpcMethods(
         await upsertAsset(fs, filePath, fileContent)
       }
       undoRedo.addUndoFile(undoAcc)
+      return {}
+    },
+    async removeAsset(req) {
+      const filePath = req.path
+      // TODO: remove ALL gltf/glb related files...
+      if (await fs.existFile(filePath)) {
+        const prevValue = await fs.readFile(filePath)
+        await fs.rm(filePath)
+        undoRedo.addUndoFile([{ prevValue, newValue: null, path: filePath }])
+        const asd = engine.addEntity()
+        Transform.create(asd)
+      }
       return {}
     }
   }

--- a/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
+++ b/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
@@ -38,4 +38,5 @@ service DataService {
   rpc GetAssetCatalog(Empty) returns (AssetCatalogResponse) {}
   rpc GetAssetData(Asset) returns (AssetData) {}
   rpc ImportAsset(ImportAssetRequest) returns (Empty) {}
+  rpc RemoveAsset(Asset) returns (Empty) {}
 }

--- a/packages/@dcl/inspector/src/lib/logic/in-memory-storage.ts
+++ b/packages/@dcl/inspector/src/lib/logic/in-memory-storage.ts
@@ -21,7 +21,7 @@ export function createInMemoryStorage(initialFs: Record<string, Buffer> = {}) {
       }
       return content
     },
-    async delete(fileId: string): Promise<boolean> {
+    delete(fileId: string): boolean {
       return storage.delete(fileId)
     },
     storage
@@ -45,7 +45,7 @@ export function createFsInMemory(initialFs: Record<string, Buffer> = {}): FileSy
       return fs.writeFile(filePath.replace(/^\/+/g, ''), content)
     },
     async rm(filePath: string): Promise<void> {
-      await fs.delete(filePath)
+      fs.delete(filePath.replace(/^\/+/g, ''))
     },
     async readdir(dirPath: string): Promise<{ name: string; isDirectory: boolean }[]> {
       const resolvedDirPath = dirPath.replace(/^\/+/g, '').replace(/^\.\/|^\.+/g, '')

--- a/packages/@dcl/inspector/src/vars.css
+++ b/packages/@dcl/inspector/src/vars.css
@@ -3,7 +3,6 @@
   --dropdown-bg-color: var(--vscode-dropdown-background, #D8D8D8);
   --dropdown-border-color: var(--vscode-dropdown-border, #b9b9b9);
   --dropdown-hover-bg-color: var(--vscode-list-hoverBackground, #e4e4e4);
-  --transparent-color: transparent;
   --list-item-bg-color: var(--vscode-list-dropBackground, #36343D);
   --list-item-hover-bg-color: var(--vscode-list-hoverBackground, #504E58);
   --tree-bg-color: var(--vscode-panel-background, #252526);
@@ -17,10 +16,12 @@
 
   /* DCL Colors */
   --primary: #ff2d55;
+  --primary-darker: #cc2443;
 
   /* Color definitions */
   --white: #FFFFFF;
   --black: #000000;
+  --transparent: transparent;
 
   /* Context menu */
   --contexify-zIndex: 999;
@@ -43,6 +44,10 @@
   --contexify-arrow-color: var(--contexify-item-color);
   --contexify-activeArrow-color: var(--contexify-arrow-color);
 
+  /* Modal */
+  --modal-content-bg-color: var(--tree-bg-color);
+  --modal-content-border-color: var(--tree-border-color);
+  --modal-overlay-bg-color: rgba(0, 0, 0, 0.6);
 
   /* Margins */
   --sidebar: 314px


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/757

![May-05-2023 13-21-56](https://user-images.githubusercontent.com/2366069/236514526-70003008-844a-4f7c-be3b-a80d482481f2.gif)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddee27e</samp>

This pull request adds and updates several components and files in the `@dcl/inspector` package, mainly to improve the UI and functionality of the inspector tool. It introduces the `react-modal` and `classnames` modules as dependencies, and uses them to create a `Modal` component and to apply conditional styles to the `Button` and `Block` components. It also adds the ability to remove an asset from the project, and shows a warning modal if the asset is used by some components. It simplifies some code by using hooks and variables, and fixes some minor issues with the input validation and the context menu.

