### PR TITLE
fix: bump @dcl/mini-rpc again

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -15,7 +15,7 @@
         "@babylonjs/materials": "^5.48.0",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/mini-rpc": "^1.0.5",
+        "@dcl/mini-rpc": "^1.0.6",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@reduxjs/toolkit": "^1.9.5",
@@ -253,9 +253,9 @@
       "dev": true
     },
     "node_modules/@dcl/mini-rpc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.5.tgz",
-      "integrity": "sha512-E53eLXxuZ4ZqLjoVoKBxmgaJ/LE8H9XLjiz7FhhCH/GAqmL9+yCtgH2G5V4Bs1iDq0AzEyQr43bRKFpxDw5qmQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.6.tgz",
+      "integrity": "sha512-Oo61XGPub4s2uGowwjpW2mJs3CVIRDY0kQzJGF2fn3z4MePoq3jTBQbNU7bpkonFmAuoQCR0kJB63GEPRtjdsg==",
       "dev": true,
       "dependencies": {
         "fp-future": "^1.0.1",
@@ -5597,9 +5597,9 @@
       "dev": true
     },
     "@dcl/mini-rpc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.5.tgz",
-      "integrity": "sha512-E53eLXxuZ4ZqLjoVoKBxmgaJ/LE8H9XLjiz7FhhCH/GAqmL9+yCtgH2G5V4Bs1iDq0AzEyQr43bRKFpxDw5qmQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@dcl/mini-rpc/-/mini-rpc-1.0.6.tgz",
+      "integrity": "sha512-Oo61XGPub4s2uGowwjpW2mJs3CVIRDY0kQzJGF2fn3z4MePoq3jTBQbNU7bpkonFmAuoQCR0kJB63GEPRtjdsg==",
       "dev": true,
       "requires": {
         "fp-future": "^1.0.1",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -9,7 +9,7 @@
     "@babylonjs/materials": "^5.48.0",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
-    "@dcl/mini-rpc": "^1.0.5",
+    "@dcl/mini-rpc": "^1.0.6",
     "@dcl/rpc": "^1.1.1",
     "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
     "@reduxjs/toolkit": "^1.9.5",


### PR DESCRIPTION
Fixes an issue when using multiple MessageTransport instances in the same document