### PR TITLE
fix: play_sound undefined values

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/PlaySoundAction.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/PlaySoundAction.tsx
@@ -34,15 +34,15 @@ const options = [
 ]
 
 const PlaySoundAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
-  const [payload, setPayload] = useState<ActionPayload<ActionType.PLAY_SOUND>>({
+  const [payload, setPayload] = useState<Partial<ActionPayload<ActionType.PLAY_SOUND>>>({
     ...value
   })
 
   const files = useAppSelector(selectAssetCatalog)
 
   const removeBase = useCallback(
-    (path: string) => {
-      return files?.basePath ? path.replace(files.basePath + '/', '') : path
+    (path?: string) => {
+      return path ? (files?.basePath ? path.replace(files.basePath + '/', '') : path) : ''
     },
     [files]
   )
@@ -96,7 +96,10 @@ const PlaySoundAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
   )
 
   const error = useMemo(() => {
-    return !files || !files.assets.some(($) => $.path === payload.src)
+    if (!files || !payload.src) {
+      return false
+    }
+    return !files.assets.some(($) => $.path === payload.src)
   }, [files, payload])
 
   const renderPathInfo = () => {

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/types.ts
@@ -1,6 +1,6 @@
 import { ActionPayload, ActionType } from '@dcl/asset-packs'
 
 export interface Props {
-  value: ActionPayload[ActionType.PLAY_SOUND]
-  onUpdate: (value: ActionPayload[ActionType.PLAY_SOUND]) => void
+  value: Partial<ActionPayload<ActionType.PLAY_SOUND>>
+  onUpdate: (value: ActionPayload<ActionType.PLAY_SOUND>) => void
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/PlaySoundAction/utils.ts
@@ -1,5 +1,7 @@
 import { ActionPayload, ActionType } from '@dcl/asset-packs'
 
-export function isValid(payload: ActionPayload<ActionType.PLAY_SOUND>) {
+export function isValid(
+  payload: Partial<ActionPayload<ActionType.PLAY_SOUND>>
+): payload is ActionPayload<ActionType.PLAY_SOUND> {
   return !!payload.src
 }


### PR DESCRIPTION
The `play_sound` action was working fine with pre-popullated values from smart items, but when creating an action from scratch it throws due to undefined values, because the typings were wrong (not using `Partial`).

This PR fixes that.