### PR TITLE
fix: use text decoder for buffers

### DIFF
--- a/packages/@dcl/inspector/jest.config.js
+++ b/packages/@dcl/inspector/jest.config.js
@@ -39,6 +39,7 @@ module.exports = isE2E ? {
   testEnvironment: "jsdom",
   transformIgnorePatterns: [
     `/node_modules/(?!(@babylonjs)|(@dcl/ecs-math))`,
-  ]
+    ],
+    setupFiles: ['./test/setup.ts']
 }
 

--- a/packages/@dcl/inspector/src/lib/data-layer/host/scene.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/scene.ts
@@ -17,7 +17,7 @@ export interface SceneProvider {
 }
 
 function bufferToScene(sceneBuffer: Buffer): Scene {
-  return JSON.parse(sceneBuffer.toString())
+  return JSON.parse(new TextDecoder().decode(sceneBuffer))
 }
 
 function sceneToBuffer(scene: Scene): Buffer {

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/fs-composite-provider.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/fs-composite-provider.ts
@@ -25,7 +25,7 @@ export async function createFsCompositeProvider(
           composite
         }
       } else {
-        const compositeContent = (await fs.readFile(itemPath)).toString()
+        const compositeContent = new TextDecoder().decode(await fs.readFile(itemPath))
         const json = JSON.parse(compositeContent)
         const composite = Composite.fromJson(json)
         return {

--- a/packages/@dcl/inspector/src/lib/logic/preferences/io.ts
+++ b/packages/@dcl/inspector/src/lib/logic/preferences/io.ts
@@ -72,7 +72,7 @@ export async function readPreferencesFromFile(fs: FileSystemInterface, path: str
 
   const fileContent = await fs.readFile(path)
   try {
-    return parseInspectorPreferences(fileContent.toString('utf-8'))
+    return parseInspectorPreferences(new TextDecoder().decode(fileContent))
   } catch (error) {
     if (error instanceof InvalidPreferences) {
       console.log(`bad preferences file: ${error}, returning default preferences`)

--- a/packages/@dcl/inspector/test/setup.ts
+++ b/packages/@dcl/inspector/test/setup.ts
@@ -1,0 +1,3 @@
+import { TextEncoder, TextDecoder } from 'util'
+
+Object.assign(global, { TextDecoder, TextEncoder })


### PR DESCRIPTION
This fixes the issue where the encoding is lost, which happens when Buffers are sent over postMessage because they are received as ArrayBuffers.