### PR TITLE
fix: undo not working with re-parenting entities

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/transform.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/transform.ts
@@ -59,8 +59,8 @@ export function createDefaultTransform(entity: EcsEntity) {
     if (reparentQueue?.size) {
       const ctx = entity.context.deref()
       for (const child of reparentQueue) {
-        const childEnity = ctx?.getEntityOrNull(child)
-        childEnity && reparentEntity(childEnity)
+        const childEntity = ctx?.getEntityOrNull(child)
+        if (childEntity) childEntity.parent = entity
       }
       reparentQueue.clear()
     }
@@ -134,11 +134,9 @@ const transformContextSymbol = Symbol('transform-component-context')
 function getTransformContextForEntity(entity: EcsEntity): InternalTransformContext | undefined {
   const ctx = entity.context.deref() as any
   if (ctx) {
-    let current = ctx[transformContextSymbol]
-    if (!current) {
-      current = { pendingParentQueues: new Map() }
-      ctx[transformContextSymbol] = current
+    if (!ctx[transformContextSymbol]) {
+      ctx[transformContextSymbol] = { pendingParentQueues: new Map() }
     }
-    return current
+    return ctx[transformContextSymbol]
   }
 }


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/844

There was a race-condition when using the entities scheduled for future re-parenting.

Walkthrough
1. `getOrCreateEntity` on `SceneContext` initializes an `Entity` and pushes it to the `this.#entities` map (**in that order**)
2. When initializing an `Entity`, we are calling `createDefaultTransform`, which checks the scheduled re-parenting list for assigning childs
3. `createDefaultTransform` calls `reparentEntity`, which relies on the list of entities from `SceneContext` to find the desired parent and then clears the scheduled re-parenting list
4.  Since the list of entities on `SceneContext` is incomplete because we are initializing the `Entity`, and this `Entity` is not yet pushed it (thus the importance of the order on step 1), `reparentEntity` never finds the desired parent, and the list get's cleared leaving the orphan behind

Fixed it by removing the call to `reparentEntity` and manually assigning the parent on `createDefaultTransform`. Calling `reparentEntity` inside `createDefaultTransform` is redundant since we already know who the parent and the child is and we don't need all those checks.