### PR TITLE
chore: remove postinstall

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@dcl/inspector",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "devDependencies": {
         "@babylonjs/core": "^5.48.0",
         "@babylonjs/gui": "^5.48.0",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -55,9 +55,9 @@
     "directory": "packages/@dcl/inspector"
   },
   "scripts": {
-    "build": "node ./build.js",
-    "postinstall": "ts-node --project ./scripts/tsconfig.json ./scripts/postinstall.ts",
-    "start": "node ./build.js --watch"
+    "build": "npm run copy-bin && node ./build.js",
+    "copy-bin": "ts-node --project ./scripts/tsconfig.json ./scripts/copy-bin.ts",
+    "start": "npm run copy-bin && node ./build.js --watch"
   },
   "types": "dist/tooling-entrypoint.d.ts",
   "typings": "dist/tooling-entrypoint.d.ts"

--- a/packages/@dcl/inspector/scripts/copy-bin.ts
+++ b/packages/@dcl/inspector/scripts/copy-bin.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { resolve } from 'path'
 
-console.log('Copying "@dcl/asset-packs/bin/index.js" into "public/scene.js"...')
+console.log('Copying "@dcl/asset-packs/bin/index.js" into "public/bin/index.js"...')
 const binDirPath = resolve(__dirname, '../public/bin')
 if (!fs.existsSync(binDirPath)) {
   fs.mkdirSync(binDirPath)

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -59,7 +59,6 @@
     },
     "../inspector": {
       "version": "0.1.0",
-      "hasInstallScript": true,
       "devDependencies": {
         "@babylonjs/core": "^5.48.0",
         "@babylonjs/gui": "^5.48.0",


### PR DESCRIPTION
Remove `postinstall`, it was breaking the CLI E2E tests