### PR TITLE
refactor: paths are always absolute

### DIFF
--- a/packages/@dcl/inspector/src/components/Assets/Assets.tsx
+++ b/packages/@dcl/inspector/src/components/Assets/Assets.tsx
@@ -50,7 +50,7 @@ function Assets() {
       </div>
       <div className="Assets-content">
         {tab === AssetsTab.AssetsPack && <AssetsCatalog />}
-        {tab === AssetsTab.FileSystem && <ProjectAssetExplorer onImportAsset={handleTabClick(AssetsTab.Import)} />}
+        {tab === AssetsTab.FileSystem && <ProjectAssetExplorer />}
         {tab === AssetsTab.Import && <ImportAsset onSave={handleSave} />}
       </div>
     </div>

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -16,6 +16,7 @@ import { Container } from '../../Container'
 import { TextField } from '../TextField'
 import { Props } from './types'
 import { fromGltf, toGltf, isValidInput, getModel } from './utils'
+import { withAssetDir } from '../../../lib/data-layer/host/fs-utils'
 
 const DROP_TYPES = ['project-asset-gltf']
 
@@ -30,8 +31,8 @@ export default withSdk<Props>(
     const { getInputProps, isValid } = useComponentInput(
       entity,
       GltfContainer,
-      fromGltf,
-      toGltf,
+      fromGltf(files.basePath),
+      toGltf(files.basePath),
       handleInputValidation,
       [files]
     )
@@ -53,7 +54,7 @@ export default withSdk<Props>(
           if (monitor.didDrop()) return
           const node = context.tree.get(value)!
           const model = getModel(node, context.tree)
-          if (model) void handleDrop(model.asset.src)
+          if (model) void handleDrop(withAssetDir(model.asset.src))
         },
         canDrop: ({ value, context }: ProjectAssetDrop) => {
           const node = context.tree.get(value)!

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.spec.ts
@@ -6,13 +6,13 @@ describe('GltfInspector/utils', () => {
   describe('fromGltf', () => {
     it('should return a "PBGltfContainer" schema', () => {
       const result = { src: 'some-path' }
-      expect(utils.fromGltf(result)).toStrictEqual(result)
+      expect(utils.fromGltf('')(result)).toStrictEqual(result)
     })
   })
   describe('toGltf', () => {
     it('should return a "PBGltfContainer" schema', () => {
       const result = { src: 'some-path' }
-      expect(utils.fromGltf(result)).toStrictEqual(result)
+      expect(utils.fromGltf('')(result)).toStrictEqual(result)
     })
   })
   describe('isValidInput', () => {
@@ -25,7 +25,7 @@ describe('GltfInspector/utils', () => {
           }
         ]
       }
-      expect(utils.isValidInput(assets, 'root/path')).toBe(true)
+      expect(utils.isValidInput(assets, 'path')).toBe(true)
     })
     it('should return false when the file is not found', () => {
       const assets = {

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/utils.ts
@@ -5,15 +5,18 @@ import { TreeNode } from '../../ProjectAssetExplorer/ProjectView'
 import { isAssetNode } from '../../ProjectAssetExplorer/utils'
 import { AssetNodeItem } from '../../ProjectAssetExplorer/types'
 import { AssetCatalogResponse } from '../../../tooling-entrypoint'
+import { removeBasePath } from '../../../hooks/catalog/useFileSystem'
 
-export function fromGltf(value: PBGltfContainer) {
-  return { src: value.src }
+export const fromGltf = (base: string) => (value: PBGltfContainer) => {
+  return { src: removeBasePath(base, value.src) }
 }
 
-export const toGltf = fromGltf
+export const toGltf = (base: string) => (value: PBGltfContainer) => {
+  return { src: base ? base + '/' + value.src : value.src }
+}
 
-export function isValidInput({ assets }: AssetCatalogResponse, src: string): boolean {
-  return !!assets.find(($) => $.path === src)
+export function isValidInput({ basePath, assets }: AssetCatalogResponse, src: string): boolean {
+  return !!assets.find(($) => (basePath ? basePath + '/' + src : src) === $.path)
 }
 
 export const isAsset = (value: string): boolean => value.endsWith('.gltf') || value.endsWith('.glb')

--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
@@ -9,7 +9,7 @@ import { Container } from '../Container'
 import { TextField } from '../EntityInspector/TextField'
 import { Block } from '../Block'
 import Button from '../Button'
-import { useFileSystem } from '../../hooks/catalog/useFileSystem'
+import { removeBasePath, useFileSystem } from '../../hooks/catalog/useFileSystem'
 
 import { GLTFValidation } from '@babylonjs/loaders'
 
@@ -65,7 +65,7 @@ const ImportAsset = withSdk<PropTypes>(({ sdk, onSave }) => {
   const [validationError, setValidationError] = useState<ValidationError>(null)
   const [assetName, setAssetName] = useState<string>('')
   const [assetExtension, setAssetExtension] = useState<string>('')
-  const [systemFiles] = useFileSystem()
+  const [{ basePath, assets }] = useFileSystem()
 
   const handleDrop = async (acceptedFiles: File[]) => {
     // TODO: handle zip file. GLB with multiple external image references
@@ -122,8 +122,8 @@ const ImportAsset = withSdk<PropTypes>(({ sdk, onSave }) => {
     setAssetName(event.target.value)
   }, [])
 
-  const invalidName = !!systemFiles.assets.find((asset) => {
-    const [packageName, otherAssetName] = asset.path.split('/')
+  const invalidName = !!assets.find((asset) => {
+    const [packageName, otherAssetName] = removeBasePath(basePath, asset.path).split('/')
     if (packageName === 'builder')
       return false
     else

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectAssetExplorer.tsx
@@ -2,11 +2,11 @@ import { useAssetTree } from '../../hooks/catalog/useAssetTree'
 import { useFileSystem } from '../../hooks/catalog/useFileSystem'
 import ProjectView from './ProjectView'
 
-import { AssetNodeFolder, PropTypes } from './types'
+import { AssetNodeFolder } from './types'
 
 import './ProjectAssetExplorer.css'
 
-export function ProjectAssetExplorer({ onImportAsset }: PropTypes) {
+export function ProjectAssetExplorer() {
   const [files] = useFileSystem()
   const { tree } = useAssetTree(files)
   const folders = tree.children.filter((item) => item.type === 'folder') as AssetNodeFolder[]

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -134,7 +134,7 @@ function ProjectView({ folders }: Props) {
 
   const handleRemove = useCallback(
     async (value: string) => {
-      const path = getFullNodePath(tree.get(value)!).slice(1)
+      const path = withAssetDir(getFullNodePath(tree.get(value)!).slice(1))
       const entitiesWithAsset = getEntitiesWithAsset(path)
       if (entitiesWithAsset.length) {
         return setModal({ isOpen: true, value: path, entities: entitiesWithAsset })
@@ -148,8 +148,8 @@ function ProjectView({ folders }: Props) {
     async (path: string, _: Entity[] = []) => {
       if (!sdk) return
       const { dataLayer } = sdk
-      fileSystemEvent.emit('change')
       await dataLayer.removeAsset({ path })
+      fileSystemEvent.emit('change')
     },
     [sdk]
   )

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/types.ts
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/types.ts
@@ -1,7 +1,3 @@
-export interface PropTypes {
-  onImportAsset(): void
-}
-
 export interface IAsset {
   src: string
   type: 'unknown' | 'gltf' | 'composite'

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -55,7 +55,7 @@ const Renderer: React.FC = () => {
   const addAsset = async (asset: AssetNodeItem, position: Vector3) => {
     if (!sdk) return
     const { operations } = sdk
-    operations.addAsset(ROOT, asset.asset.src, asset.name, position)
+    operations.addAsset(ROOT, withAssetDir(asset.asset.src), asset.name, position)
     await operations.dispatch()
   }
 

--- a/packages/@dcl/inspector/src/hooks/catalog/useAssetTree.ts
+++ b/packages/@dcl/inspector/src/hooks/catalog/useAssetTree.ts
@@ -2,9 +2,13 @@ import { useMemo } from 'react'
 
 import { AssetCatalogResponse } from '../../tooling-entrypoint'
 import { buildAssetTree } from '../../components/ProjectAssetExplorer/utils'
+import { removeBasePath } from './useFileSystem'
 
 /* istanbul ignore next */
 export const useAssetTree = (files: AssetCatalogResponse) => {
-  const tree = useMemo(() => buildAssetTree(files.assets.map((item) => item.path)), [files])
+  const tree = useMemo(
+    () => buildAssetTree(files.assets.map((item) => removeBasePath(files.basePath, item.path))),
+    [files]
+  )
   return { tree }
 }

--- a/packages/@dcl/inspector/src/hooks/catalog/useFileSystem.ts
+++ b/packages/@dcl/inspector/src/hooks/catalog/useFileSystem.ts
@@ -7,6 +7,10 @@ import { AssetCatalogResponse } from '../../tooling-entrypoint'
 type FileSystemEvent = { change: unknown }
 export const fileSystemEvent = mitt<FileSystemEvent>()
 
+export const removeBasePath = (basePath: string, path: string) => {
+  return basePath ? path.replace(basePath + '/', '') : path
+}
+
 /* istanbul ignore next */
 export const useFileSystem = (): [AssetCatalogResponse, boolean] => {
   const [files, setFiles] = useState<AssetCatalogResponse>({ basePath: '', assets: [] })

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -80,7 +80,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
     const newInputs = fromComponentValueToInput(componentValue)
     // set "skipSync" to avoid cyclic component value change
     updateInputs(newInputs, true)
-  }, [componentValue])
+  }, [componentValue, ...deps])
 
   useEffect(() => {
     setIsValid(validate(input))

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/SceneContext.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/SceneContext.ts
@@ -7,7 +7,6 @@ import future from 'fp-future'
 
 import { CrdtStreamMessage } from '../../data-layer/proto/gen/data-layer.gen'
 import { DataLayerRpcClient } from '../../data-layer/types'
-import { withAssetDir } from '../../data-layer/host/fs-utils'
 import { createEditorComponents } from '../../sdk/components'
 import { serializeCrdtMessages } from '../../sdk/crdt-logger'
 import { ComponentOperation } from './component-operations'
@@ -153,7 +152,7 @@ export class SceneContext {
   async getFile(src: string): Promise<Uint8Array | null> {
     if (!src) return null
     try {
-      const response = await this.dataLayer.getAssetData({ path: withAssetDir(src) })
+      const response = await this.dataLayer.getAssetData({ path: src })
       return response.data
     } catch (err) {
       console.error('Error fetching file ' + src, err)

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -93,7 +93,7 @@ export function generateMainComposite({ engine, components }: TempEngine) {
       z: 8
     }
   })
-  components.GltfContainer.create(gltfEntity, { src: 'scene/models/test-glb.glb' })
+  components.GltfContainer.create(gltfEntity, { src: 'assets/scene/models/test-glb.glb' })
   cubeIdComponent.create(gltfEntity)
   components.Name.create(gltfEntity, { value: 'Gltf Test' })
 

--- a/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
@@ -1,7 +1,7 @@
 import { IEngine, OnChangeFunction } from '@dcl/ecs'
 
 import { DataLayerRpcServer, FileSystemInterface } from '../types'
-import { EXTENSIONS, getCurrentCompositePath, getFileName, getFilesInDirectory, withAssetDir } from './fs-utils'
+import { EXTENSIONS, getCurrentCompositePath, getFilesInDirectory, withAssetDir } from './fs-utils'
 import { stream } from './stream'
 import { FileOperation, initUndoRedo } from './undo-redo'
 import upsertAsset from './upsert-asset'
@@ -71,7 +71,7 @@ export async function initRpcMethods(
         return EXTENSIONS.some((ext) => itemLower.endsWith(ext))
       })
 
-      return { basePath, assets: files.map(($) => ({ path: $.replace(basePath + '/', '') })) }
+      return { basePath, assets: files.map(($) => ({ path: $ })) }
     },
     /**
      * Import asset into the file system.


### PR DESCRIPTION
fixes assets path on `main.composite` to be always absolute, thus making preview work as expected 

![Jun-15-2023 19-45-19](https://github.com/decentraland/js-sdk-toolchain/assets/2366069/d5778d6d-54a2-4260-a567-bba3b02cd68d)
