### PR TITLE
feat: add support for vscode

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^0.0.0-20231007231138.commit-4ee8384"
+        "@dcl/asset-packs": "^1.2.1"
       },
       "devDependencies": {
         "@babylonjs/core": "^6.18.0",
@@ -279,9 +279,9 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "0.0.0-20231007231138.commit-4ee8384",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231007231138.commit-4ee8384.tgz",
-      "integrity": "sha512-q2bzkYGqH8rJB3OjIxux35ljPyTyDqyhr+/rgqB8QIXgGjcSyPco9ITg8LYEbdnHhzz+7XIQJhOObj0TfyEPKg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.1.tgz",
+      "integrity": "sha512-aNUGZnpyS8wS9MEhwoU22GU8SL3EQOEB8z5QtbeJBIFR4BcjY8HRu+UAXULNyaxpy+ddL/qACSuSAD59HgBk2g==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.18",
@@ -7750,9 +7750,9 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "@dcl/asset-packs": {
-      "version": "0.0.0-20231007231138.commit-4ee8384",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231007231138.commit-4ee8384.tgz",
-      "integrity": "sha512-q2bzkYGqH8rJB3OjIxux35ljPyTyDqyhr+/rgqB8QIXgGjcSyPco9ITg8LYEbdnHhzz+7XIQJhOObj0TfyEPKg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.1.tgz",
+      "integrity": "sha512-aNUGZnpyS8wS9MEhwoU22GU8SL3EQOEB8z5QtbeJBIFR4BcjY8HRu+UAXULNyaxpy+ddL/qACSuSAD59HgBk2g==",
       "requires": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.18",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^0.0.0-20231007231138.commit-4ee8384"
+    "@dcl/asset-packs": "^1.2.1"
   },
   "devDependencies": {
     "@babylonjs/core": "^6.18.0",


### PR DESCRIPTION
This PR updates `@dcl/asset-packs` to a version that can be used from VSCode