### PR TITLE
fix: remove quests-client due to ESM

### DIFF
--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -16,7 +16,6 @@
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
-        "@dcl/quests-client": "^1.0.0",
         "@dcl/quests-manager": "^0.1.2",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
@@ -145,16 +144,6 @@
       "resolved": "../ecs",
       "link": true
     },
-    "node_modules/@dcl/ecs-math": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-2.0.2.tgz",
-      "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
-    },
-    "node_modules/@dcl/explorer": {
-      "version": "1.0.143989-20230907142850.commit-0c0a775",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.143989-20230907142850.commit-0c0a775.tgz",
-      "integrity": "sha512-1yBSljhlamCKGiRo43jyH7qgWGusZnhz2cpjv1LHJHw4LVOuqNwu0aiYc4VFsrrKUyedGx78Rhrp9Gi2rzOCUw=="
-    },
     "node_modules/@dcl/hashing": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
@@ -168,11 +157,6 @@
     "node_modules/@dcl/inspector": {
       "resolved": "../inspector",
       "link": true
-    },
-    "node_modules/@dcl/js-runtime": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.15.tgz",
-      "integrity": "sha512-m5gPrM9L37/z4bcFaBsGc8QiDttPQ5PqMi1Q0QYdGowDOD9nwm7Qy61iUg9z4LXSpNniL310XV3KH1aLN7PJUQ=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.11.0",
@@ -216,36 +200,10 @@
         "@dcl/ts-proto": "1.154.0"
       }
     },
-    "node_modules/@dcl/quests-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/quests-client/-/quests-client-1.0.0.tgz",
-      "integrity": "sha512-HmkXfBeDSAZHpV6u8dMxH/O9uiZvj/qGpqUfiYzQo2Ex6EVED9uC2q9Yc7k/BwkwNYe46QMEnyt08HQwLTQGpg==",
-      "dependencies": {
-        "@dcl/protocol": "^1.0.0-6160718705.commit-03626d7",
-        "@dcl/rpc": "^1.1.2",
-        "@dcl/sdk": "^7.1.18-5135429602.commit-241816a",
-        "mitt": "^3.0.1"
-      }
-    },
     "node_modules/@dcl/quests-manager": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@dcl/quests-manager/-/quests-manager-0.1.2.tgz",
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
-    },
-    "node_modules/@dcl/react-ecs": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.15.tgz",
-      "integrity": "sha512-/yhcBGIkotsf+y7mUo9TVtnmXYajlHdG0FrFKgyWH/CwyKCEbV4Jxx5psJkMTEYKOz+sPMKc16vwzzRL1lzPRw==",
-      "dependencies": {
-        "@dcl/ecs": "7.3.15",
-        "react": "^18.2.0",
-        "react-reconciler": "^0.29.0"
-      }
-    },
-    "node_modules/@dcl/react-ecs/node_modules/@dcl/ecs": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-      "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
     },
     "node_modules/@dcl/rpc": {
       "version": "1.1.2",
@@ -265,89 +223,6 @@
         "ajv-errors": "^3.0.0",
         "ajv-keywords": "^5.1.0"
       }
