### PR TITLE
fix: gltf path error

### DIFF
--- a/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useComponentInput.ts
@@ -32,7 +32,7 @@ export const useComponentInput = <ComponentValueType extends object, InputType e
   )
   const [focusedOn, setFocusedOn] = useState<string | null>(null)
   const skipSyncRef = useRef(false)
-  const [isValid, setIsValid] = useState(false)
+  const [isValid, setIsValid] = useState(true)
 
   const updateInputs = useCallback((value: InputType | null, skipSync = false) => {
     skipSyncRef.current = skipSync


### PR DESCRIPTION
Fixes https://github.com/decentraland/sdk/issues/954

The issues was that the initial state of `isValid` was `false`, so it was always initially rendered with an error, then once the validation happened it was rendered without the error, but you could see the red border for a split second.