### PR TITLE
fix: Dropdown search empty message

### DIFF
--- a/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.tsx
+++ b/packages/@dcl/inspector/src/components/ui/Dropdown/Dropdown.tsx
@@ -92,6 +92,20 @@ const Dropdown: React.FC<Props> = (props) => {
     [searchable, search]
   )
 
+  const filteredOptiones = useMemo(() => {
+    return options.filter(filterOptions)
+  }, [options, filterOptions])
+
+  const renderEmptyMessage = useCallback(() => {
+    if (options.length > 0 && filteredOptiones.length === 0) {
+      return 'There are no results for this search.'
+    }
+
+    if (options.length === 0) {
+      return empty || 'No options available.'
+    }
+  }, [empty, options, filteredOptiones])
+
   const selectedValue = useMemo(() => {
     return options.find((option) => isOptionSelected(value, option.value))
   }, [options, value])
@@ -129,7 +143,7 @@ const Dropdown: React.FC<Props> = (props) => {
         )}
         {showOptions ? (
           <div className={cx('DropdownOptions', { searchable })}>
-            {searchable ? (
+            {searchable && options.length > 0 ? (
               <TextField
                 className="DropdownSearch"
                 placeholder="Search"
@@ -138,20 +152,18 @@ const Dropdown: React.FC<Props> = (props) => {
                 onClick={handleSearchClick}
               />
             ) : null}
-            {options.length > 0 ? (
-              options
-                .filter(filterOptions)
-                .map((option, idx) => (
-                  <Option
-                    key={idx}
-                    {...option}
-                    onClick={handleSelectOption}
-                    selected={isOptionSelected(value, option.value)}
-                    minWidth={minWidth}
-                  />
-                ))
+            {filteredOptiones.length > 0 ? (
+              filteredOptiones.map((option, idx) => (
+                <Option
+                  key={idx}
+                  {...option}
+                  onClick={handleSelectOption}
+                  selected={isOptionSelected(value, option.value)}
+                  minWidth={minWidth}
+                />
+              ))
             ) : (
-              <Option className="DropdownEmptyOption" label={empty} disabled />
+              <Option className="DropdownEmptyOption" label={renderEmptyMessage()} disabled />
             )}
           </div>
         ) : null}


### PR DESCRIPTION
This PR fixes the dropdown search flow.

- Hide the search text field when the dropdown doesn't have available options
![image](https://github.com/decentraland/js-sdk-toolchain/assets/3170051/b59424c9-8fd9-48ca-81b2-2e1f8e0c13dd)

- Show an empty message when there are no results for the search
![image](https://github.com/decentraland/js-sdk-toolchain/assets/3170051/b25ad642-2d19-4fde-9c56-4c28333a444c)
