### PR TITLE
feat: Update inspector components styles

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -30,7 +30,7 @@
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "@well-known-components/pushable-channel": "^1.0.3",
         "classnames": "^2.3.2",
-        "decentraland-ui": "^3.87.2",
+        "decentraland-ui": "^4.10.0",
         "dotenv": "^16.3.1",
         "esbuild": "^0.18.17",
         "fp-future": "^1.0.1",
@@ -3041,11 +3041,12 @@
       }
     },
     "node_modules/decentraland-ui": {
-      "version": "3.92.1",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-4.10.0.tgz",
+      "integrity": "sha512-vRUeTMa9q4dOrkKlNrlh+n0dyedXw27ckT/DE6Ia7vkwfDAgGREP1RYoJOadGZ2bM1hgOFWH6rlmZ8deInCzfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@dcl/schemas": "^6.10.0",
+        "@dcl/schemas": "^9.4.1",
         "balloon-css": "^0.5.0",
         "classnames": "^2.3.2",
         "deep-equal": "^2.0.5",
@@ -3053,11 +3054,11 @@
         "events": "^3.3.0",
         "fp-future": "^1.0.1",
         "parallax-js": "^3.1.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.4.0",
+        "react-tile-map": "^0.4.1",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
@@ -3076,9 +3077,9 @@
       }
     },
     "node_modules/decentraland-ui/node_modules/@dcl/schemas": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.19.0.tgz",
-      "integrity": "sha512-S8lrq8L1vriVXkBzeycxppjbfgJ5XofA9pbCKdteJR+79r6Dn5oLo3t5g7RcMQDihdjWdDLbbwxlEAkPgmvc8w==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.4.1.tgz",
+      "integrity": "sha512-oM9y5CuKKMH6kjJLXpD9JC1L1JTCkJDshUk5TUNkkvWaP2ljXaxnU99a1LoI7jfKnTkBAASK685bf0totbXdcQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.11.0",
@@ -4171,8 +4172,9 @@
     },
     "node_modules/impetus": {
       "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/impetus/-/impetus-0.8.8.tgz",
+      "integrity": "sha512-7ejVjFxRAiBlnZQbdNGzUGgxMvLjVke/QNP2TFN/VK8baASsuRiE8YuSbD0qyiU8Pae+w95De4ZYz+rxSo5FJw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "npm": ">=2.13.0"
       }
@@ -5256,13 +5258,15 @@
     },
     "node_modules/mouse-event-offset": {
       "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
+      "dev": true
     },
     "node_modules/mouse-wheel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -5698,8 +5702,9 @@
     },
     "node_modules/parse-unit": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -6396,9 +6401,10 @@
       }
     },
     "node_modules/react-tile-map": {
-      "version": "0.4.0",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
+      "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
@@ -6427,9 +6433,10 @@
       }
     },
     "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.11",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
@@ -6639,8 +6646,9 @@
     },
     "node_modules/right-now": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
+      "dev": true
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -6776,8 +6784,9 @@
     },
     "node_modules/signum": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
+      "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7042,8 +7051,9 @@
     },
     "node_modules/to-px": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
+      "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parse-unit": "^1.0.1"
       }
@@ -7070,8 +7080,9 @@
     },
     "node_modules/touch-pinch": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/touch-pinch/-/touch-pinch-1.0.1.tgz",
+      "integrity": "sha512-If5caiHlfY2JBQYM8XWjOB4mwEidkYpjLXV6zx1uuama0lrbGNVxhzG0wSpaAdHduoGVtWKAQNoCLrgJDEnnfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "dprop": "^1.0.0",
         "events": "^1.0.2",
@@ -7081,16 +7092,18 @@
     },
     "node_modules/touch-pinch/node_modules/events": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
     },
     "node_modules/touch-position": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/touch-position/-/touch-position-2.0.0.tgz",
+      "integrity": "sha512-/lzepy++NyN/FcjWrYEWXrNqkontDGm6+5BzMdlFOQybTGyVq1JXm+sEzlsZjcPSThJozcs6Flp68n152tWb3w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "events": "^1.0.2",
         "mouse-event-offset": "^3.0.2"
@@ -7098,8 +7111,9 @@
     },
     "node_modules/touch-position/node_modules/events": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -9922,10 +9936,12 @@
       }
     },
     "decentraland-ui": {
-      "version": "3.92.1",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-4.10.0.tgz",
+      "integrity": "sha512-vRUeTMa9q4dOrkKlNrlh+n0dyedXw27ckT/DE6Ia7vkwfDAgGREP1RYoJOadGZ2bM1hgOFWH6rlmZ8deInCzfQ==",
       "dev": true,
       "requires": {
-        "@dcl/schemas": "^6.10.0",
+        "@dcl/schemas": "^9.4.1",
         "balloon-css": "^0.5.0",
         "classnames": "^2.3.2",
         "deep-equal": "^2.0.5",
@@ -9933,20 +9949,20 @@
         "events": "^3.3.0",
         "fp-future": "^1.0.1",
         "parallax-js": "^3.1.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.4.0",
+        "react-tile-map": "^0.4.1",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
       },
       "dependencies": {
         "@dcl/schemas": {
-          "version": "6.19.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.19.0.tgz",
-          "integrity": "sha512-S8lrq8L1vriVXkBzeycxppjbfgJ5XofA9pbCKdteJR+79r6Dn5oLo3t5g7RcMQDihdjWdDLbbwxlEAkPgmvc8w==",
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.4.1.tgz",
+          "integrity": "sha512-oM9y5CuKKMH6kjJLXpD9JC1L1JTCkJDshUk5TUNkkvWaP2ljXaxnU99a1LoI7jfKnTkBAASK685bf0totbXdcQ==",
           "dev": true,
           "requires": {
             "ajv": "^8.11.0",
@@ -10524,6 +10540,8 @@
     },
     "gl-vec2": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gl-vec2/-/gl-vec2-1.3.0.tgz",
+      "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
       "dev": true
     },
     "glob": {
@@ -10718,6 +10736,8 @@
     },
     "impetus": {
       "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/impetus/-/impetus-0.8.8.tgz",
+      "integrity": "sha512-7ejVjFxRAiBlnZQbdNGzUGgxMvLjVke/QNP2TFN/VK8baASsuRiE8YuSbD0qyiU8Pae+w95De4ZYz+rxSo5FJw==",
       "dev": true
     },
     "import-fresh": {
@@ -11518,10 +11538,14 @@
     },
     "mouse-event-offset": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
       "dev": true
     },
     "mouse-wheel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "dev": true,
       "requires": {
         "right-now": "^1.0.0",
@@ -11858,6 +11882,8 @@
     },
     "parse-unit": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
       "dev": true
     },
     "parse5": {
@@ -12342,7 +12368,9 @@
       }
     },
     "react-tile-map": {
-      "version": "0.4.0",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
+      "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
       "dev": true,
       "requires": {
         "impetus": "^0.8.8",
@@ -12363,7 +12391,9 @@
       }
     },
     "react-virtualized-auto-sizer": {
-      "version": "1.0.11",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
       "dev": true,
       "requires": {}
     },
