### PR TITLE
feat: decouple expanding-collapsing from selecting

### DIFF
--- a/packages/@dcl/inspector/src/components/Assets/Assets.tsx
+++ b/packages/@dcl/inspector/src/components/Assets/Assets.tsx
@@ -39,7 +39,7 @@ function Assets() {
         <div onClick={handleTabClick(AssetsTab.AssetsPack)}>
           <div className={cx({ underlined: tab === AssetsTab.AssetsPack })}>
             <MdImageSearch />
-            <span>ASSETS PACKS</span>
+            <span>BUILDER ASSETS</span>
           </div>
         </div>
         <div onClick={handleTabClick(AssetsTab.Import)}>

--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -1,12 +1,14 @@
 .Block {
   display: flex;
   flex-direction: column;
+  margin-bottom: 2px;
+  margin-top: 4px;
 }
 
 .Block > label {
-  margin: 8px 0px 4px 0px;
+  margin: 0px 0px 2px 0px;
   color: var(--sub-text);
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .Block .content {

--- a/packages/@dcl/inspector/src/components/Box/Box.css
+++ b/packages/@dcl/inspector/src/components/Box/Box.css
@@ -3,8 +3,8 @@
 }
 
 .Box.with-border {
-  margin: 2.4px;
-  padding: 3.2px;
+  margin: 1.2px;
+  padding: 1.2px;
   border-radius: 2.4px;
   background: #21262f;
 }

--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -1,7 +1,7 @@
 .Container {
   display: flex;
   flex-direction: column;
-  padding: 12px;
+  padding: 6px;
   height: 100%;
   overflow-y: auto;
   border-bottom: 1px solid var(--border-gray);
@@ -25,10 +25,10 @@
   margin-right: 4px;
 }
 
-.Container>span {
-  margin: 0px 0px 4px 0px;
+.Container .title span {
+  margin: 0px 0px 0px 0px;
   color: var(--text);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
@@ -3,4 +3,5 @@
   width: 100%;
   height: 100%;
   background-color: var(--tree-bg-color);
+  overflow-y: auto;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
@@ -1,11 +1,12 @@
 .TextField {
-  padding: 4px 6px;
+  padding: 2px 3px;
   border: 1px solid var(--border-gray);
   display: flex;
   margin-right: 8px;
   border-radius: 1.6px;
   flex-grow: 1;
   width: 0;
+  font-size: 12px;
 }
 
 .TextField:focus-within {

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.css
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.css
@@ -1,4 +1,6 @@
 .Hierarchy {
   height: 100%;
   background: var(--tree-bg-color);
+  overflow-y: auto;
+  padding: 6px;
 }

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -10,31 +10,20 @@ import { Tree } from '../Tree'
 import { ContextMenu } from './ContextMenu'
 import './Hierarchy.css'
 
-function HierarchyIcon({ value, hasChildrens, isOpen }: { value: Entity; hasChildrens: boolean; isOpen: boolean }) {
+function HierarchyIcon({ value }: { value: Entity }) {
   if (value === ROOT) {
-    return <span style={{ marginRight: '14px' }} />
-  }
-  if (!hasChildrens) {
+    return <span style={{ marginRight: '4px' }}></span>
+  } else {
     return (
-      <>
-        <span style={{ marginLeft: '13px' }} />
-        <FiHexagon />
-      </>
+      <FiHexagon style={{ marginRight: '4px' }}/>
     )
   }
-  const ArrowComponent = isOpen ? <IoIosArrowDown /> : <IoIosArrowForward />
-  return (
-    <>
-      {ArrowComponent}
-      <FiHexagon />
-    </>
-  )
 }
 
 const EntityTree = Tree<Entity>()
 
 const Hierarchy: React.FC = () => {
-  const { addChild, setParent, remove, rename, toggle, getId, getChildren, getLabel, isOpen, canRename, canRemove } =
+  const { addChild, setParent, remove, rename, select, setOpen, getId, getChildren, getLabel, isOpen, canRename, canRemove } =
     useTree()
   const selectedEntity = useSelectedEntity()
 
@@ -53,12 +42,13 @@ const Hierarchy: React.FC = () => {
         onSetParent={setParent}
         onRemove={remove}
         onRename={rename}
-        onToggle={toggle}
+        onSelect={select}
+        onSetOpen={setOpen}
         getId={getId}
         getChildren={getChildren}
         getLabel={getLabel}
         getIcon={(val: Entity) => (
-          <HierarchyIcon value={val} isOpen={isOpen(val)} hasChildrens={!!getChildren(val).length} />
+          <HierarchyIcon value={val} />
         )}
         isOpen={isOpen}
         isSelected={isSelected}

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.css
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.css
@@ -60,7 +60,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   align-content: flex-start;
-  justify-content: center;
+  justify-content: left;
   overflow-y: auto;
 }
 

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -96,17 +96,24 @@ function ProjectView({ folders }: Props) {
   /**
    * Callbacks
    */
-  const onToggle = useCallback(
-    (value: string, toggle: boolean) => {
+
+  const onSelect = useCallback(
+    (value: string) => {
       setLastSelected(value)
-      if (toggle) {
+    },
+    [setLastSelected]
+  )
+
+  const onSetOpen = useCallback(
+    (value: string, isOpen: boolean) => {
+      if (isOpen) {
         open.add(value)
       } else {
         open.delete(value)
       }
       setOpen(new Set(open))
     },
-    [open, setOpen, setLastSelected]
+    [open, setOpen]
   )
 
   const getEntitiesWithAsset = useCallback(
@@ -207,7 +214,8 @@ function ProjectView({ folders }: Props) {
             onSetParent={noop}
             onRemove={handleRemove}
             onRename={noop}
-            onToggle={onToggle}
+            onSelect={onSelect}
+            onSetOpen={onSetOpen}
             getId={(value: string) => value.toString()}
             getChildren={getChildren}
             getLabel={(val: string) => <span>{tree.get(val)?.name ?? val}</span>}
@@ -215,9 +223,8 @@ function ProjectView({ folders }: Props) {
             isSelected={(val: string) => lastSelected === val}
             canRename={() => false}
             canRemove={(val) => tree.get(val)?.type === 'asset'}
-            canToggle={() => true}
             canAddChild={() => false}
-            getIcon={(val) => <NodeIcon value={tree.get(val)} isOpen={isOpen(val)} />}
+            getIcon={(val) => <NodeIcon value={tree.get(val)} />}
             getDragContext={handleDragContext}
             dndType={DRAG_N_DROP_ASSET_KEY}
           />
@@ -272,25 +279,16 @@ function NodeView({
   )
 }
 
-function NodeIcon({ value, isOpen }: { value?: TreeNode; isOpen: boolean }) {
+function NodeIcon({ value }: { value?: TreeNode }) {
   if (!value) return null
   if (value.type === 'folder') {
-    return isOpen ? (
-      <>
-        <IoIosArrowDown />
-        <FolderIcon />
-      </>
-    ) : (
-      <>
-        <IoIosArrowForward />
-        <FolderIcon />
-      </>
-    )
+    return <div style={{ marginRight: '4px', marginLeft: '2px', marginTop: '2px' }}><FolderIcon /></div>
   }
+  else
   return (
     <>
       <svg style={{ width: '4px', height: '4px' }} />
-      <IoIosImage />
+      <IoIosImage style={{ marginRight: '4px'}} />
     </>
   )
 }

--- a/packages/@dcl/inspector/src/components/Tree/Tree.css
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.css
@@ -1,5 +1,5 @@
 .Tree {
-  font-size: 13px;
+  font-size: 12px;
   color: var(--white);
   width: 100%;
 }
@@ -51,7 +51,18 @@
   flex-shrink: 0;
 }
 
-.Tree .entity-label {
+.Tree .item-area {
+  display: flex;
+  align-items: center;
+}
+
+.Tree .selectable-area {
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.Tree .selectable-area div {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -26,7 +26,7 @@ export const useTree = () => {
   }, [sdk])
 
   const [tree, setTree] = useState(getTree())
-  const entitiesToggle = new Set<Entity>()
+  const entitiesToggle = new Set<Entity>([ROOT])
 
   useEffect(() => {
     setTree(getTree())
@@ -59,7 +59,6 @@ export const useTree = () => {
 
   const isOpen = useCallback(
     (entity: Entity) => {
-      if (entity === ROOT) return true
       return entitiesToggle.has(entity)
     },
     [sdk]
@@ -107,13 +106,19 @@ export const useTree = () => {
     [sdk, handleUpdate]
   )
 
-  const toggle = useCallback(
-    async (entity: Entity, open: boolean) => {
+  const select = useCallback(
+    async (entity: Entity) => {
       if (!sdk) return
       sdk.operations.updateSelectedEntity(entity)
-      open ? entitiesToggle.add(entity) : entitiesToggle.delete(entity)
-
       await sdk.operations.dispatch()
+      handleUpdate()
+    },
+    [sdk, handleUpdate]
+  )
+
+  const setOpen = useCallback(
+    async (entity: Entity, open: boolean) => {
+      open ? entitiesToggle.add(entity) : entitiesToggle.delete(entity)
       handleUpdate()
     },
     [sdk, handleUpdate]
@@ -129,10 +134,11 @@ export const useTree = () => {
     setParent,
     rename,
     remove,
-    toggle,
+    select,
     getId,
     getChildren,
     getLabel,
+    setOpen,
     isOpen,
     canRename,
     canRemove

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -9,6 +9,7 @@ import { useSdk } from './useSdk'
  * Used to get a tree and the functions to work with it
  * @returns
  */
+/* istanbul ignore next */
 export const useTree = () => {
   const sdk = useSdk()
   // Generate a tree if the sdk is available, or an empty tree otherwise


### PR DESCRIPTION
Closes decentraland/sdk#823.

1. Click on an expand-collapse arrow in composite / asset inspectors no longer selects an entity / folder.
2. Click on icon or label in composite / assets inspectors no longer expands-collapses an entity / folder.
3. Miscellaneous UI style tweaks.