### PR TITLE
feat: duplicate entity operation

### DIFF
--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -22,7 +22,7 @@ function HierarchyIcon({ value }: { value: Entity }) {
 const EntityTree = Tree<Entity>()
 
 const Hierarchy: React.FC = () => {
-  const { addChild, setParent, remove, rename, select, setOpen, getId, getChildren, getLabel, isOpen, isHidden, canRename, canRemove } =
+  const { addChild, setParent, remove, rename, select, setOpen, duplicate, getId, getChildren, getLabel, isOpen, isHidden, canRename, canRemove, canDuplicate } =
     useTree()
   const selectedEntity = useSelectedEntity()
 
@@ -43,6 +43,7 @@ const Hierarchy: React.FC = () => {
         onRename={rename}
         onSelect={select}
         onSetOpen={setOpen}
+        onDuplicate={duplicate}
         getId={getId}
         getChildren={getChildren}
         getLabel={getLabel}
@@ -54,6 +55,7 @@ const Hierarchy: React.FC = () => {
         isHidden={isHidden}
         canRename={canRename}
         canRemove={canRemove}
+        canDuplicate={canDuplicate}
       />
     </div>
   )

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -217,6 +217,7 @@ function ProjectView({ folders }: Props) {
             onRename={noop}
             onSelect={onSelect}
             onSetOpen={onSetOpen}
+            onDuplicate={noop}
             getId={(value: string) => value.toString()}
             getChildren={getChildren}
             getLabel={(val: string) => <span>{tree.get(val)?.name ?? val}</span>}
@@ -225,6 +226,7 @@ function ProjectView({ folders }: Props) {
             isHidden={(val: string) => val === ROOT}
             canRename={() => false}
             canRemove={(val) => tree.get(val)?.type === 'asset'}
+            canDuplicate={() => false}
             canAddChild={() => false}
             getIcon={(val) => <NodeIcon value={tree.get(val)} />}
             getDragContext={handleDragContext}

--- a/packages/@dcl/inspector/src/components/Tree/ContextMenu/ContextMenu.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Menu, Item } from 'react-contexify'
 import { MdOutlineDriveFileRenameOutline as RenameIcon } from 'react-icons/md'
-import { AiFillFileAdd as AddChildIcon, AiFillDelete as DeleteIcon } from 'react-icons/ai'
+import { AiFillFileAdd as AddChildIcon, AiFillDelete as DeleteIcon, AiFillCopy as DuplicateIcon } from 'react-icons/ai'
 
 import { useContextMenu } from '../../../hooks/sdk/useContextMenu'
 
@@ -10,9 +10,11 @@ export interface Props {
   enableAdd?: boolean
   enableEdit?: boolean
   enableRemove?: boolean
+  enableDuplicate?: boolean
   onAddChild: () => void
   onEdit: () => void
   onRemove: () => void
+  onDuplicate: () => void
   extra?: JSX.Element | null
 }
 
@@ -21,13 +23,15 @@ function ContextMenu({
   enableAdd = true,
   enableEdit = true,
   enableRemove = true,
+  enableDuplicate = true,
   onAddChild,
   onEdit,
   onRemove,
+  onDuplicate,
   extra
 }: Props) {
   const { handleAction } = useContextMenu()
-  const someActionIsEnabled = enableAdd || enableEdit || enableRemove
+  const someActionIsEnabled = enableAdd || enableEdit || enableRemove || enableDuplicate
 
   if (!someActionIsEnabled && !extra) return null
 
@@ -38,6 +42,9 @@ function ContextMenu({
       </Item>
       <Item hidden={!enableAdd} id="add-child" onClick={handleAction(onAddChild)}>
         <AddChildIcon /> Add child
+      </Item>
+      <Item hidden={!enableDuplicate} id="duplicate" onClick={handleAction(onDuplicate)}>
+        <DuplicateIcon /> Duplicate
       </Item>
       <Item hidden={!enableRemove} id="delete" onClick={handleAction(onRemove)}>
         <DeleteIcon /> Delete

--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -24,12 +24,14 @@ type Props<T> = {
   canRename?: (value: T) => boolean
   canAddChild?: (value: T) => boolean
   canRemove?: (value: T) => boolean
+  canDuplicate?: (value: T) => boolean
   onSetOpen: (value: T, isOpen: boolean) => void
   onSelect: (value: T) => void
   onSetParent: (value: T, parent: T) => void
   onRename: (value: T, label: string) => void
   onAddChild: (value: T, label: string) => void
   onRemove: (value: T) => void
+  onDuplicate: (value: T) => void
   getDragContext?: () => unknown
   dndType?: string
   tree?: unknown
@@ -59,9 +61,11 @@ export function Tree<T>() {
       canRename,
       canAddChild,
       canRemove,
+      canDuplicate,
       onRename,
       onAddChild,
       onRemove,
+      onDuplicate,
       onSetOpen,
       getDragContext = () => ({}),
       dndType = 'tree'
@@ -75,6 +79,7 @@ export function Tree<T>() {
     const enableAddChild = canAddChild ? canAddChild(value) : true
     const enableRemove = canRemove ? canRemove(value) : true
     const enableOpen = getChildren(value).length > 0
+    const enableDuplicate = canDuplicate ? canDuplicate(value) : true
     const extraContextMenu = getExtraContextMenu ? getExtraContextMenu(value) : null
     const [editMode, setEditMode] = useState(false)
     const [insertMode, setInsertMode] = useState(false)
@@ -134,6 +139,10 @@ export function Tree<T>() {
       onRemove(value)
     }
 
+    const handleDuplicate = () => {
+      onDuplicate(value)
+    }
+
     const ref = (node: HTMLDivElement | null) => drag(drop(node))
 
     const controlsProps = {
@@ -141,9 +150,11 @@ export function Tree<T>() {
       enableAdd: enableAddChild,
       enableEdit: enableRename,
       enableRemove,
+      enableDuplicate,
       onAddChild: handleNewChild,
       onEdit: handleToggleEdit,
       onRemove: handleRemove,
+      onDuplicate: handleDuplicate,
       extra: extraContextMenu
     }
 

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -121,6 +121,16 @@ export const useTree = () => {
     [sdk, handleUpdate]
   )
 
+  const duplicate = useCallback(
+    async (entity: Entity) => {
+      if (entity === ROOT || !sdk) return
+      sdk.operations.duplicateEntity(entity)
+      await sdk.operations.dispatch()
+      handleUpdate()
+    },
+    [sdk, handleUpdate]
+  )
+
   const setOpen = useCallback(
     async (entity: Entity, open: boolean) => {
       open ? entitiesToggle.add(entity) : entitiesToggle.delete(entity)
@@ -132,6 +142,7 @@ export const useTree = () => {
   const isNotRoot = useCallback((entity: Entity) => entity !== ROOT, [])
   const canRename = isNotRoot
   const canRemove = isNotRoot
+  const canDuplicate = isNotRoot
 
   return {
     tree,
@@ -140,6 +151,7 @@ export const useTree = () => {
     rename,
     remove,
     select,
+    duplicate,
     getId,
     getChildren,
     getLabel,
@@ -147,6 +159,7 @@ export const useTree = () => {
     isOpen,
     isHidden,
     canRename,
-    canRemove
+    canRemove,
+    canDuplicate
   }
 }

--- a/packages/@dcl/inspector/src/lib/sdk/operations/duplicate-entity.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/duplicate-entity.spec.ts
@@ -1,0 +1,45 @@
+import { IEngine, Engine, TransformComponentExtended, Entity, Name } from '@dcl/ecs'
+import { duplicateEntity } from './duplicate-entity'
+import { EditorComponentNames, EditorComponents, createEditorComponents } from '../components'
+import * as components from '@dcl/ecs/dist/components'
+
+describe('duplicateEntity', () => {
+  let engine: IEngine
+  let TransformComponent: TransformComponentExtended
+  let NameComponent: typeof Name
+  let SelectionComponent: EditorComponents['Selection']
+  beforeEach(() => {
+    engine = Engine()
+    NameComponent = components.Name(engine)
+    TransformComponent = components.Transform(engine)
+    createEditorComponents(engine)
+    SelectionComponent = engine.getComponent(EditorComponentNames.Selection) as EditorComponents['Selection']
+  })
+  it('should correctly duplicate an entity', () => {
+    const original = engine.addEntity()
+    TransformComponent.create(original)
+    const originalChild = engine.addEntity()
+    TransformComponent.create(originalChild, { parent: original, position: { x: 1, y: 1, z: 1 } })
+    NameComponent.create(originalChild, { value: 'child' })
+
+    const duplicate = duplicateEntity(engine)(original)
+    expect(duplicate).not.toBe(null)
+    expect(duplicate).not.toBe(original)
+    expect(duplicate).not.toBe(originalChild)
+    expect(SelectionComponent.getOrNull(duplicate)).not.toBeNull()
+
+    let duplicateChild: Entity | null = null
+    for (const [entity, entityTransform] of engine.getEntitiesWith(TransformComponent)) {
+      if (entityTransform.parent === duplicate) {
+        duplicateChild = entity
+        break
+      }
+    }
+
+    expect(duplicateChild).not.toBe(null)
+    expect(duplicateChild).not.toBe(original)
+    expect(duplicateChild).not.toBe(originalChild)
+    expect(duplicateChild).not.toBe(duplicate)
+    expect(NameComponent.get(duplicateChild!).value).toBe(NameComponent.get(originalChild).value)
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/operations/duplicate-entity.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/duplicate-entity.ts
@@ -1,0 +1,37 @@
+import { Entity, IEngine, getComponentEntityTree, Transform } from '@dcl/ecs'
+import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue'
+import updateSelectedEntity from './update-selected-entity'
+
+export function duplicateEntity(engine: IEngine) {
+  return function duplicateEntity(entity: Entity) {
+    const originalToDuplicate: Map<Entity, Entity> = new Map()
+    const TransformComponent = engine.getComponent(Transform.componentId) as typeof Transform
+
+    for (const entityIterator of getComponentEntityTree(engine, entity, TransformComponent)) {
+      const duplicate = engine.addEntity()
+      originalToDuplicate.set(entityIterator, duplicate)
+      // copy values of all components of original entity
+      for (const component of engine.componentsIter()) {
+        if (component.has(entityIterator) && isLastWriteWinComponent(component)) {
+          const componentValue = component.get(entityIterator)
+          component.create(duplicate, JSON.parse(JSON.stringify(componentValue)))
+        }
+      }
+    }
+
+    // if Transform points to an entity within subtree being duplicated, re-direct it to duplicated entity
+    for (const image of originalToDuplicate.values()) {
+      const transform = TransformComponent.getMutableOrNull(image)
+      if (transform === null || !transform.parent) continue
+      if (originalToDuplicate.has(transform.parent)) {
+        transform.parent = originalToDuplicate.get(transform.parent)
+      }
+    }
+
+    const duplicate = originalToDuplicate.get(entity)!
+    updateSelectedEntity(engine)(duplicate)
+    return duplicate
+  }
+}
+
+export default duplicateEntity

--- a/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/index.ts
@@ -11,6 +11,7 @@ import removeSelectedEntities from './remove-selected-entities'
 import addAsset from './add-asset'
 import addComponent from './add-component'
 import removeComponent from './remove-component'
+import duplicateEntity from './duplicate-entity'
 
 export interface Dispatch {
   dirty?: boolean
@@ -27,6 +28,7 @@ export function createOperations(engine: IEngine) {
     removeComponent: removeComponent(engine),
     updateSelectedEntity: updateSelectedEntity(engine),
     removeSelectedEntities: removeSelectedEntities(engine),
+    duplicateEntity: duplicateEntity(engine),
     dispatch: async ({ dirty = true }: Dispatch = {}) => {
       await engine.update(1)
       saveEvent.emit('change', dirty)


### PR DESCRIPTION
Closes decentraland/sdk#709.

1. Add "Duplicate entity" option to composite inspector's context menu.
2. This operation creates a copy of entity's subtree, with properly adjusted Transform parenting.
3. Duplicate becomes selected.