### PR TITLE
fix: trigger conditions on drag n drop

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
+        "@dcl/asset-packs": "^0.0.0-20230920192724.commit-d46ddb6",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -273,12 +273,13 @@
       }
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "0.0.0-20230915180527.commit-250509a",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230915180527.commit-250509a.tgz",
-      "integrity": "sha512-MAr7p1bw6GrYXmETW2/LcbgdHrfOOpYDzh1Vio/+lxCjCuId0Kq0FTDfMuWiihkzXGFSrRzKaHE9z/n4jaDXxg==",
+      "version": "0.0.0-20230920192724.commit-d46ddb6",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230920192724.commit-d46ddb6.tgz",
+      "integrity": "sha512-fTazdOewtnpteCE3X8yAA4ArNMEEQhE2gUU6CS1f3HZpooGDmEdfvPkB6LvOitBeKZsIVWdaoUvTbDEEiGQJ3g==",
       "dev": true,
       "dependencies": {
-        "@dcl/sdk": "^7.3.12"
+        "@dcl/sdk": "^7.3.12",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/@dcl/catalyst-contracts": {
@@ -8027,12 +8028,13 @@
       }
     },
     "@dcl/asset-packs": {
-      "version": "0.0.0-20230915180527.commit-250509a",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230915180527.commit-250509a.tgz",
-      "integrity": "sha512-MAr7p1bw6GrYXmETW2/LcbgdHrfOOpYDzh1Vio/+lxCjCuId0Kq0FTDfMuWiihkzXGFSrRzKaHE9z/n4jaDXxg==",
+      "version": "0.0.0-20230920192724.commit-d46ddb6",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20230920192724.commit-d46ddb6.tgz",
+      "integrity": "sha512-fTazdOewtnpteCE3X8yAA4ArNMEEQhE2gUU6CS1f3HZpooGDmEdfvPkB6LvOitBeKZsIVWdaoUvTbDEEiGQJ3g==",
       "dev": true,
       "requires": {
-        "@dcl/sdk": "^7.3.12"
+        "@dcl/sdk": "^7.3.12",
+        "mitt": "^3.0.1"
       }
     },
     "@dcl/catalyst-contracts": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -7,7 +7,7 @@
     "@babylonjs/inspector": "^6.18.0",
     "@babylonjs/loaders": "^6.18.0",
     "@babylonjs/materials": "^6.18.0",
-    "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
+    "@dcl/asset-packs": "^0.0.0-20230920192724.commit-d46ddb6",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
     "@dcl/mini-rpc": "^1.0.7",

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerCondition/TriggerCondition.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerCondition/TriggerCondition.tsx
@@ -33,7 +33,7 @@ export const TriggerConditionContainer = ({
   }, [conditions])
 
   const handleAddNewCondition = useCallback(
-    (e: React.MouseEvent) => {
+    (_event: React.MouseEvent) => {
       addCondition({ entity: undefined, type: TriggerConditionType.WHEN_STATE_IS, value: '' })
     },
     [addCondition]
@@ -84,16 +84,18 @@ export const TriggerConditionContainer = ({
           <AddButton onClick={handleAddNewCondition} />
         </div>
       </div>
-      <div className="TriggerOperation">
-        <Dropdown
-          options={[
-            { value: '', text: 'Select an operation type' },
-            ...Array.from(conditionOperation).map(({ value, text }) => ({ value, text }))
-          ]}
-          value={trigger.operation}
-          onChange={onChangeOperation}
-        />
-      </div>
+      {conditions.length >= 2 ? (
+        <div className="TriggerOperation">
+          <Dropdown
+            options={[
+              { value: '', text: 'Select an operation type' },
+              ...Array.from(conditionOperation).map(({ value, text }) => ({ value, text }))
+            ]}
+            value={trigger.operation}
+            onChange={onChangeOperation}
+          />
+        </div>
+      ) : null}
       {conditions.map((condition, idx) => {
         const isDisabled = !condition.entity || !availableStates.get(condition.entity)
         return (

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-child.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-child.ts
@@ -30,6 +30,10 @@ export function addChild(engine: IEngine) {
             const triggers = component as EditorComponentsTypes['Triggers']
             const updatedValue = triggers.value.map((trigger) => ({
               ...trigger,
+              conditions: (trigger.conditions || []).map((condition) => ({
+                ...condition,
+                entity: (condition.entity as any) === '{selfEntity}' ? child : condition.entity
+              })),
               actions: trigger.actions.map((action) => ({
                 ...action,
                 entity: (action.entity as any) === '{selfEntity}' ? child : action.entity


### PR DESCRIPTION
This PR fixes conditions by replacing `{selfEntity}` on drag n dropped items. It also hides the `operation` dropdown when there are less than 2 conditions, since it's not necessary on that scenario.