### PR TITLE
chore: include comment blocks in apis' methods

### DIFF
--- a/scripts/utils/stringParser.ts
+++ b/scripts/utils/stringParser.ts
@@ -22,3 +22,84 @@ export function getBlock(str: string, fromPosition: number) {
     return ''
   }
 }
+
+type Line = {
+  // First index after \n
+  start: number
+  // the previous index of \n
+  end: number
+  // line properties
+  isEmpty: boolean
+  isPureComment: boolean
+  content: string
+}
+
+// Only support, lines with //, or /** this */ or /** and the end of block in another line */
+// It doesn't support `/** comment */ const code = 'some' /** multi comment block in one line */`
+export function parseFileLines(content: string): Line[] {
+  const contentLines = content.split('\n')
+  const lines: Line[] = []
+  let commentBlockStarted = false
+  let currentIndex = 0
+
+  for (const contentLine of contentLines) {
+    const thisLine: Line = {
+      start: currentIndex,
+      end: currentIndex + contentLine.length,
+      isEmpty: false,
+      isPureComment: false,
+      content: contentLine
+    }
+    currentIndex += contentLine.length + 1
+
+    const trimmedLine = contentLine.trim()
+    if (trimmedLine.startsWith('/*') || commentBlockStarted) {
+      const endOfCommentBlock = trimmedLine.indexOf('*/')
+      if (endOfCommentBlock !== -1) {
+        thisLine.isPureComment = true
+        commentBlockStarted = false
+      } else {
+        commentBlockStarted = true
+      }
+      thisLine.isPureComment = true
+    } else if (trimmedLine.startsWith('//')) {
+      thisLine.isPureComment = true
+    } else {
+      commentBlockStarted = false
+    }
+
+    lines.push(thisLine)
+  }
+
+  return lines
+}
+
+export function getLineByIndex(lines: Line[], index: number): number {
+  return lines.findIndex((line) => index >= line.start && index <= line.end)
+}
+
+export function getCommentBeforeAt(lines: Line[], index: number): string | undefined {
+  if (index === -1) return
+
+  let lineIndex = getLineByIndex(lines, index)
+  if (lineIndex === -1) return
+
+  lineIndex -= 1
+  const commentLines: Line[] = []
+  while (lineIndex >= 0) {
+    if (lines[lineIndex].isPureComment || lines[lineIndex].isEmpty) {
+      commentLines.push(lines[lineIndex])
+      lineIndex -= 1
+    } else {
+      break
+    }
+  }
+
+  const comments = commentLines
+    .reverse()
+    .map((item) => item.content)
+    .join('\n')
+  if (comments.length === 0) return
+
+  return comments
+}


### PR DESCRIPTION
Include comment blocks from the protocol specification into the `apis.d.ts` file

## Example with `~system/Runtime`

Before 
```typescript
	// Function declaration section
        export function getRealm(body: GetRealmRequest): Promise<GetRealmResponse>;
    export function getWorldTime(body: GetWorldTimeRequest): Promise<GetWorldTimeResponse>;
    export function readFile(body: ReadFileRequest): Promise<ReadFileResponse>;
    export function getSceneInformation(body: CurrentSceneEntityRequest): Promise<CurrentSceneEntityResponse>;
```
![imagen](https://github.com/decentraland/js-sdk-toolchain/assets/8042536/220b0b51-5dff-4d68-9d7b-33a8a2b95ffe)


Now
```typescript
	// Function declaration section
        /** Provides information about the current realm */
    export function getRealm(body: GetRealmRequest): Promise<GetRealmResponse>;
    /**
     * Provides information about the Decentraland Time, which is coordinated
     * across players.
     */
    export function getWorldTime(body: GetWorldTimeRequest): Promise<GetWorldTimeResponse>;
    /**
     * Returns the file content of a deployed asset. If the file doesn't
     * exist or cannot be retrieved, the RPC call throws an error.
     * This method is called to load any assets deployed among the scene,
     * runtime may cache this response much more than the provided "fetch" function.
     */
    export function readFile(body: ReadFileRequest): Promise<ReadFileResponse>;
    /** Returns information about the current scene. This is the replacement of GetBootstrapData */
    export function getSceneInformation(body: CurrentSceneEntityRequest): Promise<CurrentSceneEntityResponse>;
```
![imagen](https://github.com/decentraland/js-sdk-toolchain/assets/8042536/dc02b5f5-b08d-4c83-aace-6185bcb9b671)
