### PR TITLE
Validate imported GLTF files.

### DIFF
--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
@@ -58,11 +58,8 @@
   justify-content: center;
   position: relative;
 }
-.ImportAsset .Container .remove-icon {
-  display: none;
-}
 
-.ImportAsset .Container:hover .remove-icon {
+.ImportAsset .Container .remove-icon {
   position: absolute;
   display: flex;
   align-items: center;


### PR DESCRIPTION
After user clicks on red "Import" button, GLTF is validated by a function provided by Babylon.
File size check is included into validation procedure.
Red border around file name is displayed only when the name is incorrect.
The red cross button which removes an asset is deliberately made always visible.