### PR TITLE
UI tweaks

### DIFF
--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -16,7 +16,7 @@
   flex-direction: row;
   align-items: center;
   cursor: pointer;
-  user-select: none
+  user-select: none;
 }
 
 .Container .title svg {

--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -29,6 +29,5 @@
   margin: 0px 0px 0px 0px;
   color: var(--text);
   font-size: 13px;
-  font-weight: 600;
   cursor: pointer;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
@@ -7,6 +7,7 @@
 }
 
 .EntityInspector .entity-label {
+  font-size: 13px;
   padding: 6px;
   font-weight: 600;
   text-align: left;

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.css
@@ -5,3 +5,10 @@
   background-color: var(--tree-bg-color);
   overflow-y: auto;
 }
+
+.EntityInspector .entity-label {
+  padding: 6px;
+  font-weight: 600;
+  text-align: left;
+  border-bottom: 1px solid var(--border-gray);
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -1,24 +1,39 @@
+import { useEffect, useState } from 'react'
+
 import { Entity } from '@dcl/ecs'
 
 import { useSelectedEntity } from '../../hooks/sdk/useSelectedEntity'
 import { withSdk } from '../../hoc/withSdk'
-import { SdkContextValue } from '../../lib/sdk/context'
+import { SdkContextEvents, SdkContextValue } from '../../lib/sdk/context'
+import { useChange } from '../../hooks/sdk/useChange'
 
 import { SceneInspector } from './SceneInspector'
 import { TransformInspector } from './TransformInspector'
 import { GltfInspector } from './GltfInspector'
 import './EntityInspector.css'
 
-const getLabel = (sdk: SdkContextValue, entity: Entity) => {
+const getLabel = (sdk: SdkContextValue, entity: Entity | null) => {
+  if (entity === null) return null
   const nameComponent = sdk.components.Name.getOrNull(entity)
-  return entity === 0 ? 'Scene' : (nameComponent ? nameComponent.value : entity.toString())
+  return entity === 0 ? 'Scene' : (nameComponent && nameComponent.value.length > 0 ? nameComponent.value : entity.toString())
 }
 
 export const EntityInspector = withSdk(({ sdk }) => {
   const entity = useSelectedEntity()
-  const inspectors = [SceneInspector, TransformInspector, GltfInspector]
+  const [label, setLabel] = useState<string | null>()
 
-  const label = entity !== null ? getLabel(sdk, entity) : null
+  useEffect(() => {
+    setLabel(getLabel(sdk, entity))
+  }, [sdk, entity])
+
+  const handleUpdate = (event: SdkContextEvents['change']) => {
+    if (event.entity === entity && event.component === sdk.components.Name) {
+      setLabel(getLabel(sdk, entity))
+    }
+  }
+  useChange(handleUpdate, [entity])
+
+  const inspectors = [SceneInspector, TransformInspector, GltfInspector]
 
   return (
     <div className="EntityInspector" key={entity}>

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -2,30 +2,30 @@ import { Entity } from '@dcl/ecs'
 
 import { useSelectedEntity } from '../../hooks/sdk/useSelectedEntity'
 import { withSdk } from '../../hoc/withSdk'
+import { SdkContextValue } from '../../lib/sdk/context'
 
 import { SceneInspector } from './SceneInspector'
 import { TransformInspector } from './TransformInspector'
 import { GltfInspector } from './GltfInspector'
 import './EntityInspector.css'
 
+const getLabel = (sdk: SdkContextValue, entity: Entity) => {
+  const nameComponent = sdk.components.Name.getOrNull(entity)
+  return entity === 0 ? 'Scene' : (nameComponent ? nameComponent.value : entity.toString())
+}
+
 export const EntityInspector = withSdk(({ sdk }) => {
   const entity = useSelectedEntity()
+  const inspectors = [SceneInspector, TransformInspector, GltfInspector]
 
-  if (entity !== null) {
-    const nameComponent = sdk.components.Name.getOrNull(entity)
-    const label = entity === 0 as Entity ? 'Scene' : (nameComponent ? nameComponent.value : entity.toString())
+  const label = entity !== null ? getLabel(sdk, entity) : null
 
-    const inspectors = [SceneInspector, TransformInspector, GltfInspector]
-
-    return (
-      <div className="EntityInspector" key={entity}>
-        <div className="entity-label">{label}</div>
-        {inspectors.map((Inspector, index) => entity !== null && <Inspector key={index} entity={entity} />)}
-      </div>
-    )
-  } else {
-    return <div className="EntityInspector"></div>
-  }
+  return (
+    <div className="EntityInspector" key={entity}>
+      <div className="entity-label">{label}</div>
+      {inspectors.map((Inspector, index) => entity !== null && <Inspector key={index} entity={entity} />)}
+    </div>
+  )
 })
 
 export default EntityInspector

--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -1,18 +1,31 @@
+import { Entity } from '@dcl/ecs'
+
 import { useSelectedEntity } from '../../hooks/sdk/useSelectedEntity'
+import { withSdk } from '../../hoc/withSdk'
 
 import { SceneInspector } from './SceneInspector'
 import { TransformInspector } from './TransformInspector'
 import { GltfInspector } from './GltfInspector'
 import './EntityInspector.css'
 
-export const EntityInspector: React.FC = () => {
+export const EntityInspector = withSdk(({ sdk }) => {
   const entity = useSelectedEntity()
 
-  const inspectors = [SceneInspector, TransformInspector, GltfInspector]
+  if (entity !== null) {
+    const nameComponent = sdk.components.Name.getOrNull(entity)
+    const label = entity === 0 as Entity ? 'Scene' : (nameComponent ? nameComponent.value : entity.toString())
 
-  return (
-    <div className="EntityInspector" key={entity}>
-      {inspectors.map((Inspector, index) => entity !== null && <Inspector key={index} entity={entity} />)}
-    </div>
-  )
-}
+    const inspectors = [SceneInspector, TransformInspector, GltfInspector]
+
+    return (
+      <div className="EntityInspector" key={entity}>
+        <div className="entity-label">{label}</div>
+        {inspectors.map((Inspector, index) => entity !== null && <Inspector key={index} entity={entity} />)}
+      </div>
+    )
+  } else {
+    return <div className="EntityInspector"></div>
+  }
+})
+
+export default EntityInspector

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -71,7 +71,7 @@ export default withSdk<Props>(
     const inputProps = getInputProps('src')
 
     return (
-      <Container label="Gltf" className={cx('Gltf', { hover: isHover })}>
+      <Container label="GLTF container" className={cx('Gltf', { hover: isHover })}>
         <Menu id={contextMenuId}>
           <Item id="delete" onClick={handleAction(handleRemove)}>
             <DeleteIcon /> Delete

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -18,7 +18,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
   }
 
   return (
-    <Container label="Scene" className="Scene">
+    <Container label="Settings" className="Scene">
       <Block label="Base">
         <TextField label="" {...getInputProps('layout.base')} />
       </Block>

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 import { Entity } from '@dcl/ecs'
-import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io'
 import { FiHexagon } from 'react-icons/fi'
 
 import { ROOT } from '../../lib/sdk/tree'

--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
@@ -7,19 +7,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
   background-color: #24252b;
   color: #fff;
-  padding: 24px;
+  padding: 6px;
   border: 2px dashed #666;
   border-radius: 8px;
   cursor: pointer;
-}
-
-.ImportAsset > div > span:first-of-type {
-  font-size: 24px;
-  padding: 8px;
+  overflow-y: auto;
 }
 
 .ImportAsset > div > span:last-of-type {
@@ -28,26 +25,26 @@
 
 .ImportAsset .upload-icon {
   background-color: var(--list-item-hover-bg-color);
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  margin: 16px
+  margin: 16px;
+  flex-shrink: 0;
 }
 
 .ImportAsset .Container {
   overflow: visible;
   height: unset;
   background-color: var(--list-item-hover-bg-color);
-  overflow: visible;
   margin-right: 20px;
 }
 
 .ImportAsset .Container svg {
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
 }
 
 .ImportAsset .Container .content {
@@ -65,8 +62,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  top: -16px;
-  right: -16px;
+  top: -12px;
+  right: -12px;
   background-color: var(--primary);
   border-radius: 50%;
 }

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.css
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.css
@@ -1,10 +1,10 @@
 .Tile {
   display: flex;
   flex-direction: column;
-  margin: 8px;
+  margin: 4px;
   align-items: center;
   height: 72px;
-  width: 72px;
+  width: 84px;
   border-radius: 8px;
   background-color: var(--tree-border-color);
   cursor: pointer;
@@ -16,7 +16,7 @@
   overflow: hidden;
   white-space: nowrap;
   width: inherit;
-  padding: 0 8px;
+  padding: 0 6px;
   text-align: center;
   font-size: 10px;
 }

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.tsx
@@ -43,7 +43,7 @@ export const Tile = withContextMenu<Props>(({
           </MenuItem>
         </Menu>
       )}
-      <div ref={drag} className="Tile" key={value.name} onDoubleClick={onSelect}>
+      <div ref={drag} className="Tile" key={value.name} onDoubleClick={onSelect} title={value.name}>
         {value.type === 'folder' ? <FolderIcon /> : <IoIosImage />}
         <span>{value.name}</span>
       </div>

--- a/packages/@dcl/inspector/src/lib/babylon/setup/input.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/setup/input.ts
@@ -27,10 +27,10 @@ export function initKeyboard(canvas: HTMLCanvasElement, scene: BABYLON.Scene) {
     if (e.type === BABYLON.PointerEventTypes.POINTERDOWN) {
       const evt = e.event as PointerEvent
       scene.getEngine().getRenderingCanvas()!.focus()
-      interactWithScene(scene, 'pointerDown', evt.offsetX, evt.offsetY, evt.pointerId)
+      if (evt.button === 0) interactWithScene(scene, 'pointerDown', evt.offsetX, evt.offsetY, evt.pointerId)
     } else if (e.type === BABYLON.PointerEventTypes.POINTERUP) {
       const evt = e.event as PointerEvent
-      interactWithScene(scene, 'pointerUp', evt.offsetX, evt.offsetY, evt.pointerId)
+      if (evt.button === 0) interactWithScene(scene, 'pointerUp', evt.offsetX, evt.offsetY, evt.pointerId)
     }
   })
 }


### PR DESCRIPTION
1. Right mouse click should not select an entity in composite renderer.
2. Display entity's name in entity inspector.
3. Miscellaneous style tweaks in asset inspector.
4. Fix broken mechanism for rejecting imported assets with names that already exist.