### PR TITLE
feat: camera client

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -15,7 +15,7 @@
         "@babylonjs/materials": "^5.48.0",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/mini-rpc": "^1.0.2",
+        "@dcl/mini-rpc": "^1.0.4",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@reduxjs/toolkit": "^1.9.5",
@@ -253,9 +253,9 @@
       "dev": true
     },
     "node_modules/@dcl/mini-rpc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.2.tgz",
-      "integrity": "sha512-qYSW7KX31bnfQBWDKdzLR4f7CxZsk7oOFbfQ08HiPEDzLTQNj5oIZBryZFuN/WeU18VY7rjrAVEAgh1UIS6Iiw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.4.tgz",
+      "integrity": "sha512-7bBAaEQdtclukVuOBXSw9qNrpkjGxZ8AGfGbFMzvIqi/1NGhXhn1TmE704w+wdLjIpIKTRjJ+JfT24Kj/v/Mtg==",
       "dev": true,
       "dependencies": {
         "fp-future": "^1.0.1",
@@ -5597,9 +5597,9 @@
       "dev": true
     },
     "@dcl/mini-rpc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.2.tgz",
-      "integrity": "sha512-qYSW7KX31bnfQBWDKdzLR4f7CxZsk7oOFbfQ08HiPEDzLTQNj5oIZBryZFuN/WeU18VY7rjrAVEAgh1UIS6Iiw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.4.tgz",
+      "integrity": "sha512-7bBAaEQdtclukVuOBXSw9qNrpkjGxZ8AGfGbFMzvIqi/1NGhXhn1TmE704w+wdLjIpIKTRjJ+JfT24Kj/v/Mtg==",
       "dev": true,
       "requires": {
         "fp-future": "^1.0.1",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -9,7 +9,7 @@
     "@babylonjs/materials": "^5.48.0",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
-    "@dcl/mini-rpc": "^1.0.2",
+    "@dcl/mini-rpc": "^1.0.4",
     "@dcl/rpc": "^1.1.1",
     "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
     "@reduxjs/toolkit": "^1.9.5",

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/camera.ts
@@ -57,6 +57,10 @@ export class CameraManager {
     scene.activeCamera.attachControl(inputSource, true)
   }
 
+  getCamera() {
+    return this.camera
+  }
+
   getGlobalPosition() {
     return this.camera.globalPosition
   }

--- a/packages/@dcl/inspector/src/lib/rpc/camera/camera.spec.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/camera.spec.ts
@@ -1,0 +1,43 @@
+import { FreeCamera, NullEngine, Scene, Vector3, ScreenshotTools } from '@babylonjs/core'
+import { InMemoryTransport } from '@dcl/mini-rpc'
+import { CameraClient } from './client'
+import { CameraServer } from './server'
+
+describe('CameraRPC', () => {
+  const parent = new InMemoryTransport()
+  const iframe = new InMemoryTransport()
+
+  parent.connect(iframe)
+  iframe.connect(parent)
+
+  const engine = new NullEngine()
+  const scene = new Scene(engine)
+  const camera = new FreeCamera('camera', new Vector3(0, 0, 0), scene)
+
+  const client = new CameraClient(parent)
+  const _server = new CameraServer(iframe, engine, camera)
+
+  describe('When using the takeScreenshot method of the client', () => {
+    it('should generate a screenshot on the server and relay it back to the client', async () => {
+      const image = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==`
+      const spy = jest.spyOn(ScreenshotTools, 'CreateScreenshotAsync')
+      spy.mockResolvedValue(image)
+      await expect(client.takeScreenshot(1024, 1024)).resolves.toBe(image)
+      expect(spy).toHaveBeenCalledWith(engine, camera, expect.objectContaining({ width: 1024, height: 1024 }))
+    })
+  })
+  describe('When using the setPosition method of the client', () => {
+    it('should set the position of the camera in the server', async () => {
+      const spy = jest.spyOn(camera.position, 'set')
+      await expect(client.setPosition(8, 0, 8)).resolves.toBe(undefined)
+      expect(spy).toHaveBeenCalledWith(8, 0, 8)
+    })
+  })
+  describe('When using the setTarget method of the client', () => {
+    it('should set the target of the camera in the server', async () => {
+      const spy = jest.spyOn(camera, 'setTarget')
+      await expect(client.setTarget(8, 0, 8)).resolves.toBe(undefined)
+      expect(spy).toHaveBeenCalledWith(new Vector3(8, 0, 8))
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/lib/rpc/camera/camera.spec.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/camera.spec.ts
@@ -24,6 +24,7 @@ describe('CameraRPC', () => {
       spy.mockResolvedValue(image)
       await expect(client.takeScreenshot(1024, 1024)).resolves.toBe(image)
       expect(spy).toHaveBeenCalledWith(engine, camera, expect.objectContaining({ width: 1024, height: 1024 }))
+      spy.mockRestore()
     })
   })
   describe('When using the setPosition method of the client', () => {
@@ -31,6 +32,7 @@ describe('CameraRPC', () => {
       const spy = jest.spyOn(camera.position, 'set')
       await expect(client.setPosition(8, 0, 8)).resolves.toBe(undefined)
       expect(spy).toHaveBeenCalledWith(8, 0, 8)
+      spy.mockRestore()
     })
   })
   describe('When using the setTarget method of the client', () => {
@@ -38,6 +40,7 @@ describe('CameraRPC', () => {
       const spy = jest.spyOn(camera, 'setTarget')
       await expect(client.setTarget(8, 0, 8)).resolves.toBe(undefined)
       expect(spy).toHaveBeenCalledWith(new Vector3(8, 0, 8))
+      spy.mockRestore()
     })
   })
 })

--- a/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
@@ -1,7 +1,7 @@
-import { RPC } from '../../logic/rpc'
+import { RPC } from '@dcl/mini-rpc'
 import { CameraRPC } from './types'
 
-export class CameraClient extends RPC<string, object, CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
+export class CameraClient extends RPC<CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
   constructor(transport: RPC.Transport) {
     super(CameraRPC.name, transport)
   }

--- a/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
@@ -1,0 +1,20 @@
+import { RPC } from '../../logic/rpc'
+import { CameraRPC } from './types'
+
+export class CameraClient extends RPC<string, object, CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
+  constructor(transport: RPC.Transport) {
+    super(CameraRPC.name, transport)
+  }
+
+  takeScreenshot = (width: number, height: number, precision?: number) => {
+    return this.request('take_screenshot', { width, height, precision })
+  }
+
+  setTarget = (x: number, y: number, z: number) => {
+    return this.request('set_target', { x, y, z })
+  }
+
+  setPosition = (x: number, y: number, z: number) => {
+    return this.request('set_position', { x, y, z })
+  }
+}

--- a/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
@@ -1,0 +1,21 @@
+import { Engine, FreeCamera, ScreenshotTools, Vector3 } from '@babylonjs/core'
+import { RPC } from '../../logic/rpc'
+import { CameraRPC } from './types'
+
+export class CameraServer extends RPC<string, object, CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
+  constructor(transport: RPC.Transport, engine: Engine, camera: FreeCamera) {
+    super(CameraRPC.name, transport)
+
+    this.handle('set_position', async ({ x, y, z }) => {
+      camera.position.set(x, y, z)
+    })
+
+    this.handle('set_target', async ({ x, y, z }) => {
+      camera.setTarget(new Vector3(x, y, z))
+    })
+
+    this.handle('take_screenshot', async ({ width, height, precision }) => {
+      return ScreenshotTools.CreateScreenshotAsync(engine, camera, { width, height, precision })
+    })
+  }
+}

--- a/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
@@ -1,8 +1,8 @@
 import { Engine, FreeCamera, ScreenshotTools, Vector3 } from '@babylonjs/core'
-import { RPC } from '../../logic/rpc'
+import { RPC } from '@dcl/mini-rpc'
 import { CameraRPC } from './types'
 
-export class CameraServer extends RPC<string, object, CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
+export class CameraServer extends RPC<CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
   constructor(transport: RPC.Transport, engine: Engine, camera: FreeCamera) {
     super(CameraRPC.name, transport)
 

--- a/packages/@dcl/inspector/src/lib/rpc/camera/types.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/types.ts
@@ -1,0 +1,21 @@
+export namespace CameraRPC {
+  export const name = 'CameraRPC'
+
+  export enum Method {
+    TAKE_SCREENSHOT = 'take_screenshot',
+    SET_TARGET = 'set_target',
+    SET_POSITION = 'set_position'
+  }
+
+  export type Params = {
+    [Method.TAKE_SCREENSHOT]: { width: number; height: number; precision?: number }
+    [Method.SET_TARGET]: { x: number; y: number; z: number }
+    [Method.SET_POSITION]: { x: number; y: number; z: number }
+  }
+
+  export type Result = {
+    [Method.TAKE_SCREENSHOT]: string
+    [Method.SET_TARGET]: void
+    [Method.SET_POSITION]: void
+  }
+}

--- a/packages/@dcl/inspector/src/lib/sdk/context.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/context.ts
@@ -1,5 +1,6 @@
 import { Scene } from '@babylonjs/core'
 import { ComponentDefinition, CrdtMessageType, Entity, IEngine } from '@dcl/ecs'
+import { MessageTransport } from '@dcl/mini-rpc'
 import { Emitter } from 'mitt'
 
 import { ITheme } from '../../components/AssetsCatalog'
@@ -13,7 +14,6 @@ import { Gizmos } from '../babylon/decentraland/gizmo-manager'
 import { CameraManager } from '../babylon/decentraland/camera'
 import { InspectorPreferences } from '../logic/preferences/types'
 import { getParentUrl } from '../../redux/data-layer/sagas/connect'
-import { MessageTransport } from '../logic/transports'
 import { CameraServer } from '../rpc/camera/server'
 
 export type SdkContextEvents = {

--- a/packages/@dcl/inspector/src/lib/sdk/context.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/context.ts
@@ -12,6 +12,9 @@ import { createOperations } from './operations'
 import { Gizmos } from '../babylon/decentraland/gizmo-manager'
 import { CameraManager } from '../babylon/decentraland/camera'
 import { InspectorPreferences } from '../logic/preferences/types'
+import { getParentUrl } from '../../redux/data-layer/sagas/connect'
+import { MessageTransport } from '../logic/transports'
+import { CameraServer } from '../rpc/camera/server'
 
 export type SdkContextEvents = {
   change: { entity: Entity; operation: CrdtMessageType; component?: ComponentDefinition<any>; value?: any }
@@ -54,6 +57,13 @@ export async function createSdkContext(
 
   // register some globals for debugging
   Object.assign(globalThis, { inspectorEngine: engine })
+
+  // if there is a parent, initialize rpc servers
+  const parentUrl = getParentUrl()
+  if (parentUrl) {
+    const tranport = new MessageTransport(window, window.parent, parentUrl)
+    new CameraServer(tranport, renderer.engine, renderer.editorCamera.getCamera())
+  }
 
   return {
     engine,

--- a/packages/@dcl/inspector/src/tooling-entrypoint.ts
+++ b/packages/@dcl/inspector/src/tooling-entrypoint.ts
@@ -1,2 +1,3 @@
 export * from './lib/data-layer/remote-data-layer'
+export * from './lib/rpc/camera/client'
 export * from './lib/logic/storage'


### PR DESCRIPTION
This PR adds a camera client that can be used to control the camera and take screenshots when the inspector is used via an iframe, ie:

```ts
import { CameraClient, MessageTransport } from '@dcl/inspector'

const iframe = document.getElementById('inspector')
const transport = new MessageTransport(window, iframe.contentWindow)
const camera = new CameraClient(transport)

await camera.setPosition(0, 1, 0)
await camera.setTarget(8, 1, 8)
const screenshot = await camera.takeScreenshot(1024, 1024)
```