### PR TITLE
Fix child being added twice

### DIFF
--- a/packages/@dcl/inspector/src/components/Input/Input.tsx
+++ b/packages/@dcl/inspector/src/components/Input/Input.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react'
 
-import { PropTypes } from './types'
+import { BlurBehavior, PropTypes } from './types'
 
 import './Input.css'
 
 const submittingKeys = new Set(['Enter'])
 const cancelingKeys = new Set(['Escape', 'Tab'])
 
-const Input = ({ value, onCancel, onSubmit, onChange, placeholder }: PropTypes) => {
+const Input = ({ value, onCancel, onSubmit, onChange, placeholder, blurBehavior }: PropTypes) => {
   const ref = useRef<HTMLInputElement>(null)
   const [stateValue, setStateValue] = useState(value)
 
@@ -17,28 +17,22 @@ const Input = ({ value, onCancel, onSubmit, onChange, placeholder }: PropTypes) 
 
     const getValue = () => ref.current?.value || value
 
-    const onBodyClick = (e: MouseEvent) => {
-      if (e.target !== ref.current) onSubmit && onSubmit(getValue())
-    }
-
     const onKeyUp = (e: KeyboardEvent) => {
-      if (cancelingKeys.has(e.key)) {
-        ref.current?.removeEventListener('blur', onBlur)
-        onCancel && onCancel()
-      }
-      if (submittingKeys.has(e.key)) {
-        ref.current?.removeEventListener('blur', onBlur)
-        onSubmit && onSubmit(getValue())
-      }
+      if (cancelingKeys.has(e.key)) onCancel && onCancel()
+      if (submittingKeys.has(e.key)) onSubmit && onSubmit(getValue())
     }
 
-    const onBlur = (_: Event) => onSubmit && onSubmit(getValue())
+    let onBlur: (e: Event) => void
+    if (blurBehavior == BlurBehavior.SUBMIT)
+      onBlur = (_: Event) => onSubmit && onSubmit(getValue())
+    else if (blurBehavior == BlurBehavior.CANCEL)
+      onBlur = (_: Event) => onCancel && onCancel()
+    else
+      onBlur = (_: Event) => {}
 
-    document.body.addEventListener('click', onBodyClick)
     ref.current?.addEventListener('keyup', onKeyUp)
     ref.current?.addEventListener('blur', onBlur)
     return () => {
-      document.body.removeEventListener('click', onBodyClick)
       ref.current?.removeEventListener('keyup', onKeyUp)
       ref.current?.removeEventListener('blur', onBlur)
     }

--- a/packages/@dcl/inspector/src/components/Input/Input.tsx
+++ b/packages/@dcl/inspector/src/components/Input/Input.tsx
@@ -22,8 +22,14 @@ const Input = ({ value, onCancel, onSubmit, onChange, placeholder }: PropTypes) 
     }
 
     const onKeyUp = (e: KeyboardEvent) => {
-      if (cancelingKeys.has(e.key)) onCancel && onCancel()
-      if (submittingKeys.has(e.key)) onSubmit && onSubmit(getValue())
+      if (cancelingKeys.has(e.key)) {
+        ref.current?.removeEventListener('blur', onBlur)
+        onCancel && onCancel()
+      }
+      if (submittingKeys.has(e.key)) {
+        ref.current?.removeEventListener('blur', onBlur)
+        onSubmit && onSubmit(getValue())
+      }
     }
 
     const onBlur = (_: Event) => onSubmit && onSubmit(getValue())

--- a/packages/@dcl/inspector/src/components/Input/Input.tsx
+++ b/packages/@dcl/inspector/src/components/Input/Input.tsx
@@ -23,9 +23,7 @@ const Input = ({ value, onCancel, onSubmit, onChange, placeholder, blurBehavior 
     }
 
     let onBlur: (e: Event) => void
-    if (blurBehavior == BlurBehavior.SUBMIT)
-      onBlur = (_: Event) => onSubmit && onSubmit(getValue())
-    else if (blurBehavior == BlurBehavior.CANCEL)
+    if (blurBehavior == BlurBehavior.CANCEL)
       onBlur = (_: Event) => onCancel && onCancel()
     else
       onBlur = (_: Event) => {}

--- a/packages/@dcl/inspector/src/components/Input/types.ts
+++ b/packages/@dcl/inspector/src/components/Input/types.ts
@@ -1,7 +1,6 @@
 export enum BlurBehavior {
-  SUBMIT = 0,
-  CANCEL = 1,
-  DO_NOTHING = 2
+  CANCEL = 0,
+  DO_NOTHING = 1
 }
 
 export interface PropTypes {

--- a/packages/@dcl/inspector/src/components/Input/types.ts
+++ b/packages/@dcl/inspector/src/components/Input/types.ts
@@ -1,6 +1,13 @@
+export enum BlurBehavior {
+  SUBMIT = 0,
+  CANCEL = 1,
+  DO_NOTHING = 2
+}
+
 export interface PropTypes {
   value: string
   placeholder?: string
+  blurBehavior?: BlurBehavior
   onChange?(value: string): void
   onCancel?: () => void
   onSubmit?: (newValue: string) => void

--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -7,6 +7,7 @@ import { Input } from '../Input'
 import { ContextMenu } from './ContextMenu'
 
 import './Tree.css'
+import { BlurBehavior } from '../Input/types'
 
 type Props<T> = {
   value: T
@@ -153,7 +154,7 @@ function Tree<T>(_props: Props<T>) {
           )}
         </div>
         <TreeChildren {...props} />
-        {insertMode && <Input value="" onCancel={quitInsertMode} onSubmit={handleAddChild} />}
+        {insertMode && <Input value="" onCancel={quitInsertMode} onSubmit={handleAddChild} blurBehavior={BlurBehavior.CANCEL}/>}
       </div>
     )
   })


### PR DESCRIPTION
The problem is caused by `onBlur` event firing before hook's clean up function (which removes `onBlur` listener). When a user presses ENTER, input submits (creating a new child), then react re-renders and removes an input (which fires `onBlur` which submits again), and only then calls hook's clean up.

Furthermore, the blur behavior of search input and "add child" input should be different. For search input we don't want to do anything when blur happens, and for "add child" we want to either submit or cancel. We've chosen the latter in this PR.

 