### PR TITLE
update: scene permissions for non PX scenes

### DIFF
--- a/packages/@dcl/inspector/test/e2e/Assets.spec.ts
+++ b/packages/@dcl/inspector/test/e2e/Assets.spec.ts
@@ -13,17 +13,17 @@ describe('Assets', () => {
   }, 100_000)
 
   test('Drag asset from file system into renderer', async () => {
-    // There should not be an entity in the Hierarchy tree with the name casla.glb at the start
-    await expect(Hierarchy.getId('casla-glb.glb')).rejects.toThrow()
+    // There should not be an entity in the Hierarchy tree with the name example.glb at the start
+    await expect(Hierarchy.getId('example.glb')).rejects.toThrow()
 
     await Assets.selectTab(AssetsTab.FileSystem)
     await Assets.openFolder('scene')
-    await Assets.openFolder('scene/models2')
+    await Assets.openFolder('scene/models')
 
-    await Assets.addFileSystemAsset('scene/models2/casla-glb.glb')
+    await Assets.addFileSystemAsset('scene/models/example.glb')
 
-    // There should be an entity in the Hierarchy tree with the name Pebbles
-    await expect(Hierarchy.getId('casla-glb.glb')).resolves.toBeGreaterThanOrEqual(152)
+    // There should be an entity in the Hierarchy tree with the name example.glb
+    await expect(Hierarchy.getId('example.glb')).resolves.toBeGreaterThanOrEqual(152)
   }, 100_000)
 
   test('Drag asset from Builder into renderer', async () => {

--- a/test/sdk-commands/utils/validations.spec.ts
+++ b/test/sdk-commands/utils/validations.spec.ts
@@ -34,8 +34,12 @@ describe('build:helpers', () => {
     jest.spyOn(projectValidation, 'assertValidProjectFolder')
 
     const res = await projectValidation.assertValidProjectFolder(components, 'some/path')
+    const expectedScene = {
+      ...scene,
+      requiredPermissions: ['ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE', 'ALLOW_TO_TRIGGER_AVATAR_EMOTE']
+    }
 
-    expect(res).toEqual({ kind: 'scene', scene, workingDirectory: 'some/path' })
+    expect(res).toEqual({ kind: 'scene', scene: expectedScene, workingDirectory: 'some/path' })
     expect(fileExists).toBeCalledWith(path.resolve('some/path/package.json'))
     expect(readFile).toBeCalledWith(path.resolve('some/path/scene.json'), 'utf8')
   })


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2947ea3</samp>

Improve scene validation logic and add workaround for unity-renderer permissions. Refactor `scene-validations.ts` with type annotations and return value.