### PR TITLE
fix: Add text map for Action and Trigger types

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -35,6 +35,21 @@ import { Props } from './types'
 
 import './ActionInspector.css'
 
+const ActionMapOption: Record<string, string> = {
+  [ActionType.PLAY_ANIMATION]: 'Play Animation',
+  [ActionType.STOP_ANIMATION]: 'Stop Animation',
+  [ActionType.SET_STATE]: 'Set State',
+  [ActionType.START_TWEEN]: 'Start Tween',
+  [ActionType.SET_COUNTER]: 'Set Counter',
+  [ActionType.INCREMENT_COUNTER]: 'Increment Counter',
+  [ActionType.DECREASE_COUNTER]: 'Decrease Counter',
+  [ActionType.PLAY_SOUND]: 'Play Sound',
+  [ActionType.STOP_SOUND]: 'Stop Sound',
+  [ActionType.SET_VISIBILITY]: 'Set Visibility',
+  [ActionType.ATTACH_TO_PLAYER]: 'Attach to Player',
+  [ActionType.DETACH_FROM_PLAYER]: 'Detach from Player'
+}
+
 export default withSdk<Props>(
   withContextMenu<Props & WithSdkProps>(({ sdk, entity: entityId, contextMenuId }) => {
     const { Actions, States, Counter } = sdk.components
@@ -447,7 +462,10 @@ export default withSdk<Props>(
                   disabled={availableActions.length === 0}
                   options={[
                     { text: 'Select an Action', value: '' },
-                    ...availableActions.map((availableAction) => ({ text: availableAction, value: availableAction }))
+                    ...availableActions.map((availableAction) => ({
+                      text: ActionMapOption[availableAction],
+                      value: availableAction
+                    }))
                   ]}
                   value={action.type}
                   onChange={(e) => handleChangeType(e, idx)}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerEvent/TriggerEvent.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { VscTrash as RemoveIcon } from 'react-icons/vsc'
 import { IoIosGitBranch as ConditionalIcon } from 'react-icons/io'
+import { TriggerType } from '@dcl/asset-packs'
 import { Block } from '../../../Block'
 import { Button } from '../../../Button'
 import { Dropdown } from '../../../Dropdown'
@@ -9,6 +10,16 @@ import MoreOptionsMenu from '../../MoreOptionsMenu'
 import type { Props } from './types'
 
 import './TriggerEvent.css'
+
+const TriggerMapOption: Record<string, string> = {
+  [TriggerType.ON_CLICK]: 'On Click',
+  [TriggerType.ON_SPAWN]: 'On Spawn',
+  [TriggerType.ON_STATE_CHANGE]: 'On State Change',
+  [TriggerType.ON_COUNTER_CHANGE]: 'On Counter Change',
+  [TriggerType.ON_TWEEN_END]: 'On Tween End',
+  [TriggerType.ON_PLAYER_ENTERS_AREA]: 'Player Enters Area',
+  [TriggerType.ON_PLAYER_LEAVES_AREA]: 'Player Leaves Area'
+}
 
 export const TriggerEvent = ({
   trigger,
@@ -33,7 +44,11 @@ export const TriggerEvent = ({
           </MoreOptionsMenu>
         </div>
       </div>
-      <Dropdown options={availableTriggers} value={trigger.type} onChange={onChangeTriggerType} />
+      <Dropdown
+        options={availableTriggers.map((availableTrigger) => TriggerMapOption[availableTrigger])}
+        value={trigger.type}
+        onChange={onChangeTriggerType}
+      />
       {children}
     </Block>
   )


### PR DESCRIPTION
This PR adds a text map for Action and Trigger types.

Closes https://github.com/decentraland/sdk/issues/969