### PR TITLE
fix: ensure `node_modules/**` is ignored to avoid delays trying to pr…

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
+++ b/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
@@ -44,7 +44,7 @@ export async function getDCLIgnorePatterns(components: Pick<CliComponents, 'fs'>
   ignored.push(...defaultDclIgnore)
 
   // by default many files need to be ignored
-  ignored.push('.*', 'node_modules', '**/*.ts', '**/*.tsx')
+  ignored.push('.*', 'node_modules', '**/*.ts', '**/*.tsx', 'node_modules/**')
 
   return Array.from(new Set(ignored))
 }

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -21,9 +21,6 @@ export async function getPublishableFiles(
 ): Promise<Array<string>> {
   const ignorePatterns = await getDCLIgnorePatterns(components, projectRoot)
 
-  // ensure `node_modules/**` is ignored
-  ignorePatterns.push('node_modules/**')
-
   const ig = ignore().add(ignorePatterns)
   const allFiles = globSync('**/*', {
     cwd: projectRoot,

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -21,8 +21,10 @@ export async function getPublishableFiles(
 ): Promise<Array<string>> {
   const ignorePatterns = await getDCLIgnorePatterns(components, projectRoot)
 
-  const ig = ignore().add(ignorePatterns)
+  // ensure `node_modules/**` is ignored
+  ignorePatterns.push('node_modules/**')
 
+  const ig = ignore().add(ignorePatterns)
   const allFiles = globSync('**/*', {
     cwd: projectRoot,
     absolute: false,


### PR DESCRIPTION
…ocess it

The .dclignore from SDK7 Template has an incorrect format for `node_modules` ignore.

It's using `node_modules` and it should be `node_modules/**`.

This makes the `globSync` to take some seconds to process, doing the hot-reload very slow.

This PR ensures that the `node_modules/**` is ignored from the ContentMapping generation in the `globSync` function.

Required for acceptable performance on: https://github.com/decentraland/unity-renderer/pull/5782