@@ -12523,6 +12553,8 @@
     },
     "right-now": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
       "dev": true
     },
     "rxjs": {
@@ -12623,6 +12655,8 @@
     },
     "signum": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
       "dev": true
     },
     "sisteransi": {
@@ -12835,6 +12869,8 @@
     },
     "to-px": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
+      "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "dev": true,
       "requires": {
         "parse-unit": "^1.0.1"
@@ -12855,6 +12891,8 @@
     },
     "touch-pinch": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/touch-pinch/-/touch-pinch-1.0.1.tgz",
+      "integrity": "sha512-If5caiHlfY2JBQYM8XWjOB4mwEidkYpjLXV6zx1uuama0lrbGNVxhzG0wSpaAdHduoGVtWKAQNoCLrgJDEnnfQ==",
       "dev": true,
       "requires": {
         "dprop": "^1.0.0",
@@ -12865,12 +12903,16 @@
       "dependencies": {
         "events": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
           "dev": true
         }
       }
     },
     "touch-position": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/touch-position/-/touch-position-2.0.0.tgz",
+      "integrity": "sha512-/lzepy++NyN/FcjWrYEWXrNqkontDGm6+5BzMdlFOQybTGyVq1JXm+sEzlsZjcPSThJozcs6Flp68n152tWb3w==",
       "dev": true,
       "requires": {
         "events": "^1.0.2",
@@ -12879,6 +12921,8 @@
       "dependencies": {
         "events": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
           "dev": true
         }
       }

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^5.48.0",
         "@babylonjs/loaders": "^5.48.0",
         "@babylonjs/materials": "^5.48.0",
-        "@dcl/asset-packs": "^0.0.0-20230906131904.commit-b044e5a",
+        "@dcl/asset-packs": "^0.0.0-20230906220135.commit-6800ff7",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "0.0.0-20230906131904.commit-b044e5a",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230906131904.commit-b044e5a.tgz",
-      "integrity": "sha512-lZOyJvk7UPSWxL84lhyzwJP4Myp3TuKkezp8m3etzMm/e0MUeyT2fibzCG5FuuUJXda+oLYQP4WoOFov/HuwOQ==",
+      "version": "0.0.0-20230906220135.commit-6800ff7",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230906220135.commit-6800ff7.tgz",
+      "integrity": "sha512-ilAlrB2Cj94EUwpeIkXLb6LTL9mf+p457O+VOurUoCqNW9PBrTLOlD4p/eHptwFjdF9cTdNJAjuJt8bq/r21eA==",
       "dev": true,
       "dependencies": {
         "@dcl/sdk": "^7.3.12"
@@ -7847,9 +7847,9 @@
       }
     },
     "@dcl/asset-packs": {
-      "version": "0.0.0-20230906131904.commit-b044e5a",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230906131904.commit-b044e5a.tgz",
-      "integrity": "sha512-lZOyJvk7UPSWxL84lhyzwJP4Myp3TuKkezp8m3etzMm/e0MUeyT2fibzCG5FuuUJXda+oLYQP4WoOFov/HuwOQ==",
+      "version": "0.0.0-20230906220135.commit-6800ff7",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230906220135.commit-6800ff7.tgz",
+      "integrity": "sha512-ilAlrB2Cj94EUwpeIkXLb6LTL9mf+p457O+VOurUoCqNW9PBrTLOlD4p/eHptwFjdF9cTdNJAjuJt8bq/r21eA==",
       "dev": true,
       "requires": {
         "@dcl/sdk": "^7.3.12"
@@ -10540,8 +10540,6 @@
     },
     "gl-vec2": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/gl-vec2/-/gl-vec2-1.3.0.tgz",
-      "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
       "dev": true
     },
     "glob": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -7,7 +7,7 @@
     "@babylonjs/inspector": "^5.48.0",
     "@babylonjs/loaders": "^5.48.0",
     "@babylonjs/materials": "^5.48.0",
-    "@dcl/asset-packs": "^0.0.0-20230906131904.commit-b044e5a",
+    "@dcl/asset-packs": "^0.0.0-20230906220135.commit-6800ff7",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
     "@dcl/mini-rpc": "^1.0.7",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -24,7 +24,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@well-known-components/pushable-channel": "^1.0.3",
     "classnames": "^2.3.2",
-    "decentraland-ui": "^3.87.2",
+    "decentraland-ui": "^4.10.0",
     "dotenv": "^16.3.1",
     "esbuild": "^0.18.17",
     "fp-future": "^1.0.1",

--- a/packages/@dcl/inspector/src/components/Block/Block.tsx
+++ b/packages/@dcl/inspector/src/components/Block/Block.tsx
@@ -5,9 +5,9 @@ import { Props } from './types'
 
 import './Block.css'
 
