### PR TITLE
fix: Inspector component styles

### DIFF
--- a/packages/@dcl/inspector/src/components/Block/Block.css
+++ b/packages/@dcl/inspector/src/components/Block/Block.css
@@ -23,3 +23,11 @@
   padding: 5px;
   border-radius: 2px;
 }
+
+.Block:has(.content > .Field):not(:first-child) {
+  margin-top: 0;
+}
+
+.Block .content:has(.Field) {
+  column-gap: 8px;
+}

--- a/packages/@dcl/inspector/src/components/Box/Box.css
+++ b/packages/@dcl/inspector/src/components/Box/Box.css
@@ -2,18 +2,14 @@
   height: calc(100% - 4.8px);
 }
 
-.Box.with-border {
+.Box {
   margin: 1.2px;
   padding: 1.2px;
   border-radius: 2.4px;
   background: #21262f;
 }
 
-.Box.with-border>.content:hover {
-  border: 1px solid var(--border-focused);
-}
-
-.Box.with-border>.content {
+.Box > .content {
   border: 1px solid var(--main-bg-color);
   background: var(--main-bg-color);
   width: 100%;

--- a/packages/@dcl/inspector/src/components/Box/Box.tsx
+++ b/packages/@dcl/inspector/src/components/Box/Box.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import cx from 'classnames'
 import './Box.css'
 
 interface Props {
@@ -7,7 +8,7 @@ interface Props {
 
 function Box({ children, className }: React.PropsWithChildren<Props>) {
   return (
-    <div className={`Box with-border ${className ?? ''}`}>
+    <div className={cx('Box', className)}>
       <div className="content">{children}</div>
     </div>
   )

--- a/packages/@dcl/inspector/src/components/Container/Container.css
+++ b/packages/@dcl/inspector/src/components/Container/Container.css
@@ -63,3 +63,9 @@
 .Container > .title > .RightContent > .MoreOptionsMenu > .MoreOptionsContent {
   min-width: 175px;
 }
+
+.Container .content:has(.Block > .content > .Field) {
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+}

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.css
@@ -20,8 +20,8 @@
   align-items: center;
   width: 100%;
   position: relative;
-  column-gap: 4px;
-  row-gap: 15px;
+  column-gap: 8px;
+  row-gap: 12px;
 }
 
 .ActionInspector > .content > .Block > .content .row .field {
@@ -45,15 +45,15 @@
   gap: 4px;
 }
 
-.ActionInspector > .content > .Block > .content .row .field > .TextField {
+.ActionInspector > .content > .Block > .content .row .field > .Text.Field {
   width: 100%;
 }
 
-.ActionInspector > .content > .Block > .content .row .field.duration .TextField {
+.ActionInspector > .content > .Block > .content .row .field.duration .Text.Field {
   width: 50px;
 }
 
-.ActionInspector > .content > .Block > .content .row .field.duration .TextField input {
+.ActionInspector > .content > .Block > .content .row .field.duration .Text.Field input {
   min-width: 50px;
 }
 

--- a/packages/@dcl/inspector/src/components/EntityInspector/AddButton/AddButton.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AddButton/AddButton.css
@@ -1,6 +1,7 @@
 .AddButton {
   margin-top: 16px;
   border: 1px solid #3a3d41;
+  border-radius: 4px;
   background: #1e1e1e;
   display: flex;
   padding: 4px;

--- a/packages/@dcl/inspector/src/components/EntityInspector/AddButton/AddButton.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AddButton/AddButton.css
@@ -1,5 +1,5 @@
 .AddButton {
-  margin-top: 16px;
+  margin-top: 12px;
   border: 1px solid #3a3d41;
   border-radius: 4px;
   background: #1e1e1e;

--- a/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.css
@@ -1,7 +1,0 @@
-.AudioSource > .content > .Block.volume > .content {
-  gap: 4px;
-}
-
-.AudioSource > .content > .Block.volume > .content > .TextField {
-  width: 40px;
-}

--- a/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/AudioSourceInspector.tsx
@@ -19,8 +19,6 @@ import { TextField, CheckboxField, RangeField } from '../../ui'
 import { fromAudioSource, toAudioSource, isValidInput, isAudio, isValidVolume } from './utils'
 import type { Props } from './types'
 
-import './AudioSourceInspector.css'
-
 const DROP_TYPES = ['project-asset']
 
 export default withSdk<Props>(({ sdk, entity }) => {

--- a/packages/@dcl/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/CounterInspector/CounterInspector.css
@@ -2,7 +2,7 @@
   height: auto;
 }
 
-.CounterInspector .content .TextField {
+.CounterInspector .content .Text.Field {
   margin-top: 8px;
-  width: 100%
+  width: 100%;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.css
@@ -1,3 +1,0 @@
-.Container.GltfInspector .content {
-  gap: 4px;
-}

--- a/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/GltfInspector/GltfInspector.tsx
@@ -11,8 +11,6 @@ import { fromGltf, toGltf, isValidInput, COLLISION_LAYERS, isModel } from './uti
 import { useAppSelector } from '../../../redux/hooks'
 import { selectAssetCatalog } from '../../../redux/app'
 
-import './GltfInspector.css'
-
 export default withSdk<Props>(({ sdk, entity }) => {
   const files = useAppSelector(selectAssetCatalog)
   const { GltfContainer } = sdk.components

--- a/packages/@dcl/inspector/src/components/EntityInspector/StatesInspector/StatesInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/StatesInspector/StatesInspector.css
@@ -1,7 +1,7 @@
 .StatesInspector.Container {
   height: auto;
 }
-.StatesInspector:is(.open)>.title {
+.StatesInspector:is(.open) > .title {
   border-bottom: 1px solid var(--border-gray);
   padding-bottom: 12px;
 }
@@ -10,8 +10,8 @@
   align-items: normal;
 }
 
-.StatesInspector .states-list .content .TextField {
-  width: 100%
+.StatesInspector .states-list .content .Text.Field {
+  width: 100%;
 }
 
 .StatesInspector .states-list .content .row {
@@ -19,6 +19,6 @@
   align-items: center;
 }
 
-.StatesInspector .states-list .content .row+.row {
+.StatesInspector .states-list .content .row + .row {
   margin-top: 4px;
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TransformInspector/TransformInspector.css
@@ -1,7 +1,3 @@
 .Container.Transform svg {
   margin-right: 5px;
 }
-
-.Container.Transform .content {
-  gap: 4px;
-}

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerAction/TriggerAction.css
@@ -43,7 +43,7 @@
   flex: 1;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
+  gap: 12px 8px;
 }
 
 .TriggerActionsContainer > .TriggerAction > .RightMenu {

--- a/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerCondition/TriggerCondition.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TriggerInspector/TriggerCondition/TriggerCondition.css
@@ -43,7 +43,7 @@
   flex: 1;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
+  gap: 12px 8px;
 }
 
 .TriggerConditionsContainer > .TriggerCondition > .RightMenu {

--- a/packages/@dcl/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.css
+++ b/packages/@dcl/inspector/src/components/EntityInspector/VisibilityComponentInspector/VisibilityComponentInspector.css
@@ -15,7 +15,7 @@
   align-items: center;
   width: 100%;
   position: relative;
-  gap: 4px;
+  gap: 12px 8px;
 }
 
 .VisibilityContainer > .content > .Block > .content .row .field {

--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
@@ -91,12 +91,12 @@
   width: 120px;
 }
 
-.ImportAsset .file-container .TextField {
+.ImportAsset .file-container .Text.Field {
   width: auto;
   height: 24px;
 }
 
-.ImportAsset .file-container .error .TextField {
+.ImportAsset .file-container .error .Text.Field {
   border-color: red;
 }
 

--- a/packages/@dcl/inspector/src/components/ui/CheckboxField/CheckboxField.css
+++ b/packages/@dcl/inspector/src/components/ui/CheckboxField/CheckboxField.css
@@ -1,20 +1,17 @@
-.Block .content:has(.CheckboxField .error-message) {
+.Block .content:has(.Checkbox.Field .ErrorMessage) {
   align-items: flex-start;
 }
 
-.CheckboxField {
+.Checkbox.Field {
   flex-grow: 1;
 }
-*:has(> .CheckboxField + *) {
-  gap: 4px;
-}
 
-.CheckboxField .input-container {
+.Checkbox.Field .InputContainer {
   display: flex;
   align-items: center;
 }
 
-.CheckboxField .input-container input[type='checkbox'] {
+.Checkbox.Field .InputContainer input[type='checkbox'] {
   -webkit-appearance: none;
   appearance: none;
   outline: none;
@@ -27,11 +24,11 @@
   cursor: pointer;
 }
 
-.CheckboxField .input-container input[type='checkbox']:checked {
+.Checkbox.Field .InputContainer input[type='checkbox']:checked {
   position: relative;
 }
 
-.CheckboxField .input-container input[type='checkbox']:checked::before {
+.Checkbox.Field .InputContainer input[type='checkbox']:checked::before {
   content: url('data:image/svg+xml;utf8,<svg width="12" height="10" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.6467 0.893333L4.22667 9.66667L3.52667 9.62L0.586667 5.46667L1.28667 4.95333L3.9 8.64L10.9467 0.333333L11.6467 0.893333Z" fill="white"/></svg>');
   font-size: 14px;
   color: var(--base-01);
@@ -40,38 +37,26 @@
   top: -1px;
 }
 
-.CheckboxField .input-container input[type='checkbox']:focus {
+.Checkbox.Field .InputContainer input[type='checkbox']:focus {
   border-color: var(--base-01);
 }
 
-.CheckboxField .input-container:not(.error):not(.disabled) input[type='checkbox']:hover:not(:focus) {
+.Checkbox.Field .InputContainer:not(.error):not(.disabled) input[type='checkbox']:hover:not(:focus) {
   border-color: var(--base-09);
 }
 
-.CheckboxField .input-container.disabled input[type='checkbox'] {
+.Checkbox.Field .InputContainer.disabled input[type='checkbox'] {
   background: var(--base-12);
   border-color: var(--base-12);
 }
-.CheckboxField .input-container label {
+.Checkbox.Field .InputContainer label {
   text-wrap: nowrap;
 }
 
-.CheckboxField .input-container.disabled label {
+.Checkbox.Field .InputContainer.disabled label {
   color: var(--base-09);
 }
 
-.CheckboxField .input-container.error input[type='checkbox'] {
+.Checkbox.Field .InputContainer.error input[type='checkbox'] {
   border-color: var(--error-main);
-}
-
-.CheckboxField .error-message {
-  display: flex;
-  align-items: center;
-  color: var(--error-main);
-  font-size: 12px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 100%;
-  min-height: 16px;
-  gap: 2px;
 }

--- a/packages/@dcl/inspector/src/components/ui/CheckboxField/CheckboxField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/CheckboxField/CheckboxField.tsx
@@ -1,14 +1,9 @@
 import React, { useCallback, useState } from 'react'
 import cx from 'classnames'
-import { IoAlertCircleOutline as AlertIcon } from 'react-icons/io5'
-
+import { ErrorMessage } from '../ErrorMessage'
 import { Props } from './types'
 
 import './CheckboxField.css'
-
-function isErrorMessage(error?: boolean | string): boolean {
-  return !!error && typeof error === 'string'
-}
 
 const CheckboxField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const { className, checked, label, error, disabled, onChange, type = 'checkbox', ...rest } = props
@@ -23,9 +18,9 @@ const CheckboxField = React.forwardRef<HTMLInputElement, Props>((props, ref) => 
   )
 
   return (
-    <div className={cx('CheckboxField', className, { disabled: disabled })}>
+    <div className={cx('Checkbox Field', className, { disabled: disabled })}>
       <div
-        className={cx('input-container', {
+        className={cx('InputContainer', {
           disabled: disabled,
           error: !!error
         })}
@@ -40,12 +35,7 @@ const CheckboxField = React.forwardRef<HTMLInputElement, Props>((props, ref) => 
         />
         <label>{label}</label>
       </div>
-      {isErrorMessage(error) && (
-        <p className="error-message">
-          <AlertIcon />
-          <span>{error}</span>
-        </p>
-      )}
+      <ErrorMessage error={error} />
     </div>
   )
 })

--- a/packages/@dcl/inspector/src/components/ui/ColorField/ColorField.css
+++ b/packages/@dcl/inspector/src/components/ui/ColorField/ColorField.css
@@ -1,18 +1,18 @@
-.ColorField {
+.Color.Field {
   display: flex;
   flex: 1;
 }
 
-.ColorField > .HybridField > .InputContainer > .DropdownContainer:first-of-type {
+.Color.Field > .HybridField > .InputContainer > .DropdownContainer:first-of-type {
   flex-grow: 0;
   width: 90px;
 }
 
-.ColorField > .HybridField > .InputContainer > *:last-child {
+.Color.Field > .HybridField > .InputContainer > *:last-child {
   flex: 1;
 }
 
-.ColorField .ColorPreview {
+.Color.Field .ColorPreview {
   height: 14px;
   width: 14px;
   border-radius: 50%;

--- a/packages/@dcl/inspector/src/components/ui/ColorField/ColorField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/ColorField/ColorField.tsx
@@ -22,7 +22,7 @@ const ColorField: React.FC<Props> = ({ label, value, onChange }) => {
     selectedOption === Options.BASICS || (isStockColor && selectedOption !== Options.CUSTOM)
 
   return (
-    <div className="ColorField">
+    <div className="Color Field">
       {label && <label>{label}</label>}
       <HybridField
         options={OPTIONS}

--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
@@ -1,17 +1,17 @@
-.DropdownContainer {
+.Dropdown.Field {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  gap: 2px;
+  gap: 6px;
 }
 
-.DropdownContainer .DropdownLabel {
+.Dropdown.Field .DropdownLabel {
   color: var(--white);
   font-size: 12px;
   font-weight: 400;
 }
 
-.DropdownContainer .Dropdown {
+.Dropdown.Field .DropdownContainer {
   position: relative;
   display: flex;
   align-items: center;
@@ -24,15 +24,15 @@
   cursor: pointer;
 }
 
-.DropdownContainer .Dropdown:hover {
+.Dropdown.Field .DropdownContainer:hover {
   border-color: var(--base-09);
 }
 
-.DropdownContainer .Dropdown.focused {
+.Dropdown.Field .DropdownContainer.focused {
   border-color: var(--base-01);
 }
 
-.DropdownContainer .Dropdown.disabled {
+.Dropdown.Field .DropdownContainer.disabled {
   background: var(--base-12);
   border-color: var(--base-12);
   color: var(--base-09);
@@ -40,20 +40,20 @@
   pointer-events: none;
 }
 
-.DropdownContainer .Dropdown.error {
+.Dropdown.Field .DropdownContainer.error {
   border-color: var(--error-main);
 }
 
-.DropdownContainer .Dropdown .DropIcon {
+.Dropdown.Field .DropdownContainer .DropIcon {
   line-height: 100%;
 }
 
-.DropdownContainer .Dropdown .DropIcon svg {
+.Dropdown.Field .DropdownContainer .DropIcon svg {
   height: 16px;
   width: 16px;
 }
 
-.DropdownContainer .Dropdown .DropdownSelectedValue {
+.Dropdown.Field .DropdownContainer .DropdownSelectedValue {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -61,7 +61,7 @@
   padding: 10px;
 }
 
-.DropdownContainer .Dropdown .DropdownOptions {
+.Dropdown.Field .DropdownContainer .DropdownOptions {
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -79,22 +79,27 @@
   box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.4);
 }
 
-.DropdownContainer .Dropdown .DropdownOptions.searchable .DropdownSearch.TextField {
+.Dropdown.Field .DropdownContainer .DropdownOptions.searchable .DropdownSearch.Text.Field {
   padding: 0px 7px 6px 7px;
 }
 
-.DropdownContainer .Dropdown .DropdownOptions.searchable {
+.Dropdown.Field .DropdownContainer .DropdownOptions.searchable {
   gap: unset;
 }
 
-.DropdownContainer
-  .Dropdown
+.Dropdown.Field
+  .DropdownContainer
   .DropdownOptions.searchable
-  .DropdownSearch.TextField
+  .DropdownSearch.Text.Field
   .InputContainer:not(.hovered):not(.focused) {
   border-color: var(--base-12);
 }
 
-.DropdownContainer > .Dropdown > .DropdownOptions > .OptionContainer.DropdownEmptyOption > .OptionContent > .Option {
+.Dropdown.Field
+  > .DropdownContainer
+  > .DropdownOptions
+  > .OptionContainer.DropdownEmptyOption
+  > .OptionContent
+  > .Option {
   text-wrap: pretty;
 }

--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
@@ -8,6 +8,7 @@
 .DropdownContainer .DropdownLabel {
   color: var(--white);
   font-size: 12px;
+  font-weight: 400;
 }
 
 .DropdownContainer .Dropdown {

--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.css
@@ -75,7 +75,9 @@
   max-height: 132px;
   overflow-y: auto;
   cursor: initial;
+  box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.4);
 }
+
 .DropdownContainer .Dropdown .DropdownOptions.searchable .DropdownSearch.TextField {
   padding: 0px 7px 6px 7px;
 }

--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.tsx
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.tsx
@@ -1,19 +1,17 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import cx from 'classnames'
 import { VscChevronDown as DownArrowIcon, VscSearch as SearchIcon } from 'react-icons/vsc'
-import { IoAlertCircleOutline as AlertIcon } from 'react-icons/io5'
 import { useOutsideClick } from '../../../hooks/useOutsideClick'
 import { TextField } from '../TextField'
-import { isErrorMessage } from '../utils'
+import { ErrorMessage } from '../ErrorMessage'
 import { Option } from './Option'
 import type { Props as OptionProp } from './Option/types'
 import type { Props } from './types'
 import './Dropdown.css'
 
-const FONT_WIDTH = 12
+const FONT_SIZE = 13
 const FONT_WEIGHT = 700
 const WIDTH_CONST = 1200
-const EMPTY_WIDTH_CONST = 1455
 const ICON_SIZE = 16
 
 function isOptionSelected(currentValue?: any, optionValue?: any) {
@@ -104,17 +102,17 @@ const Dropdown: React.FC<Props> = (props) => {
         const rightIconWidth = option.rightIcon ? ICON_SIZE + 4 : 0
         return Math.max(
           minWidth,
-          (label.length * FONT_WIDTH * FONT_WEIGHT + leftIconWidth + rightIconWidth) / WIDTH_CONST
+          (label.length * FONT_SIZE * FONT_WEIGHT + leftIconWidth + rightIconWidth) / WIDTH_CONST
         )
       }, 0)
     }
   }, [options, empty])
 
   return (
-    <div className="DropdownContainer" ref={ref}>
+    <div className="Dropdown Field" ref={ref}>
       {label ? <label className="DropdownLabel">{label}</label> : null}
       <div
-        className={cx('Dropdown', className, {
+        className={cx('DropdownContainer', className, {
           focused: isFocused,
           disabled: !!disabled,
           open: !!showOptions,
@@ -159,12 +157,7 @@ const Dropdown: React.FC<Props> = (props) => {
           <DownArrowIcon size={ICON_SIZE} />
         </div>
       </div>
-      {isErrorMessage(error) && (
-        <p className="error-message">
-          <AlertIcon />
-          <span>{error}</span>
-        </p>
-      )}
+      <ErrorMessage error={error} />
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Option/Option.css
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Option/Option.css
@@ -31,9 +31,9 @@
 
 .OptionContainer .Option {
   flex: 1;
-  font-size: 12px;
+  font-size: 13px;
   font-style: normal;
-  font-weight: 700;
+  font-weight: 500;
   text-wrap: nowrap;
 }
 

--- a/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.css
+++ b/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.css
@@ -1,11 +1,11 @@
-.FileUploadFieldContainer {
+.FileUpload.Field {
   display: flex;
   flex-direction: column;
   width: 100%;
   gap: 4px;
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer {
+.FileUpload.Field .FileUploadContainer {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -13,11 +13,11 @@
   gap: 4px;
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer .TextField {
+.FileUpload.Field .FileUploadContainer .FileUploadInput {
   margin-right: 0;
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer .FileUploadFieldButton {
+.FileUpload.Field .FileUploadContainer .FileUploadButton {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -31,22 +31,22 @@
   color: var(--base-01);
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer .FileUploadFieldButton:hover {
+.FileUpload.Field .FileUploadContainer .FileUploadButton:hover {
   border-color: var(--base-09);
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer .FileUploadFieldButton:focus {
+.FileUpload.Field .FileUploadContainer .FileUploadButton:focus {
   border-color: var(--base-01);
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer.disabled .FileUploadFieldButton {
+.FileUpload.Field .FileUploadContainer.disabled .FileUploadButton {
   pointer-events: none;
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer.droppeable .FileUploadFieldInput .input-container {
+.FileUpload.Field .FileUploadContainer.droppeable .FileUploadFieldInput .input-container {
   border: 1px dashed var(--base-01);
 }
 
-.FileUploadFieldContainer .FileUploadInputContainer > input {
+.FileUpload.Field .FileUploadContainer > input {
   display: none;
 }

--- a/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import cx from 'classnames'
 import { VscFolderOpened as FolderIcon } from 'react-icons/vsc'
-import { IoAlertCircleOutline as AlertIcon } from 'react-icons/io5'
 
 import { selectAssetCatalog } from '../../../redux/app'
 import { useAppSelector } from '../../../redux/hooks'
@@ -15,6 +14,7 @@ import { TreeNode } from '../../ProjectAssetExplorer/ProjectView'
 import { AssetNodeItem } from '../../ProjectAssetExplorer/types'
 
 import { TextField } from '../TextField'
+import { ErrorMessage } from '../ErrorMessage'
 
 import { type Props } from './types'
 
@@ -128,10 +128,10 @@ const FileUploadField: React.FC<Props> = ({
   }, [error, dropError])
 
   return (
-    <div className={cx('FileUploadFieldContainer', className)}>
-      <div className={cx('FileUploadInputContainer', { error: hasError, disabled, droppeable: canDrop })}>
+    <div className={cx('FileUpload Field', className)}>
+      <div className={cx('FileUploadContainer', { error: hasError, disabled, droppeable: canDrop })}>
         <TextField
-          className="FileUploadFieldInput"
+          className="FileUploadInput"
           ref={drop}
           placeholder="Path File"
           onChange={handleChangeTextField}
@@ -142,17 +142,12 @@ const FileUploadField: React.FC<Props> = ({
         />
         <input type="file" ref={inputRef} onChange={handleChange} accept={parseAccept(accept)} />
         {isEnabledFileExplorer && (
-          <button className="FileUploadFieldButton" onClick={handleClick} disabled={disabled}>
+          <button className="FileUploadButton" onClick={handleClick} disabled={disabled}>
             <FolderIcon size={16} />
           </button>
         )}
       </div>
-      {hasError && (
-        <div className="FileUploadFieldError">
-          <AlertIcon size={16} />
-          File not valid.
-        </div>
-      )}
+      {hasError && <ErrorMessage error={'File not valid.'} />}
     </div>
   )
 }

--- a/packages/@dcl/inspector/src/components/ui/HybridField/HybridField.css
+++ b/packages/@dcl/inspector/src/components/ui/HybridField/HybridField.css
@@ -1,15 +1,15 @@
-.HybridField > .InputContainer:has(.TextField .ErrorMessage) {
+.Hybrid.Field > .InputContainer:has(.Text.Field .ErrorMessage) {
   align-items: flex-start;
 }
 
-.HybridField {
+.Hybrid.Field {
   display: flex;
   flex-direction: column;
   flex: 1;
   gap: 4px;
 }
 
-.HybridField .InputContainer {
+.Hybrid.Field .InputContainer {
   display: flex;
   align-items: center;
   flex-grow: 1;

--- a/packages/@dcl/inspector/src/components/ui/HybridField/HybridField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/HybridField/HybridField.tsx
@@ -66,7 +66,7 @@ const HybridField: React.FC<Props> = ({
   )
 
   return (
-    <div className={cx('HybridField', className)}>
+    <div className={cx('Hybrid Field', className)}>
       <div className="InputContainer">
         <Dropdown
           options={options}

--- a/packages/@dcl/inspector/src/components/ui/RangeField/RangeField.css
+++ b/packages/@dcl/inspector/src/components/ui/RangeField/RangeField.css
@@ -2,20 +2,20 @@
   --slider-track-height: 8px;
 }
 
-.RangeFieldContainer {
+.Range.Field {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   gap: 6px;
 }
 
-.RangeFieldContainer label {
+.Range.Field label {
   color: var(--sub-text);
   font-size: 11px;
   font-weight: 400;
 }
 
-.RangeFieldContainer .RangeField {
+.Range.Field .RangeContainer {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -23,14 +23,14 @@
   gap: 8px;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer {
+.Range.Field .RangeContainer .InputContainer {
   position: relative;
   display: flex;
   width: 100%;
   left: 5px;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput {
+.Range.Field .RangeContainer .InputContainer .RangeInput {
   width: calc(100% - 15px);
   appearance: none;
   position: relative;
@@ -38,8 +38,8 @@
   outline: none;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::before,
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::after {
+.Range.Field .RangeContainer .InputContainer .RangeInput::before,
+.Range.Field .RangeContainer .InputContainer .RangeInput::after {
   content: '';
   position: absolute;
   top: -1px;
@@ -48,25 +48,25 @@
   border-radius: 50%;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::before {
+.Range.Field .RangeContainer .InputContainer .RangeInput::before {
   left: -5px;
   background: var(--accent-blue-04);
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::before {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::before {
   background: var(--base-12);
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::after {
+.Range.Field .RangeContainer .InputContainer .RangeInput::after {
   right: -5px;
   background: var(--base-11);
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::after {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::after {
   background: var(--base-11);
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-webkit-slider-runnable-track {
+.Range.Field .RangeContainer .InputContainer .RangeInput::-webkit-slider-runnable-track {
   height: var(--slider-track-height);
   appearance: none;
   background: linear-gradient(
@@ -76,26 +76,11 @@
   );
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-webkit-slider-runnable-track {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-webkit-slider-runnable-track {
   background: linear-gradient(90deg, var(--base-12) 50%, var(--base-11) 50%);
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-moz-range-track {
-  height: var(--slider-track-height);
-  appearance: none;
-  margin-top: -1px;
-  background: linear-gradient(
-    90deg,
-    var(--accent-blue-04) var(--completionPercentage, 0%),
-    var(--base-10) var(--completionPercentage, 0%)
-  );
-}
-
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-moz-range-track {
-  background: linear-gradient(90deg, var(--base-12) 50%, var(--base-11) 50%);
-}
-
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-ms-track {
+.Range.Field .RangeContainer .InputContainer .RangeInput::-moz-range-track {
   height: var(--slider-track-height);
   appearance: none;
   margin-top: -1px;
@@ -106,11 +91,26 @@
   );
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-ms-track {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-moz-range-track {
   background: linear-gradient(90deg, var(--base-12) 50%, var(--base-11) 50%);
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-webkit-slider-thumb {
+.Range.Field .RangeContainer .InputContainer .RangeInput::-ms-track {
+  height: var(--slider-track-height);
+  appearance: none;
+  margin-top: -1px;
+  background: linear-gradient(
+    90deg,
+    var(--accent-blue-04) var(--completionPercentage, 0%),
+    var(--base-10) var(--completionPercentage, 0%)
+  );
+}
+
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-ms-track {
+  background: linear-gradient(90deg, var(--base-12) 50%, var(--base-11) 50%);
+}
+
+.Range.Field .RangeContainer .InputContainer .RangeInput::-webkit-slider-thumb {
   appearance: none;
   width: 20px;
   height: 20px;
@@ -123,21 +123,21 @@
   z-index: 1;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput:focus-visible {
+.Range.Field .RangeContainer .InputContainer .RangeInput:focus-visible {
   outline: none;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput:focus::-webkit-slider-thumb {
+.Range.Field .RangeContainer .InputContainer .RangeInput:focus::-webkit-slider-thumb {
   border: 1px solid var(--base-01);
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-webkit-slider-thumb {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-webkit-slider-thumb {
   background: var(--base-12);
   left: calc(50% - 10px);
   cursor: default;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-moz-range-thumb {
+.Range.Field .RangeContainer .InputContainer .RangeInput::-moz-range-thumb {
   appearance: none;
   width: 20px;
   height: 20px;
@@ -150,17 +150,17 @@
   z-index: 1;
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput:focus::-moz-range-thumb {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput:focus::-moz-range-thumb {
   border: 1px solid var(--base-01);
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-moz-range-thumb {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-moz-range-thumb {
   background: var(--base-12);
   left: calc(50% - 10px);
   cursor: default;
 }
 
-.RangeFieldContainer .RangeField .RangeInputContainer .RangeInput::-ms-thumb {
+.Range.Field .RangeContainer .InputContainer .RangeInput::-ms-thumb {
   appearance: none;
   width: 20px;
   height: 20px;
@@ -173,16 +173,16 @@
   z-index: 1;
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput:focus::-ms-thumb {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput:focus::-ms-thumb {
   border: 1px solid var(--base-01);
 }
 
-.RangeFieldContainer .RangeField.disabled .RangeInputContainer .RangeInput::-ms-thumb {
+.Range.Field .RangeContainer.disabled .InputContainer .RangeInput::-ms-thumb {
   background: var(--base-12);
   left: calc(50% - 10px);
   cursor: default;
 }
 
-.RangeFieldContainer .RangeField .RangeTextInput {
+.Range.Field .RangeContainer .RangeTextInput > .InputContainer input {
   width: 50px;
 }

--- a/packages/@dcl/inspector/src/components/ui/RangeField/RangeField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeField/RangeField.tsx
@@ -81,10 +81,10 @@ const RangeField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   }, [inputValue, isValidValue])
 
   return (
-    <div className="RangeFieldContainer">
+    <div className="Range Field">
       {label ? <label>{label}</label> : null}
-      <div className={cx('RangeField', { error, disabled })}>
-        <div className="RangeInputContainer">
+      <div className={cx('RangeContainer', { error, disabled })}>
+        <div className="InputContainer">
           <input
             ref={ref}
             type="range"

--- a/packages/@dcl/inspector/src/components/ui/TextField/TextField.css
+++ b/packages/@dcl/inspector/src/components/ui/TextField/TextField.css
@@ -1,16 +1,12 @@
-.Block .content:has(.TextField .ErrorMessage) {
+.Block .content:has(.Text.Field .ErrorMessage) {
   align-items: baseline;
 }
 
-.TextField {
+.Text.Field {
   flex-grow: 1;
 }
 
-*:has(> .TextField + *) {
-  gap: 4px;
-}
-
-.TextField .InputContainer {
+.Text.Field .InputContainer {
   display: flex;
   align-items: center;
   position: relative;
@@ -23,33 +19,33 @@
   font-size: 12px;
 }
 
-.TextField .InputContainer.disabled {
+.Text.Field .InputContainer.disabled {
   background-color: var(--base-12);
   border-color: var(--base-12);
 }
 
-.TextField .InputContainer.disabled input {
+.Text.Field .InputContainer.disabled input {
   color: var(--base-09);
 }
 
-.TextField .InputContainer.focused {
+.Text.Field .InputContainer.focused {
   border-color: var(--base-01);
 }
 
-.TextField .InputContainer.hovered:not(.focused):not(.error) {
+.Text.Field .InputContainer.hovered:not(.focused):not(.error) {
   border-color: var(--base-09);
 }
 
-.TextField .InputContainer.error {
+.Text.Field .InputContainer.error {
   border-color: var(--error-main);
 }
 
-.TextField .InputContainer.hovered.error,
-.TextField .InputContainer.focused.error {
+.Text.Field .InputContainer.hovered.error,
+.Text.Field .InputContainer.focused.error {
   border-color: var(--error-light);
 }
 
-.TextField .InputContainer input {
+.Text.Field .InputContainer input {
   flex: 1;
   color: var(--text);
   background-color: var(--transparent);
@@ -63,45 +59,45 @@
   width: 100%;
 }
 
-.TextField .InputContainer input::placeholder {
+.Text.Field .InputContainer input::placeholder {
   color: var(--base-09);
 }
 
-.TextField .InputContainer:has(.left-content) {
+.Text.Field .InputContainer:has(.left-content) {
   padding: 0px 0px 0px 8px;
 }
 
-.TextField .InputContainer:has(.right-content) {
+.Text.Field .InputContainer:has(.right-content) {
   padding: 0px 8px 0px 0px;
 }
 
-.TextField .InputContainer .left-content,
-.TextField .InputContainer .right-content {
+.Text.Field .InputContainer .left-content,
+.Text.Field .InputContainer .right-content {
   display: flex;
   align-items: center;
   min-width: 12px;
   line-height: normal;
 }
 
-.TextField .InputContainer .left-content .input-label,
-.TextField .InputContainer .right-content .input-label {
+.Text.Field .InputContainer .left-content .input-label,
+.Text.Field .InputContainer .right-content .input-label {
   display: block;
   color: var(--base-09);
   flex-shrink: 0;
 }
 
-.TextField .InputContainer .left-content .left-icon,
-.TextField .InputContainer .right-content .right-icon {
+.Text.Field .InputContainer .left-content .left-icon,
+.Text.Field .InputContainer .right-content .right-icon {
   display: inline-flex;
   position: relative;
 }
 
-.TextField .InputContainer .left-content .left-icon svg,
-.TextField .InputContainer .right-content .right-icon svg {
+.Text.Field .InputContainer .left-content .left-icon svg,
+.Text.Field .InputContainer .right-content .right-icon svg {
   margin: 0;
 }
 
-.TextField.drop {
+.Text.Field.drop {
   border-color: white;
   border-style: dashed;
 }

--- a/packages/@dcl/inspector/src/components/ui/TextField/TextField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/TextField/TextField.tsx
@@ -94,7 +94,7 @@ const TextField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   }, [rightLabel, rightIcon])
 
   return (
-    <div className={cx('TextField', className)}>
+    <div className={cx('Text Field', className)}>
       <div
         className={cx('InputContainer', {
           hovered: isHovered,


### PR DESCRIPTION
This PR fixes a few inspector component styles.

- Remove the panel's blue border when hovering
- Adds a border radius to the components. Add button
- Decrease the Add button margin-top
- Add a shadow to the dropdown menu
- Fix the Dropdown option font size
- Adjust the gap between different fields.
- Refactor UI components class name