-    },
-    "node_modules/@dcl/sdk": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.15.tgz",
-      "integrity": "sha512-JwmModP8h2gg+7l2IQpHHWY9xzLjvtGf6MaF0XS34+mir20vcseUbhEOub+PpSOyNNQCPFB4y44NKsritBWYrA==",
-      "dependencies": {
-        "@dcl/ecs": "7.3.15",
-        "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.143989-20230907142850.commit-0c0a775",
-        "@dcl/js-runtime": "7.3.15",
-        "@dcl/react-ecs": "7.3.15",
-        "@dcl/sdk-commands": "7.3.15"
-      }
-    },
-    "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.15.tgz",
-      "integrity": "sha512-3SxQDE9oWWgVAtXQtuAwyiZm9xB3Vs35p6Ae1R3jZN2dsE2W8Cbe6bJBFCDGZIiPlR3q4ufN8MD7Xa6t98LQ7Q==",
-      "dependencies": {
-        "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.15",
-        "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.15",
-        "@dcl/linker-dapp": "0.10.1",
-        "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-6200210039.commit-75f18e8",
-        "@dcl/rpc": "^1.1.1",
-        "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
-        "@segment/analytics-node": "^1.0.0-beta.22",
-        "@well-known-components/env-config-provider": "^1.2.0",
-        "@well-known-components/fetch-component": "^2.0.2",
-        "@well-known-components/http-server": "^2.0.0-20230501134558.commit-be9a25d",
-        "@well-known-components/logger": "^3.1.2",
-        "@well-known-components/metrics": "^2.0.1",
-        "archiver": "^5.3.1",
-        "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
-        "colorette": "^2.0.19",
-        "dcl-catalyst-client": "^21.5.0",
-        "esbuild": "^0.18.17",
-        "extract-zip": "2.0.1",
-        "fp-future": "^1.0.1",
-        "glob": "^9.3.2",
-        "ignore": "^5.2.4",
-        "node-fetch": "^2.7.0",
-        "open": "^8.4.0",
-        "portfinder": "^1.0.32",
-        "prompts": "^2.4.2",
-        "typescript": "^5.0.2",
-        "undici": "^5.19.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "sdk-commands": "dist/index.js"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/@dcl/ecs": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-      "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/@dcl/inspector": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.15.tgz",
-      "integrity": "sha512-Vb8L0ddqwEW5hNGuhzJUluvxetAL4JYfTZ3qZUvBOLoTnCL9Qtn61wnE08dbcEU1U7aQUuBPd3jgwpeJPun5Ug=="
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/@dcl/linker-dapp": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
-      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/@dcl/protocol": {
-      "version": "1.0.0-6200210039.commit-75f18e8",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-6200210039.commit-75f18e8.tgz",
-      "integrity": "sha512-713H4P0TfuamhxvcQd0ck4tBYap+k/JKMUL9xYT0XJ3Fuog2tLhqYORW43c4n9dVoU4ljciNvfUqhqLE8NIweA==",
-      "dependencies": {
-        "@dcl/ts-proto": "1.154.0"
-      }
-    },
-    "node_modules/@dcl/sdk/node_modules/@dcl/ecs": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-      "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
     },
     "node_modules/@dcl/ts-proto": {
       "version": "1.154.0",
@@ -2080,11 +1955,6 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2170,17 +2040,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
@@ -2600,32 +2459,6 @@
         "rabin-wasm": "cli/bin.js"
       }
     },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-reconciler": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-      "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2695,14 +2528,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3042,16 +2867,6 @@
     "@dcl/ecs": {
       "version": "file:../ecs"
     },
-    "@dcl/ecs-math": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-2.0.2.tgz",
-      "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
-    },
-    "@dcl/explorer": {
-      "version": "1.0.143989-20230907142850.commit-0c0a775",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.143989-20230907142850.commit-0c0a775.tgz",
-      "integrity": "sha512-1yBSljhlamCKGiRo43jyH7qgWGusZnhz2cpjv1LHJHw4LVOuqNwu0aiYc4VFsrrKUyedGx78Rhrp9Gi2rzOCUw=="
-    },
     "@dcl/hashing": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
@@ -3111,11 +2926,6 @@
         "typescript": "^5.0.2"
       }
     },
-    "@dcl/js-runtime": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.15.tgz",
-      "integrity": "sha512-m5gPrM9L37/z4bcFaBsGc8QiDttPQ5PqMi1Q0QYdGowDOD9nwm7Qy61iUg9z4LXSpNniL310XV3KH1aLN7PJUQ=="
-    },
     "@dcl/linker-dapp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.11.0.tgz",
@@ -3160,38 +2970,10 @@
         "@dcl/ts-proto": "1.154.0"
       }
     },
