### PR TITLE
feat: manual save

### DIFF
--- a/packages/@dcl/inspector/src/components/Toolbar/Toolbar.css
+++ b/packages/@dcl/inspector/src/components/Toolbar/Toolbar.css
@@ -6,7 +6,8 @@
 }
 
 .Toolbar .undo svg,
-.Toolbar .redo svg {
+.Toolbar .redo svg,
+.Toolbar .save svg {
   transform: translateY(2px);
 }
 

--- a/packages/@dcl/inspector/src/components/Toolbar/Toolbar.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/Toolbar.tsx
@@ -11,7 +11,7 @@ import { ToolbarButton } from './ToolbarButton'
 import './Toolbar.css'
 
 const Toolbar = withSdk(({ sdk }) => {
-  const [isDirty] = useSave()
+  const [save, isDirty] = useSave()
   const handleInspector = useCallback(() => {
     const { debugLayer } = sdk.scene
     if (debugLayer.isVisible()) {
@@ -31,13 +31,9 @@ const Toolbar = withSdk(({ sdk }) => {
     []
   )
 
-  const handleSave = useCallback(async () => {
-    await sdk.dataLayer.save({})
-  }, [])
-
   return (
     <div className="Toolbar">
-      <ToolbarButton className="save" onClick={handleSave}>
+      <ToolbarButton className="save" onClick={save}>
         {isDirty ? <BiSave /> : <BiBadgeCheck/>}
       </ToolbarButton>
       <ToolbarButton className="undo" onClick={handleUndoRedo(sdk?.dataLayer.undo)}>

--- a/packages/@dcl/inspector/src/components/Toolbar/Toolbar.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/Toolbar.tsx
@@ -1,13 +1,17 @@
 import { useCallback } from 'react'
-import { BiUndo, BiRedo } from 'react-icons/bi'
+import { BiUndo, BiRedo, BiSave, BiBadgeCheck } from 'react-icons/bi'
 import { RiListSettingsLine } from 'react-icons/ri'
+
+import { fileSystemEvent } from '../../hooks/catalog/useFileSystem'
+import { useSave } from '../../hooks/editor/useSave'
 import { withSdk } from '../../hoc/withSdk'
 import { Gizmos } from './Gizmos'
 import { ToolbarButton } from './ToolbarButton'
+
 import './Toolbar.css'
-import { fileSystemEvent } from '../../hooks/catalog/useFileSystem'
 
 const Toolbar = withSdk(({ sdk }) => {
+  const [isDirty] = useSave()
   const handleInspector = useCallback(() => {
     const { debugLayer } = sdk.scene
     if (debugLayer.isVisible()) {
@@ -27,8 +31,15 @@ const Toolbar = withSdk(({ sdk }) => {
     []
   )
 
+  const handleSave = useCallback(async () => {
+    await sdk.dataLayer.save({})
+  }, [])
+
   return (
     <div className="Toolbar">
+      <ToolbarButton className="save" onClick={handleSave}>
+        {isDirty ? <BiSave /> : <BiBadgeCheck/>}
+      </ToolbarButton>
       <ToolbarButton className="undo" onClick={handleUndoRedo(sdk?.dataLayer.undo)}>
         <BiUndo />
       </ToolbarButton>

--- a/packages/@dcl/inspector/src/components/Toolbar/ToolbarButton/ToolbarButton.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/ToolbarButton/ToolbarButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cx from 'classnames'
+
 import './ToolbarButton.css'
 
 const ToolbarButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = (props) => {

--- a/packages/@dcl/inspector/src/hooks/editor/useSave.ts
+++ b/packages/@dcl/inspector/src/hooks/editor/useSave.ts
@@ -1,0 +1,17 @@
+import mitt from 'mitt'
+import { useState } from 'react'
+
+import { useSdk } from '../sdk/useSdk'
+
+type SaveEvent = { change: boolean }
+export const saveEvent = mitt<SaveEvent>()
+
+/* istanbul ignore next */
+export const useSave = () => {
+  const [isDirty, setIsDirty] = useState(false)
+  useSdk(() => {
+    saveEvent.on('change', (value: boolean) => setIsDirty(value))
+  })
+
+  return [isDirty]
+}

--- a/packages/@dcl/inspector/src/hooks/editor/useSave.ts
+++ b/packages/@dcl/inspector/src/hooks/editor/useSave.ts
@@ -1,17 +1,21 @@
 import mitt from 'mitt'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useSdk } from '../sdk/useSdk'
 
 type SaveEvent = { change: boolean }
 export const saveEvent = mitt<SaveEvent>()
 
-/* istanbul ignore next */
-export const useSave = () => {
+export const useSave = (): [() => Promise<void>, boolean] => {
+  const sdk = useSdk()
   const [isDirty, setIsDirty] = useState(false)
-  useSdk(() => {
-    saveEvent.on('change', (value: boolean) => setIsDirty(value))
-  })
 
-  return [isDirty]
+  const saveFn = useCallback(async () => {
+    await sdk?.dataLayer.save({})
+    setIsDirty(false)
+  }, [sdk])
+
+  saveEvent.on('change', (value: boolean) => setIsDirty(value))
+
+  return [saveFn, isDirty]
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -5,7 +5,7 @@ import { defineMeshRendererComponent } from '@dcl/ecs/dist/components/extended/M
 import { createEditorComponents } from '../../sdk/components'
 import { dumpEngineToComposite } from '../host/utils/engine-to-composite'
 import { Composite } from '@dcl/ecs'
-import { GltfContainer, Material, PointerEvents } from '@dcl/ecs/dist/components'
+import { GltfContainer, PointerEvents } from '@dcl/ecs/dist/components'
 import { defineMaterialComponent } from '@dcl/ecs/dist/components/extended/Material'
 import { defineMeshColliderComponent } from '@dcl/ecs/dist/components/extended/MeshCollider'
 

--- a/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
@@ -30,7 +30,6 @@ export function stream(
   ctx.engine.addTransport(transport)
 
   async function processMessage(message: Uint8Array) {
-    console.log('tick')
     transport.onmessage!(message)
     await ctx.engine.update(1)
     addUndoCrdt()

--- a/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/undo-redo.ts
@@ -9,7 +9,6 @@ import {
 import upsertAsset from './upsert-asset'
 import { FileSystemInterface } from '../types'
 import { findPrevValue } from './utils/component'
-import { EditorComponentIds } from '../../sdk/components'
 
 export type UndoRedoCrdt = { $case: 'crdt'; operations: CrdtOperation[] }
 export type UndoRedoFile = { $case: 'file'; operations: FileOperation[] }

--- a/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
+++ b/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
@@ -39,4 +39,5 @@ service DataService {
   rpc GetAssetData(Asset) returns (AssetData) {}
   rpc ImportAsset(ImportAssetRequest) returns (Empty) {}
   rpc RemoveAsset(Asset) returns (Empty) {}
+  rpc Save(Empty) returns (Empty) {}
 }

--- a/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
@@ -1,4 +1,7 @@
 import { IEngine } from '@dcl/ecs'
+
+import { saveEvent } from '../../../hooks/editor/useSave'
+
 import removeEntity from './remove-entity'
 import updateValue from './update-value'
 import addChild from './add-child'
@@ -6,6 +9,10 @@ import updateSelectedEntity from './update-selected-entity'
 import setParent from './set-parent'
 import removeSelectedEntities from './remove-selected-entities'
 import addAsset from './add-asset'
+
+export interface Dispatch {
+  dirty?: boolean
+}
 
 export function createOperations(engine: IEngine) {
   return {
@@ -16,7 +23,10 @@ export function createOperations(engine: IEngine) {
     setParent: setParent(engine),
     updateSelectedEntity: updateSelectedEntity(engine),
     removeSelectedEntities: removeSelectedEntities(engine),
-    dispatch: () => engine.update(1)
+    dispatch: ({ dirty = true }: Dispatch = {}) => {
+      void engine.update(1)
+      saveEvent.emit('change', dirty)
+    }
   }
 }
 

--- a/packages/@dcl/inspector/src/lib/sdk/tree.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/tree.ts
@@ -86,7 +86,6 @@ export const getTreeFromEngine = (
             // If the orphan is already an ancestor of the entity, we skip it otherwise we would create a cycle
             continue
           }
-          const { label } = EntityNode.get(orphan)
           // Add orphan to parent's children
           setParent(orphan, entity)
           dirtyEngine = true


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/767

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9c9151</samp>

This pull request adds a save feature to the inspector tool that allows the user to save the engine state to the file system. It also fixes some CSS and formatting issues in the toolbar component and removes some unused imports and variables from the data layer. It updates the `data-layer.proto` file to include the new `Save` RPC method.