### PR TITLE
fix: hide colliders

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -297,7 +297,7 @@ function processColliders($: BABYLON.AssetContainer) {
   for (let i = 0; i < $.meshes.length; i++) {
     const mesh = $.meshes[i]
 
-    if (mesh.name.toLowerCase().endsWith('collider')) {
+    if (mesh.name.toLowerCase().includes('collider')) {
       mesh.checkCollisions = true
       mesh.visibility = 0
       mesh.isPickable = false


### PR DESCRIPTION
This fixes some issues in Templates where the colliders are named like `_collider.01` and where not properly removed in the inspector, even though they are hidden by the client.