### PR TITLE
feat: expose helpers for @dcl/inspector

### DIFF
--- a/packages/@dcl/inspector/src/lib/data-layer/host/index.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/index.ts
@@ -3,6 +3,9 @@ import { createEngineContext } from './utils/engine'
 import { initRpcMethods } from '../host/rpc-methods'
 import { DataLayerRpcServer, FileSystemInterface } from '../types'
 
+export * from './utils/engine'
+export * from './utils/engine-to-composite'
+
 export type DataLayerHost = {
   rpcMethods: DataLayerRpcServer
   engine: IEngine


### PR DESCRIPTION
I need `createEngineContext` and `dumpEngineToComposite` helpers in order to use them from the Builder and easily create a composite using the SDK instead of building the json by hand.