### PR TITLE
fix: Gltf removal

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -36,9 +36,9 @@ export default withSdk<Props>(
       [files]
     )
 
-    const handleRemove = useCallback(() => {
-      sdk.operations.removeComponent(entity, GltfContainer.componentId)
-      sdk.operations.dispatch()
+    const handleRemove = useCallback(async () => {
+      sdk.operations.removeComponent(entity, GltfContainer)
+      await sdk.operations.dispatch()
     }, [])
     const handleDrop = useCallback(async (src: string) => {
       const { operations } = sdk

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -23,7 +23,7 @@ export default withSdk<Props>(
     const { handleAction } = useContextMenu()
 
     const handleRemove = useCallback(() => {
-      sdk.operations.removeComponent(entity, Transform.componentId)
+      sdk.operations.removeComponent(entity, Transform)
       sdk.operations.dispatch()
     }, [])
 

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -55,11 +55,11 @@ export const putGltfContainerComponent: ComponentOperation = (entity, component)
     const currentValue = entity.ecsComponentValues.gltfContainer
     entity.ecsComponentValues.gltfContainer = newValue || undefined
 
-    // for simplicity of the example, we will remove the Gltf on every update.
-    if (newValue && currentValue?.src !== newValue?.src) {
-      removeGltf(entity)
-      loadGltf(entity, newValue.src)
-    }
+    const shouldLoadGltf = newValue && currentValue?.src !== newValue?.src
+    const shouldRemoveGltf = !newValue || shouldLoadGltf
+
+    if (shouldRemoveGltf) removeGltf(entity)
+    if (shouldLoadGltf) loadGltf(entity, newValue.src)
   }
 }
 

--- a/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.spec.ts
@@ -1,4 +1,4 @@
-import { Entity, IEngine } from '@dcl/ecs'
+import { Entity, IEngine, LastWriteWinElementSetComponentDefinition } from '@dcl/ecs'
 import removeComponent from './remove-component'
 
 describe('removeComponent', () => {
@@ -19,37 +19,21 @@ describe('removeComponent', () => {
     })
     describe('and then passing the entity and the component id to the removeComponent operation', () => {
       let entity: Entity
-      let componentId: number
       let removeComponentOperation: ReturnType<typeof removeComponent>
       const deleteFromMock = jest.fn()
-      const componentMock = {
-        createOrReplace: jest.fn(),
+      const component = {
         deleteFrom: deleteFromMock
-      } as unknown
+      } as unknown as LastWriteWinElementSetComponentDefinition<unknown>
       beforeEach(() => {
         entity = 0 as Entity
-        componentId = 0
         removeComponentOperation = removeComponent(engine)
-        getComponentMock.mockReturnValue(componentMock)
       })
       afterEach(() => {
-        getComponentMock.mockReset()
         deleteFromMock.mockReset()
       })
-      it('should add the component to the entity', () => {
-        removeComponentOperation(entity, componentId)
+      it('should remove the component to the entity', () => {
+        removeComponentOperation(entity, component)
         expect(deleteFromMock).toHaveBeenCalledWith(entity)
-      })
-      describe('and the component is not an LWW component', () => {
-        beforeEach(() => {
-          getComponentMock.mockReturnValue({})
-        })
-        afterEach(() => {
-          getComponentMock.mockReset()
-        })
-        it('should throw an error', () => {
-          expect(() => removeComponentOperation(entity, componentId)).toThrowError()
-        })
       })
     })
   })

--- a/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/remove-component.ts
@@ -1,14 +1,8 @@
-import { Entity, IEngine } from '@dcl/ecs'
-import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue'
+import { Entity, IEngine, LastWriteWinElementSetComponentDefinition } from '@dcl/ecs'
 
-export function removeComponent(engine: IEngine) {
-  return function removeComponent(entity: Entity, componentId: number) {
-    const component = engine.getComponent(componentId)
-    if (isLastWriteWinComponent(component)) {
-      component.deleteFrom(entity)
-    } else {
-      throw new Error('Cannot add component: it must be an LWW component')
-    }
+export function removeComponent(_engine: IEngine) {
+  return function removeComponent<T>(entity: Entity, component: LastWriteWinElementSetComponentDefinition<T>) {
+    component.deleteFrom(entity)
   }
 }
 


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/819

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4130007</samp>

This pull request improves the type safety, readability, and consistency of the component removal operation in the inspector, by using component definitions instead of numeric ids, and by refactoring some functions. It affects the files `GltfInspector.tsx`, `TransformInspector.tsx`, `gltf-container.ts`, and `remove-component.ts`.