### PR TITLE
feat: center view on entity

### DIFF
--- a/packages/@dcl/inspector/README.md
+++ b/packages/@dcl/inspector/README.md
@@ -10,7 +10,7 @@ This also rebuilds the library section (data-layer) and exposes in `dist/` folde
 For faster development experience, we are faking the file-system for the data-layer, if you want to use your actual file-system, you can either:
 
 * Run the extension from VSCode on a scene
-* Run `sdk-commands start -- --data-layer --port 8001` in a scene & go to localhost:8000/?ws=ws://127.0.0.1:8001/data-layer
+* Run `npx sdk-commands start --data-layer --port 8001` in a scene & go to localhost:8000/?ws=ws://127.0.0.1:8001/data-layer
 
 ## Build
 The `make build ` in the repo root builds all the necessary for package publishment.

--- a/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
+++ b/packages/@dcl/inspector/src/components/Hierarchy/Hierarchy.tsx
@@ -35,7 +35,8 @@ const Hierarchy: React.FC = () => {
     isHidden,
     canRename,
     canRemove,
-    canDuplicate
+    canDuplicate,
+    centerViewOnEntity
   } = useTree()
   const selectedEntity = useSelectedEntity()
 
@@ -55,6 +56,7 @@ const Hierarchy: React.FC = () => {
         onRemove={remove}
         onRename={rename}
         onSelect={select}
+        onDoubleSelect={centerViewOnEntity}
         onSetOpen={setOpen}
         onDuplicate={duplicate}
         getId={getId}

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -219,6 +219,7 @@ function ProjectView({ folders }: Props) {
             onRemove={handleRemove}
             onRename={noop}
             onSelect={onSelect}
+            onDoubleSelect={noop}
             onSetOpen={onSetOpen}
             onDuplicate={noop}
             getId={(value: string) => value.toString()}

--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -27,6 +27,7 @@ type Props<T> = {
   canDuplicate?: (value: T) => boolean
   onSetOpen: (value: T, isOpen: boolean) => void
   onSelect: (value: T) => void
+  onDoubleSelect?: (value: T) => void
   onSetParent: (value: T, parent: T) => void
   onRename: (value: T, label: string) => void
   onAddChild: (value: T, label: string) => void
@@ -67,6 +68,7 @@ export function Tree<T>() {
         onAddChild,
         onRemove,
         onDuplicate,
+        onDoubleSelect,
         onSetOpen,
         getDragContext = () => ({}),
         dndType = 'tree'
@@ -108,8 +110,9 @@ export function Tree<T>() {
       const quitEditMode = () => setEditMode(false)
       const quitInsertMode = () => setInsertMode(false)
 
-      const handleSelect = (_: React.MouseEvent) => {
+      const handleSelect = (event: React.MouseEvent) => {
         onSelect(value)
+        if (event.detail > 1 && onDoubleSelect) onDoubleSelect(value)
       }
 
       const handleOpen = (_: React.MouseEvent) => {

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -139,6 +139,16 @@ export const useTree = () => {
     [sdk, handleUpdate]
   )
 
+  const centerViewOnEntity = useCallback(
+    (entity: Entity) => {
+      if (!sdk || entity === ROOT) return
+      const babylonEntity = sdk.sceneContext.getEntityOrNull(entity)
+      if (babylonEntity !== null)
+        sdk.editorCamera.centerViewOnEntity(babylonEntity)
+    },
+    [sdk]
+  )
+
   const isNotRoot = useCallback((entity: Entity) => entity !== ROOT, [])
   const canRename = isNotRoot
   const canRemove = isNotRoot
@@ -160,6 +170,7 @@ export const useTree = () => {
     isHidden,
     canRename,
     canRemove,
-    canDuplicate
+    canDuplicate,
+    centerViewOnEntity
   }
 }

--- a/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useTree.ts
@@ -143,8 +143,7 @@ export const useTree = () => {
     (entity: Entity) => {
       if (!sdk || entity === ROOT) return
       const babylonEntity = sdk.sceneContext.getEntityOrNull(entity)
-      if (babylonEntity !== null)
-        sdk.editorCamera.centerViewOnEntity(babylonEntity)
+      if (babylonEntity !== null) sdk.editorCamera.centerViewOnEntity(babylonEntity)
     },
     [sdk]
   )

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
@@ -2,12 +2,25 @@ import * as BABYLON from '@babylonjs/core'
 import { Keys, keyState } from './keys'
 import { PARCEL_SIZE } from '../../utils/scene'
 import mitt, { Emitter } from 'mitt'
+import { EcsEntity } from './EcsEntity'
+import { fitSphereIntoCameraFrustum, getWorldMatrix } from '../../logic/math'
+import { Vector3, Quaternion } from '@dcl/ecs-math'
+import { Matrix } from '@dcl/ecs-math/dist/Matrix'
 
 type SpeedChangeEvent = { change: number }
 
 enum SpeedIncrement {
   FASTER = 1,
   SLOWER = -1
+}
+
+type AnimationData = {
+  startPos: Vector3,
+  endPos: Vector3,
+  startQuat: Quaternion,
+  endQuat: Quaternion,
+  timePassed: number,
+  duration: number
 }
 
 export class CameraManager {
@@ -18,10 +31,12 @@ export class CameraManager {
   private zoomSensitivity: number
   private camera: BABYLON.FreeCamera
   private speedChangeObservable: Emitter<SpeedChangeEvent>
+  private getAspectRatio: () => number
+  private animation: AnimationData | null
 
   constructor(
     scene: BABYLON.Scene,
-    inputSource: HTMLElement,
+    inputSource: HTMLCanvasElement,
     speeds: Array<number>,
     initialSpeedIndex: number,
     minY: number,
@@ -32,6 +47,8 @@ export class CameraManager {
     this.minY = minY
     this.zoomSensitivity = zoomSensitivity
     this.speedChangeObservable = mitt<SpeedChangeEvent>()
+    this.getAspectRatio = () => { return inputSource.width / inputSource.height }
+    this.animation = null
 
     this.camera = this.createCamera(scene)
     scene.activeCamera?.detachControl()
@@ -54,6 +71,31 @@ export class CameraManager {
   setFreeCameraInvertRotation(invert: boolean) {
     const sign = invert ? -1 : 1
     this.camera.angularSensibility = sign * CameraManager.ANGULAR_SENSIBILITY
+  }
+
+  centerViewOnEntity(entity: EcsEntity) {
+    // get a bounding sphere from bounding box
+    const {min, max} = entity.getHierarchyBoundingVectors()
+    let center: BABYLON.Vector3
+    let radius: number
+    // Babylon returns (MAX_VALUE, MAX_VALUE, MAX_VALUE), (MIN_VALUE, MIN_VALUE, MIN_VALUE) for empty nodes
+    if (min.x === Number.MAX_VALUE) {
+      center = entity.getWorldMatrix().getTranslation()
+      radius = 1
+    } else {
+      center = min.add(max).scale(0.5)
+      radius = max.subtract(center).length()
+    }
+    const position = fitSphereIntoCameraFrustum(this.camera.position, this.camera.fov, this.getAspectRatio(), this.camera.minZ, this.minY, center, radius)
+
+    this.animation = {
+      startPos: this.camera.position,
+      endPos: position,
+      startQuat: Quaternion.fromLookAt(this.camera.position, this.camera.target),
+      endQuat: Quaternion.fromLookAt(position, center),
+      duration: 0.2,
+      timePassed: 0
+    }
   }
 
   private createCamera(scene: BABYLON.Scene) {
@@ -102,11 +144,7 @@ export class CameraManager {
       }
     })
 
-    scene.registerBeforeRender(() => {
-      if (camera.position.y <= this.minY) {
-        camera.position.y = this.minY
-      }
-    })
+    scene.registerBeforeRender(() => { this.onRenderFrame(scene) })
     return camera
   }
 
@@ -118,5 +156,28 @@ export class CameraManager {
     }
     this.camera.speed = this.speeds[this.speedIndex]
     this.speedChangeObservable.emit('change', this.camera.speed)
+  }
+
+  private onRenderFrame(scene: BABYLON.Scene) {
+    if (this.animation !== null) {
+      const dt = scene.getEngine().getDeltaTime()
+      this.animation.timePassed += dt / 1000
+      this.animation.timePassed = Math.min(this.animation.duration, this.animation.timePassed)
+      const t = this.animation.timePassed / this.animation.duration
+
+      const position = Vector3.lerp(this.animation.startPos, this.animation.endPos, t)
+      this.camera.position = new BABYLON.Vector3(position.x, position.y, position.z)
+
+      const quat = Quaternion.slerp(this.animation.startQuat, this.animation.endQuat, t)
+      const direction = Vector3.rotate(Vector3.create(0, 0, 1), quat)
+      this.camera.target = this.camera.position.add(new BABYLON.Vector3(direction.x, direction.y, direction.z))
+
+      if (this.animation.timePassed >= this.animation.duration)
+        this.animation = null
+    }
+
+    if (this.camera.position.y <= this.minY) {
+      this.camera.position.y = this.minY
+    }
   }
 }

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
@@ -3,9 +3,8 @@ import { Keys, keyState } from './keys'
 import { PARCEL_SIZE } from '../../utils/scene'
 import mitt, { Emitter } from 'mitt'
 import { EcsEntity } from './EcsEntity'
-import { fitSphereIntoCameraFrustum, getWorldMatrix } from '../../logic/math'
+import { fitSphereIntoCameraFrustum } from '../../logic/math'
 import { Vector3, Quaternion } from '@dcl/ecs-math'
-import { Matrix } from '@dcl/ecs-math/dist/Matrix'
 
 type SpeedChangeEvent = { change: number }
 
@@ -15,11 +14,11 @@ enum SpeedIncrement {
 }
 
 type AnimationData = {
-  startPos: Vector3,
-  endPos: Vector3,
-  startQuat: Quaternion,
-  endQuat: Quaternion,
-  timePassed: number,
+  startPos: Vector3
+  endPos: Vector3
+  startQuat: Quaternion
+  endQuat: Quaternion
+  timePassed: number
   duration: number
 }
 
@@ -47,7 +46,9 @@ export class CameraManager {
     this.minY = minY
     this.zoomSensitivity = zoomSensitivity
     this.speedChangeObservable = mitt<SpeedChangeEvent>()
-    this.getAspectRatio = () => { return inputSource.width / inputSource.height }
+    this.getAspectRatio = () => {
+      return inputSource.width / inputSource.height
+    }
     this.animation = null
 
     this.camera = this.createCamera(scene)
@@ -75,7 +76,7 @@ export class CameraManager {
 
   centerViewOnEntity(entity: EcsEntity) {
     // get a bounding sphere from bounding box
-    const {min, max} = entity.getHierarchyBoundingVectors()
+    const { min, max } = entity.getHierarchyBoundingVectors()
     let center: BABYLON.Vector3
     let radius: number
     // Babylon returns (MAX_VALUE, MAX_VALUE, MAX_VALUE), (MIN_VALUE, MIN_VALUE, MIN_VALUE) for empty nodes
@@ -86,7 +87,15 @@ export class CameraManager {
       center = min.add(max).scale(0.5)
       radius = max.subtract(center).length()
     }
-    const position = fitSphereIntoCameraFrustum(this.camera.position, this.camera.fov, this.getAspectRatio(), this.camera.minZ, this.minY, center, radius)
+    const position = fitSphereIntoCameraFrustum(
+      this.camera.position,
+      this.camera.fov,
+      this.getAspectRatio(),
+      this.camera.minZ,
+      this.minY,
+      center,
+      radius
+    )
 
     this.animation = {
       startPos: this.camera.position,
@@ -144,7 +153,9 @@ export class CameraManager {
       }
     })
 
-    scene.registerBeforeRender(() => { this.onRenderFrame(scene) })
+    scene.registerBeforeRender(() => {
+      this.onRenderFrame(scene)
+    })
     return camera
   }
 
@@ -172,8 +183,7 @@ export class CameraManager {
       const direction = Vector3.rotate(Vector3.create(0, 0, 1), quat)
       this.camera.target = this.camera.position.add(new BABYLON.Vector3(direction.x, direction.y, direction.z))
 
-      if (this.animation.timePassed >= this.animation.duration)
-        this.animation = null
+      if (this.animation.timePassed >= this.animation.duration) this.animation = null
     }
 
     if (this.camera.position.y <= this.minY) {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -1,9 +1,7 @@
 import mitt from 'mitt'
-import { IAxisDragGizmo, Quaternion, Vector3 } from '@babylonjs/core'
+import { Quaternion } from '@babylonjs/core'
 import { EcsEntity } from './EcsEntity'
 import { Entity, TransformType } from '@dcl/ecs'
-import { getLayoutManager } from './layout-manager'
-import { inBounds } from '../../utils/layout'
 import { snapManager, snapPosition, snapRotation, snapScale } from './snap-manager'
 import { SceneContext } from './SceneContext'
 import { GizmoType } from '../../utils/gizmo'
@@ -35,24 +33,6 @@ export function createGizmoManager(context: SceneContext) {
   gizmoManager.scaleGizmoEnabled = false
   gizmoManager.gizmos.positionGizmo!.updateGizmoRotationToMatchAttachedMesh = false
   gizmoManager.gizmos.rotationGizmo!.updateGizmoRotationToMatchAttachedMesh = true
-
-  const layoutManager = getLayoutManager(context.scene)
-
-  function dragBehavior(gizmo: IAxisDragGizmo) {
-    gizmo.dragBehavior.validateDrag = function validateDrag(targetPosition: Vector3) {
-      const yIsInBounds = targetPosition.y >= 0 || (!!lastEntity && lastEntity.position.y < targetPosition.y)
-      const layout = layoutManager.getLayout()
-      if (!layout) return true
-      const isAlreadyOutOfBounds = !!lastEntity && !inBounds(layout, lastEntity?.position)
-      const xzIsInBounds = inBounds(layout, targetPosition)
-      // Allow drag if target position is within bounds, or if the gizmo is already out of bounds (it can get there by modifiying the transform values manually)
-      return (yIsInBounds && xzIsInBounds) || isAlreadyOutOfBounds
-    }
-  }
-
-  dragBehavior(gizmoManager.gizmos.positionGizmo!.xGizmo)
-  dragBehavior(gizmoManager.gizmos.positionGizmo!.yGizmo)
-  dragBehavior(gizmoManager.gizmos.positionGizmo!.zGizmo)
 
   let lastEntity: EcsEntity | null = null
   let rotationGizmoAlignmentDisabled = false

--- a/packages/@dcl/inspector/src/lib/babylon/setup/setup.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/setup/setup.ts
@@ -97,7 +97,7 @@ export function setupEngine(engine: BABYLON.Engine, canvas: HTMLCanvasElement, p
   const editorColor = BABYLON.Color3.FromHexString('#17141B')
   const editorEnvHelper = scene.createDefaultEnvironment({
     groundColor: editorColor,
-    skyboxColor: editorColor,
+    skyboxColor: new BABYLON.Color3(0.1, 0.5, 0.99),
     skyboxSize: 1000,
     groundSize: 1000
   })!

--- a/packages/@dcl/inspector/src/lib/logic/math.ts
+++ b/packages/@dcl/inspector/src/lib/logic/math.ts
@@ -51,6 +51,12 @@ export function fitSphereIntoCone(
   return Vector3.add(pos, Vector3.scale(normalizedDirection, t))
 }
 
+/*
+  Given a sphere and camera's frustum, finds a point on the line between
+  sphere's and camera's positions such that a sphere would fit into a frustum,
+  if a camera was situated at that point and was looking at sphere's center.
+  It also ensures that computed position respects minimal height contstraint.
+*/
 export function fitSphereIntoCameraFrustum(
   cameraPos: Vector3,
   verticalFov: number,
@@ -77,10 +83,12 @@ export function fitSphereIntoCameraFrustum(
   let position = fitSphereIntoCone(adjustedCameraPos, coneAngle, spherePos, adjustedSphereRadius)
   if (position.y < cameraMinY) {
     let direction = Vector3.subtract(spherePos, position)
+    // if Y limit is violated and camera looks up, symmetrically reflect its position so that it looks down
     if (direction.y > 0) {
       position = Vector3.add(spherePos, direction)
       direction = Vector3.scale(direction, -1)
     }
+    // camera looks down, therefore raising it won't violate sphere-frustum fit
     if (position.y < cameraMinY) {
       position.y = cameraMinY
     }

--- a/packages/@dcl/inspector/src/lib/logic/math.ts
+++ b/packages/@dcl/inspector/src/lib/logic/math.ts
@@ -31,3 +31,46 @@ export function areSRTMatrixesEqualWithEpsilon(m1: Matrix.ReadonlyMatrix, m2: Ma
     Math.abs(Quaternion.angle(rOut1, rOut2)) < Epsilon
   )
 }
+
+/*
+  Calculates position of an apex of a cone with following properties:
+  1. Cone's axis of rotation is the line between pos and spherePos.
+  2. Sphere centered at spherePos with radius sphereRadius is inscribed into the cone.
+*/
+export function fitSphereIntoCone(pos: Vector3, coneAngle: number, spherePos: Vector3, sphereRadius: number): Vector3.MutableVector3 {
+  const direction = Vector3.subtract(spherePos, pos)
+  if (Vector3.equalsWithEpsilon(direction, Vector3.Zero()))
+    throw new Error(`near equal pos and spherePos: ${JSON.stringify(pos)}`)
+  const t = Vector3.length(direction) - (sphereRadius / Math.tan(coneAngle))
+  const normalizedDirection = Vector3.normalize(direction)
+  return Vector3.add(pos, Vector3.scale(normalizedDirection, t))
+}
+
+export function fitSphereIntoCameraFrustum(cameraPos: Vector3, verticalFov: number, aspectRatio: number, cameraNearZ: number, cameraMinY: number, spherePos: Vector3, sphereRadius: number): Vector3 {
+  let adjustedCameraPos = cameraPos
+  if (Vector3.equalsWithEpsilon(Vector3.subtract(spherePos, cameraPos), Vector3.Zero()))
+    adjustedCameraPos = Vector3.add(spherePos, Vector3.create(0, 1, 0))
+
+  const horizontalFov = 2 * Math.atan(aspectRatio * Math.tan(verticalFov / 2))
+  const coneAngle = Math.min(horizontalFov, verticalFov) / 2
+
+  let adjustedSphereRadius = sphereRadius
+  // if a sphere is too small, parts of it would be behind near plane of camera
+  const distance = sphereRadius * (1 / Math.sin(coneAngle) - 1)
+  if (distance < cameraNearZ) {
+    adjustedSphereRadius = cameraNearZ / (1 / Math.sin(coneAngle) - 1)
+  }
+
+  let position = fitSphereIntoCone(adjustedCameraPos, coneAngle, spherePos, adjustedSphereRadius)
+  if (position.y < cameraMinY) {
+    let direction = Vector3.subtract(spherePos, position)
+    if (direction.y > 0) {
+      position = Vector3.add(spherePos, direction)
+      direction = Vector3.scale(direction, -1)
+    }
+    if (position.y < cameraMinY) {
+      position.y = cameraMinY
+    }
+  }
+  return position
+}

--- a/packages/@dcl/inspector/src/lib/logic/math.ts
+++ b/packages/@dcl/inspector/src/lib/logic/math.ts
@@ -37,16 +37,29 @@ export function areSRTMatrixesEqualWithEpsilon(m1: Matrix.ReadonlyMatrix, m2: Ma
   1. Cone's axis of rotation is the line between pos and spherePos.
   2. Sphere centered at spherePos with radius sphereRadius is inscribed into the cone.
 */
-export function fitSphereIntoCone(pos: Vector3, coneAngle: number, spherePos: Vector3, sphereRadius: number): Vector3.MutableVector3 {
+export function fitSphereIntoCone(
+  pos: Vector3,
+  coneAngle: number,
+  spherePos: Vector3,
+  sphereRadius: number
+): Vector3.MutableVector3 {
   const direction = Vector3.subtract(spherePos, pos)
   if (Vector3.equalsWithEpsilon(direction, Vector3.Zero()))
     throw new Error(`near equal pos and spherePos: ${JSON.stringify(pos)}`)
-  const t = Vector3.length(direction) - (sphereRadius / Math.tan(coneAngle))
+  const t = Vector3.length(direction) - sphereRadius / Math.tan(coneAngle)
   const normalizedDirection = Vector3.normalize(direction)
   return Vector3.add(pos, Vector3.scale(normalizedDirection, t))
 }
 
-export function fitSphereIntoCameraFrustum(cameraPos: Vector3, verticalFov: number, aspectRatio: number, cameraNearZ: number, cameraMinY: number, spherePos: Vector3, sphereRadius: number): Vector3 {
+export function fitSphereIntoCameraFrustum(
+  cameraPos: Vector3,
+  verticalFov: number,
+  aspectRatio: number,
+  cameraNearZ: number,
+  cameraMinY: number,
+  spherePos: Vector3,
+  sphereRadius: number
+): Vector3 {
   let adjustedCameraPos = cameraPos
   if (Vector3.equalsWithEpsilon(Vector3.subtract(spherePos, cameraPos), Vector3.Zero()))
     adjustedCameraPos = Vector3.add(spherePos, Vector3.create(0, 1, 0))


### PR DESCRIPTION
Closes decentraland/sdk#758.
Closes decentraland/sdk#879.

1. When a user double clicks on entity's row in composite inspector, camera transitions to a position where it looks at the center of entity's bounding sphere (including descendants). Position is picked in a way that ensures bounding sphere roughly fitting camera's frustum.
2. Remove boundaries check for translation tool.
3. Change Inspector's skybox color to sky blue.