### PR TITLE
fix: repair asset removal

### DIFF
--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -69,7 +69,7 @@ function ProjectView({ folders, onImportAsset }: Props) {
             open.add(name)
             matchesList.push(name)
           }
-          tree.set(name, { ...children, matches: matches ? [name] : [], parent: null })
+          tree.set(name, { ...children, matches: matches ? [name] : [], parent: node })
         }
       }
       if (matchesList.length) {
@@ -192,7 +192,6 @@ function ProjectView({ folders, onImportAsset }: Props) {
             getIcon={(val) => <NodeIcon value={tree.get(val)} isOpen={isOpen(val)} />}
             getDragContext={handleDragContext}
             dndType={DRAG_N_DROP_ASSET_KEY}
-            getExtraContextMenu={(val) => <ContextMenu value={tree.get(val)} onImportAsset={onImportAsset} />}
           />
         </div>
         <div className="FolderView">

--- a/packages/@dcl/inspector/src/components/Tree/Tree.css
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.css
@@ -51,3 +51,7 @@
   color: var(--contexify-item-color);
   margin-right: 4px;
 }
+
+.Tree .contexify_item {
+  width: 100%;
+}


### PR DESCRIPTION
Closes decentraland/sdk#809.

Fix asset removal. Ensure that context menu items fill all available width (previously it wasn't the case for asset inspector's context menus). Remove context menu from folders in asset folder tree (it is currently useless, as all imports go to root directory anyway).