-const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, error, children }, ref) => {
+const Block = React.forwardRef<null, React.PropsWithChildren<Props>>(({ label, error, className, children }, ref) => {
   return (
-    <div ref={ref} className={cx('Block', { error })}>
+    <div ref={ref} className={cx('Block', className, { error })}>
       {label && <label>{label}</label>}
       <div className="content">{children}</div>
     </div>

--- a/packages/@dcl/inspector/src/components/Block/types.ts
+++ b/packages/@dcl/inspector/src/components/Block/types.ts
@@ -1,4 +1,5 @@
 export type Props = {
   label?: string
   error?: boolean
+  className?: string
 }

--- a/packages/@dcl/inspector/src/components/Button/Button.css
+++ b/packages/@dcl/inspector/src/components/Button/Button.css
@@ -13,16 +13,11 @@
 
 .Button:disabled {
   opacity: 0.5;
-  cursor: default
+  cursor: default;
 }
 
 .Button.active {
   background-color: #6c6974;
-}
-
-.Button svg {
-  width: 24px;
-  height: 24px;
 }
 
 .Button.big {
@@ -36,5 +31,5 @@
 
 .Button.danger:hover,
 .Button.danger.active {
-  background-color: var(--primary-darker)
+  background-color: var(--primary-darker);
 }

--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -19,7 +19,7 @@
   user-select: none;
 }
 
-.Container .title svg {
+.Container .title svg.icon {
   width: 14px;
   height: 14px;
   margin-right: 4px;
@@ -30,4 +30,10 @@
   color: var(--text);
   font-size: 13px;
   cursor: pointer;
+}
+
+.Container .title .right-content {
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
 }

--- a/packages/@dcl/inspector/src/components/Container/Container.tsx
+++ b/packages/@dcl/inspector/src/components/Container/Container.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import cx from 'classnames'
 import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io'
 
 import { Props } from './types'
@@ -9,7 +10,7 @@ const Container: React.FC<React.PropsWithChildren<Props>> = (props) => {
   const [open, setOpen] = useState<boolean>(true)
   const Icon = open ? <IoIosArrowDown className="icon" /> : <IoIosArrowForward className="icon" />
   return (
-    <div className={`Container ${props.className ?? ''}`}>
+    <div className={cx('Container', props.className, { open })}>
       {props.label && (
         <div className="title" onClick={() => setOpen(!open)}>
           {Icon}

--- a/packages/@dcl/inspector/src/components/Container/Container.tsx
+++ b/packages/@dcl/inspector/src/components/Container/Container.tsx
@@ -7,13 +7,14 @@ import './Container.css'
 
 const Container: React.FC<React.PropsWithChildren<Props>> = (props) => {
   const [open, setOpen] = useState<boolean>(true)
-  const Icon = open ? <IoIosArrowDown /> : <IoIosArrowForward />
+  const Icon = open ? <IoIosArrowDown className="icon" /> : <IoIosArrowForward className="icon" />
   return (
     <div className={`Container ${props.className ?? ''}`}>
       {props.label && (
         <div className="title" onClick={() => setOpen(!open)}>
           {Icon}
           <span>{props.label}</span>
+          {props.rightContent && <span className="right-content">{props.rightContent}</span>}
         </div>
       )}
       {open && <div className="content">{props.children}</div>}

--- a/packages/@dcl/inspector/src/components/Container/types.ts
+++ b/packages/@dcl/inspector/src/components/Container/types.ts
@@ -1,4 +1,5 @@
 export type Props = {
   label?: string
   className?: string
+  rightContent?: JSX.Element
 }

--- a/packages/@dcl/inspector/src/components/Dropdown/Dropdown.css
+++ b/packages/@dcl/inspector/src/components/Dropdown/Dropdown.css
@@ -10,10 +10,12 @@
 }
 
 .DropdownContainer .Dropdown {
-  padding: 2px 3px;
-  border: 1px solid var(--border-gray);
   display: flex;
-  border-radius: 1.6px;
+  border: 1px solid var(--background-gray);
+  border-radius: 5px;
+  padding: 2px 3px;
   font-size: 12px;
   height: 25px;
+  background: var(--background-gray);
+  color: var(--text);
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
@@ -6,6 +6,11 @@
 .ActionInspector > .content > .Block > .content {
   display: flex;
   flex-direction: column;
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 4px;
+  border: 1px solid #303031;
+  background: var(--tree-bg-color);
 }
 
 .ActionInspector > .content > .Block > .content .row {

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
@@ -1,11 +1,63 @@
-.ActionInspector > .content {
+.ActionInspector > .title {
+  border-bottom: 1px solid var(--border-gray);
+  padding-bottom: 12px;
+}
+
+.ActionInspector > .content > .Block > .content {
   display: flex;
   flex-direction: column;
 }
 
+.ActionInspector > .content > .Block > .content .row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  gap: 4px;
+}
+
+.ActionInspector > .content > .Block > .content .row .field {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.ActionInspector > .content > .Block > .content .row .DropdownContainer label,
+.ActionInspector > .content > .Block > .content .row .field label {
+  margin: 0px 0px 6px 0px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.ActionInspector > .content > .Block > .content .row .field label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+}
+
+.ActionInspector > .content > .Block > .content .row .field .TextField {
+  width: 100%;
+}
+
 .ActionInspector .content .AddButton {
-  align-self: flex-end;
-  margin-top: 10px;
+  margin-top: 16px;
+  border: 1px solid #3a3d41;
+  background: #1e1e1e;
+  display: flex;
+  padding: 4px;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+  color: #ccc;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  width: 100%;
 }
 
 .ActionInspector .content .RemoveButton {
@@ -26,4 +78,14 @@
 
 .ActionInspector .content .Block .content .DropdownContainer {
   flex: 1;
+}
+
+.ActionInspector .content .Block .content .MoreOptionsMenu {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.ActionInspector .content .Block .content .MoreOptionsMenu .MoreOptionsContent {
+  min-width: 125px;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
@@ -1,4 +1,4 @@
-.ActionInspector > .title {
+.ActionInspector:is(.open) > .title {
   border-bottom: 1px solid var(--border-gray);
   padding-bottom: 12px;
 }
@@ -92,5 +92,5 @@
 }
 
 .ActionInspector .content .Block .content .MoreOptionsMenu .MoreOptionsContent {
-  min-width: 125px;
+  min-width: 140px;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -157,6 +157,8 @@ export default withSdk<Props>(
           trigger={<QuestionIcon size={16} />}
           position="right center"
           on="hover"
+          hideOnScroll
+          hoverable
         />
       )
     }
@@ -172,6 +174,8 @@ export default withSdk<Props>(
           trigger={<InfoIcon size={16} />}
           position="top center"
           on="hover"
+          hideOnScroll
+          hoverable
         />
       )
     }

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Item } from 'react-contexify'
-import { AiFillDelete as DeleteIcon, AiOutlinePlus as AddIcon, AiOutlineMinus as RemoveIcon } from 'react-icons/ai'
 import { Action, ActionType } from '@dcl/asset-packs'
+import { Item } from 'react-contexify'
+import { AiFillDelete as DeleteIcon, AiOutlinePlus as AddIcon } from 'react-icons/ai'
+import { VscQuestion as QuestionIcon, VscTrash as RemoveIcon, VscInfo as InfoIcon } from 'react-icons/vsc'
+import { Popup } from 'decentraland-ui/dist/components/Popup/Popup'
 
 import { WithSdkProps, withSdk } from '../../../hoc/withSdk'
 import { withContextMenu } from '../../../hoc/withContextMenu'
@@ -19,6 +21,8 @@ import { TextField } from '../TextField'
 import { Props } from './types'
 
 import './ActionInspector.css'
+import MoreOptionsMenu from '../MoreOptionsMenu'
+import Button from '../../Button'
 
 export default withSdk<Props>(
   withContextMenu<Props & WithSdkProps>(({ sdk, entity, contextMenuId }) => {
@@ -142,8 +146,38 @@ export default withSdk<Props>(
       return null
     }
 
+    const renderMoreInfo = () => {
+      return (
+        <Popup
+          content={
+            <>
+              Learn more about this feature in the <a href="">docs</a>.
+            </>
+          }
+          trigger={<QuestionIcon size={16} />}
+          position="right center"
+          on="hover"
+        />
+      )
+    }
+
+    const renderSelectAnimationMoreInfo = () => {
+      return (
+        <Popup
+          content={
+            <>
+              Learn more about animations in the <a href="">docs</a>.
+            </>
+          }
+          trigger={<InfoIcon size={16} />}
+          position="top center"
+          on="hover"
+        />
+      )
+    }
+
     return (
-      <Container label="Action" className="ActionInspector">
+      <Container label="Action" className="ActionInspector" rightContent={renderMoreInfo()}>
         <ContextMenu id={contextMenuId}>
           <Item id="delete" onClick={handleAction(handleRemove)}>
             <DeleteIcon /> Delete
@@ -153,41 +187,51 @@ export default withSdk<Props>(
         {actions.map((action: Action, idx: number) => {
           return (
             <Block key={`action-${idx}`}>
-              <Dropdown
-                label={'Action'}
-                disabled={availableActions.length === 0}
-                options={availableActions}
-                value={action.type}
-                onChange={(e) => handleChangeType(e, idx)}
-              />
-              {action.type === ActionType.PLAY_ANIMATION && entityAnimations.length > 0 ? (
+              <div className="row">
+                <div className="field">
+                  <label>Name</label>
+                  <TextField
+                    type="text"
+                    value={action.name}
+                    onChange={(e) => handleChangeName(e, idx)}
+                    onFocus={handleFocusInput}
+                    onBlur={handleFocusInput}
+                  />
+                </div>
                 <Dropdown
-                  label={'Animations'}
-                  options={[
-                    { value: '', text: 'Select an Animation' },
-                    ...entityAnimations.map((animation) => ({ text: animation.name, value: animation.name }))
-                  ]}
-                  value={action.animation}
-                  onChange={(e) => handleChangeAnimation(e, idx)}
+                  label={'Select Action'}
+                  disabled={availableActions.length === 0}
+                  options={availableActions}
+                  value={action.type}
+                  onChange={(e) => handleChangeType(e, idx)}
                 />
+                <MoreOptionsMenu>
+                  <Button className="RemoveButton" onClick={(e) => handleRemoveAction(e, idx)}>
+                    <RemoveIcon /> Remove Action
+                  </Button>
+                </MoreOptionsMenu>
+              </div>
+              {action.type === ActionType.PLAY_ANIMATION && entityAnimations.length > 0 ? (
+                <div className="row">
+                  <div className="field">
+                    <label>Select Animation {renderSelectAnimationMoreInfo()}</label>
+                    <Dropdown
+                      options={[
+                        { value: '', text: 'Select an Animation' },
+                        ...entityAnimations.map((animation) => ({ text: animation.name, value: animation.name }))
+                      ]}
+                      value={action.animation}
+                      onChange={(e) => handleChangeAnimation(e, idx)}
+                    />
+                  </div>
+                </div>
               ) : null}
-              <TextField
-                label="Name"
-                type="text"
-                value={action.name}
-                onChange={(e) => handleChangeName(e, idx)}
-                onFocus={handleFocusInput}
-                onBlur={handleFocusInput}
-              />
-              <button className="RemoveButton" onClick={(e) => handleRemoveAction(e, idx)}>
-                <RemoveIcon />
-              </button>
             </Block>
           )
         })}
 
         <button className="AddButton" onClick={handleAddNewAction}>
-          <AddIcon />
+          <AddIcon /> Add New Action
         </button>
       </Container>
     )

--- a/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
@@ -18,15 +18,24 @@
 .MoreOptionsMenu .MoreOptionsContent {
   position: absolute;
   right: 0;
-  padding: 8px 0px;
+  padding: 8px;
   border-radius: 2px;
   background: #3c3c3c;
-  min-width: 175px;
+  min-width: 185px;
   z-index: 1;
 }
 
-.MoreOptionsMenu .MoreOptionsContent .RemoveButton {
+.MoreOptionsMenu .MoreOptionsContent .Button {
   display: flex;
   align-items: center;
   gap: 4px;
+  padding: 4px;
+}
+
+.MoreOptionsMenu .MoreOptionsContent .Button:not(:hover) {
+  background-color: transparent;
+}
+
+.MoreOptionsMenu .MoreOptionsContent .Button:hover:not(:disabled) {
+  background-color: #454545;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
@@ -1,0 +1,31 @@
+.MoreOptionsMenu {
+  position: relative;
+  width: auto;
+}
+
+.MoreOptionsMenu .MoreOptionsButton {
+  background-color: transparent;
+  border-color: transparent;
+  color: white;
+  transform: rotate(90deg);
+}
+
+.MoreOptionsMenu .MoreOptionsButton.Button:hover:not(:disabled) {
+  background-color: transparent;
+}
+
+.MoreOptionsMenu .MoreOptionsContent {
+  position: absolute;
+  right: 0;
+  padding: 8px 0px;
+  border-radius: 2px;
+  background: #3c3c3c;
+  min-width: 175px;
+  z-index: 1;
+}
+
+.MoreOptionsMenu .MoreOptionsContent .RemoveButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.css
@@ -3,11 +3,12 @@
   width: auto;
 }
 
-.MoreOptionsMenu .MoreOptionsButton {
+.MoreOptionsMenu .MoreOptionsButton.Button {
   background-color: transparent;
   border-color: transparent;
   color: white;
   transform: rotate(90deg);
+  padding: 0;
 }
 
 .MoreOptionsMenu .MoreOptionsButton.Button:hover:not(:disabled) {

--- a/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/MoreOptionsMenu.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback, useState } from 'react'
+import { VscEllipsis as EllipsisIcon } from 'react-icons/vsc'
+import Button from '../../Button'
+import { useOutsideClick } from '../../../hooks/useOutsideClick'
+
+import './MoreOptionsMenu.css'
+
+export const MoreOptionsMenu = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
+  const [showMoreOptions, setShowMoreOptions] = useState<boolean>(false)
+
+  const handleShowMoreOptions = useCallback(
+    (_e: React.MouseEvent<HTMLButtonElement>) => {
+      setShowMoreOptions(!showMoreOptions)
+    },
+    [showMoreOptions, setShowMoreOptions]
+  )
+
+  const handleClosePanel = useCallback(() => {
+    setShowMoreOptions(false)
+  }, [setShowMoreOptions])
+
+  const ref = useOutsideClick(handleClosePanel)
+
+  return (
+    <div className="MoreOptionsMenu" ref={ref}>
+      <Button className="MoreOptionsButton" onClick={handleShowMoreOptions}>
+        <EllipsisIcon size={16} />
+      </Button>
+      {showMoreOptions && <div className="MoreOptionsContent">{children}</div>}
+    </div>
+  )
+}
+
+export default React.memo(MoreOptionsMenu)

--- a/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/index.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/MoreOptionsMenu/index.ts
@@ -1,0 +1,3 @@
+import { MoreOptionsMenu } from './MoreOptionsMenu'
+
+export default MoreOptionsMenu

--- a/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextField/TextField.css
@@ -1,9 +1,10 @@
 .TextField {
   padding: 2px 3px;
-  border: 1px solid var(--border-gray);
+  background-color: var(--background-gray);
+  border: 1px solid var(--background-gray);
   display: flex;
   margin-right: 8px;
-  border-radius: 1.6px;
+  border-radius: 5px;
   flex-grow: 1;
   width: 0;
   font-size: 12px;
@@ -13,13 +14,13 @@
   border-color: var(--border-focused);
 }
 
-.TextField>label {
+.TextField > label {
   color: var(--secondary-text);
   display: block;
   margin-right: 8px;
 }
 
-.TextField>input {
+.TextField > input {
   width: 100%;
   color: var(--text);
   background-color: var(--transparent);

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 4px;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
@@ -1,0 +1,5 @@
+.TriggerAction {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { VscTrash as RemoveIcon } from 'react-icons/vsc'
+
+import Button from '../../../Button'
+import { Dropdown } from '../../../Dropdown'
+import MoreOptionsMenu from '../../MoreOptionsMenu'
+
+import type { Props } from './types'
+
+import './TriggerAction.css'
+
+export const TriggerAction = ({
+  action,
+  availableActions,
+  onChangeEntity,
+  onChangeAction,
+  onRemoveTriggerAction
+}: Props) => {
+  return (
+    <div className="TriggerAction">
+      <Dropdown
+        options={
+          availableActions
+            ? [
+                { value: '', text: 'Select an Entity' },
+                ...Array.from(availableActions).map(([entity, { name }]) => {
+                  return { value: entity, text: name }
+                })
+              ]
+            : []
+        }
+        value={action.entity}
+        onChange={onChangeEntity}
+      />
+      <Dropdown
+        disabled={!action.entity || !availableActions.get(action.entity)}
+        options={
+          action.entity && availableActions.get(action.entity)?.action
+            ? [
+                { value: '', text: 'Select an Action' },
+                ...(availableActions.get(action.entity)?.action ?? []).map(({ name }) => {
+                  return { value: name, text: name }
+                })
+              ]
+            : []
+        }
+        value={action.name}
+        onChange={onChangeAction}
+      />
+      <MoreOptionsMenu>
+        <Button className="RemoveButton" onClick={onRemoveTriggerAction}>
+          <RemoveIcon /> Remove Trigger Action
+        </Button>
+      </MoreOptionsMenu>
+    </div>
+  )
+}
+
+export default React.memo(TriggerAction)

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/index.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/index.ts
@@ -1,0 +1,2 @@
+import { TriggerAction } from './TriggerAction'
+export default TriggerAction

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/types.ts
@@ -1,6 +1,5 @@
 import type { Entity } from '@dcl/ecs'
-import type { Action } from '../../ActionInspector/types'
-import type { TriggerAction } from '../types'
+import type { Action, TriggerAction } from '@dcl/asset-packs'
 
 export type Props = {
   action: TriggerAction

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/types.ts
@@ -1,0 +1,11 @@
+import type { Entity } from '@dcl/ecs'
+import type { Action } from '../../ActionInspector/types'
+import type { TriggerAction } from '../types'
+
+export type Props = {
+  action: TriggerAction
+  availableActions: Map<Entity, { name: string; action: Action[] }>
+  onChangeEntity: React.ChangeEventHandler<HTMLSelectElement>
+  onChangeAction: React.ChangeEventHandler<HTMLSelectElement>
+  onRemoveTriggerAction: React.MouseEventHandler<HTMLButtonElement>
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
@@ -54,4 +54,5 @@
   display: flex;
   flex-direction: column;
   margin-top: 8px;
+  gap: 8px;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
@@ -1,3 +1,11 @@
+.TriggerEventContainer > .content {
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 4px;
+  border: 1px solid #303031;
+  background: var(--tree-bg-color);
+}
+
 .TriggerEventContainer > .content > .DropdownContainer {
   margin-bottom: 12px;
 }
@@ -8,6 +16,13 @@
   align-items: center;
 }
 
+.TriggerEventContainer > .content > .TriggerEventTitle span {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
 .TriggerEventContainer > .content > .TriggerActionsTitle {
   display: flex;
   flex-direction: row;
@@ -15,6 +30,12 @@
 
   border-bottom: 1px solid var(--border-gray);
   padding-bottom: 4px;
+}
+
+.TriggerEventContainer > .content > .TriggerActionsTitle span {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 500;
 }
 
 .TriggerEventContainer .RightContent {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.css
@@ -1,0 +1,36 @@
+.TriggerEventContainer > .content > .DropdownContainer {
+  margin-bottom: 12px;
+}
+
+.TriggerEventContainer > .content > .TriggerEventTitle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.TriggerEventContainer > .content > .TriggerActionsTitle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  border-bottom: 1px solid var(--border-gray);
+  padding-bottom: 4px;
+}
+
+.TriggerEventContainer .RightContent {
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+}
+
+.TriggerEventContainer > .content > .TriggerActionsTitle .RightContent .AddButton {
+  background-color: transparent;
+  border-color: transparent;
+  color: white;
+}
+
+.TriggerEventContainer > .content > .TriggerActionsContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { VscAdd as AddIcon, VscTrash as RemoveIcon } from 'react-icons/vsc'
+
+import { Block } from '../../../Block'
+import Button from '../../../Button'
+import { Dropdown } from '../../../Dropdown'
+import MoreOptionsMenu from '../../MoreOptionsMenu'
+
+import { Triggers as AvailableTriggers } from '../types'
+import type { Props } from './types'
+
+import './TriggerEvent.css'
+
+export const TriggerEvent = ({
+  trigger,
+  onChangeTriggerType,
+  onAddNewTriggerAction,
+  onRemoveTriggerEvent,
+  children
+}: Props) => {
+  return (
+    <Block className="TriggerEventContainer">
+      <div className="TriggerEventTitle">
+        <span>Trigger Event</span>
+        <div className="RightContent">
+          <MoreOptionsMenu>
+            <Button className="RemoveButton" onClick={onRemoveTriggerEvent}>
+              <RemoveIcon /> Remove Trigger Event
+            </Button>
+          </MoreOptionsMenu>
+        </div>
+      </div>
+      <Dropdown
+        options={Object.values(AvailableTriggers).filter((v) => isNaN(Number(v))) as string[]}
+        value={trigger.type}
+        onChange={onChangeTriggerType}
+      />
+      <div className="TriggerActionsTitle">
+        <span>Assigned Actions</span>
+        <div className="RightContent">
+          <Button className="AddButton" onClick={onAddNewTriggerAction}>
+            <AddIcon size={16} />
+          </Button>
+        </div>
+      </div>
+      <div className="TriggerActionsContainer">{children}</div>
+    </Block>
+  )
+}
+
+export default React.memo(TriggerEvent)

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { TriggerType } from '@dcl/asset-packs'
 import { VscAdd as AddIcon, VscTrash as RemoveIcon } from 'react-icons/vsc'
 
 import { Block } from '../../../Block'
@@ -6,7 +7,6 @@ import Button from '../../../Button'
 import { Dropdown } from '../../../Dropdown'
 import MoreOptionsMenu from '../../MoreOptionsMenu'
 
-import { Triggers as AvailableTriggers } from '../types'
 import type { Props } from './types'
 
 import './TriggerEvent.css'
@@ -31,7 +31,7 @@ export const TriggerEvent = ({
         </div>
       </div>
       <Dropdown
-        options={Object.values(AvailableTriggers).filter((v) => isNaN(Number(v))) as string[]}
+        options={Object.values(TriggerType).filter((v) => isNaN(Number(v))) as string[]}
         value={trigger.type}
         onChange={onChangeTriggerType}
       />

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/index.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/index.ts
@@ -1,0 +1,2 @@
+import { TriggerEvent } from './TriggerEvent'
+export default TriggerEvent

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/types.ts
@@ -1,4 +1,4 @@
-import type { Trigger } from '../types'
+import type { Trigger } from '@dcl/asset-packs'
 
 export type Props = {
   trigger: Trigger

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/types.ts
@@ -1,0 +1,9 @@
+import type { Trigger } from '../types'
+
+export type Props = {
+  trigger: Trigger
+  onChangeTriggerType: React.ChangeEventHandler<HTMLSelectElement>
+  onAddNewTriggerAction: React.MouseEventHandler<HTMLButtonElement>
+  onRemoveTriggerEvent: React.MouseEventHandler<HTMLButtonElement>
+  children: JSX.Element | JSX.Element[]
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.css
@@ -1,4 +1,4 @@
-.TriggerInspector > .title {
+.TriggerInspector:is(.open) > .title {
   border-bottom: 1px solid var(--border-gray);
   padding-bottom: 12px;
 }
@@ -15,13 +15,6 @@
 
 .TriggerInspector .content .Block .content .DropdownContainer {
   flex: 1;
-}
-
-.TriggerInspector .content .RemoveButton {
-  height: 100%;
-  background-color: transparent;
-  border-color: transparent;
-  color: white;
 }
 
 .TriggerInspector .content > .AddButton {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.css
@@ -1,11 +1,20 @@
+.TriggerInspector > .title {
+  border-bottom: 1px solid var(--border-gray);
+  padding-bottom: 12px;
+}
+
 .TriggerInspector > .content {
   display: flex;
   flex-direction: column;
 }
 
-.TriggerInspector .content .AddButton {
-  align-self: flex-end;
-  margin-top: 10px;
+.TriggerInspector > .content > .Block > .content {
+  display: flex;
+  flex-direction: column;
+}
+
+.TriggerInspector .content .Block .content .DropdownContainer {
+  flex: 1;
 }
 
 .TriggerInspector .content .RemoveButton {
@@ -15,11 +24,19 @@
   color: white;
 }
 
-.TriggerInspector .content .Block .content {
-  gap: 15px;
-  align-items: flex-end;
-}
-
-.TriggerInspector .content .Block .content .DropdownContainer {
-  flex: 1;
+.TriggerInspector .content > .AddButton {
+  margin-top: 16px;
+  border: 1px solid #3a3d41;
+  background: #1e1e1e;
+  display: flex;
+  padding: 4px;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+  color: #ccc;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
@@ -205,6 +205,8 @@ export default withSdk<Props>(
           trigger={<QuestionIcon size={16} />}
           position="right center"
           on="hover"
+          hideOnScroll
+          hoverable
         />
       )
     }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerInspector.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Entity } from '@dcl/ecs'
+import { Action, Trigger, TriggerType, TriggerAction } from '@dcl/asset-packs'
 import { Item } from 'react-contexify'
-import { AiFillDelete as DeleteIcon, AiOutlinePlus as AddIcon, AiOutlineMinus as RemoveIcon } from 'react-icons/ai'
-import { Action, Trigger, TriggerType } from '@dcl/asset-packs'
+import { AiFillDelete as DeleteIcon, AiOutlinePlus as AddIcon } from 'react-icons/ai'
+import { VscQuestion as QuestionIcon } from 'react-icons/vsc'
+import { Popup } from 'decentraland-ui/dist/components/Popup/Popup'
 
 import { WithSdkProps, withSdk } from '../../../hoc/withSdk'
 import { withContextMenu } from '../../../hoc/withContextMenu'
@@ -12,12 +14,13 @@ import { useContextMenu } from '../../../hooks/sdk/useContextMenu'
 import { useEntitiesWith } from '../../../hooks/sdk/useEntitiesWith'
 import { EditorComponentsTypes } from '../../../lib/sdk/components'
 
-import { Block } from '../../Block'
 import { Container } from '../../Container'
 import { ContextMenu } from '../../ContexMenu'
-import { Dropdown } from '../../Dropdown'
 
-import { Props } from './types'
+import TriggerEvent from './TriggerEvent'
+import TriggerActionContainer from './TriggerAction'
+
+import type { Props } from './types'
 
 import './TriggerInspector.css'
 
@@ -33,15 +36,21 @@ export default withSdk<Props>(
     const [triggers, setTriggers] = useState<Trigger[]>(componentValue === null ? [] : componentValue.value)
     const hasTriggers = useHasComponent(entity, Triggers)
 
-    const areValidActions = useCallback(
+    const areValidAction = useCallback(
+      (updatedActions: TriggerAction[]) =>
+        updatedActions.length > 0 && !updatedActions.some((action) => !action.entity || !action.name),
+      []
+    )
+
+    const areValidTriggers = useCallback(
       (updatedTriggers: Trigger[]) =>
         updatedTriggers.length > 0 &&
-        !updatedTriggers.some((action) => !action.type || !action?.entity || !action.action),
+        !updatedTriggers.some((trigger) => !trigger.type || !areValidAction(trigger.actions as TriggerAction[])),
       []
     )
 
     useEffect(() => {
-      if (areValidActions(triggers)) {
+      if (areValidTriggers(triggers)) {
         if (isComponentEqual({ value: triggers })) {
           return
         }
@@ -67,11 +76,40 @@ export default withSdk<Props>(
       await sdk.operations.dispatch()
     }, [])
 
-    const handleAddNewTrigger = useCallback(() => {
-      setTriggers((prev: Trigger[]) => {
-        return [...prev, { type: TriggerType.ON_CLICK }]
-      })
-    }, [setTriggers])
+    const handleAddNewTrigger = useCallback(
+      (e: React.MouseEvent) => {
+        e.stopPropagation()
+        setTriggers((prev: Trigger[]) => {
+          return [
+            ...prev,
+            {
+              type: TriggerType.ON_CLICK,
+              actions: [
+                {
+                  entity: undefined,
+                  name: ''
+                }
+              ]
+            }
+          ]
+        })
+      },
+      [setTriggers]
+    )
+
+    const handleAddNewTriggerAction = useCallback(
+      (e: React.MouseEvent, idx: number) => {
+        setTriggers((prev: Trigger[]) => {
+          const data = [...prev]
+          data[idx] = {
+            ...data[idx],
+            actions: [...data[idx].actions, { entity: undefined, name: '' }]
+          }
+          return data
+        })
+      },
+      [setTriggers]
+    )
 
     const handleChangeType = useCallback(
       ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>, idx: number) => {
@@ -88,13 +126,21 @@ export default withSdk<Props>(
     )
 
     const handleChangeEnitty = useCallback(
-      ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>, idx: number) => {
+      ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>, triggerIdx: number, actionIdx: number) => {
         setTriggers((prev: Trigger[]) => {
           const data = [...prev]
-          data[idx] = {
-            ...data[idx],
+          const actions = [...data[triggerIdx].actions]
+
+          actions[actionIdx] = {
+            ...actions[actionIdx],
             entity: entitiesWithAction?.find((entity) => entity.toString() === value)
           }
+
+          data[triggerIdx] = {
+            ...data[triggerIdx],
+            actions: [...actions]
+          }
+
           return data
         })
       },
@@ -102,13 +148,21 @@ export default withSdk<Props>(
     )
 
     const handleChangeAction = useCallback(
-      ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>, idx: number) => {
+      ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>, triggerIdx: number, actionIdx: number) => {
         setTriggers((prev: Trigger[]) => {
           const data = [...prev]
-          data[idx] = {
-            ...data[idx],
-            action: value as TriggerType
+          const actions = [...data[triggerIdx].actions]
+
+          actions[actionIdx] = {
+            ...actions[actionIdx],
+            name: value
           }
+
+          data[triggerIdx] = {
+            ...data[triggerIdx],
+            actions: [...actions]
+          }
+
           return data
         })
       },
@@ -124,66 +178,68 @@ export default withSdk<Props>(
       })
     }, [])
 
+    const handleRemoveTriggerAction = useCallback((e: React.MouseEvent, triggerIdx: number, actionIdx: number) => {
+      e.stopPropagation()
+      setTriggers((prev: Trigger[]) => {
+        const data = [...prev]
+        data[triggerIdx] = {
+          ...data[triggerIdx],
+          actions: [...data[triggerIdx].actions.slice(0, actionIdx)]
+        }
+        return data
+      })
+    }, [])
+
     if (!hasTriggers) {
       return null
     }
 
+    const renderMoreInfo = () => {
+      return (
+        <Popup
+          content={
+            <>
+              Learn more about this feature in the <a href="">docs</a>.
+            </>
+          }
+          trigger={<QuestionIcon size={16} />}
+          position="right center"
+          on="hover"
+        />
+      )
+    }
+
     return (
-      <Container label="Trigger" className="TriggerInspector">
+      <Container label="Trigger" className="TriggerInspector" rightContent={renderMoreInfo()}>
         <ContextMenu id={contextMenuId}>
           <Item id="delete" onClick={handleAction(handleRemove)}>
             <DeleteIcon /> Delete
           </Item>
         </ContextMenu>
-        {triggers.map((trigger: Trigger, idx: number) => {
+        {triggers.map((trigger: Trigger, triggerIdx: number) => {
           return (
-            <Block key={`trigger-${idx}`}>
-              <Dropdown
-                label={'Interaction'}
-                options={Object.values(TriggerType).filter((v) => isNaN(Number(v))) as string[]}
-                value={trigger.type}
-                onChange={(e) => handleChangeType(e, idx)}
-              />
-              <Dropdown
-                label={'Entity'}
-                options={
-                  availableActions
-                    ? [
-                        { value: '', text: 'Select an Entity' },
-                        ...Array.from(availableActions).map(([entity, { name }]) => {
-                          return { value: entity, text: name }
-                        })
-                      ]
-                    : []
-                }
-                value={trigger.entity}
-                onChange={(e) => handleChangeEnitty(e, idx)}
-              />
-              <Dropdown
-                label={'Action'}
-                disabled={!trigger.entity || !availableActions.get(trigger.entity)}
-                options={
-                  trigger.entity && availableActions.get(trigger.entity)?.action
-                    ? [
-                        { value: '', text: 'Select an Action' },
-                        ...(availableActions.get(trigger.entity)?.action ?? []).map(({ name }) => {
-                          return { value: name, text: name }
-                        })
-                      ]
-                    : []
-                }
-                value={trigger.action}
-                onChange={(e) => handleChangeAction(e, idx)}
-              />
-              <button className="RemoveButton" onClick={(e) => handleRemoveTrigger(e, idx)}>
-                <RemoveIcon />
-              </button>
-            </Block>
+            <TriggerEvent
+              trigger={trigger}
+              onChangeTriggerType={(e) => handleChangeType(e, triggerIdx)}
+              onAddNewTriggerAction={(e) => handleAddNewTriggerAction(e, triggerIdx)}
+              onRemoveTriggerEvent={(e) => handleRemoveTrigger(e, triggerIdx)}
+            >
+              {trigger.actions.map((action, actionIdx) => {
+                return (
+                  <TriggerActionContainer
+                    action={action}
+                    availableActions={availableActions}
+                    onChangeEntity={(e) => handleChangeEnitty(e, triggerIdx, actionIdx)}
+                    onChangeAction={(e) => handleChangeAction(e, triggerIdx, actionIdx)}
+                    onRemoveTriggerAction={(e) => handleRemoveTriggerAction(e, triggerIdx, actionIdx)}
+                  />
+                )
+              })}
+            </TriggerEvent>
           )
         })}
-
         <button className="AddButton" onClick={handleAddNewTrigger}>
-          <AddIcon />
+          <AddIcon size={16} /> Add New Trigger Event
         </button>
       </Container>
     )

--- a/packages/@dcl/inspector/src/index.css
+++ b/packages/@dcl/inspector/src/index.css
@@ -10,3 +10,8 @@ input[type=number] {
   -moz-appearance: textfield;
   appearance: none;
 }
+
+.ui.popup,
+.ui.inverted.popup {
+  height: auto;
+}


### PR DESCRIPTION
This PR updates the Trigger and Action component styles.

It also uses the new trigger schema defined in the package `@dcl/asset-pack to allow handling more than one action per trigger event.

Actions:
<img width="359" alt="image" src="https://github.com/decentraland/js-sdk-toolchain/assets/3170051/86299347-e35f-4787-9d5a-a24cf7c3e6c8">

Triggers:
<img width="364" alt="image" src="https://github.com/decentraland/js-sdk-toolchain/assets/3170051/46cde3bb-0074-4725-a57f-f3ee6675053d">
