### PR TITLE
fix: context menu triggering input's onBlur cb

### DIFF
--- a/packages/@dcl/inspector/src/components/Input/Input.tsx
+++ b/packages/@dcl/inspector/src/components/Input/Input.tsx
@@ -6,6 +6,16 @@ import './Input.css'
 
 const submittingKeys = new Set(['Enter'])
 const cancelingKeys = new Set(['Escape', 'Tab'])
+const dismissableTargets = new Set(['menu', 'menuitem'])
+
+type Roles = { role: string; parentRole: string }
+const getRolesFromTarget = (target: HTMLElement | null): Roles => {
+  if (!target) return { role: '', parentRole: '' }
+  return {
+    role: target.role ?? '',
+    parentRole: target.parentElement?.role ?? ''
+  }
+}
 
 const Input = ({ value, onCancel, onSubmit, onChange, onBlur, placeholder }: PropTypes) => {
   const ref = useRef<HTMLInputElement>(null)
@@ -22,7 +32,19 @@ const Input = ({ value, onCancel, onSubmit, onChange, onBlur, placeholder }: Pro
       if (submittingKeys.has(e.key)) onSubmit && onSubmit(getValue())
     }
 
-    const onBlurCallback = (e: FocusEvent) => { onBlur && onBlur(e) }
+    const onBlurCallback = (e: FocusEvent) => {
+      const relatedTarget = e.relatedTarget as HTMLElement | null
+      const { parentRole, role} = getRolesFromTarget(relatedTarget)
+      // custom fix for context menu to avoid stealing focus (thus triggering onBlur on input's)
+      // when hiding. We check if the relatedTarget's role and it's parent role is in the
+      // dismissable targets list. If it is, instead of running the onBlur cb, we focus the input.
+      // Otherwise, we run the onBlur cb...
+      if (dismissableTargets.has(role) || dismissableTargets.has(parentRole)) {
+        ref.current?.focus()
+      } else {
+        onBlur && onBlur(e)
+      }
+    }
 
     ref.current?.addEventListener('keyup', onKeyUp)
     ref.current?.addEventListener('blur', onBlurCallback)


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/814

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ec4d39</samp>

Fix Input component losing value on right-click. Add logic to `Input.tsx` to refocus the input when clicking on a dismissable element.