### PR TITLE
feat: gizmo warning

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -13,9 +13,10 @@ import { ROOT } from '../../lib/sdk/tree'
 import { AssetNodeItem } from '../ProjectAssetExplorer/types'
 import { IAsset } from '../AssetsCatalog/types'
 import { getModel, isAsset } from '../EntityInspector/GltfInspector/utils'
+import { useIsMounted } from '../../hooks/useIsMounted'
+import { Warnings } from './Warnings'
 
 import './Renderer.css'
-import { useIsMounted } from '../../hooks/useIsMounted'
 
 const fixedNumber = (val: number) => Math.round(val * 1e2) / 1e2
 
@@ -110,6 +111,7 @@ const Renderer: React.FC = () => {
           <Dimmer active />
         </div>
       )}
+      <Warnings />
       <canvas ref={canvasRef} id="canvas" touch-action="none" />
     </div>
   )

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/RotationGizmoLocalAlignmentDisabled/RotationGizmoLocalAlignmentDisabled.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/RotationGizmoLocalAlignmentDisabled/RotationGizmoLocalAlignmentDisabled.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Warning } from '../Warning'
+import { useGizmoAlignment } from '../../../../hooks/editor/useGizmoAlignment'
+import { useSelectedEntity } from '../../../../hooks/sdk/useSelectedEntity'
+import { ROOT } from '../../../../lib/sdk/tree'
+import { withSdk } from '../../../../hoc/withSdk'
+import { useComponentValue } from '../../../../hooks/sdk/useComponentValue'
+import { GizmoType } from '../../../../lib/utils/gizmo'
+
+const RotationGizmoLocalAlignmentDisabled: React.FC = withSdk(({ sdk }) => {
+  const selectedEntity = useSelectedEntity()
+  const [selection] = useComponentValue(selectedEntity || ROOT, sdk.components.Selection)
+  const { isRotationGizmoAlignmentDisabled } = useGizmoAlignment()
+  if (selectedEntity && selection.gizmo === GizmoType.ROTATION && isRotationGizmoAlignmentDisabled) {
+    return (
+      <Warning
+        title={
+          <span>
+            The <b>rotation gizmo</b> can't be aligned to the entity when it's not scaled proportionally
+          </span>
+        }
+      />
+    )
+  } else {
+    return null
+  }
+})
+
+export default React.memo(RotationGizmoLocalAlignmentDisabled)

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/RotationGizmoLocalAlignmentDisabled/index.ts
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/RotationGizmoLocalAlignmentDisabled/index.ts
@@ -1,0 +1,2 @@
+import RotationGizmoLocalAlignmentDisabled from './RotationGizmoLocalAlignmentDisabled'
+export { RotationGizmoLocalAlignmentDisabled }

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/Warning.css
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/Warning.css
@@ -1,0 +1,15 @@
+.Warning {
+  color: var(--white);
+  background-color: var(--tree-bg-color);
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.Warning .icon {
+  color: var(--danger);
+  margin-right: 4px;
+  width: 16px;
+  height: 16px;
+}

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/Warning.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/Warning.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { CiWarning } from 'react-icons/ci'
+
+import './Warning.css'
+
+type Props = {
+  title: React.ReactNode
+}
+
+const Warning: React.FC<Props> = ({ title }) => {
+  return (
+    <div className="Warning">
+      <CiWarning className="icon" />
+      {title}
+    </div>
+  )
+}
+
+export default React.memo(Warning)

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/index.ts
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/Warning/index.ts
@@ -1,0 +1,2 @@
+import Warning from './Warning'
+export { Warning }

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/Warnings.css
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/Warnings.css
@@ -1,0 +1,8 @@
+.Warnings {
+  position: absolute;
+  bottom: 5px;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/Warnings.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/Warnings.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { RotationGizmoLocalAlignmentDisabled } from './RotationGizmoLocalAlignmentDisabled'
+import './Warnings.css'
+
+const Warnings: React.FC = () => {
+  return (
+    <div className="Warnings">
+      <RotationGizmoLocalAlignmentDisabled />
+    </div>
+  )
+}
+
+export default React.memo(Warnings)

--- a/packages/@dcl/inspector/src/components/Renderer/Warnings/index.ts
+++ b/packages/@dcl/inspector/src/components/Renderer/Warnings/index.ts
@@ -1,0 +1,2 @@
+import Warnings from './Warnings'
+export { Warnings }

--- a/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.css
+++ b/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.css
@@ -78,6 +78,10 @@
   position: relative;
 }
 
+.Gizmos .panel .alignment label {
+  color: var(--secondary-text);
+}
+
 .Gizmos .panel .alignment.disabled .icon {
   cursor: not-allowed;
   opacity: 0.5;

--- a/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
@@ -65,7 +65,7 @@ export const Gizmos = withSdk(({ sdk }) => {
         onClick={handleScaleGizmo}
       />
       <BsCaretDown className="open-panel" onClick={handleTogglePanel} />
-      <div ref={ref} className={cx('panel', { visible: showPanel })}>
+      <div ref={ref} className={cx('panel', { visible: true })}>
         <div className="title">
           <label>Snap</label>
           <SnapToggleIcon className="icon" onClick={toggle} />

--- a/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
@@ -65,7 +65,7 @@ export const Gizmos = withSdk(({ sdk }) => {
         onClick={handleScaleGizmo}
       />
       <BsCaretDown className="open-panel" onClick={handleTogglePanel} />
-      <div ref={ref} className={cx('panel', { visible: true })}>
+      <div ref={ref} className={cx('panel', { visible: showPanel })}>
         <div className="title">
           <label>Snap</label>
           <SnapToggleIcon className="icon" onClick={toggle} />

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.spec.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.spec.ts
@@ -1,0 +1,157 @@
+import { Scene, NullEngine, Engine, TransformNode, Quaternion, Vector3 } from '@babylonjs/core'
+import { Gizmos, createGizmoManager } from './gizmo-manager'
+import { SceneContext } from './SceneContext'
+import { TransformComponentExtended } from '@dcl/ecs'
+import { Operations } from '../../sdk/operations'
+import { EcsEntity } from './EcsEntity'
+import { GizmoType } from '../../utils/gizmo'
+
+describe('GizmoManager', () => {
+  let engine: Engine
+  let scene: Scene
+  let context: SceneContext
+  beforeEach(() => {
+    engine = new NullEngine()
+    scene = new Scene(engine)
+    context = {
+      scene,
+      operations: {
+        updateValue: jest.fn(),
+        dispatch: jest.fn()
+      } as unknown as Operations,
+      Transform: { getOrNull: jest.fn() } as unknown as TransformComponentExtended
+    } as SceneContext
+  })
+  describe('When creating a new gizmo manager', () => {
+    let gizmos: Gizmos
+    beforeEach(() => {
+      gizmos = createGizmoManager(context)
+    })
+    it('should return a gizmo manager', () => {
+      expect(gizmos).toBeDefined()
+    })
+    describe('When setting an entity', () => {
+      let entity: TransformNode
+      let handler: jest.Mock
+      beforeEach(() => {
+        entity = new TransformNode('entity', scene)
+        entity.rotationQuaternion = new Quaternion(0, 0, 0, 1)
+        handler = jest.fn()
+        gizmos.onChange(handler)
+        gizmos.setEntity(entity as EcsEntity)
+      })
+      afterEach(() => {
+        entity.dispose()
+        gizmos.unsetEntity()
+      })
+      it('should set the entity', () => {
+        expect(gizmos.getEntity()).toBe(entity)
+      })
+      it('should emit a change event', () => {
+        expect(handler).toHaveBeenCalled()
+      })
+      describe('and the entity was already set', () => {
+        it('should skip setting the entity', () => {
+          const handler = jest.fn()
+          gizmos.onChange(handler)
+          gizmos.setEntity(entity as EcsEntity)
+          expect(handler).not.toHaveBeenCalled()
+        })
+      })
+      describe('and dragging a gizmo', () => {
+        it('should update the transform value', () => {
+          gizmos.gizmoManager.gizmos.positionGizmo?.onDragEndObservable.notifyObservers({} as any)
+          expect(context.operations.updateValue).toHaveBeenCalled()
+          expect(context.operations.dispatch).toHaveBeenCalled()
+        })
+        describe('and the entity is not proportionally scaled', () => {
+          beforeEach(() => {
+            entity.scaling = new Vector3(1, 2, 1)
+          })
+          afterEach(() => {
+            entity.scaling = Vector3.Zero()
+          })
+          describe('and the rotation gizmo is not world aligned', () => {
+            beforeEach(() => {
+              gizmos.setRotationGizmoWorldAligned(false)
+              gizmos.gizmoManager.gizmos.scaleGizmo?.onDragEndObservable.notifyObservers({} as any)
+            })
+            it('should force the rotation gizmo to be world aligned', () => {
+              expect(gizmos.isRotationGizmoWorldAligned()).toBe(true)
+            })
+            it('should disable the rotation gizmo alignment', () => {
+              expect(gizmos.isRotationGizmoAlignmentDisabled()).toBe(true)
+            })
+            it('should ignore setting the rotation gizmo alignment', () => {
+              const handler = jest.fn()
+              gizmos.onChange(handler)
+              gizmos.setRotationGizmoWorldAligned(false)
+              expect(handler).not.toHaveBeenCalled()
+            })
+            it('should allow setting the position gizmo alignment', () => {
+              const handler = jest.fn()
+              gizmos.onChange(handler)
+              expect(gizmos.isPositionGizmoWorldAligned()).toBe(true)
+              gizmos.setPositionGizmoWorldAligned(false)
+              expect(gizmos.isPositionGizmoWorldAligned()).toBe(false)
+              expect(handler).toHaveBeenCalled()
+              handler.mockClear()
+              gizmos.setPositionGizmoWorldAligned(true)
+              expect(gizmos.isPositionGizmoWorldAligned()).toBe(true)
+              expect(handler).toHaveBeenCalled()
+            })
+            describe('and the entity is then proportionally scaled', () => {
+              beforeEach(() => {
+                entity.scaling = new Vector3(1, 1, 1)
+                gizmos.gizmoManager.gizmos.scaleGizmo?.onDragEndObservable.notifyObservers({} as any)
+              })
+              it('should enable the rotation gizmo alignment', () => {
+                expect(gizmos.isRotationGizmoAlignmentDisabled()).toBe(false)
+              })
+              it('should restore the rotation gizmo alignment to be not aligned with the world', () => {
+                expect(gizmos.isRotationGizmoWorldAligned()).toBe(false)
+              })
+              it('should allow setting the rotation gizmo alignment', () => {
+                const handler = jest.fn()
+                gizmos.onChange(handler)
+                gizmos.setRotationGizmoWorldAligned(true)
+                expect(handler).toHaveBeenCalled()
+              })
+            })
+          })
+        })
+      })
+    })
+    describe('When getting the gizmo types', () => {
+      it('should return the gizmo types', () => {
+        expect(gizmos.getGizmoTypes()).toEqual([GizmoType.POSITION, GizmoType.ROTATION, GizmoType.SCALE])
+      })
+    })
+    describe('When setting the gizmo type', () => {
+      describe('and the gizmo type is position', () => {
+        it('should enable the position gizmo and disable the others', () => {
+          gizmos.setGizmoType(GizmoType.POSITION)
+          expect(gizmos.gizmoManager.positionGizmoEnabled).toBe(true)
+          expect(gizmos.gizmoManager.rotationGizmoEnabled).toBe(false)
+          expect(gizmos.gizmoManager.scaleGizmoEnabled).toBe(false)
+        })
+      })
+      describe('and the gizmo type is rotation', () => {
+        it('should enable the rotation gizmo and disable the others', () => {
+          gizmos.setGizmoType(GizmoType.ROTATION)
+          expect(gizmos.gizmoManager.positionGizmoEnabled).toBe(false)
+          expect(gizmos.gizmoManager.rotationGizmoEnabled).toBe(true)
+          expect(gizmos.gizmoManager.scaleGizmoEnabled).toBe(false)
+        })
+      })
+      describe('and the gizmo type is scale', () => {
+        it('should enable the scale gizmo and disable the others', () => {
+          gizmos.setGizmoType(GizmoType.SCALE)
+          expect(gizmos.gizmoManager.positionGizmoEnabled).toBe(false)
+          expect(gizmos.gizmoManager.rotationGizmoEnabled).toBe(false)
+          expect(gizmos.gizmoManager.scaleGizmoEnabled).toBe(true)
+        })
+      })
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -43,15 +43,19 @@ export function createGizmoManager(context: SceneContext) {
 
   let lastEntity: EcsEntity | null = null
   let rotationGizmoAlignmentDisabled = false
+  let shouldRestorRotationGizmoAlignment = false
 
   function fixRotationGizmoAlignment(value: TransformType) {
     const isProportional = value.scale.x === value.scale.y && value.scale.y === value.scale.z
+    rotationGizmoAlignmentDisabled = !isProportional
     if (!isProportional && !isRotationGizmoWorldAligned()) {
-      rotationGizmoAlignmentDisabled = true
       setRotationGizmoWorldAligned(true) // set to world
-    } else if (rotationGizmoAlignmentDisabled && isProportional) {
-      rotationGizmoAlignmentDisabled = false
+      shouldRestorRotationGizmoAlignment = true
+    } else if (shouldRestorRotationGizmoAlignment && isProportional) {
       setRotationGizmoWorldAligned(false) // restore to local
+      shouldRestorRotationGizmoAlignment = false
+    } else {
+      events.emit('change')
     }
   }
 

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -59,7 +59,7 @@ export function createGizmoManager(context: SceneContext) {
     }
   }
 
-  function update() {
+  function getTransform(): TransformType {
     if (lastEntity) {
       const parent = context.Transform.getOrNull(lastEntity.entityId)?.parent || (0 as Entity)
       const value = {
@@ -68,8 +68,17 @@ export function createGizmoManager(context: SceneContext) {
         rotation: snapRotation(lastEntity.rotationQuaternion!),
         parent
       }
-      fixRotationGizmoAlignment(value)
-      context.operations.updateValue(context.Transform, lastEntity.entityId, value)
+      return value
+    } else {
+      throw new Error('No entity selected')
+    }
+  }
+
+  function update() {
+    if (lastEntity) {
+      const transform = getTransform()
+      fixRotationGizmoAlignment(transform)
+      context.operations.updateValue(context.Transform, lastEntity.entityId, transform)
       void context.operations.dispatch()
     }
   }
@@ -123,6 +132,9 @@ export function createGizmoManager(context: SceneContext) {
       if (entity === lastEntity) return
       gizmoManager.attachToNode(entity)
       lastEntity = entity
+      // fix gizmo rotation if necessary
+      const transform = getTransform()
+      fixRotationGizmoAlignment(transform)
       events.emit('change')
     },
     getEntity() {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -46,7 +46,8 @@ export function createGizmoManager(context: SceneContext) {
   let shouldRestorRotationGizmoAlignment = false
 
   function fixRotationGizmoAlignment(value: TransformType) {
-    const isProportional = value.scale.x === value.scale.y && value.scale.y === value.scale.z
+    const isProportional =
+      Math.abs(value.scale.x) === Math.abs(value.scale.y) && Math.abs(value.scale.y) === value.scale.z
     rotationGizmoAlignmentDisabled = !isProportional
     if (!isProportional && !isRotationGizmoWorldAligned()) {
       setRotationGizmoWorldAligned(true) // set to world


### PR DESCRIPTION
Closes: https://github.com/decentraland/sdk/issues/780

This PR adds a warning when the user is using the Rotation gizmo with a local alignment (ie. aligned to the entity) and the entity is not proportionally scaled (which is currently not supported by Babylon), so it forces the gizmo to be world aligned (which works with non-proportional scaled entities).

https://github.com/decentraland/js-sdk-toolchain/assets/2781777/ed61af37-7b09-4674-80ac-542c8f6614d2

I also fixed a few issues that I found testing the alignment feature further:

- The rotation gizmo would not be disabled if the change that made it become non-proportional came from the renderer's engine, is fixed ✅ 
- Disable the rotation gizmo when changing between selected entities (before it would need you to interact with the new entity before it disabled it), is fixed ✅ 
- The entity was considered non-proportional when the values for the different axes where the same, but with different sign (ie. 1, -1, 1 was non-proportional, but in fact it is), this is fixed ✅ 
