### PR TITLE
add: proportional scaling on Transform

### DIFF
--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -15,6 +15,7 @@
   display: flex;
   flex-direction: row;
   flex-grow: 1;
+  align-items: center;
 }
 
 .Block.error {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/Link.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/Link.css
@@ -1,0 +1,3 @@
+.Link {
+  cursor: pointer;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/Link.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/Link.tsx
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react'
+import { MdLink as LinkIcon, MdLinkOff as LinkOffIcon } from 'react-icons/md'
+
+import { Props } from './types'
+
+import './Link.css'
+
+export function Link({ field, getInputProps }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const inputProps = getInputProps(field, (e) => e.target.checked)
+  const { value } = inputProps
+
+  const handleClick = useCallback(() => {
+    if (inputRef.current) inputRef.current.click()
+  }, [getInputProps])
+
+  const icon = !!value ? <LinkIcon /> : <LinkOffIcon />
+
+  return (
+    <>
+      <input ref={inputRef} checked={!!value} {...inputProps} type="checkbox" style={{ display: 'none' }} />
+      <div className="Link" onClick={handleClick}>
+        {icon}
+      </div>
+    </>
+  )
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/index.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/index.ts
@@ -1,0 +1,3 @@
+import { Link } from './Link'
+import { Props } from './types'
+export { Link, Props }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/Link/types.ts
@@ -1,0 +1,7 @@
+import { useComponentInput } from '../../../../hooks/sdk/useComponentInput'
+import { TransformConfig } from '../../../../lib/sdk/components/TransformConfig'
+
+export type Props = {
+  field: keyof TransformConfig
+  getInputProps: ReturnType<typeof useComponentInput>['getInputProps']
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.css
@@ -1,0 +1,3 @@
+.Container.Transform svg {
+  margin-right: 5px;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { Item } from 'react-contexify'
 import { AiFillDelete as DeleteIcon } from 'react-icons/ai'
 
@@ -10,27 +10,52 @@ import { withContextMenu } from '../../../hoc/withContextMenu'
 import { useContextMenu } from '../../../hooks/sdk/useContextMenu'
 
 import { Props } from './types'
-import { fromTransform, toTransform } from './utils'
+import { fromTransform, toTransform, fromTransformConfig } from './utils'
 import { Block } from '../../Block'
 import { Container } from '../../Container'
 import { TextField } from '../TextField'
+import { Link, Props as LinkProps } from './Link'
+
+import './TransformInspector.css'
 
 export default withSdk<Props>(
   withContextMenu<WithSdkProps & Props>(({ sdk, entity, contextMenuId }) => {
-    const { Transform } = sdk.components
+    const { Transform, TransformConfig } = sdk.components
 
     const hasTransform = useHasComponent(entity, Transform)
-    const { getInputProps } = useComponentInput(entity, Transform, fromTransform, toTransform, isValidNumericInput)
+    const transform = Transform.getOrNull(entity) ?? undefined
+    const config = TransformConfig.getOrNull(entity) ?? undefined
+    const { getInputProps } = useComponentInput(
+      entity,
+      Transform,
+      fromTransform,
+      toTransform(transform, config),
+      isValidNumericInput
+    )
+    const { getInputProps: getConfigProps } = useComponentInput(
+      entity,
+      TransformConfig,
+      fromTransformConfig,
+      fromTransformConfig
+    )
     const { handleAction } = useContextMenu()
+
+    useEffect(() => {
+      if (!hasTransform) return
+      if (!config) {
+        sdk.operations.addComponent(entity, TransformConfig.componentId)
+        void sdk.operations.dispatch()
+      }
+    }, [hasTransform])
 
     const handleRemove = useCallback(async () => {
       sdk.operations.removeComponent(entity, Transform)
       await sdk.operations.dispatch()
     }, [])
 
-    if (!hasTransform) {
-      return null
-    }
+    const _getConfigProps = getConfigProps as LinkProps['getInputProps']
+
+    if (!hasTransform) return null
 
     return (
       <Container label="Transform" className="Transform">
@@ -48,6 +73,7 @@ export default withSdk<Props>(
           <TextField label="X" type="number" {...getInputProps('scale.x')} />
           <TextField label="Y" type="number" {...getInputProps('scale.y')} />
           <TextField label="Z" type="number" {...getInputProps('scale.z')} />
+          <Link field="porportionalScaling" getInputProps={_getConfigProps} />
         </Block>
         <Block label="Rotation">
           <TextField label="X" type="number" {...getInputProps('rotation.x')} />

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/utils.spec.ts
@@ -1,16 +1,18 @@
 import { TransformType } from '@dcl/ecs'
-import { fromTransform, toTransform } from './utils'
+import { fromTransform, fromTransformConfig, getScale, mapToNumber, toTransform } from './utils'
 import { TransformInput } from './types'
+
+const getTransform = (): TransformType => ({
+  position: { x: 8, y: 0, z: 8 },
+  scale: { x: 1, y: 1, z: 1 },
+  rotation: { x: 0, y: 0, z: 0, w: 1 }
+})
 
 describe('TransformInspector utils', () => {
   describe('when converting the TransformType into a TransformInput', () => {
     let transform: TransformType
     beforeEach(() => {
-      transform = {
-        position: { x: 8, y: 0, z: 8 },
-        scale: { x: 1, y: 1, z: 1 },
-        rotation: { x: 0, y: 0, z: 0, w: 1 }
-      }
+      transform = getTransform()
     })
     it('should convert position values to strings with two decimals', () => {
       const input = fromTransform(transform)
@@ -41,23 +43,176 @@ describe('TransformInspector utils', () => {
       }
     })
     it('should convert position string values into numbers', () => {
-      const transform = toTransform(input)
+      const transform = toTransform()(input)
       expect(transform.position.x).toBe(8)
       expect(transform.position.y).toBe(0)
       expect(transform.position.z).toBe(8)
     })
     it('should convert scale string values into numbers', () => {
-      const transform = toTransform(input)
+      const transform = toTransform()(input)
       expect(transform.scale.x).toBe(1)
       expect(transform.scale.y).toBe(1)
       expect(transform.scale.z).toBe(1)
     })
     it('should convert rotation euler angles into a quaternion', () => {
-      const tranform = toTransform(input)
+      const tranform = toTransform()(input)
       expect(tranform.rotation.x).toBe(0)
       expect(tranform.rotation.y).toBe(0)
       expect(tranform.rotation.z).toBe(0)
       expect(tranform.rotation.w).toBe(1)
+    })
+    it('should scale values porportionally', () => {
+      const newValue = { ...input, scale: { x: '2.00', y: '1.00', z: '1.00' } }
+      const config = { porportionalScaling: true }
+      const transform = toTransform(getTransform(), config)(newValue)
+      expect(transform.scale.x).toBe(2)
+      expect(transform.scale.y).toBe(2)
+      expect(transform.scale.z).toBe(2)
+    })
+  })
+  describe('mapToNumber', () => {
+    it('should map object values to numbers', () => {
+      const input = {
+        a: '123',
+        b: '456',
+        c: '789'
+      }
+
+      const result = mapToNumber(input)
+
+      expect(result).toEqual({
+        a: 123,
+        b: 456,
+        c: 789
+      })
+    })
+
+    it('should handle empty object', () => {
+      const input = {}
+
+      const result = mapToNumber(input)
+
+      expect(result).toEqual({})
+    })
+
+    it('should handle non-string values', () => {
+      const input = {
+        a: 123,
+        b: true,
+        c: null
+      }
+
+      const result = mapToNumber(input)
+
+      expect(result).toEqual({
+        a: 123,
+        b: 1,
+        c: 0
+      })
+    })
+
+    it('should handle mixed string and non-string values', () => {
+      const input = {
+        a: '123',
+        b: 456,
+        c: '789',
+        d: true
+      }
+
+      const result = mapToNumber(input)
+
+      expect(result).toEqual({
+        a: 123,
+        b: 456,
+        c: 789,
+        d: 1
+      })
+    })
+  })
+  describe('getScale', () => {
+    it('should return the same value when maintainPorportion is false', () => {
+      const oldValue = { x: 1, y: 2, z: 3 }
+      const value = { x: 4, y: 5, z: 6 }
+      const mantainProportion = false
+
+      const result = getScale(oldValue, value, mantainProportion)
+
+      expect(result).toEqual(value)
+    })
+
+    it('should scale proportionally when x is changed', () => {
+      const oldValue = { x: 2, y: 4, z: 6 }
+      const value = { x: 4, y: 5, z: 6 }
+      const mantainProportion = true
+
+      const result = getScale(oldValue, value, mantainProportion)
+
+      expect(result).toEqual({ x: 4, y: 10, z: 12 })
+    })
+
+    it('should scale proportionally when y is changed', () => {
+      const oldValue = { x: 1, y: 2, z: 3 }
+      const value = { x: 1, y: 4, z: 3 }
+      const mantainProportion = true
+
+      const result = getScale(oldValue, value, mantainProportion)
+
+      expect(result).toEqual({ x: 2, y: 4, z: 6 })
+    })
+
+    it('should scale proportionally when z is changed', () => {
+      const oldValue = { x: 2, y: 4, z: 6 }
+      const value = { x: 2, y: 4, z: 3 }
+      const mantainProportion = true
+
+      const result = getScale(oldValue, value, mantainProportion)
+
+      expect(result).toEqual({ x: 1, y: 2, z: 3 })
+    })
+
+    it('should return the same value when no dimensions are changed', () => {
+      const oldValue = { x: 1, y: 2, z: 3 }
+      const value = { x: 1, y: 2, z: 3 }
+      const mantainProportion = true
+
+      const result = getScale(oldValue, value, mantainProportion)
+
+      expect(result).toEqual(value)
+    })
+  })
+  describe('when converting the TransformConfig to TransformConfigInput', () => {
+    it('should return an object with porportionalScaling set to true when passed true', () => {
+      const input = {
+        porportionalScaling: true
+      }
+
+      const result = fromTransformConfig(input)
+
+      expect(result).toEqual({
+        porportionalScaling: true
+      })
+    })
+
+    it('should return an object with porportionalScaling set to false when passed false', () => {
+      const input = {
+        porportionalScaling: false
+      }
+
+      const result = fromTransformConfig(input)
+
+      expect(result).toEqual({
+        porportionalScaling: false
+      })
+    })
+
+    it('should return an object with porportionalScaling set to false when not provided', () => {
+      const input = {}
+
+      const result = fromTransformConfig(input)
+
+      expect(result).toEqual({
+        porportionalScaling: false
+      })
     })
   })
 })

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.tsx
@@ -24,7 +24,7 @@ export const TriggerActionContainer = ({ trigger, availableActions, onUpdateActi
   }, [actions])
 
   const handleAddNewAction = useCallback(
-    (e: React.MouseEvent) => {
+    (_: React.MouseEvent) => {
       addActions({ entity: undefined, name: '' })
     },
     [addActions]
@@ -51,7 +51,7 @@ export const TriggerActionContainer = ({ trigger, availableActions, onUpdateActi
   )
 
   const handleRemoveAction = useCallback(
-    (e: React.MouseEvent, idx: number) => {
+    (_: React.MouseEvent, idx: number) => {
       removeActions(idx)
     },
     [removeActions]

--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.spec.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.spec.ts
@@ -1,0 +1,121 @@
+import { isValidNumericInput } from './useComponentInput'
+
+describe('isValidNumericInput', () => {
+  it('should return true for a valid numeric input', () => {
+    const validInput = {
+      numericValue: '42'
+    }
+
+    const result = isValidNumericInput(validInput.numericValue)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for an empty string', () => {
+    const emptyStringInput = {
+      emptyString: ''
+    }
+
+    const result = isValidNumericInput(emptyStringInput.emptyString)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false for a non-numeric string', () => {
+    const nonNumericStringInput = {
+      nonNumericString: 'abc'
+    }
+
+    const result = isValidNumericInput(nonNumericStringInput.nonNumericString)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true for a boolean true value', () => {
+    const trueBooleanInput = {
+      trueValue: true
+    }
+
+    const result = isValidNumericInput(trueBooleanInput.trueValue)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for a boolean false value', () => {
+    const falseBooleanInput = {
+      falseValue: false
+    }
+
+    const result = isValidNumericInput(falseBooleanInput.falseValue)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true for an array of valid numeric values', () => {
+    const validNumericArrayInput = {
+      numericArray: ['1', '2', '3']
+    }
+
+    const result = isValidNumericInput(validNumericArrayInput.numericArray)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for an array with an invalid numeric value', () => {
+    const invalidNumericArrayInput = {
+      invalidNumericArray: ['1', 'abc', '3']
+    }
+
+    const result = isValidNumericInput(invalidNumericArrayInput.invalidNumericArray)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true for a nested object with valid numeric values', () => {
+    const nestedValidNumericInput = {
+      nestedObject: {
+        numericValue: '42'
+      }
+    }
+
+    const result = isValidNumericInput(nestedValidNumericInput.nestedObject)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for a nested object with an invalid numeric value', () => {
+    const nestedInvalidNumericInput = {
+      nestedObject: {
+        numericValue: 'abc'
+      }
+    }
+
+    const result = isValidNumericInput(nestedInvalidNumericInput.nestedObject)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true for a nested object with a valid numeric array', () => {
+    const nestedValidNumericArrayInput = {
+      nestedObject: {
+        numericArray: ['1', '2', '3']
+      }
+    }
+
+    const result = isValidNumericInput(nestedValidNumericArrayInput.nestedObject)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false for a nested object with an invalid numeric array', () => {
+    const nestedInvalidNumericArrayInput = {
+      nestedObject: {
+        numericArray: ['1', 'abc', '3']
+      }
+    }
+
+    const result = isValidNumericInput(nestedInvalidNumericArrayInput.nestedObject)
+
+    expect(result).toBe(false)
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/components/TransformConfig.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/TransformConfig.ts
@@ -1,0 +1,3 @@
+export type TransformConfig = {
+  porportionalScaling?: boolean
+}

--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -7,8 +7,9 @@ import {
   Trigger,
   createComponents as createAssetPacksComponents
 } from '@dcl/asset-packs'
-import { Layout } from '../utils/layout'
-import { GizmoType } from '../utils/gizmo'
+import { Layout } from '../../utils/layout'
+import { GizmoType } from '../../utils/gizmo'
+import { TransformConfig } from './TransformConfig'
 
 export type Component<T = unknown> = ComponentDefinition<T>
 export type Node = { entity: Entity; children: Entity[] }
@@ -28,13 +29,15 @@ export enum EditorComponentNames {
   Nodes = 'inspector::Nodes',
   Actions = ComponentName.ACTIONS,
   Triggers = ComponentName.TRIGGERS,
-  States = ComponentName.STATES
+  States = ComponentName.STATES,
+  TransformConfig = 'inspector::TransformConfig'
 }
 
 export type EditorComponentsTypes = {
   Selection: { gizmo: GizmoType }
   Scene: { layout: Layout }
   Nodes: { value: Node[] }
+  TransformConfig: TransformConfig
   Actions: { value: Action[] }
   Triggers: { value: Trigger[] }
   States: States
@@ -44,6 +47,7 @@ export type EditorComponents = {
   Selection: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Selection']>
   Scene: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Scene']>
   Nodes: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Nodes']>
+  TransformConfig: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['TransformConfig']>
   Actions: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Actions']>
   Triggers: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Triggers']>
   States: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['States']>
@@ -111,10 +115,15 @@ export function createEditorComponents(engine: IEngine): EditorComponents {
 
   const { Actions, Triggers, States } = createAssetPacksComponents(engine as any)
 
+  const TransformConfig = engine.defineComponent(EditorComponentNames.TransformConfig, {
+    porportionalScaling: Schemas.Optional(Schemas.Boolean)
+  })
+
   return {
     Selection,
     Scene,
     Nodes,
+    TransformConfig,
     Actions: Actions as unknown as LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Actions']>,
     Triggers: Triggers as unknown as LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Triggers']>,
     States: States as unknown as LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['States']>

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -70,7 +70,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
+        "@dcl/asset-packs": "^0.0.0-20230920192724.commit-d46ddb6",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -330,6 +330,11 @@
       "version": "7.3.15",
       "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.15.tgz",
       "integrity": "sha512-Vb8L0ddqwEW5hNGuhzJUluvxetAL4JYfTZ3qZUvBOLoTnCL9Qtn61wnE08dbcEU1U7aQUuBPd3jgwpeJPun5Ug=="
+    },
+    "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
+      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
     },
     "node_modules/@dcl/sdk/node_modules/@dcl/ecs": {
       "version": "7.3.15",
@@ -3057,7 +3062,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20230915180527.commit-250509a",
+        "@dcl/asset-packs": "^0.0.0-20230920192724.commit-d46ddb6",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -3267,6 +3272,11 @@
           "version": "7.3.15",
           "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.15.tgz",
           "integrity": "sha512-Vb8L0ddqwEW5hNGuhzJUluvxetAL4JYfTZ3qZUvBOLoTnCL9Qtn61wnE08dbcEU1U7aQUuBPd3jgwpeJPun5Ug=="
+        },
+        "@dcl/linker-dapp": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
+          "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
         }
       }
     },


### PR DESCRIPTION
closes https://github.com/decentraland/sdk/issues/821

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83da1a4</samp>

This pull request adds a new feature to the entity inspector that allows editing the transform properties of entities with proportional scaling. It also refactors some components, hooks, and utils to improve the code quality and test coverage. It affects the files `TransformInspector.tsx`, `utils.ts`, `utils.spec.ts`, `TriggerAction.tsx`, `useComponentInput.ts`, `components/index.ts`, `Block.css`, `Link/*`, `TransformInspector.css`, `useComponentValue.ts`, and `TransformConfig.ts`.