### PR TITLE
feat: validate composite before include it in the bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,10 +187,14 @@ jobs:
           node -e "\
             let pkg=require('./package.json');\
             pkg.dependencies['@dcl/inspector']='$INSPECTOR_URL';\
+            pkg.dependencies['@dcl/ecs']='$ECS_S3_URL';\
+            pkg.dependencies['@dcl/js-runtime']='$JS_RUNTIME_S3_URL';\
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));\
           "
         env:
+          ECS_S3_URL: ${{ secrets.SDK_TEAM_S3_BASE_URL }}/${{ steps.publish_ecs.outputs.s3-bucket-key }}
           INSPECTOR_URL: ${{ secrets.SDK_TEAM_S3_BASE_URL }}/${{ steps.publish_decentraland_inspector.outputs.s3-bucket-key }}
+          JS_RUNTIME_S3_URL: ${{ secrets.SDK_TEAM_S3_BASE_URL }}/${{ steps.publish_dcl_js_runtime.outputs.s3-bucket-key }}
 
       - name: publish @dcl/sdk-commands package
         uses: menduz/oddish-action@master

--- a/packages/@dcl/ecs/.gitignore
+++ b/packages/@dcl/ecs/.gitignore
@@ -5,3 +5,4 @@ tsdoc-metadata.json
 coverage
 src/components/generated
 src/composite/proto/gen
+dist-cjs

--- a/packages/@dcl/ecs/package.json
+++ b/packages/@dcl/ecs/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist",
+    "dist-cjs",
     "etc"
   ],
   "homepage": "https://github.com/decentraland/ecs#readme",
@@ -24,7 +25,7 @@
     "directory": "packages/@dcl/ecs"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/packages/@dcl/ecs/tsconfig.cjs.json
+++ b/packages/@dcl/ecs/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist-cjs"
+  }
+}

--- a/packages/@dcl/ecs/tsconfig.json
+++ b/packages/@dcl/ecs/tsconfig.json
@@ -17,5 +17,5 @@
     "types": ["@dcl/js-runtime"]
   },
   "include": ["src"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "dist-cjs"]
 }

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dcl/ecs": "file:../ecs",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "0.7.0",
@@ -44,6 +45,13 @@
         "@types/node-fetch": "^2.6.1",
         "@types/uuid": "^9.0.1",
         "@types/ws": "^8.5.4"
+      }
+    },
+    "../ecs": {
+      "version": "7.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/js-runtime": "file:../js-runtime"
       }
     },
     "../inspector": {
@@ -104,6 +112,10 @@
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^1.0.3"
       }
+    },
+    "node_modules/@dcl/ecs": {
+      "resolved": "../ecs",
+      "link": true
     },
     "node_modules/@dcl/hashing": {
       "version": "1.1.3",
@@ -2363,6 +2375,12 @@
         "@dcl/schemas": "^6.4.2",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^1.0.3"
+      }
+    },
+    "@dcl/ecs": {
+      "version": "file:../ecs",
+      "requires": {
+        "@dcl/js-runtime": "file:../js-runtime"
       }
     },
     "@dcl/hashing": {

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -7,6 +7,7 @@
     "sdk-commands": "./dist/index.js"
   },
   "dependencies": {
+    "@dcl/ecs": "file:../ecs",
     "@dcl/hashing": "1.1.3",
     "@dcl/inspector": "file:../inspector",
     "@dcl/linker-dapp": "0.7.0",

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -12,6 +12,7 @@ import { CliComponents } from '../components'
 import { colors } from '../components/log'
 import { printProgressInfo, printProgressStep } from './beautiful-logs'
 import { CliError } from './error'
+import { getAllComposites } from './composite'
 
 export type BundleComponents = Pick<CliComponents, 'logger' | 'fs'>
 
@@ -203,6 +204,12 @@ function compositeLoader(components: BundleComponents, options: CompileOptions):
             )
             contents = `export const compositeFromLoader = {${data.compositeLines.join(',')}}`
             watchFiles = data.watchFiles
+
+            if (data.withErrors) {
+              components.logger.log(
+                'Warning: some composites are not included because of errors while compiling them. There can be unexpected behavior in the scene, check the errors and try to fix them.'
+              )
+            }
           }
           shouldReload = false
         }
@@ -215,34 +222,6 @@ function compositeLoader(components: BundleComponents, options: CompileOptions):
       })
     }
   }