-    "@dcl/quests-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/quests-client/-/quests-client-1.0.0.tgz",
-      "integrity": "sha512-HmkXfBeDSAZHpV6u8dMxH/O9uiZvj/qGpqUfiYzQo2Ex6EVED9uC2q9Yc7k/BwkwNYe46QMEnyt08HQwLTQGpg==",
-      "requires": {
-        "@dcl/protocol": "^1.0.0-6160718705.commit-03626d7",
-        "@dcl/rpc": "^1.1.2",
-        "@dcl/sdk": "^7.1.18-5135429602.commit-241816a",
-        "mitt": "^3.0.1"
-      }
-    },
     "@dcl/quests-manager": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@dcl/quests-manager/-/quests-manager-0.1.2.tgz",
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
-    },
-    "@dcl/react-ecs": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.15.tgz",
-      "integrity": "sha512-/yhcBGIkotsf+y7mUo9TVtnmXYajlHdG0FrFKgyWH/CwyKCEbV4Jxx5psJkMTEYKOz+sPMKc16vwzzRL1lzPRw==",
-      "requires": {
-        "@dcl/ecs": "7.3.15",
-        "react": "^18.2.0",
-        "react-reconciler": "^0.29.0"
-      },
-      "dependencies": {
-        "@dcl/ecs": {
-          "version": "7.3.15",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-          "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
-        }
-      }
     },
     "@dcl/rpc": {
       "version": "1.1.2",
@@ -3210,90 +2992,6 @@
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
         "ajv-keywords": "^5.1.0"
-      }
-    },
-    "@dcl/sdk": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.15.tgz",
-      "integrity": "sha512-JwmModP8h2gg+7l2IQpHHWY9xzLjvtGf6MaF0XS34+mir20vcseUbhEOub+PpSOyNNQCPFB4y44NKsritBWYrA==",
-      "requires": {
-        "@dcl/ecs": "7.3.15",
-        "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.143989-20230907142850.commit-0c0a775",
-        "@dcl/js-runtime": "7.3.15",
-        "@dcl/react-ecs": "7.3.15",
-        "@dcl/sdk-commands": "7.3.15"
-      },
-      "dependencies": {
-        "@dcl/ecs": {
-          "version": "7.3.15",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-          "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
-        }
-      }
-    },
-    "@dcl/sdk-commands": {
-      "version": "7.3.15",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.15.tgz",
-      "integrity": "sha512-3SxQDE9oWWgVAtXQtuAwyiZm9xB3Vs35p6Ae1R3jZN2dsE2W8Cbe6bJBFCDGZIiPlR3q4ufN8MD7Xa6t98LQ7Q==",
-      "requires": {
-        "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.15",
-        "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.15",
-        "@dcl/linker-dapp": "0.10.1",
-        "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-6200210039.commit-75f18e8",
-        "@dcl/rpc": "^1.1.1",
-        "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
-        "@segment/analytics-node": "^1.0.0-beta.22",
-        "@well-known-components/env-config-provider": "^1.2.0",
-        "@well-known-components/fetch-component": "^2.0.2",
-        "@well-known-components/http-server": "^2.0.0-20230501134558.commit-be9a25d",
-        "@well-known-components/logger": "^3.1.2",
-        "@well-known-components/metrics": "^2.0.1",
-        "archiver": "^5.3.1",
-        "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
-        "colorette": "^2.0.19",
-        "dcl-catalyst-client": "^21.5.0",
-        "esbuild": "^0.18.17",
-        "extract-zip": "2.0.1",
-        "fp-future": "^1.0.1",
-        "glob": "^9.3.2",
-        "ignore": "^5.2.4",
-        "node-fetch": "^2.7.0",
-        "open": "^8.4.0",
-        "portfinder": "^1.0.32",
-        "prompts": "^2.4.2",
-        "typescript": "^5.0.2",
-        "undici": "^5.19.1",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@dcl/ecs": {
-          "version": "7.3.15",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.15.tgz",
-          "integrity": "sha512-bSPIrfovacv1q4Y+NbT7x7WDUwH01rfsv2PhPZcgAIySl4pgoUWEi0UVb+04A+TPrvtkipf9lm3t5Uj6hTl5Ng=="
-        },
-        "@dcl/inspector": {
-          "version": "7.3.15",
-          "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.15.tgz",
-          "integrity": "sha512-Vb8L0ddqwEW5hNGuhzJUluvxetAL4JYfTZ3qZUvBOLoTnCL9Qtn61wnE08dbcEU1U7aQUuBPd3jgwpeJPun5Ug=="
-        },
-        "@dcl/linker-dapp": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
-          "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
-        },
-        "@dcl/protocol": {
-          "version": "1.0.0-6200210039.commit-75f18e8",
-          "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-6200210039.commit-75f18e8.tgz",
-          "integrity": "sha512-713H4P0TfuamhxvcQd0ck4tBYap+k/JKMUL9xYT0XJ3Fuog2tLhqYORW43c4n9dVoU4ljciNvfUqhqLE8NIweA==",
-          "requires": {
-            "@dcl/ts-proto": "1.154.0"
-          }
-        }
       }
     },
     "@dcl/ts-proto": {
@@ -4537,11 +4235,6 @@
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4623,14 +4316,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lru-cache": {
       "version": "7.18.3",
@@ -4948,23 +4633,6 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "react-reconciler": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-      "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      }
-    },
     "readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5010,14 +4678,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,6 @@
     "@dcl/linker-dapp": "^0.11.0",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
     "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
