### PR TITLE
fix: bump @dcl/mini-rpc

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -15,7 +15,7 @@
         "@babylonjs/materials": "^5.48.0",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/mini-rpc": "^1.0.4",
+        "@dcl/mini-rpc": "^1.0.5",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@reduxjs/toolkit": "^1.9.5",
@@ -253,9 +253,9 @@
       "dev": true
     },
     "node_modules/@dcl/mini-rpc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.4.tgz",
-      "integrity": "sha512-7bBAaEQdtclukVuOBXSw9qNrpkjGxZ8AGfGbFMzvIqi/1NGhXhn1TmE704w+wdLjIpIKTRjJ+JfT24Kj/v/Mtg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.5.tgz",
+      "integrity": "sha512-E53eLXxuZ4ZqLjoVoKBxmgaJ/LE8H9XLjiz7FhhCH/GAqmL9+yCtgH2G5V4Bs1iDq0AzEyQr43bRKFpxDw5qmQ==",
       "dev": true,
       "dependencies": {
         "fp-future": "^1.0.1",
@@ -5597,9 +5597,9 @@
       "dev": true
     },
     "@dcl/mini-rpc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.4.tgz",
-      "integrity": "sha512-7bBAaEQdtclukVuOBXSw9qNrpkjGxZ8AGfGbFMzvIqi/1NGhXhn1TmE704w+wdLjIpIKTRjJ+JfT24Kj/v/Mtg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.5.tgz",
+      "integrity": "sha512-E53eLXxuZ4ZqLjoVoKBxmgaJ/LE8H9XLjiz7FhhCH/GAqmL9+yCtgH2G5V4Bs1iDq0AzEyQr43bRKFpxDw5qmQ==",
       "dev": true,
       "requires": {
         "fp-future": "^1.0.1",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -9,7 +9,7 @@
     "@babylonjs/materials": "^5.48.0",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
-    "@dcl/mini-rpc": "^1.0.4",
+    "@dcl/mini-rpc": "^1.0.5",
     "@dcl/rpc": "^1.1.1",
     "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
     "@reduxjs/toolkit": "^1.9.5",

--- a/packages/@dcl/inspector/src/lib/logic/storage/iframe.ts
+++ b/packages/@dcl/inspector/src/lib/logic/storage/iframe.ts
@@ -1,4 +1,4 @@
-import { RPC, MessageTransport } from '@dcl/mini-rpc'
+import { RPC, MessageTransport, Transport } from '@dcl/mini-rpc'
 import { Storage } from './types'
 
 export namespace IframeStorage {
@@ -29,7 +29,7 @@ export namespace IframeStorage {
   export const id = 'IframeStorage'
 
   export class Client extends RPC<Method, Params, Result> {
-    constructor(transport: RPC.Transport) {
+    constructor(transport: Transport) {
       super(id, transport)
     }
 
@@ -55,7 +55,7 @@ export namespace IframeStorage {
   }
 
   export class Server extends RPC<Method, Params, Result> {
-    constructor(transport: RPC.Transport) {
+    constructor(transport: Transport) {
       super(id, transport)
     }
   }

--- a/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/client.ts
@@ -1,8 +1,8 @@
-import { RPC } from '@dcl/mini-rpc'
+import { RPC, Transport } from '@dcl/mini-rpc'
 import { CameraRPC } from './types'
 
 export class CameraClient extends RPC<CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
-  constructor(transport: RPC.Transport) {
+  constructor(transport: Transport) {
     super(CameraRPC.name, transport)
   }
 

--- a/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
+++ b/packages/@dcl/inspector/src/lib/rpc/camera/server.ts
@@ -1,9 +1,9 @@
 import { Engine, FreeCamera, ScreenshotTools, Vector3 } from '@babylonjs/core'
-import { RPC } from '@dcl/mini-rpc'
+import { RPC, Transport } from '@dcl/mini-rpc'
 import { CameraRPC } from './types'
 
 export class CameraServer extends RPC<CameraRPC.Method, CameraRPC.Params, CameraRPC.Result> {
-  constructor(transport: RPC.Transport, engine: Engine, camera: FreeCamera) {
+  constructor(transport: Transport, engine: Engine, camera: FreeCamera) {
     super(CameraRPC.name, transport)
 
     this.handle('set_position', async ({ x, y, z }) => {


### PR DESCRIPTION
This PR bumps the version of `@dcl/mini-rpc` which moves the `Transport` type outside of the `RPC` namespace, this fixes some typing issues.