### PR TITLE
chore: add more e2e tests

### DIFF
--- a/packages/@dcl/inspector/jest-puppeteer.config.js
+++ b/packages/@dcl/inspector/jest-puppeteer.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   launch: {
-    headless: 'new', // Change this to false to run the test on a non-headless Chrome
-    // slowMo: 100
+    headless: false, // Change this to false to run the test on a non-headless Chrome
+    slowMo: 100
   },
   browserContext: 'default',
 }

--- a/packages/@dcl/inspector/jest-puppeteer.config.js
+++ b/packages/@dcl/inspector/jest-puppeteer.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   launch: {
-    headless: false, // Change this to false to run the test on a non-headless Chrome
-    slowMo: 100
+    headless: 'new', // Change this to false to run the test on a non-headless Chrome
+    // slowMo: 100
   },
   browserContext: 'default',
 }

--- a/packages/@dcl/inspector/src/components/Assets/Assets.tsx
+++ b/packages/@dcl/inspector/src/components/Assets/Assets.tsx
@@ -25,19 +25,19 @@ function Assets() {
   return (
     <div className="Assets">
       <div className="Assets-buttons">
-        <div onClick={handleTabClick(AssetsTab.FileSystem)}>
+        <div className="tab" onClick={handleTabClick(AssetsTab.FileSystem)} data-test-id={AssetsTab.FileSystem}>
           <div className={cx({ underlined: tab === AssetsTab.FileSystem })}>
             <FolderOpen />
             <span>LOCAL ASSETS</span>
           </div>
         </div>
-        <div onClick={handleTabClick(AssetsTab.AssetsPack)}>
+        <div className="tab" onClick={handleTabClick(AssetsTab.AssetsPack)} data-test-id={AssetsTab.AssetsPack}>
           <div className={cx({ underlined: tab === AssetsTab.AssetsPack })}>
             <MdImageSearch />
             <span>BUILDER ASSETS</span>
           </div>
         </div>
-        <div onClick={handleTabClick(AssetsTab.Import)}>
+        <div className="tab" onClick={handleTabClick(AssetsTab.Import)} data-test-id={AssetsTab.Import}>
           <div>
             <HiOutlinePlus />
           </div>

--- a/packages/@dcl/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
+++ b/packages/@dcl/inspector/src/components/AssetsCatalog/AssetsCatalog.tsx
@@ -43,7 +43,7 @@ function ThemeCell({ value, onClick }: ThemeProps) {
   }
 
   return (
-    <div onClick={handleClick} className="theme">
+    <div onClick={handleClick} className="theme" data-test-id={value.id} data-test-label={value.title}>
       <img src={getThemeThumbnailUrl(value.thumbnail)} alt={value.title} />
       <h4>{value.title}</h4>
       <div></div>
@@ -86,7 +86,7 @@ function AssetCell({ value }: AssetProps) {
   const [, drag] = useDrag(() => ({ type: 'builder-asset', item: { value } }), [value])
 
   return (
-    <div ref={drag}>
+    <div className="asset" ref={drag} data-test-id={value.id} data-test-label={value.name}>
       <img src={getStorageUrl(value.thumbnail)} alt={value.tags.join(', ')} />
     </div>
   )

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/Tile/Tile.tsx
@@ -33,7 +33,15 @@ export const Tile = withContextMenu<Props>(
             </MenuItem>
           </Menu>
         )}
-        <div ref={drag} className="Tile" key={value.name} onDoubleClick={onSelect} title={value.name}>
+        <div
+          ref={drag}
+          className="Tile"
+          key={value.name}
+          onDoubleClick={onSelect}
+          title={value.name}
+          data-test-id={valueId}
+          data-test-label={value.name}
+        >
           {value.type === 'folder' ? <FolderIcon /> : <IoIosImage />}
           <span>{value.name}</span>
         </div>

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useDrop } from 'react-dnd'
+import cx from 'classnames'
 import { Vector3 } from '@babylonjs/core'
 
 import { withAssetDir } from '../../lib/data-layer/host/fs-utils'
@@ -137,7 +138,7 @@ const Renderer: React.FC = () => {
   drop(canvasRef)
 
   return (
-    <div className="Renderer">
+    <div className={cx('Renderer', { 'is-loaded': !isLoading, 'is-loading': isLoading })}>
       {isLoading && <Loading />}
       <Warnings />
       <CameraSpeed />

--- a/packages/@dcl/inspector/test/e2e/Assets.spec.ts
+++ b/packages/@dcl/inspector/test/e2e/Assets.spec.ts
@@ -12,17 +12,27 @@ describe('Assets', () => {
     await App.waitUntilReady()
   }, 100_000)
 
-  test('Drag builder asset into renderer', async () => {
+  test('Drag asset from file system into renderer', async () => {
+    // There should not be an entity in the Hierarchy tree with the name casla.glb at the start
+    await expect(Hierarchy.getId('casla-glb.glb')).rejects.toThrow()
+
+    await Assets.selectTab(AssetsTab.FileSystem)
+    await Assets.openFolder('scene')
+    await Assets.openFolder('scene/models2')
+
+    await Assets.addFileSystemAsset('scene/models2/casla-glb.glb')
+
+    // There should be an entity in the Hierarchy tree with the name Pebbles
+    await expect(Hierarchy.getId('casla-glb.glb')).resolves.toBeGreaterThanOrEqual(152)
+  }, 100_000)
+
+  test('Drag asset from Builder into renderer', async () => {
     // There should not be an entity in the Hierarchy tree with the name Pebbles at the start
     await expect(Hierarchy.getId('Pebbles')).rejects.toThrow()
 
     await Assets.selectTab(AssetsTab.AssetsPack)
     await Assets.selectAssetPack('Voxels Pack')
-    await Assets.selectAsset('Pebbles')
-
-    // wait for renderer to load
-    await page.waitForSelector('.Renderer.is-loading')
-    await page.waitForSelector('.Renderer.is-loaded')
+    await Assets.addBuilderAsset('Pebbles')
 
     // There should be an entity in the Hierarchy tree with the name Pebbles
     await expect(Hierarchy.getId('Pebbles')).resolves.toBeGreaterThanOrEqual(152)

--- a/packages/@dcl/inspector/test/e2e/Assets.spec.ts
+++ b/packages/@dcl/inspector/test/e2e/Assets.spec.ts
@@ -1,0 +1,30 @@
+import { AssetsTab } from '../../src/components/Assets/types'
+import { E2E_URL } from './_config'
+import { App } from './pageObjects/App'
+import { Assets } from './pageObjects/Assets'
+import { Hierarchy } from './pageObjects/Hierarchy'
+import { installMouseHelper } from './utils/install-mouse-helper'
+
+describe('Assets', () => {
+  beforeAll(async () => {
+    await installMouseHelper(page)
+    await page.goto(E2E_URL)
+    await App.waitUntilReady()
+  }, 100_000)
+
+  test('Drag builder asset into renderer', async () => {
+    // There should not be an entity in the Hierarchy tree with the name Pebbles at the start
+    await expect(Hierarchy.getId('Pebbles')).rejects.toThrow()
+
+    await Assets.selectTab(AssetsTab.AssetsPack)
+    await Assets.selectAssetPack('Voxels Pack')
+    await Assets.selectAsset('Pebbles')
+
+    // wait for renderer to load
+    await page.waitForSelector('.Renderer.is-loading')
+    await page.waitForSelector('.Renderer.is-loaded')
+
+    // There should be an entity in the Hierarchy tree with the name Pebbles
+    await expect(Hierarchy.getId('Pebbles')).resolves.toBeGreaterThanOrEqual(152)
+  }, 100_000)
+})

--- a/packages/@dcl/inspector/test/e2e/Hierarchy.spec.ts
+++ b/packages/@dcl/inspector/test/e2e/Hierarchy.spec.ts
@@ -1,15 +1,12 @@
+import { E2E_URL } from './_config'
 import { App } from './pageObjects/App'
 import { Hierarchy } from './pageObjects/Hierarchy'
 import { installMouseHelper } from './utils/install-mouse-helper'
 
-const url = process.env['E2E_URL'] || 'http://localhost:8000'
-
-console.log('Running E2E test on URL:', url)
-
 describe('Hierarchy', () => {
   beforeAll(async () => {
     await installMouseHelper(page)
-    await page.goto(url)
+    await page.goto(E2E_URL)
     await App.waitUntilReady()
   }, 100_000)
 

--- a/packages/@dcl/inspector/test/e2e/_config.ts
+++ b/packages/@dcl/inspector/test/e2e/_config.ts
@@ -1,0 +1,3 @@
+export const E2E_URL = process.env['E2E_URL'] || 'http://localhost:8000'
+
+console.log('Running E2E test on URL:', E2E_URL)

--- a/packages/@dcl/inspector/test/e2e/pageObjects/Assets.ts
+++ b/packages/@dcl/inspector/test/e2e/pageObjects/Assets.ts
@@ -1,0 +1,28 @@
+import { AssetsTab } from '../../../src/components/Assets/types'
+import { dragAndDrop } from '../utils/drag-and-drop'
+
+class AssetsPageObject {
+  async selectTab(tab: AssetsTab) {
+    const element = await page.$(`.Assets .tab[data-test-id="${tab}"]`)
+    if (element) {
+      await element.click()
+    }
+  }
+
+  async selectAssetPack(assetPack: string) {
+    const element = await page.$(`.Assets .theme[data-test-label="${assetPack}"]`)
+    if (element) {
+      await element.click()
+    }
+  }
+
+  async selectAsset(asset: string) {
+    await dragAndDrop(`.Assets .asset[data-test-label="${asset}"]`, `.Renderer canvas`)
+    // simulate a mouse move to trigger the onPointerObservable from getPointerCoords in mouse-utils.ts
+    const renderer = await page.$(`.Renderer canvas`)
+    const box = await renderer!.boundingBox()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2)
+  }
+}
+
+export const Assets = new AssetsPageObject()

--- a/packages/@dcl/inspector/test/e2e/utils/drag-and-drop.ts
+++ b/packages/@dcl/inspector/test/e2e/utils/drag-and-drop.ts
@@ -86,7 +86,7 @@ export async function dragAndDrop(sourceSelector: string, destinationSelector: s
     },
     sourceSelector,
     destinationSelector,
-    sourceBox!,
-    destinationBox!
+    sourceBox! as any,
+    destinationBox! as any
   )
 }


### PR DESCRIPTION
This PR adds e2e test for two use cases: dragging an asset from the file system into the canvas and making sure it is added to the entity tree, and also from the builder assets