### PR TITLE
start & deploy improvements

### DIFF
--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -13,7 +13,7 @@
         "@dcl/ecs": "file:../ecs",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "file:../inspector",
-        "@dcl/linker-dapp": "0.10.1",
+        "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6200210039.commit-75f18e8",
         "@dcl/rpc": "^1.1.1",
@@ -59,16 +59,13 @@
     },
     "../inspector": {
       "version": "0.1.0",
-      "dependencies": {
-        "earcut": "^2.2.4"
-      },
       "devDependencies": {
         "@babylonjs/core": "^6.18.0",
         "@babylonjs/gui": "^6.18.0",
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20230913161419.commit-562cd5d",
+        "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -76,7 +73,6 @@
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/react": "^14.0.0",
-        "@types/earcut": "^2.1.1",
         "@types/jest-environment-puppeteer": "^5.0.3",
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -159,9 +155,9 @@
       "link": true
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
-      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.11.0.tgz",
+      "integrity": "sha512-5iiQcS5mizxdZ7WKYqOFuaDtDhvOP1Cc92LEQjG60rbzxdP6gWZI3bjlROQukDX/TBplvUq7QsZTTuYtP+hS0g=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -2840,7 +2836,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20230913161419.commit-562cd5d",
+        "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -2848,7 +2844,6 @@
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@reduxjs/toolkit": "^1.9.5",
         "@testing-library/react": "^14.0.0",
-        "@types/earcut": "^2.1.1",
         "@types/jest-environment-puppeteer": "^5.0.3",
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -2861,7 +2856,6 @@
         "classnames": "^2.3.2",
         "decentraland-ui": "^4.10.0",
         "dotenv": "^16.3.1",
-        "earcut": "^2.2.4",
         "esbuild": "^0.18.17",
         "fp-future": "^1.0.1",
         "jest-environment-jsdom": "^29.5.0",
@@ -2884,9 +2878,9 @@
       }
     },
     "@dcl/linker-dapp": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
-      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.11.0.tgz",
+      "integrity": "sha512-5iiQcS5mizxdZ7WKYqOFuaDtDhvOP1Cc92LEQjG60rbzxdP6gWZI3bjlROQukDX/TBplvUq7QsZTTuYtP+hS0g=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -11,7 +11,7 @@
     "@dcl/ecs": "file:../ecs",
     "@dcl/hashing": "1.1.3",
     "@dcl/inspector": "file:../inspector",
-    "@dcl/linker-dapp": "0.10.1",
+    "@dcl/linker-dapp": "^0.11.0",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
     "@dcl/protocol": "1.0.0-6200210039.commit-75f18e8",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -85,12 +85,10 @@ export async function getAddressAndSignature(
   }
 
   const sceneInfo = await getSceneInfo(components, scene, messageToSign, skipValidations)
-  const queryParams = new URLSearchParams(sceneInfo as any).toString()
-
   const { router: commonRouter } = setRoutes(components, sceneInfo)
   const router = setDeployRoutes(commonRouter, components, awaitResponse, sceneInfo, files, deployCallback)
 
-  const { program } = await runLinkerApp(components, router, { ...linkOptions, uri: `/?${queryParams}` })
+  const { program } = await runLinkerApp(components, router, { ...linkOptions, uri: `/` })
   return { program }
 }
 

--- a/packages/@dcl/sdk-commands/src/logic/project-validations.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-validations.ts
@@ -120,12 +120,15 @@ export async function startValidations(components: Pick<CliComponents, 'spawner'
       (packageJson.dependencies['@dcl/js-runtime'] || packageJson.dependencies['@dcl/sdk'])
     ) {
       packageJson.dependencies['@dcl/js-runtime'] = sdkVersion
-      delete packageJson.devDependencies['@dcl/js-runtime']
+      if (packageJson.devDependencies && packageJson.devDependencies['@dcl/js-runtime']) {
+        delete packageJson.devDependencies['@dcl/js-runtime']
+      }
     } else {
+      packageJson.devDependencies = packageJson.devDependencies || {}
       packageJson.devDependencies['@dcl/js-runtime'] = sdkVersion
     }
     await components.fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8')
   } catch (e) {
-    components.logger.error('Failed to run scene validations', e as any)
+    components.logger.error('Failed to run scene validations')
   }
 }

