### PR TITLE
fix: refresh entity inspector

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -1,18 +1,17 @@
 import { useSelectedEntity } from '../../hooks/sdk/useSelectedEntity'
-import { ROOT } from '../../lib/sdk/tree'
 
-import { GltfInspector } from './GltfInspector'
 import { SceneInspector } from './SceneInspector'
 import { TransformInspector } from './TransformInspector'
+import { GltfInspector } from './GltfInspector'
 
 export const EntityInspector: React.FC = () => {
   const entity = useSelectedEntity()
 
+  const inspectors = [SceneInspector, TransformInspector, GltfInspector]
+
   return (
     <div className="EntityInspector" key={entity}>
-      {entity && <TransformInspector entity={entity} />}
-      {entity && <GltfInspector entity={entity} />}
-      {!entity && <SceneInspector entity={ROOT} />}
+      {inspectors.map((Compoment, index) => entity !== null && <Compoment key={index} entity={entity} />)}
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -11,7 +11,7 @@ export const EntityInspector: React.FC = () => {
 
   return (
     <div className="EntityInspector" key={entity}>
-      {inspectors.map((Compoment, index) => entity !== null && <Compoment key={index} entity={entity} />)}
+      {inspectors.map((Inspector, index) => entity !== null && <Inspector key={index} entity={entity} />)}
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -27,9 +27,19 @@ export default withSdk<Props>(
 
     const hasGltf = useHasComponent(entity, GltfContainer)
     const handleInputValidation = useCallback(({ src }: { src: string }) => isValidInput(files, src), [files])
-    const { getInputProps, isValid } = useComponentInput(entity, GltfContainer, fromGltf, toGltf, handleInputValidation, [files])
+    const { getInputProps, isValid } = useComponentInput(
+      entity,
+      GltfContainer,
+      fromGltf,
+      toGltf,
+      handleInputValidation,
+      [files]
+    )
 
-    const handleRemove = useCallback(() => GltfContainer.deleteFrom(entity), [])
+    const handleRemove = useCallback(async () => {
+      await sdk.operations.removeComponent(entity, GltfContainer.componentId)
+      await sdk.operations.dispatch()
+    }, [])
     const handleDrop = useCallback(async (src: string) => {
       const { operations } = sdk
       operations.updateValue(GltfContainer, entity, { src })
@@ -43,7 +53,7 @@ export default withSdk<Props>(
           if (monitor.didDrop()) return
           const node = context.tree.get(value)!
           const model = getModel(node, context.tree)
-          if (model) handleDrop(model.asset.src)
+          if (model) void handleDrop(model.asset.src)
         },
         canDrop: ({ value, context }: ProjectAssetDrop) => {
           const node = context.tree.get(value)!

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -36,9 +36,9 @@ export default withSdk<Props>(
       [files]
     )
 
-    const handleRemove = useCallback(async () => {
-      await sdk.operations.removeComponent(entity, GltfContainer.componentId)
-      await sdk.operations.dispatch()
+    const handleRemove = useCallback(() => {
+      sdk.operations.removeComponent(entity, GltfContainer.componentId)
+      sdk.operations.dispatch()
     }, [])
     const handleDrop = useCallback(async (src: string) => {
       const { operations } = sdk

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -22,9 +22,9 @@ export default withSdk<Props>(
     const { getInputProps } = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
     const { handleAction } = useContextMenu()
 
-    const handleRemove = useCallback(async () => {
-      await sdk.operations.removeComponent(entity, Transform.componentId)
-      await sdk.operations.dispatch()
+    const handleRemove = useCallback(() => {
+      sdk.operations.removeComponent(entity, Transform.componentId)
+      sdk.operations.dispatch()
     }, [])
 
     if (!hasTransform) {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -22,7 +22,10 @@ export default withSdk<Props>(
     const { getInputProps } = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
     const { handleAction } = useContextMenu()
 
-    const handleRemove = useCallback(() => Transform.deleteFrom(entity), [])
+    const handleRemove = useCallback(async () => {
+      await sdk.operations.removeComponent(entity, Transform.componentId)
+      await sdk.operations.dispatch()
+    }, [])
 
     if (!hasTransform) {
       return null

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -32,25 +32,12 @@ function HierarchyIcon({ value, hasChildrens, isOpen }: { value: Entity; hasChil
 }
 
 const Hierarchy: React.FC = () => {
-  const {
-    addChild,
-    setParent,
-    remove,
-    rename,
-    toggle,
-    getId,
-    getChildren,
-    getLabel,
-    isOpen,
-    canRename,
-    canRemove,
-    canToggle
-  } = useTree()
+  const { addChild, setParent, remove, rename, toggle, getId, getChildren, getLabel, isOpen, canRename, canRemove } =
+    useTree()
   const selectedEntity = useSelectedEntity()
 
   const isSelected = useCallback(
     (entity: Entity) => {
-      if (entity === ROOT) return !selectedEntity
       return selectedEntity === entity
     },
     [selectedEntity]
@@ -75,7 +62,6 @@ const Hierarchy: React.FC = () => {
         isSelected={isSelected}
         canRename={canRename}
         canRemove={canRemove}
-        canToggle={canToggle}
       />
     </Container>
   )

--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { useDrag, useDrop } from 'react-dnd'
-import { IoIosArrowDown, IoIosArrowForward, IoIosImage } from 'react-icons/io'
+import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io'
 
 import { withContextMenu } from '../../hoc/withContextMenu'
 import { Input } from '../Input'

--- a/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
@@ -2,7 +2,6 @@ import { Entity } from '@dcl/ecs'
 import { useCallback } from 'react'
 
 import { useSdk } from './useSdk'
-import { isLastWriteWinComponent } from './useComponentValue'
 
 export const useEntityComponent = () => {
   const sdk = useSdk()
@@ -24,12 +23,10 @@ export const useEntityComponent = () => {
   )
 
   const addComponent = useCallback(
-    (entity: Entity, componentId: number) => {
+    async (entity: Entity, componentId: number) => {
       if (!sdk) return
-      const component = sdk.engine.getComponent(componentId)
-      if (isLastWriteWinComponent(component)) {
-        component.create(entity)
-      }
+      await sdk.operations.addComponent(entity, componentId)
+      await sdk.operations.dispatch()
     },
     [sdk]
   )

--- a/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
@@ -23,10 +23,10 @@ export const useEntityComponent = () => {
   )
 
   const addComponent = useCallback(
-    async (entity: Entity, componentId: number) => {
+    (entity: Entity, componentId: number) => {
       if (!sdk) return
-      await sdk.operations.addComponent(entity, componentId)
-      await sdk.operations.dispatch()
+      sdk.operations.addComponent(entity, componentId)
+      sdk.operations.dispatch()
     },
     [sdk]
   )

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -110,12 +110,8 @@ export const useTree = () => {
   const toggle = useCallback(
     async (entity: Entity, open: boolean) => {
       if (!sdk) return
-      if (entity === ROOT) {
-        sdk.operations.removeSelectedEntities()
-      } else {
-        sdk.operations.updateSelectedEntity(entity)
-        open ? entitiesToggle.add(entity) : entitiesToggle.delete(entity)
-      }
+      sdk.operations.updateSelectedEntity(entity)
+      open ? entitiesToggle.add(entity) : entitiesToggle.delete(entity)
 
       await sdk.operations.dispatch()
       handleUpdate()
@@ -126,7 +122,6 @@ export const useTree = () => {
   const isNotRoot = useCallback((entity: Entity) => entity !== ROOT, [])
   const canRename = isNotRoot
   const canRemove = isNotRoot
-  const canToggle = useCallback(() => true, [])
 
   return {
     tree,
@@ -140,7 +135,6 @@ export const useTree = () => {
     getLabel,
     isOpen,
     canRename,
-    canRemove,
-    canToggle
+    canRemove
   }
 }

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -17,9 +17,11 @@ const updateGizmoManager = (entity: EcsEntity, value: { gizmo: number } | null) 
   const context = entity.context.deref()!
   let processedSomeEntity = false
 
+  const Transform = context.engine.getComponent('core::Transform')
+
   for (const [_entity] of context.engine.getEntitiesWith(context.editorComponents.Selection)) {
     processedSomeEntity = true
-    if (entity.entityId === _entity) {
+    if (entity.entityId === _entity && Transform.has(_entity)) {
       context.gizmos.setEntity(entity)
       const types = context.gizmos.getGizmoTypes()
       const type = types[value?.gizmo || 0]

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -1,5 +1,5 @@
 import mitt from 'mitt'
-import { GizmoManager, IAxisDragGizmo, Vector3 } from '@babylonjs/core'
+import { GizmoManager, IAxisDragGizmo, Quaternion, Vector3 } from '@babylonjs/core'
 import { EcsEntity } from './EcsEntity'
 import { Entity, TransformType } from '@dcl/ecs'
 import { getLayoutManager } from './layout-manager'
@@ -71,7 +71,7 @@ export function createGizmoManager(context: SceneContext) {
       const value = {
         position: snapPosition(lastEntity.position),
         scale: snapScale(lastEntity.scaling),
-        rotation: snapRotation(lastEntity.rotationQuaternion!),
+        rotation: lastEntity.rotationQuaternion ? snapRotation(lastEntity.rotationQuaternion) : Quaternion.Zero(),
         parent
       }
       return value

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-component.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-component.spec.ts
@@ -1,0 +1,56 @@
+import { Entity, IEngine } from '@dcl/ecs'
+import addComponent from './add-component'
+
+describe('addComponent', () => {
+  let engine: IEngine
+  const getComponentMock = jest.fn()
+  beforeEach(() => {
+    engine = {
+      getComponent: getComponentMock
+    } as unknown as IEngine
+  })
+  afterEach(() => {
+    getComponentMock.mockReset()
+  })
+  describe('When creating the addComponent operation', () => {
+    it('should return a function', () => {
+      const addComponentOperation = addComponent(engine)
+      expect(addComponentOperation).toBeInstanceOf(Function)
+    })
+    describe('and then passing the entity and the component id to the addComponent operation', () => {
+      let entity: Entity
+      let componentId: number
+      let addComponentOperation: ReturnType<typeof addComponent>
+      const createMock = jest.fn()
+      const componentMock = {
+        createOrReplace: jest.fn(),
+        create: createMock
+      } as unknown
+      beforeEach(() => {
+        entity = 0 as Entity
+        componentId = 0
+        addComponentOperation = addComponent(engine)
+        getComponentMock.mockReturnValue(componentMock)
+      })
+      afterEach(() => {
+        getComponentMock.mockReset()
+        createMock.mockReset()
+      })
+      it('should add the component to the entity', () => {
+        addComponentOperation(entity, componentId)
+        expect(createMock).toHaveBeenCalledWith(entity)
+      })
+      describe('and the component is not an LWW component', () => {
+        beforeEach(() => {
+          getComponentMock.mockReturnValue({})
+        })
+        afterEach(() => {
+          getComponentMock.mockReset()
+        })
+        it('should throw an error', () => {
+          expect(() => addComponentOperation(entity, componentId)).toThrowError()
+        })
+      })
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
@@ -1,0 +1,13 @@
+import { Entity, IEngine } from '@dcl/ecs'
+import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue'
+
+export function addComponent(engine: IEngine) {
+  return function addComponent(entity: Entity, componentId: number) {
+    const component = engine.getComponent(componentId)
+    if (isLastWriteWinComponent(component)) {
+      component.create(entity)
+    }
+  }
+}
+
+export default addComponent

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
@@ -6,6 +6,8 @@ export function addComponent(engine: IEngine) {
     const component = engine.getComponent(componentId)
     if (isLastWriteWinComponent(component)) {
       component.create(entity)
+    } else {
+      throw new Error('Cannot add component: it must be an LWW component')
     }
   }
 }

--- a/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
@@ -9,6 +9,8 @@ import updateSelectedEntity from './update-selected-entity'
 import setParent from './set-parent'
 import removeSelectedEntities from './remove-selected-entities'
 import addAsset from './add-asset'
+import addComponent from './add-component'
+import removeComponent from './remove-component'
 
 export interface Dispatch {
   dirty?: boolean
@@ -21,6 +23,8 @@ export function createOperations(engine: IEngine) {
     addChild: addChild(engine),
     addAsset: addAsset(engine),
     setParent: setParent(engine),
+    addComponent: addComponent(engine),
+    removeComponent: removeComponent(engine),
     updateSelectedEntity: updateSelectedEntity(engine),
     removeSelectedEntities: removeSelectedEntities(engine),
     dispatch: ({ dirty = true }: Dispatch = {}) => {

--- a/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.spec.ts
@@ -1,0 +1,56 @@
+import { Entity, IEngine } from '@dcl/ecs'
+import removeComponent from './remove-component'
+
+describe('removeComponent', () => {
+  let engine: IEngine
+  const getComponentMock = jest.fn()
+  beforeEach(() => {
+    engine = {
+      getComponent: getComponentMock
+    } as unknown as IEngine
+  })
+  afterEach(() => {
+    getComponentMock.mockReset()
+  })
+  describe('When creating the removeComponent operation', () => {
+    it('should return a function', () => {
+      const removeComponentOperation = removeComponent(engine)
+      expect(removeComponentOperation).toBeInstanceOf(Function)
+    })
+    describe('and then passing the entity and the component id to the removeComponent operation', () => {
+      let entity: Entity
+      let componentId: number
+      let removeComponentOperation: ReturnType<typeof removeComponent>
+      const deleteFromMock = jest.fn()
+      const componentMock = {
+        createOrReplace: jest.fn(),
+        deleteFrom: deleteFromMock
+      } as unknown
+      beforeEach(() => {
+        entity = 0 as Entity
+        componentId = 0
+        removeComponentOperation = removeComponent(engine)
+        getComponentMock.mockReturnValue(componentMock)
+      })
+      afterEach(() => {
+        getComponentMock.mockReset()
+        deleteFromMock.mockReset()
+      })
+      it('should add the component to the entity', () => {
+        removeComponentOperation(entity, componentId)
+        expect(deleteFromMock).toHaveBeenCalledWith(entity)
+      })
+      describe('and the component is not an LWW component', () => {
+        beforeEach(() => {
+          getComponentMock.mockReturnValue({})
+        })
+        afterEach(() => {
+          getComponentMock.mockReset()
+        })
+        it('should throw an error', () => {
+          expect(() => removeComponentOperation(entity, componentId)).toThrowError()
+        })
+      })
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
@@ -1,0 +1,13 @@
+import { Entity, IEngine } from '@dcl/ecs'
+import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue'
+
+export function removeComponent(engine: IEngine) {
+  return function removeComponent(entity: Entity, componentId: number) {
+    const component = engine.getComponent(componentId)
+    if (isLastWriteWinComponent(component)) {
+      component.deleteFrom(entity)
+    }
+  }
+}
+
+export default removeComponent

--- a/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
@@ -6,6 +6,8 @@ export function removeComponent(engine: IEngine) {
     const component = engine.getComponent(componentId)
     if (isLastWriteWinComponent(component)) {
       component.deleteFrom(entity)
+    } else {
+      throw new Error('Cannot add component: it must be an LWW component')
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/785
Fixes https://github.com/decentraland/sdk/issues/786

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4da005e</samp>

This pull request updates the inspector tool to use the sdk operations for adding and removing components from entities, and simplifies some of the logic and imports of the inspector components and hooks. It also fixes some issues with the gizmo-manager and the rotation handling of entities.