-    "@dcl/quests-client": "^1.0.0",
     "@dcl/quests-manager": "^0.1.2",
     "@dcl/rpc": "^1.1.1",
     "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",

--- a/packages/@dcl/sdk-commands/src/commands/quests/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/quests/index.ts
@@ -1,11 +1,10 @@
 import { Result } from 'arg'
 import { isAddress } from 'eth-connect'
 import { validate } from 'uuid'
-import { validateCreateQuest } from '@dcl/quests-client/dist/utils'
 
 import { declareArgs } from '../../logic/args'
 import { CliComponents } from '../../components'
-import { createQuestByPrompting, executeSubcommand, setUpManager, urlRegex } from './utils'
+import { createQuestByPrompting, executeSubcommand, setUpManager, urlRegex, validateCreateQuest } from './utils'
 import { CreateQuest } from './types'
 import { colors } from '../../components/log'
 import { CliError } from '../../logic/error'

--- a/packages/@dcl/sdk-commands/src/commands/quests/types.ts
+++ b/packages/@dcl/sdk-commands/src/commands/quests/types.ts
@@ -17,23 +17,23 @@ export interface QuestDefinition {
   connections: Connection[]
 }
 
-interface Connection {
+export interface Connection {
   stepFrom: string
   stepTo: string
 }
 
-interface Step {
+export interface Step {
   id: string
   description: string
   tasks: Task[]
 }
 
-interface Action {
+export interface Action {
   type: string
   parameters: { [key: string]: string }
 }
 
-interface Task {
+export interface Task {
   id: string
   description: string
   actionItems: Action[]

--- a/packages/@dcl/sdk-commands/src/commands/quests/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/quests/utils.ts
@@ -6,9 +6,8 @@ import { Authenticator } from '@dcl/crypto'
 import { dirname, resolve } from 'path'
 import { Router } from '@well-known-components/http-server'
 import prompts from 'prompts'
-import { validateStepsAndConnections } from '@dcl/quests-client/dist/utils'
 
-import { CreateQuest, QuestLinkerActionType } from './types'
+import { CreateQuest, QuestLinkerActionType, Step, Connection, Task, Action } from './types'
 import { CliComponents } from '../../components'
 import { createWallet } from '../../logic/account'
 import { LinkerResponse } from '../../linker-dapp/routes'
@@ -365,4 +364,177 @@ export const setUpManager = (components: Pick<CliComponents, 'fs' | 'logger' | '
   })
 
   return { router }
+}
+
+export function validateStep(step: Partial<Step>): boolean {
+  if (!step?.id?.length) {
+    throw new Error(`Step: ${JSON.stringify(step)} is missing an ID`)
+  }
+
+  if (!step?.description?.length) {
+    throw new Error(`Step: ${step.id} is missing its description`)
+  }
+
+  if (!step.tasks?.length || !Array.isArray(step.tasks)) {
+    throw new Error(`Step: ${step.id} contains invalid tasks`)
+  }
+
+  const ids = new Set()
+
+  for (const task of step.tasks) {
+    validateTask(task)
+
+    if (ids.has(task.id)) {
+      throw new Error(`${step.id} is repeated. Each Task's id must be unique`)
+    } else {
+      ids.add(task.id)
+    }
+  }
+
+  return true
+}
+
+export function validateTask(task: Partial<Task>): boolean {
+  if (!task?.id?.length) {
+    throw new Error(`Task: ${JSON.stringify(task)} is missing an ID`)
+  }
+
+  if (!task?.description?.length) {
+    throw new Error(`Task: ${task.id} is missing its description`)
+  }
+
+  if (!task?.actionItems?.length || !Array.isArray(task.actionItems)) {
+    throw new Error(`Task: ${task.id} contains invalid action items`)
+  }
+
+  for (const at of task.actionItems) {
+    validateActionItem(at)
+  }
+
+  return true
+}
+
+export function validateActionItem(action: Partial<Action>): boolean {
+  switch (action.type) {
+    case 'CUSTOM': {
+      const keys = Object.keys(action.parameters || {})
+      if (!keys.length) {
+        throw new Error(`Custom Action must contain at least one parameter. eg: ID`)
+      }
+      return true
+    }
+    case 'LOCATION': {
+      const keys = Object.keys(action.parameters || {})
+      if (!keys.includes('X') || !keys.includes('Y')) {
+        throw new Error(`Location Action must contain X and Y parameters`)
+      }
+      return true
+    }
+    case 'EMOTE': {
+      const keys = Object.keys(action.parameters || {})
+      if (!keys.includes('X') || !keys.includes('Y') || !keys.includes('id')) {
+        throw new Error(`Emote Action must contain X, Y, and ID parameters`)
+      }
+      return true
+    }
+    case 'JUMP': {
+      const keys = Object.keys(action.parameters || {})
+      if (!keys.includes('X') || !keys.includes('Y')) {
+        throw new Error(`Jump Action must contain X, Y, and ID parameters`)
+      }
+      return true
+    }
+    default:
+      throw new Error(`Invalid Action: ${JSON.stringify(action)}`)
+  }
+}
+
+export function validateStepsAndConnections(quest: Pick<CreateQuest, 'definition'>): boolean {
+  if (!quest.definition) {
+    throw new Error('Quest must have a definition')
+  }
+
+  validateConnections(quest.definition.connections || [])
+
+  validateSteps(quest.definition.steps || [])
+
+  return true
+}
+
+export function validateConnections(connections: Connection[]): boolean {
+  if (!connections?.length || !Array.isArray(connections)) {
+    throw new Error("Quest's definition must have its connections defined")
+  }
+
+  if (!connections.every((connection) => connection.stepFrom?.length && connection.stepTo?.length)) {
+    throw new Error("Quest's definition must have valid connections")
+  }
+
+  if (!connections.every((connection) => connection.stepFrom !== connection.stepTo)) {
+    throw new Error("Quest's connections are invalid. A Connection cannot go from and to the same step")
+  }
+
+  return true
+}
+
+export function validateSteps(steps: Step[]): boolean {
+  if (!steps?.length || !Array.isArray(steps)) {
+    throw new Error("Quest's definition must have its steps defined")
+  }
+
+  const ids = new Set()
+  for (const step of steps) {
+    validateStep(step)
+    if (ids.has(step.id)) {
+      throw new Error(`${step.id} is repeated. Each Step's id must be unique`)
+    } else {
+      ids.add(step.id)
+    }
+  }
+
+  return true
+}
+
+export function validateCreateQuest(quest: CreateQuest): boolean {
+  if (!quest.name || !(quest.name.length >= 5)) {
+    throw new Error("Quest's name must be at least 5 chars")
+  }
+
+  if (!quest.description || !(quest.description.length >= 5)) {
+    throw new Error("Quest's description must be at least 5 chars")
+  }
+
+  if (!quest.imageUrl?.length || !new RegExp(urlRegex).test(quest.imageUrl)) {
+    throw new Error("Quest's image URL must be a valid URL")
+  }
+
+  validateStepsAndConnections(quest)
+
+  if (quest.reward) {
+    if (!quest.reward.hook) {
+      throw new Error("Quest's reward must have its webhook defined")
+    } else {
+      if (
+        !quest.reward.hook.webhookUrl ||
+        !quest.reward.hook.webhookUrl?.length ||
+        !new RegExp(urlRegex).test(quest.reward.hook.webhookUrl)
+      ) {
+        throw new Error("Quest's reward must have a valid Webhook URL")
+      }
+    }
+
+    if (!quest.reward.items || !quest.reward.items?.length || !Array.isArray(quest.reward.items)) {
+      throw new Error("Quest's reward must have its items defined")
+    }
+
+    if (
+      !quest.reward.items.every(
+        (item) => new RegExp(urlRegex).test(item.imageLink || '') && item?.name && item.name?.length >= 3
+      )
+    ) {
+      throw new Error("Quest's reward must have valid items")
+    }
+  }
+
+  return true
 }


### PR DESCRIPTION
This PR fixes the `quests` command that is failing in the last version due to `@dcl/quests-client` lib that uses ESM for its modules

`IMPORTANT NOTE: this is a temporal patch to avoid the usage of `@dcl/quests-client` package, until it get fixed and this changes can be reverted`