### PR TITLE
fix: raycast helper system ray registration on short interval

### DIFF
--- a/packages/@dcl/ecs/src/systems/raycast.ts
+++ b/packages/@dcl/ecs/src/systems/raycast.ts
@@ -240,11 +240,14 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     }
   })
 
+  const nextTickRaycasts: (() => void)[] = []
   function registerRaycastWithCallback(
     entity: Entity,
     raycastValue: RaycastSystemOptions,
     callback: RaycastSystemCallback
   ) {
+    // Raycasts registration is delayed 1 frame to avoid same-frame raycast
+    // removal/adding (the client never receives the removal on those situations)
     const onNextTick = () => {
       const raycast = Raycast.createOrReplace(entity)
       raycast.maxDistance = raycastValue.maxDistance
@@ -264,8 +267,6 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     RaycastResult.deleteFrom(entity)
     entitiesCallbackResultMap.delete(entity)
   }
-
-  const nextTickRaycasts: (() => void)[] = []
 
   // @internal
   engine.addSystem(function EventSystem() {

--- a/packages/@dcl/ecs/src/systems/raycast.ts
+++ b/packages/@dcl/ecs/src/systems/raycast.ts
@@ -245,15 +245,18 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     raycastValue: RaycastSystemOptions,
     callback: RaycastSystemCallback
   ) {
-    const raycast = Raycast.getOrCreateMutable(entity)
-    raycast.maxDistance = raycastValue.maxDistance
-    raycast.originOffset = raycastValue.originOffset
-    raycast.collisionMask = raycastValue.collisionMask
-    raycast.direction = raycastValue.directionRawValue
-    raycast.continuous = raycastValue.continuous
-    raycast.queryType = raycastValue.queryType
+    const onNextTick = () => {
+      const raycast = Raycast.createOrReplace(entity)
+      raycast.maxDistance = raycastValue.maxDistance
+      raycast.originOffset = raycastValue.originOffset
+      raycast.collisionMask = raycastValue.collisionMask
+      raycast.direction = raycastValue.directionRawValue
+      raycast.continuous = raycastValue.continuous
+      raycast.queryType = raycastValue.queryType
 
-    entitiesCallbackResultMap.set(entity, { callback: callback })
+      entitiesCallbackResultMap.set(entity, { callback: callback })
+    }
+    nextTickRaycasts.push(onNextTick)
   }
 
   function removeRaycast(entity: Entity) {
@@ -262,8 +265,15 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     entitiesCallbackResultMap.delete(entity)
   }
 
+  const nextTickRaycasts: (() => void)[] = []
+
   // @internal
   engine.addSystem(function EventSystem() {
+    for (const addMissingRaycast of nextTickRaycasts) {
+      addMissingRaycast()
+    }
+    nextTickRaycasts.length = 0
+
     for (const [entity, data] of entitiesCallbackResultMap) {
       const raycast = Raycast.getOrNull(entity)
       if (engine.getEntityState(entity) === EntityState.Removed || !raycast) {

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -92,10 +92,16 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for LocalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -112,10 +118,16 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
+    raycastHelperSystem.registerGlobalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -132,10 +144,16 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for GlobalTarget', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, fn, {
-      target: Vector3.create(10, 10, 10),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
+    raycastHelperSystem.registerGlobalTargetRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          target: Vector3.create(10, 10, 10),
+          queryType: RaycastQueryType.RQT_HIT_FIRST
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -154,10 +172,16 @@ describe('Raycast Helper System should', () => {
     const targetEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, fn, {
-      targetEntity: targetEntity,
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
+    raycastHelperSystem.registerTargetEntityRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          targetEntity: targetEntity,
+          queryType: RaycastQueryType.RQT_HIT_FIRST
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -174,18 +198,30 @@ describe('Raycast Helper System should', () => {
   it('remove raycast and raycastResult of non-continuous raycast entity', async () => {
     const continuousRaycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(continuousRaycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST,
-      continuous: true
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: continuousRaycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST,
+          continuous: true
+        }
+      },
+      fn
+    )
 
     const nonContinuousRaycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast(nonContinuousRaycastEntity, (_result) => {}, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST,
-      continuous: false
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: nonContinuousRaycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST,
+          continuous: false
+        }
+      },
+      (_result) => {}
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(continuousRaycastEntity, {
@@ -219,11 +255,17 @@ describe('Raycast Helper System should', () => {
     const raycastEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Zero(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST,
-      continuous: true
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Zero(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST,
+          continuous: true
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -251,11 +293,17 @@ describe('Raycast Helper System should', () => {
     const raycastEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Zero(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST,
-      continuous: true
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Zero(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST,
+          continuous: true
+        }
+      },
+      fn
+    )
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -281,10 +329,16 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for LocalDirection', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, (_result) => {}, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_QUERY_ALL
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+            direction: Vector3.Forward(),
+            queryType: RaycastQueryType.RQT_QUERY_ALL
+        }
+      },
+      (_result) => {}
+    )
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -300,7 +354,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for LocalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, (_result) => {})
+    raycastHelperSystem.registerLocalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -316,10 +370,16 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, (_result) => {}, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_QUERY_ALL
-    })
+    raycastHelperSystem.registerGlobalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_QUERY_ALL
+        }
+      },
+      (_result) => {}
+    )
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -335,7 +395,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, (_result) => {})
+    raycastHelperSystem.registerGlobalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -352,10 +412,16 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for GlobalTarget', async () => {
     const raycastEntity = engine.addEntity()
     const globalTarget: Vector3 = Vector3.create(15, 8, 6)
-    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, (_result) => {}, {
-      target: globalTarget,
-      queryType: RaycastQueryType.RQT_QUERY_ALL
-    })
+    raycastHelperSystem.registerGlobalTargetRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          target: globalTarget,
+          queryType: RaycastQueryType.RQT_QUERY_ALL
+        }
+      },
+      (_result) => {}
+    )
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -371,7 +437,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalTarget without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, (_result) => {})
+    raycastHelperSystem.registerGlobalTargetRaycast({ entity: raycastEntity }, (_result) => {})
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -388,10 +454,16 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for TargetEntity', async () => {
     const raycastEntity = engine.addEntity()
     const targetEntity = engine.addEntity()
-    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, (_result) => {}, {
-      targetEntity: targetEntity,
-      queryType: RaycastQueryType.RQT_QUERY_ALL
-    })
+    raycastHelperSystem.registerTargetEntityRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          targetEntity: targetEntity,
+          queryType: RaycastQueryType.RQT_QUERY_ALL
+        }
+      },
+      (_result) => {}
+    )
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -407,7 +479,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for TargetEntity without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, (_result) => {})
+    raycastHelperSystem.registerTargetEntityRaycast({ entity: raycastEntity }, (_result) => {})
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -424,10 +496,16 @@ describe('Raycast Helper System should', () => {
   it('wait until entity has raycastResult to run callback', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
+    raycastHelperSystem.registerLocalDirectionRaycast(
+      {
+        entity: raycastEntity,
+        opts: {
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_HIT_FIRST
+        }
+      },
+      fn
+    )
 
     // update without raycastResult attachment
     await engine.update(1)

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -340,6 +340,8 @@ describe('Raycast Helper System should', () => {
       (_result) => {}
     )
 
+    await engine.update(1)
+
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
     expect(attachedRaycast.direction).toEqual({
@@ -355,6 +357,8 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for LocalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
     raycastHelperSystem.registerLocalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
+
+    await engine.update(1)
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -381,6 +385,8 @@ describe('Raycast Helper System should', () => {
       (_result) => {}
     )
 
+    await engine.update(1)
+
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
     expect(attachedRaycast.direction).toEqual({
@@ -396,6 +402,8 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for GlobalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
     raycastHelperSystem.registerGlobalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
+
+    await engine.update(1)
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -423,6 +431,8 @@ describe('Raycast Helper System should', () => {
       (_result) => {}
     )
 
+    await engine.update(1)
+
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
     expect(attachedRaycast.direction).toEqual({
@@ -438,6 +448,8 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for GlobalTarget without opts', async () => {
     const raycastEntity = engine.addEntity()
     raycastHelperSystem.registerGlobalTargetRaycast({ entity: raycastEntity }, (_result) => {})
+
+    await engine.update(1)
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
@@ -465,6 +477,8 @@ describe('Raycast Helper System should', () => {
       (_result) => {}
     )
 
+    await engine.update(1)
+
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)
     expect(attachedRaycast.direction).toEqual({
@@ -480,6 +494,8 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for TargetEntity without opts', async () => {
     const raycastEntity = engine.addEntity()
     raycastHelperSystem.registerTargetEntityRaycast({ entity: raycastEntity }, (_result) => {})
+
+    await engine.update(1)
 
     const attachedRaycast = raycastComponent.get(raycastEntity)
     expect(attachedRaycast.continuous).toBe(false)

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -115,6 +115,26 @@ describe('Raycast Helper System should', () => {
     expect(fn).toHaveBeenCalled()
   })
 
+  it('run callback on raycast result for LocalDirection (deprecated symbol)', async () => {
+    const raycastEntity = engine.addEntity()
+    const fn = jest.fn()
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
+
+    // Simulate client-side result attachment
+    raycastResultComponent.create(raycastEntity, {
+      hits: [],
+      direction: Vector3.Zero(),
+      globalOrigin: Vector3.Zero(),
+      tickNumber: 0
+    })
+
+    await engine.update(1)
+    expect(fn).toHaveBeenCalled()
+  })
+
   it('run callback on raycast result for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
@@ -128,6 +148,26 @@ describe('Raycast Helper System should', () => {
       },
       fn
     )
+
+    // Simulate client-side result attachment
+    raycastResultComponent.create(raycastEntity, {
+      hits: [],
+      direction: Vector3.Zero(),
+      globalOrigin: Vector3.Zero(),
+      tickNumber: 0
+    })
+
+    await engine.update(1)
+    expect(fn).toHaveBeenCalled()
+  })
+
+  it('run callback on raycast result for GlobalDirection (deprecated symbol)', async () => {
+    const raycastEntity = engine.addEntity()
+    const fn = jest.fn()
+    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -167,6 +207,26 @@ describe('Raycast Helper System should', () => {
     expect(fn).toHaveBeenCalled()
   })
 
+  it('run callback on raycast result for GlobalTarget (deprecated symbol)', async () => {
+    const raycastEntity = engine.addEntity()
+    const fn = jest.fn()
+    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, fn, {
+      target: Vector3.create(10, 10, 10),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
+
+    // Simulate client-side result attachment
+    raycastResultComponent.create(raycastEntity, {
+      hits: [],
+      direction: Vector3.Zero(),
+      globalOrigin: Vector3.Zero(),
+      tickNumber: 0
+    })
+
+    await engine.update(1)
+    expect(fn).toHaveBeenCalled()
+  })
+
   it('run callback on raycast result for TargetEntity', async () => {
     const raycastEntity = engine.addEntity()
     const targetEntity = engine.addEntity()
@@ -182,6 +242,28 @@ describe('Raycast Helper System should', () => {
       },
       fn
     )
+
+    // Simulate client-side result attachment
+    raycastResultComponent.create(raycastEntity, {
+      hits: [],
+      direction: Vector3.Zero(),
+      globalOrigin: Vector3.Zero(),
+      tickNumber: 0
+    })
+
+    await engine.update(1)
+    expect(fn).toHaveBeenCalled()
+  })
+
+  it('run callback on raycast result for TargetEntity (deprecated symbol)', async () => {
+    const raycastEntity = engine.addEntity()
+    const targetEntity = engine.addEntity()
+
+    const fn = jest.fn()
+    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, fn, {
+      targetEntity: targetEntity,
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -333,8 +333,8 @@ describe('Raycast Helper System should', () => {
       {
         entity: raycastEntity,
         opts: {
-            direction: Vector3.Forward(),
-            queryType: RaycastQueryType.RQT_QUERY_ALL
+          direction: Vector3.Forward(),
+          queryType: RaycastQueryType.RQT_QUERY_ALL
         }
       },
       (_result) => {}
@@ -525,6 +525,7 @@ describe('Raycast Helper System should', () => {
 
     // update without raycastResult attachment
     await engine.update(1)
+    await engine.update(1)
     expect(fn).toHaveBeenCalledTimes(0)
 
     // Simulate client-side result attachment
@@ -537,5 +538,16 @@ describe('Raycast Helper System should', () => {
 
     await engine.update(1)
     expect(fn).toHaveBeenCalled()
+  })
+
+  it('attach raycast component after 1 frame', async () => {
+    const raycastEntity = engine.addEntity()
+    raycastHelperSystem.registerGlobalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
+
+    expect(raycastComponent.getOrNull(raycastEntity)).toBeUndefined()
+
+    await engine.update(1)
+
+    expect(raycastComponent.getOrNull(raycastEntity)).toBeDefined()
   })
 })

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -239,16 +239,16 @@ describe('Raycast Helper System should', () => {
 
     await engine.update(1)
 
-    expect(raycastResultComponent.getOrNull(continuousRaycastEntity)).toBeDefined()
-    expect(raycastComponent.getOrNull(continuousRaycastEntity)).toBeDefined()
+    expect(raycastResultComponent.getOrNull(continuousRaycastEntity)).not.toBeNull()
+    expect(raycastComponent.getOrNull(continuousRaycastEntity)).not.toBeNull()
     expect(raycastResultComponent.getOrNull(nonContinuousRaycastEntity)).toBeNull()
     expect(raycastComponent.getOrNull(nonContinuousRaycastEntity)).toBeNull()
 
     await engine.update(1)
 
     expect(fn).toHaveBeenCalledTimes(2)
-    expect(raycastResultComponent.getOrNull(continuousRaycastEntity)).toBeDefined()
-    expect(raycastComponent.getOrNull(continuousRaycastEntity)).toBeDefined()
+    expect(raycastResultComponent.getOrNull(continuousRaycastEntity)).not.toBeNull()
+    expect(raycastComponent.getOrNull(continuousRaycastEntity)).not.toBeNull()
   })
 
   it('remove raycast entity correctly', async () => {
@@ -544,10 +544,10 @@ describe('Raycast Helper System should', () => {
     const raycastEntity = engine.addEntity()
     raycastHelperSystem.registerGlobalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
 
-    expect(raycastComponent.getOrNull(raycastEntity)).toBeUndefined()
+    expect(raycastComponent.getOrNull(raycastEntity)).toBeNull()
 
     await engine.update(1)
 
-    expect(raycastComponent.getOrNull(raycastEntity)).toBeDefined()
+    expect(raycastComponent.getOrNull(raycastEntity)).not.toBeNull()
   })
 })

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -115,26 +115,6 @@ describe('Raycast Helper System should', () => {
     expect(fn).toHaveBeenCalled()
   })
 
-  it('run callback on raycast result for LocalDirection (deprecated symbol)', async () => {
-    const raycastEntity = engine.addEntity()
-    const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
-
-    // Simulate client-side result attachment
-    raycastResultComponent.create(raycastEntity, {
-      hits: [],
-      direction: Vector3.Zero(),
-      globalOrigin: Vector3.Zero(),
-      tickNumber: 0
-    })
-
-    await engine.update(1)
-    expect(fn).toHaveBeenCalled()
-  })
-
   it('run callback on raycast result for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
@@ -148,26 +128,6 @@ describe('Raycast Helper System should', () => {
       },
       fn
     )
-
-    // Simulate client-side result attachment
-    raycastResultComponent.create(raycastEntity, {
-      hits: [],
-      direction: Vector3.Zero(),
-      globalOrigin: Vector3.Zero(),
-      tickNumber: 0
-    })
-
-    await engine.update(1)
-    expect(fn).toHaveBeenCalled()
-  })
-
-  it('run callback on raycast result for GlobalDirection (deprecated symbol)', async () => {
-    const raycastEntity = engine.addEntity()
-    const fn = jest.fn()
-    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, fn, {
-      direction: Vector3.Forward(),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -207,26 +167,6 @@ describe('Raycast Helper System should', () => {
     expect(fn).toHaveBeenCalled()
   })
 
-  it('run callback on raycast result for GlobalTarget (deprecated symbol)', async () => {
-    const raycastEntity = engine.addEntity()
-    const fn = jest.fn()
-    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, fn, {
-      target: Vector3.create(10, 10, 10),
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
-
-    // Simulate client-side result attachment
-    raycastResultComponent.create(raycastEntity, {
-      hits: [],
-      direction: Vector3.Zero(),
-      globalOrigin: Vector3.Zero(),
-      tickNumber: 0
-    })
-
-    await engine.update(1)
-    expect(fn).toHaveBeenCalled()
-  })
-
   it('run callback on raycast result for TargetEntity', async () => {
     const raycastEntity = engine.addEntity()
     const targetEntity = engine.addEntity()
@@ -242,28 +182,6 @@ describe('Raycast Helper System should', () => {
       },
       fn
     )
-
-    // Simulate client-side result attachment
-    raycastResultComponent.create(raycastEntity, {
-      hits: [],
-      direction: Vector3.Zero(),
-      globalOrigin: Vector3.Zero(),
-      tickNumber: 0
-    })
-
-    await engine.update(1)
-    expect(fn).toHaveBeenCalled()
-  })
-
-  it('run callback on raycast result for TargetEntity (deprecated symbol)', async () => {
-    const raycastEntity = engine.addEntity()
-    const targetEntity = engine.addEntity()
-
-    const fn = jest.fn()
-    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, fn, {
-      targetEntity: targetEntity,
-      queryType: RaycastQueryType.RQT_HIT_FIRST
-    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {

--- a/test/ecs/events/raycastHelperSystem.spec.ts
+++ b/test/ecs/events/raycastHelperSystem.spec.ts
@@ -92,16 +92,10 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for LocalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -118,16 +112,10 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerGlobalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -144,16 +132,10 @@ describe('Raycast Helper System should', () => {
   it('run callback on raycast result for GlobalTarget', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerGlobalTargetRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          target: Vector3.create(10, 10, 10),
-          queryType: RaycastQueryType.RQT_HIT_FIRST
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, fn, {
+      target: Vector3.create(10, 10, 10),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -172,16 +154,10 @@ describe('Raycast Helper System should', () => {
     const targetEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerTargetEntityRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          targetEntity: targetEntity,
-          queryType: RaycastQueryType.RQT_HIT_FIRST
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, fn, {
+      targetEntity: targetEntity,
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -198,30 +174,18 @@ describe('Raycast Helper System should', () => {
   it('remove raycast and raycastResult of non-continuous raycast entity', async () => {
     const continuousRaycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: continuousRaycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST,
-          continuous: true
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(continuousRaycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      continuous: true
+    })
 
     const nonContinuousRaycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: nonContinuousRaycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST,
-          continuous: false
-        }
-      },
-      (_result) => {}
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(nonContinuousRaycastEntity, (_result) => {}, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      continuous: false
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(continuousRaycastEntity, {
@@ -255,17 +219,11 @@ describe('Raycast Helper System should', () => {
     const raycastEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Zero(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST,
-          continuous: true
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Zero(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      continuous: true
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -293,17 +251,11 @@ describe('Raycast Helper System should', () => {
     const raycastEntity = engine.addEntity()
 
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Zero(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST,
-          continuous: true
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Zero(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      continuous: true
+    })
 
     // Simulate client-side result attachment
     raycastResultComponent.create(raycastEntity, {
@@ -329,16 +281,10 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for LocalDirection', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_QUERY_ALL
-        }
-      },
-      (_result) => {}
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, (_result) => {}, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_QUERY_ALL
+    })
 
     await engine.update(1)
 
@@ -356,7 +302,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for LocalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerLocalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, (_result) => {})
 
     await engine.update(1)
 
@@ -374,16 +320,10 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalDirection', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_QUERY_ALL
-        }
-      },
-      (_result) => {}
-    )
+    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, (_result) => {}, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_QUERY_ALL
+    })
 
     await engine.update(1)
 
@@ -401,7 +341,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalDirection without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalDirectionRaycast({ entity: raycastEntity }, (_result) => {})
+    raycastHelperSystem.registerGlobalDirectionRaycast(raycastEntity, (_result) => {})
 
     await engine.update(1)
 
@@ -420,16 +360,10 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for GlobalTarget', async () => {
     const raycastEntity = engine.addEntity()
     const globalTarget: Vector3 = Vector3.create(15, 8, 6)
-    raycastHelperSystem.registerGlobalTargetRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          target: globalTarget,
-          queryType: RaycastQueryType.RQT_QUERY_ALL
-        }
-      },
-      (_result) => {}
-    )
+    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, (_result) => {}, {
+      target: globalTarget,
+      queryType: RaycastQueryType.RQT_QUERY_ALL
+    })
 
     await engine.update(1)
 
@@ -447,7 +381,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for GlobalTarget without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerGlobalTargetRaycast({ entity: raycastEntity }, (_result) => {})
+    raycastHelperSystem.registerGlobalTargetRaycast(raycastEntity, (_result) => {})
 
     await engine.update(1)
 
@@ -466,16 +400,10 @@ describe('Raycast Helper System should', () => {
   it('create default values correctly for TargetEntity', async () => {
     const raycastEntity = engine.addEntity()
     const targetEntity = engine.addEntity()
-    raycastHelperSystem.registerTargetEntityRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          targetEntity: targetEntity,
-          queryType: RaycastQueryType.RQT_QUERY_ALL
-        }
-      },
-      (_result) => {}
-    )
+    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, (_result) => {}, {
+      targetEntity: targetEntity,
+      queryType: RaycastQueryType.RQT_QUERY_ALL
+    })
 
     await engine.update(1)
 
@@ -493,7 +421,7 @@ describe('Raycast Helper System should', () => {
 
   it('create default values correctly for TargetEntity without opts', async () => {
     const raycastEntity = engine.addEntity()
-    raycastHelperSystem.registerTargetEntityRaycast({ entity: raycastEntity }, (_result) => {})
+    raycastHelperSystem.registerTargetEntityRaycast(raycastEntity, (_result) => {})
 
     await engine.update(1)
 
@@ -512,16 +440,10 @@ describe('Raycast Helper System should', () => {
   it('wait until entity has raycastResult to run callback', async () => {
     const raycastEntity = engine.addEntity()
     const fn = jest.fn()
-    raycastHelperSystem.registerLocalDirectionRaycast(
-      {
-        entity: raycastEntity,
-        opts: {
-          direction: Vector3.Forward(),
-          queryType: RaycastQueryType.RQT_HIT_FIRST
-        }
-      },
-      fn
-    )
+    raycastHelperSystem.registerLocalDirectionRaycast(raycastEntity, fn, {
+      direction: Vector3.Forward(),
+      queryType: RaycastQueryType.RQT_HIT_FIRST
+    })
 
     // update without raycastResult attachment
     await engine.update(1)


### PR DESCRIPTION
The problem reported in the related issue was happening because if a very short interval is used to register a non-continuous raycast with the helper raycst system, it may happen that the raycast is removed from the entity (when the raycast result is read by the helper system) and in the same frame a new raycast is registered on the same entity, thus resulting in only a `putComponent()` instruction coming out  of the scene runtime, in that situation the client never gets the `removeComponent()` call, and the new raycast registration is never effective, stopping any new raycast result on the entity.

Issue: https://github.com/decentraland/sdk/issues/993

* Added 1 frame delay when registering raycasts using the helper system
* Added pertinent test