--- a/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/create-cube.ts
+++ b/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/create-cube.ts
@@ -12,12 +12,12 @@ import {
   inputSystem
 } from '@dcl/ecs'
 import { Color4 } from '@dcl/sdk/math'
-import { NetworkEntityFactory } from '@dcl/sdk/network-transport/types'
+import { NetworkManager } from '@dcl/sdk/network-transport/types'
 
 // Cube factory
 export const Cube = engine.defineComponent('cube', {})
-export function createCube(entityFactory: NetworkEntityFactory, x: number, y: number, z: number): Entity {
-  const entity = entityFactory.addEntity()
+export function createCube(entityFactory: NetworkManager, x: number, y: number, z: number): Entity {
+  const entity = entityFactory.addEntity(engine)
   // Used to track the cubes
   Cube.create(entity)
 

--- a/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/moving-platforms.ts
+++ b/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/moving-platforms.ts
@@ -1,13 +1,14 @@
 import { GltfContainer, Transform, SyncComponents, Entity } from '@dcl/ecs'
 import * as utils from '@dcl-sdk/utils'
 import { Vector3 } from '@dcl/sdk/math'
-import { NetworkEntityFactory } from '@dcl/sdk/network-transport/types'
+import { engine } from '@dcl/sdk/ecs'
+import { NetworkManager } from '@dcl/sdk/network-transport/types'
 
-export function createMovingPlatforms(networkedEntityFactory: NetworkEntityFactory) {
+export function createMovingPlatforms(networkedEntityFactory: NetworkManager) {
   //// triggerable platform
 
   //// only horizontal
-  const platform1 = networkedEntityFactory.addEntity()
+  const platform1 = networkedEntityFactory.addEntity(engine)
   GltfContainer.create(platform1, {
     src: 'models/movingPlatform.glb'
   })
@@ -16,7 +17,7 @@ export function createMovingPlatforms(networkedEntityFactory: NetworkEntityFacto
   })
   SyncComponents.create(platform1, { componentIds: [Transform.componentId] })
   //// only vertical
-  const platform2 = networkedEntityFactory.addEntity()
+  const platform2 = networkedEntityFactory.addEntity(engine)
   GltfContainer.create(platform2, {
     src: 'models/movingPlatform.glb'
   })
@@ -26,7 +27,7 @@ export function createMovingPlatforms(networkedEntityFactory: NetworkEntityFacto
   SyncComponents.create(platform2, { componentIds: [Transform.componentId] })
 
   //// path with many waypoints
-  const platform4 = networkedEntityFactory.addEntity()
+  const platform4 = networkedEntityFactory.addEntity(engine)
   GltfContainer.create(platform4, {
     src: 'models/movingPlatform.glb'
   })
@@ -35,7 +36,7 @@ export function createMovingPlatforms(networkedEntityFactory: NetworkEntityFacto
   })
   SyncComponents.create(platform4, { componentIds: [Transform.componentId] })
 
-  const platform3 = networkedEntityFactory.addEntity()
+  const platform3 = networkedEntityFactory.addEntity(engine)
   GltfContainer.create(platform3, {
     src: 'models/movingPlatform.glb'
   })


### PR DESCRIPTION
Running `npm srtart` was doing a `npm install @dcl/js-runtime`, and this removes all `npm link`. So if you were running a library inside your scene, the link was being removed.

Remove queryParams from linker-dapp, because we were already fetching this via api request and if the URL was too big then the linker-dapp fails to load