### PR TITLE
fix: Colliders when settings visibility

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.6.0"
+        "@dcl/asset-packs": "^1.7.0"
       },
       "devDependencies": {
         "@babylonjs/core": "^6.18.0",
@@ -284,9 +284,9 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.6.0.tgz",
-      "integrity": "sha512-Ntm7hrH+9u779BeQP3RLvZ9GBkvpha8n+BjUspHKLeCy3czMbDeEp2nrnGfzAwoeCFv3Zqucxd422agcM/TB8A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.7.0.tgz",
+      "integrity": "sha512-HMKd3uSyw/9p2FPebMS9LsZCwUpseTxru2q5IAty+IShtjNGb696NLaVfqrh93nEbnddAGz01/taPoy6C2IAcA==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.30",
@@ -7929,9 +7929,9 @@
       "integrity": "sha512-zA3Q+O+fW1U4soYcTAxYr3ASD8Rl555hHoUF2cAJBbM73fd2G2wDUGnCjZCsq56wbOXMIIZqw1ynKy6Q/yQAZQ=="
     },
     "@dcl/asset-packs": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.6.0.tgz",
-      "integrity": "sha512-Ntm7hrH+9u779BeQP3RLvZ9GBkvpha8n+BjUspHKLeCy3czMbDeEp2nrnGfzAwoeCFv3Zqucxd422agcM/TB8A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.7.0.tgz",
+      "integrity": "sha512-HMKd3uSyw/9p2FPebMS9LsZCwUpseTxru2q5IAty+IShtjNGb696NLaVfqrh93nEbnddAGz01/taPoy6C2IAcA==",
       "requires": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.30",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^1.6.0"
+    "@dcl/asset-packs": "^1.7.0"
   },
   "devDependencies": {
     "@babylonjs/core": "^6.18.0",

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/SetVisibilityAction/SetVisibilityAction.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/SetVisibilityAction/SetVisibilityAction.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { ActionPayload, ActionType } from '@dcl/asset-packs'
+import { ActionPayload, ActionType, Colliders } from '@dcl/asset-packs'
 import { recursiveCheck } from 'jest-matcher-deep-close-to/lib/recursiveCheck'
 import { Block } from '../../../Block'
-import { Dropdown } from '../../../ui/Dropdown'
+import { Dropdown, InfoTooltip } from '../../../ui'
+import { COLLISION_LAYERS } from '../../GltfInspector/utils'
 import type { Props } from './types'
 
 import './SetVisibilityAction.css'
@@ -25,17 +26,30 @@ const SetVisibilityAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
 
   const handleSetVisible = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) => {
-      setPayload({ ...payload, visible: value === 'true' })
+      const visible = value === 'true'
+      setPayload({
+        ...payload,
+        visible,
+        collider: visible ? payload.collider : Colliders.CL_NONE
+      })
     },
     [payload, setPayload]
   )
 
   const handleChangeCollider = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLSelectElement>) => {
-      setPayload({ ...payload, physicsCollider: value === 'true' })
+      setPayload({ ...payload, collider: parseInt(value, 10) })
     },
     [payload, setPayload]
   )
+
+  const renderPhysicsCollidersMoreInfo = useCallback(() => {
+    return (
+      <InfoTooltip
+        text={'Use the Collider property to turn on or off physical or clickable interaction with this item.'}
+      />
+    )
+  }, [])
 
   return (
     <Block className="SetVisibilityActionContainer">
@@ -50,12 +64,10 @@ const SetVisibilityAction: React.FC<Props> = ({ value, onUpdate }: Props) => {
       />
 
       <Dropdown
-        label="Select Physics Collider"
-        options={[
-          { value: 'true', label: 'Enabled' },
-          { value: 'false', label: 'Disabled' }
-        ]}
-        value={(payload.physicsCollider ?? false).toString()}
+        label={<>Collider {renderPhysicsCollidersMoreInfo()}</>}
+        placeholder="Select Collider"
+        options={COLLISION_LAYERS}
+        value={payload.collider}
         onChange={handleChangeCollider}
       />
     </Block>

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -65,7 +65,7 @@
     "../inspector": {
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.5.0"
+        "@dcl/asset-packs": "^1.7.0"
       },
       "devDependencies": {
         "@babylonjs/core": "^6.18.0",
@@ -3137,7 +3137,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^1.5.0",
+        "@dcl/asset-packs": "^1.7.0",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",


### PR DESCRIPTION
This PR updates the colliders dropdown by default to `none` when setting an action with `visibility: false`

Closes: https://github.com/decentraland/sdk/issues/981

Depends on: https://github.com/decentraland/asset-packs/pull/86