-}
-
-async function getAllComposites(
-  components: BundleComponents,
-  workingDirectory: string
-): Promise<{ watchFiles: string[]; compositeLines: string[] }> {
-  const composites: Record<string, Uint8Array> = {}
-  const files = globSync('**/*.{composite,composite.bin}', { cwd: workingDirectory })
-
-  for (const file of files) {
-    composites[file] = await components.fs.readFile(path.join(workingDirectory, file))
-  }
-
-  const watchFiles = Object.keys(composites)
-  const compositeLines: string[] = []
-
-  for (const compositeName in composites) {
-    const bin = composites[compositeName]
-    if (compositeName.endsWith('.bin')) {
-      compositeLines.push(`'${compositeName}':new Uint8Array(${JSON.stringify(Array.from(bin))})`)
-    } else {
-      const textDecoder = new TextDecoder()
-      const json = JSON.stringify(JSON.parse(textDecoder.decode(bin)))
-      compositeLines.push(`'${compositeName}':${JSON.stringify(json)}`)
-    }
-  }
-
-  return { compositeLines, watchFiles }
 }
 
 function entryPointLoader(components: BundleComponents, inputs: string[], options: CompileOptions): esbuild.Plugin {

--- a/packages/@dcl/sdk-commands/src/logic/composite.ts
+++ b/packages/@dcl/sdk-commands/src/logic/composite.ts
@@ -1,0 +1,54 @@
+import { globSync } from 'glob'
+import path from 'path'
+import { CliComponents } from '../components'
+import { Composite, Engine } from '@dcl/ecs/dist-cjs'
+
+type CompositeComponents = Pick<CliComponents, 'logger' | 'fs'>
+
+export async function getAllComposites(
+  components: CompositeComponents,
+  workingDirectory: string
+): Promise<{ watchFiles: string[]; compositeLines: string[]; withErrors: boolean }> {
+  let withErrors = false
+  const composites: Record<string, Composite.Definition> = {}
+  const watchFiles = globSync('**/*.composite', { cwd: workingDirectory })
+
+  const textDecoder = new TextDecoder()
+  for (const file of watchFiles) {
+    try {
+      const fileBuffer = await components.fs.readFile(path.join(workingDirectory, file))
+      const json = JSON.parse(textDecoder.decode(fileBuffer))
+      composites[file] = Composite.fromJson(json)
+    } catch (err: any) {
+      components.logger.log(
+        `Composite '${file}' can't be read. Please check if is a valid JSON and composite formated. ${err.stack}`
+      )
+      withErrors = true
+    }
+  }
+
+  const compositeProvider: Composite.Provider = {
+    getCompositeOrNull(src: string): Composite.Resource | null {
+      if (src in composites) {
+        return { src, composite: composites[src] }
+      }
+      return null
+    }
+  }
+
+  const compositeLines: string[] = []
+
+  for (const compositeSource in composites) {
+    const engine = Engine()
+    try {
+      const composite = compositeProvider.getCompositeOrNull(compositeSource)!
+      Composite.instance(engine, composite, compositeProvider)
+      compositeLines.push(`'${composite.src}':${JSON.stringify(Composite.toJson(composite.composite))}`)
+    } catch (err: any) {
+      components.logger.log(`Composite '${compositeSource}' can't be instanced ${err.stack}`)
+      withErrors = true
+    }
+  }
+
+  return { compositeLines, watchFiles, withErrors }
+}

--- a/packages/@dcl/sdk/src/index.ts
+++ b/packages/@dcl/sdk/src/index.ts
@@ -27,7 +27,12 @@ export async function onStart() {
   if (!response.hasEntities) {
     const mainComposite = compositeProvider.getCompositeOrNull('main.composite')
     if (mainComposite) {
-      Composite.instance(engine, mainComposite, compositeProvider)
+      try {
+        Composite.instance(engine, mainComposite, compositeProvider)
+      } catch (err) {
+        console.log(`Warning: main.composite couldn't be instanced.`)
+        console.error(err)
+      }
     }
   }
 

--- a/test/sdk-commands/blackbox/build-and-export-static.spec.ts
+++ b/test/sdk-commands/blackbox/build-and-export-static.spec.ts
@@ -8,7 +8,7 @@ describe('blackbox: build', () => {
   test('build integration test with workspace', async () => {
     const components = await initComponents()
     await runSdkCommand(components, 'build', ['--dir=test/build-ecs/fixtures', '--customEntryPoint'])
-  }, 15000)
+  }, 45000)
 
   test('build integration test with single scene', async () => {
     const components = await initComponents()

--- a/test/sdk-commands/blackbox/build-and-export-static.spec.ts
+++ b/test/sdk-commands/blackbox/build-and-export-static.spec.ts
@@ -8,7 +8,7 @@ describe('blackbox: build', () => {
   test('build integration test with workspace', async () => {
     const components = await initComponents()
     await runSdkCommand(components, 'build', ['--dir=test/build-ecs/fixtures', '--customEntryPoint'])
-  }, 45000)
+  }, 75000)
 
   test('build integration test with single scene', async () => {
     const components = await initComponents()

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=372.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=372.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 31k
-  MALLOC_COUNT = 9941
+  MALLOC_COUNT = 9942
   ALIVE_OBJS_DELTA ~= 1.84k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = -3
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 979.31k bytes
+  MEMORY_USAGE_COUNT ~= 979.59k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=372.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=373k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 32k
-  MALLOC_COUNT = 10041
+  MALLOC_COUNT = 10042
   ALIVE_OBJS_DELTA ~= 1.88k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -64,4 +64,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 979.05k bytes
+  MEMORY_USAGE_COUNT ~= 979.33k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=372.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=373k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 32k
-  MALLOC_COUNT = 10041
+  MALLOC_COUNT = 10042
   ALIVE_OBJS_DELTA ~= 1.88k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -64,4 +64,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 979.05k bytes
+  MEMORY_USAGE_COUNT ~= 979.33k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -164,6 +164,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@dcl/ecs": "file:../ecs",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "0.7.0",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=165.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=165.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 33k
-  MALLOC_COUNT = 8851
+  MALLOC_COUNT = 8852
   ALIVE_OBJS_DELTA ~= 1.89k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 13k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 723.68k bytes
+  MEMORY_USAGE_COUNT ~= 723.90k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=198.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=198.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 43k
-  MALLOC_COUNT = 11167
+  MALLOC_COUNT = 11168
   ALIVE_OBJS_DELTA ~= 2.34k
 CALL onStart()
   OPCODES ~= 0k
@@ -77,4 +77,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 8k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 874.99k bytes
+  MEMORY_USAGE_COUNT ~= 875.22k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=162.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=162.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 33k
-  MALLOC_COUNT = 8398
+  MALLOC_COUNT = 8399
   ALIVE_OBJS_DELTA ~= 1.77k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 697.44k bytes
+  MEMORY_USAGE_COUNT ~= 697.67k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=161.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=161.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 32k
-  MALLOC_COUNT = 8238
+  MALLOC_COUNT = 8239
   ALIVE_OBJS_DELTA ~= 1.73k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 681.95k bytes
+  MEMORY_USAGE_COUNT ~= 682.17k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=198.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=198.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 83k
-  MALLOC_COUNT = 14617
+  MALLOC_COUNT = 14618
   ALIVE_OBJS_DELTA ~= 3.66k
 CALL onStart()
   OPCODES ~= 0k
@@ -1652,4 +1652,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 636k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1013.14k bytes
+  MEMORY_USAGE_COUNT ~= 1013.37k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=162.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=163k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 34k
-  MALLOC_COUNT = 8739
+  MALLOC_COUNT = 8740
   ALIVE_OBJS_DELTA ~= 1.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 706.46k bytes
+  MEMORY_USAGE_COUNT ~= 706.69k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=161.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=161.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 36k
-  MALLOC_COUNT = 8357
+  MALLOC_COUNT = 8358
   ALIVE_OBJS_DELTA ~= 1.76k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 684.31k bytes
+  MEMORY_USAGE_COUNT ~= 684.54k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=317k bytes
+SCENE_COMPILED_JS_SIZE_PROD=317.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 42k
-  MALLOC_COUNT = 15989
+  MALLOC_COUNT = 15990
   ALIVE_OBJS_DELTA ~= 3.03k
 CALL onStart()
   OPCODES ~= 0k
@@ -65,4 +65,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 61k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1504.03k bytes
+  MEMORY_USAGE_COUNT ~= 1504.25k bytes


### PR DESCRIPTION
# What?
- Support CommonJS build for `@dcl/ecs`
- Include `@dcl/ecs` in `sdk-commands`
- At build-time, only composite that can be instanced are added to composite provider
- Double-check with adding a try-catch while instancing the main.composite
