### PR TITLE
fix: renderer resizing

### DIFF
--- a/packages/@dcl/inspector/src/components/Resizable/Resizable.css
+++ b/packages/@dcl/inspector/src/components/Resizable/Resizable.css
@@ -1,10 +1,10 @@
 .Resizable {
   display: flex;
+  width: 100%;
 }
 
 .Resizable .resize-handle {
-  position: absolute;
-  width: 10px;
+  width: 3px;
   height: 100%;
   cursor: col-resize;
 }

--- a/packages/@dcl/inspector/src/components/Resizable/Resizable.tsx
+++ b/packages/@dcl/inspector/src/components/Resizable/Resizable.tsx
@@ -36,11 +36,15 @@ function Resizable(props: React.PropsWithChildren<PropTypes>) {
   }, [value])
 
   const handleDrag = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const clientValue = event[eventClientValue]
-    const diff = getParentOffset() - clientValue
-    if (!dragging || clientValue <= minValue || clientValue > (props.max || Infinity)) return
-    setValue([clientValue, diff])
-    if (props.onChange) props.onChange([clientValue, diff])
+    if (!dragging) return
+    resize(event[eventClientValue])
+  }
+
+  const resize = (value: number) => {
+    const diff = getParentOffset() - value
+    if (value <= minValue || value > (props.max || Infinity)) return
+    setValue([value, diff])
+    if (props.onChange) props.onChange([value, diff])
   }
 
   const handleMouseUp = useCallback(() => setDragging(false), [])
@@ -55,7 +59,7 @@ function Resizable(props: React.PropsWithChildren<PropTypes>) {
   return (
     <div className={`Resizable ${props.type}`} onMouseMove={handleDrag}>
       <div ref={ref} style={{ [css.childs]: value[0] ?? 'auto' }}>{children[0]}</div>
-      <div className="resize-handle" style={{ [css.handle]: value[0] ?? 0 }} onMouseDown={() => setDragging(true)} />
+      <div className="resize-handle" onMouseDown={() => setDragging(true)} />
       <div style={{ [css.childs]: value[1] ?? 'auto' }}>{children[1]}</div>
     </div>
   )

--- a/packages/@dcl/inspector/src/components/Resizable/Resizable.tsx
+++ b/packages/@dcl/inspector/src/components/Resizable/Resizable.tsx
@@ -56,9 +56,14 @@ function Resizable(props: React.PropsWithChildren<PropTypes>) {
     }
   }, [])
 
+  const styles = {
+    [css.childs]: value[0] ?? 'auto',
+    [`min-${css.childs}`]: minValue
+  }
+
   return (
     <div className={`Resizable ${props.type}`} onMouseMove={handleDrag}>
-      <div ref={ref} style={{ [css.childs]: value[0] ?? 'auto' }}>{children[0]}</div>
+      <div ref={ref} style={styles}>{children[0]}</div>
       <div className="resize-handle" onMouseDown={() => setDragging(true)} />
       <div style={{ [css.childs]: value[1] ?? 'auto' }}>{children[1]}</div>
     </div>


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/762

![May-10-2023 15-43-08](https://github.com/decentraland/js-sdk-toolchain/assets/2366069/c4a7c89b-a12d-40dc-a1c1-86e789c8aed6)


<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1941e40</samp>

> _We are the inspectors of doom_
> _We wield the power of the `.Resizable` class_
> _We slice the panel with the `.resize-handle`_
> _We refactor and simplify, we are the masters of CSS_