### PR TITLE
fix: upgrade @dcl/asset-packs

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^0.0.0-20231003201348.commit-00db039",
+        "@dcl/asset-packs": "^0.0.0-20231004150938.commit-91b2f7d",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",
@@ -272,19 +272,12 @@
         "date-fns": "^2.1"
       }
     },
-    "node_modules/@dcl-sdk/utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
-      "dev": true
-    },
     "node_modules/@dcl/asset-packs": {
-      "version": "0.0.0-20231003201348.commit-00db039",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231003201348.commit-00db039.tgz",
-      "integrity": "sha512-hs1+weLQFPZIO+Tw5baih27sq2UP3/UQLrhnuXLwamPSbXFjjgNTmJyPD4Sn7aAtPzy+lowTs6rx+eapzAyzRw==",
+      "version": "0.0.0-20231004150938.commit-91b2f7d",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231004150938.commit-91b2f7d.tgz",
+      "integrity": "sha512-Dn+ojDVz2aLNimznv/qLGjOEbD/nZiqQhWTK8fF9B3nggpY55r1Z41E7+jdGYm4r/3WuZA4B7i0GStM4PIfjAw==",
       "dev": true,
       "dependencies": {
-        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/sdk": "^7.3.12",
         "mitt": "^3.0.1"
       }
@@ -8034,19 +8027,12 @@
         "date-fns": "^2.1"
       }
     },
-    "@dcl-sdk/utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.1.3.tgz",
-      "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ==",
-      "dev": true
-    },
     "@dcl/asset-packs": {
-      "version": "0.0.0-20231003201348.commit-00db039",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231003201348.commit-00db039.tgz",
-      "integrity": "sha512-hs1+weLQFPZIO+Tw5baih27sq2UP3/UQLrhnuXLwamPSbXFjjgNTmJyPD4Sn7aAtPzy+lowTs6rx+eapzAyzRw==",
+      "version": "0.0.0-20231004150938.commit-91b2f7d",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231004150938.commit-91b2f7d.tgz",
+      "integrity": "sha512-Dn+ojDVz2aLNimznv/qLGjOEbD/nZiqQhWTK8fF9B3nggpY55r1Z41E7+jdGYm4r/3WuZA4B7i0GStM4PIfjAw==",
       "dev": true,
       "requires": {
-        "@dcl-sdk/utils": "^1.1.3",
         "@dcl/sdk": "^7.3.12",
         "mitt": "^3.0.1"
       }

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -7,7 +7,7 @@
     "@babylonjs/inspector": "^6.18.0",
     "@babylonjs/loaders": "^6.18.0",
     "@babylonjs/materials": "^6.18.0",
-    "@dcl/asset-packs": "^0.0.0-20231003201348.commit-00db039",
+    "@dcl/asset-packs": "^0.0.0-20231004150938.commit-91b2f7d",
     "@dcl/ecs": "file:../ecs",
     "@dcl/ecs-math": "2.0.2",
     "@dcl/mini-rpc": "^1.0.7",


### PR DESCRIPTION
This new version of `@dcl/asset-packs` removes the dependency that seems to be causing the recent issues when building scenes with the SDK.