### PR TITLE
fix: prevent running e2e test in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: make prepare
   test-e2e:
     runs-on: ubuntu-latest
+    if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/github-script@v6
         id: get-cloudflare-url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: prepare releasable packages
         run: make prepare
   test-e2e:
+    needs: [notify_deployment]
     runs-on: ubuntu-latest
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:


### PR DESCRIPTION
The E2E test fails in main because there's not cloudflare pages deployment there to test against, so this PR disables it there.