### PR TITLE
feat: Add lock and hide inspector components

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/EntityInspector.tsx
@@ -59,13 +59,13 @@ export const EntityInspector = withSdk(({ sdk }) => {
   const inspectors = useMemo(
     () => [
       { name: sdk.components.GltfContainer.componentName, component: GltfInspector },
+      { name: sdk.components.Transform.componentName, component: TransformInspector },
       { name: sdk.components.VisibilityComponent.componentName, component: VisibilityComponentInspector },
       { name: sdk.components.Material.componentName, component: MaterialInspector },
       { name: sdk.components.MeshCollider.componentName, component: MeshColliderInspector },
       { name: sdk.components.MeshRenderer.componentName, component: MeshRendererInspector },
       { name: sdk.components.Scene.componentName, component: SceneInspector },
       { name: sdk.components.TextShape.componentName, component: TextShapeInspector },
-      { name: sdk.components.Transform.componentName, component: TransformInspector },
       { name: sdk.components.Actions.componentName, component: ActionInspector },
       { name: sdk.components.Triggers.componentName, component: TriggerInspector },
       { name: sdk.components.States.componentName, component: StatesInspector },

--- a/packages/@dcl/inspector/src/components/Tree/ActionArea/ActionArea.css
+++ b/packages/@dcl/inspector/src/components/Tree/ActionArea/ActionArea.css
@@ -1,0 +1,30 @@
+.action-area {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  column-gap: 4px;
+  visibility: hidden;
+}
+
+.Tree .item:hover:not(:has(input)) .selectable-area .action-area .action-button {
+  visibility: visible;
+}
+
+.action-area .action-button .unlock-icon > path:last-of-type,
+.action-area .action-button .visible-icon > circle,
+.action-area .action-button .visible-icon > path,
+.action-area .action-button .invisible-icon > circle,
+.action-area .action-button .invisible-icon > path {
+  color: var(--base-02);
+}
+
+.Tree .item:not(:has(input)) .selectable-area .action-area .action-button .lock-icon,
+.Tree .item:not(:has(input)) .selectable-area .action-area .action-button .invisible-icon {
+  visibility: visible;
+}
+
+.Tree .item .selectable-area:has(.action-area .action-button .invisible-icon),
+.Tree .item .selectable-area .action-area .action-button .invisible-icon > path {
+  color: var(--base-06);
+}

--- a/packages/@dcl/inspector/src/components/Tree/ActionArea/ActionArea.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/ActionArea/ActionArea.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useMemo } from 'react'
+import { IoEyeOutline as VisibleIcon, IoEyeOffOutline as InvisibleIcon } from 'react-icons/io5'
+import { MdOutlineLock as LockIcon, MdOutlineLockOpen as UnlockIcon } from 'react-icons/md'
+import { Entity, LastWriteWinElementSetComponentDefinition } from '@dcl/ecs'
+
+import { WithSdkProps, withSdk } from '../../../hoc/withSdk'
+import { useEntityComponent } from '../../../hooks/sdk/useEntityComponent'
+import { SdkContextValue } from '../../../lib/sdk/context'
+import './ActionArea.css'
+
+type Props = {
+  entity: Entity
+}
+
+const ActionArea: React.FC<WithSdkProps & Props> = ({ sdk, ...props }) => {
+  const {
+    components: { Lock, Hide }
+  } = sdk
+  const { entity } = props
+  const { addComponent, removeComponent } = useEntityComponent()
+
+  const isEntityLocked = useMemo(() => {
+    return Lock.getOrNull(entity) !== null
+  }, [entity, sdk])
+
+  const isEntityHidden = useMemo(() => {
+    return Hide.getOrNull(entity) !== null
+  }, [entity, sdk])
+
+  const handleToggleHideComponent = useCallback(() => {
+    if (isEntityHidden) {
+      removeComponent(
+        entity,
+        Hide as unknown as LastWriteWinElementSetComponentDefinition<SdkContextValue['components']>
+      )
+    } else {
+      addComponent(entity, Hide.componentId, { value: true })
+    }
+  }, [entity, sdk, isEntityHidden])
+
+  const handleToggleLockComponent = useCallback(() => {
+    if (isEntityLocked) {
+      removeComponent(
+        entity,
+        Lock as unknown as LastWriteWinElementSetComponentDefinition<SdkContextValue['components']>
+      )
+    } else {
+      addComponent(entity, Lock.componentId, { value: true })
+    }
+  }, [sdk, isEntityLocked])
+
+  const toggleLockButton = useCallback(() => {
+    return (
+      <div className="action-button">
+        {isEntityLocked ? (
+          <LockIcon className="lock-icon" size={16} onClick={handleToggleLockComponent} />
+        ) : (
+          <UnlockIcon className="unlock-icon" size={16} onClick={handleToggleLockComponent} />
+        )}
+      </div>
+    )
+  }, [isEntityLocked, handleToggleLockComponent])
+
+  const toggleVisibleButton = useCallback(() => {
+    return (
+      <div className="action-button">
+        {isEntityHidden ? (
+          <InvisibleIcon className="invisible-icon" size={16} onClick={handleToggleHideComponent} />
+        ) : (
+          <VisibleIcon className="visible-icon" size={16} onClick={handleToggleHideComponent} />
+        )}
+      </div>
+    )
+  }, [isEntityHidden, handleToggleHideComponent])
+
+  return (
+    <div className="action-area">
+      {toggleLockButton()}
+      {toggleVisibleButton()}
+    </div>
+  )
+}
+
+export default React.memo(withSdk(ActionArea))

--- a/packages/@dcl/inspector/src/components/Tree/ActionArea/index.ts
+++ b/packages/@dcl/inspector/src/components/Tree/ActionArea/index.ts
@@ -1,0 +1,2 @@
+import ActionArea from './ActionArea'
+export { ActionArea }

--- a/packages/@dcl/inspector/src/components/Tree/Tree.css
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.css
@@ -58,7 +58,7 @@
   outline: var(--input-border-color);
   border-radius: 3px;
   width: 100%;
-  color: var(--black)
+  color: var(--black);
 }
 
 .Tree .item > div > svg:only-child {
@@ -88,6 +88,37 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.Tree .item .selectable-area .action-area {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  column-gap: 4px;
+  visibility: hidden;
+}
+
+.Tree .item:hover:not(:has(input)) .selectable-area .action-area svg {
+  visibility: visible;
+}
+
+.Tree .item .selectable-area .action-area .unlock-icon > path:last-of-type,
+.Tree .item .selectable-area .action-area .visible-icon > circle,
+.Tree .item .selectable-area .action-area .visible-icon > path,
+.Tree .item .selectable-area .action-area .invisible-icon > circle,
+.Tree .item .selectable-area .action-area .invisible-icon > path {
+  color: var(--base-02);
+}
+
+.Tree .item:not(:has(input)) .selectable-area .action-area.item-locked .lock-icon,
+.Tree .item:not(:has(input)) .selectable-area .action-area.item-hidden .invisible-icon {
+  visibility: visible;
+}
+
+.Tree .item .selectable-area:has(.action-area.item-hidden),
+.Tree .item .selectable-area .action-area .invisible-icon > path {
+  color: var(--base-06);
 }
 
 .Tree .contexify svg {

--- a/packages/@dcl/inspector/src/components/Tree/Tree.css
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.css
@@ -90,37 +90,6 @@
   text-overflow: ellipsis;
 }
 
-.Tree .item .selectable-area .action-area {
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: flex-end;
-  column-gap: 4px;
-  visibility: hidden;
-}
-
-.Tree .item:hover:not(:has(input)) .selectable-area .action-area svg {
-  visibility: visible;
-}
-
-.Tree .item .selectable-area .action-area .unlock-icon > path:last-of-type,
-.Tree .item .selectable-area .action-area .visible-icon > circle,
-.Tree .item .selectable-area .action-area .visible-icon > path,
-.Tree .item .selectable-area .action-area .invisible-icon > circle,
-.Tree .item .selectable-area .action-area .invisible-icon > path {
-  color: var(--base-02);
-}
-
-.Tree .item:not(:has(input)) .selectable-area .action-area.item-locked .lock-icon,
-.Tree .item:not(:has(input)) .selectable-area .action-area.item-hidden .invisible-icon {
-  visibility: visible;
-}
-
-.Tree .item .selectable-area:has(.action-area.item-hidden),
-.Tree .item .selectable-area .action-area .invisible-icon > path {
-  color: var(--base-06);
-}
-
 .Tree .contexify svg {
   color: var(--contexify-item-color);
   margin-right: 4px;

--- a/packages/@dcl/inspector/src/components/Tree/Tree.tsx
+++ b/packages/@dcl/inspector/src/components/Tree/Tree.tsx
@@ -1,9 +1,15 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { XYCoord, useDrag, useDrop } from 'react-dnd'
 import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io'
+import { IoEyeOutline as VisibleIcon, IoEyeOffOutline as InvisibleIcon } from 'react-icons/io5'
+import { MdOutlineLock as LockIcon, MdOutlineLockOpen as UnlockIcon } from 'react-icons/md'
 import cx from 'classnames'
+import { Entity } from '@dcl/ecs'
 
+import { ROOT } from '../../lib/sdk/tree'
 import { withContextMenu } from '../../hoc/withContextMenu'
+import { useSdk } from '../../hooks/sdk/useSdk'
+import { useEntityComponent } from '../../hooks/sdk/useEntityComponent'
 import { Input } from '../Input'
 import { ContextMenu } from './ContextMenu'
 import { ClickType, DropType, calculateDropType } from './utils'
@@ -80,6 +86,8 @@ export function Tree<T>() {
         getDragContext = () => ({}),
         dndType = 'tree'
       } = props
+      const sdk = useSdk()
+      const { addComponent, removeComponent } = useEntityComponent()
       const ref = useRef<HTMLDivElement>(null)
       const id = getId(value)
       const label = getLabel(value)
@@ -96,6 +104,7 @@ export function Tree<T>() {
       const [editMode, setEditMode] = useState(false)
       const [insertMode, setInsertMode] = useState(false)
       const [dropType, setDropType] = useState<DropType | EmptyString>('')
+      const [isHovered, setIsHover] = useState(false)
       // we need this ref just for the e2e tests to work since it's caching "dropType" value for some reason...
       const dropTypeRef = useRef<DropType | EmptyString>('')
       const canDrop = useCallback(
@@ -189,6 +198,53 @@ export function Tree<T>() {
         onDuplicate(value)
       }
 
+      const handleOnHover = useCallback(
+        ({ type: eventType }: React.MouseEvent<HTMLDivElement>) => {
+          if (eventType === 'mouseenter') {
+            setIsHover(true)
+          } else if (eventType === 'mouseleave') {
+            setIsHover(false)
+          }
+        },
+        [sdk, setIsHover]
+      )
+
+      const isEntity = useMemo(() => {
+        return typeof value !== 'string' && (value as Entity) !== ROOT
+      }, [value])
+
+      const isEntityLocked = useMemo(() => {
+        if (!sdk || value === ROOT) return false
+        const entity = value as Entity
+        return sdk.components.Lock.getOrNull(entity) !== null
+      }, [value, sdk])
+
+      const isEntityHidden = useMemo(() => {
+        if (!sdk || value === ROOT) return false
+        const entity = value as Entity
+        return sdk.components.Hide.getOrNull(entity) !== null
+      }, [value, sdk])
+
+      const handleToggleHideComponent = useCallback(() => {
+        if (!sdk || value === ROOT) return
+        const entity = value as Entity
+        if (isEntityHidden) {
+          removeComponent(entity, sdk.components.Hide as any)
+        } else {
+          addComponent(entity, sdk.components.Hide.componentId, { value: true })
+        }
+      }, [value, sdk, isEntityHidden])
+
+      const handleToggleLockComponent = useCallback(() => {
+        if (!sdk || value === ROOT) return
+        const entity = value as Entity
+        if (isEntityLocked) {
+          removeComponent(entity, sdk.components.Lock as any)
+        } else {
+          addComponent(entity, sdk.components.Lock.componentId, { value: true })
+        }
+      }, [sdk, isEntityLocked])
+
       drag(drop(ref))
 
       const controlsProps = {
@@ -212,13 +268,32 @@ export function Tree<T>() {
 
       return (
         <div className={treeClassNames} data-test-id={id} data-test-label={label}>
-          <div style={getLevelStyles(level)} className={cx({ selected, item: true, hidden })}>
+          <div
+            style={getLevelStyles(level)}
+            className={cx({ selected, item: true, hidden })}
+            onMouseEnter={handleOnHover}
+            onMouseLeave={handleOnHover}
+          >
             <ContextMenu {...controlsProps} />
             <div ref={ref} style={getEditModeStyles(editMode)} className="item-area">
               <DisclosureWidget enabled={enableOpen} isOpen={open} onOpen={handleOpen} />
               <div onClick={handleSelect} onContextMenu={handleSelect} className="selectable-area">
                 {props.getIcon ? props.getIcon(value) : <></>}
                 <div>{label || id}</div>
+                {isEntity && (
+                  <div className={cx('action-area', { 'item-locked': isEntityLocked, 'item-hidden': isEntityHidden })}>
+                    {isEntityLocked ? (
+                      <LockIcon className="lock-icon" size={16} onClick={handleToggleLockComponent} />
+                    ) : (
+                      <UnlockIcon className="unlock-icon" size={16} onClick={handleToggleLockComponent} />
+                    )}
+                    {isEntityHidden ? (
+                      <InvisibleIcon className="invisible-icon" size={16} onClick={handleToggleHideComponent} />
+                    ) : (
+                      <VisibleIcon className="visible-icon" size={16} onClick={handleToggleHideComponent} />
+                    )}
+                  </div>
+                )}
               </div>
             </div>
             {editMode && typeof label === 'string' && (

--- a/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useEntityComponent.ts
@@ -1,6 +1,7 @@
-import { Entity } from '@dcl/ecs'
+import { Entity, LastWriteWinElementSetComponentDefinition } from '@dcl/ecs'
 import { useCallback } from 'react'
 
+import { SdkContextValue } from '../../lib/sdk/context'
 import { useSdk } from './useSdk'
 
 export const useEntityComponent = () => {
@@ -26,14 +27,24 @@ export const useEntityComponent = () => {
   )
 
   const addComponent = useCallback(
-    (entity: Entity, componentId: number) => {
+    (entity: Entity, componentId: number, value?: any) => {
       if (!sdk) return
-      sdk.operations.addComponent(entity, componentId)
+      sdk.operations.addComponent(entity, componentId, value)
       sdk.operations.updateSelectedEntity(entity)
       void sdk.operations.dispatch()
     },
     [sdk]
   )
 
-  return { getComponents, addComponent }
+  const removeComponent = useCallback(
+    (entity: Entity, component: LastWriteWinElementSetComponentDefinition<SdkContextValue['components']>) => {
+      if (!sdk) return
+      sdk.operations.removeComponent(entity, component)
+      sdk.operations.updateSelectedEntity(entity)
+      void sdk.operations.dispatch()
+    },
+    [sdk]
+  )
+
+  return { getComponents, addComponent, removeComponent }
 }

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
@@ -116,7 +116,8 @@ export class EcsEntity extends BABYLON.TransformNode {
   }
 
   isHidden() {
-    return !this.isEnabled(false)
+    const container = this.gltfContainer ?? this.meshRenderer
+    return container ? !container.isEnabled(false) : false
   }
 
   isLocked() {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
@@ -32,6 +32,7 @@ export class EcsEntity extends BABYLON.TransformNode {
   material?: BABYLON.StandardMaterial | BABYLON.PBRMaterial
   #gltfPathLoading?: IFuture<string>
   #gltfAssetContainerLoading: IFuture<BABYLON.AssetContainer> = future()
+  #isLocked?: boolean = false
 
   ecsComponentValues: EcsComponents = {}
 
@@ -112,6 +113,18 @@ export class EcsEntity extends BABYLON.TransformNode {
   setGltfAssetContainer(gltfAssetContainer: BABYLON.AssetContainer) {
     this.gltfAssetContainer = gltfAssetContainer
     this.#gltfAssetContainerLoading.resolve(gltfAssetContainer)
+  }
+
+  isHidden() {
+    return !this.isEnabled(false)
+  }
+
+  isLocked() {
+    return this.#isLocked
+  }
+
+  setLock(lock: boolean) {
+    this.#isLocked = lock
   }
 }
 

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/SceneContext.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/SceneContext.ts
@@ -20,6 +20,8 @@ import { getDataLayerInterface } from '../../../redux/data-layer'
 import { putMaterialComponent } from './sdkComponents/material'
 import { putNftShapeComponent } from './sdkComponents/nft'
 import { putVideoPlayerComponent } from './sdkComponents/video-player'
+import { putHideComponent } from './editorComponents/hide'
+import { putLockComponent } from './editorComponents/lock'
 
 export type LoadableScene = {
   readonly entity: Readonly<Omit<Schemas.Entity, 'id'>>
@@ -69,7 +71,9 @@ export class SceneContext {
     [this.NftShape.componentId]: putNftShapeComponent,
     [this.VideoPlayer.componentId]: putVideoPlayerComponent,
     [this.editorComponents.Selection.componentId]: putEntitySelectedComponent,
-    [this.editorComponents.Scene.componentId]: putSceneComponent
+    [this.editorComponents.Scene.componentId]: putSceneComponent,
+    [this.editorComponents.Hide.componentId]: putHideComponent,
+    [this.editorComponents.Lock.componentId]: putLockComponent
   }
 
   // this future is resolved when the scene is disposed

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
@@ -3,12 +3,13 @@ import type { ComponentOperation } from '../component-operations'
 import { updateGizmoManager } from './selection'
 
 export const putHideComponent: ComponentOperation = (entity, component) => {
-  if (!entity.meshRenderer) return
+  const container = entity.gltfContainer ?? entity.meshRenderer
+  if (!container) return
 
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
     const context = entity.context.deref()!
     const { value: isHidden } = (component.getOrNull(entity.entityId) as { value: boolean } | null) ?? {}
-    entity.meshRenderer.visibility = isHidden ? 0 : 1
+    container.setEnabled(!isHidden)
     if (isHidden) {
       context.gizmos.unsetEntity()
     } else {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
@@ -1,0 +1,17 @@
+import { ComponentType } from '@dcl/ecs'
+import type { ComponentOperation } from '../component-operations'
+import { updateGizmoManager } from './selection'
+
+export const putHideComponent: ComponentOperation = (entity, component) => {
+  if (component.componentType === ComponentType.LastWriteWinElementSet) {
+    const context = entity.context.deref()!
+    const isHidden = component.getOrNull(entity.entityId)
+    entity.setEnabled(!isHidden)
+    if (isHidden) {
+      context.gizmos.unsetEntity()
+    } else {
+      const selectionValue = context.editorComponents.Selection.getOrNull(entity.entityId)
+      updateGizmoManager(entity, selectionValue)
+    }
+  }
+}

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/hide.ts
@@ -3,10 +3,12 @@ import type { ComponentOperation } from '../component-operations'
 import { updateGizmoManager } from './selection'
 
 export const putHideComponent: ComponentOperation = (entity, component) => {
+  if (!entity.meshRenderer) return
+
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
     const context = entity.context.deref()!
-    const isHidden = component.getOrNull(entity.entityId)
-    entity.setEnabled(!isHidden)
+    const { value: isHidden } = (component.getOrNull(entity.entityId) as { value: boolean } | null) ?? {}
+    entity.meshRenderer.visibility = isHidden ? 0 : 1
     if (isHidden) {
       context.gizmos.unsetEntity()
     } else {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/lock.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/lock.ts
@@ -1,0 +1,17 @@
+import { ComponentType } from '@dcl/ecs'
+import type { ComponentOperation } from '../component-operations'
+import { updateGizmoManager } from './selection'
+
+export const putLockComponent: ComponentOperation = (entity, component) => {
+  if (component.componentType === ComponentType.LastWriteWinElementSet) {
+    const context = entity.context.deref()!
+    const isLocked = component.getOrNull(entity.entityId)
+    entity.setLock(!!isLocked)
+    if (isLocked) {
+      context.gizmos.unsetEntity()
+    } else {
+      const selectionValue = context.editorComponents.Selection.getOrNull(entity.entityId)
+      updateGizmoManager(entity, selectionValue)
+    }
+  }
+}

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/lock.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/lock.ts
@@ -5,7 +5,7 @@ import { updateGizmoManager } from './selection'
 export const putLockComponent: ComponentOperation = (entity, component) => {
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
     const context = entity.context.deref()!
-    const isLocked = component.getOrNull(entity.entityId)
+    const { value: isLocked } = (component.getOrNull(entity.entityId) as { value: boolean } | null) ?? {}
     entity.setLock(!!isLocked)
     if (isLocked) {
       context.gizmos.unsetEntity()

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -51,7 +51,7 @@ export const putEntitySelectedComponent: ComponentOperation = (entity, component
   }
 }
 
-const updateGizmoManager = (entity: EcsEntity, value: { gizmo: number } | null) => {
+export const updateGizmoManager = (entity: EcsEntity, value: { gizmo: number } | null) => {
   const context = entity.context.deref()!
   let processedSomeEntity = false
 

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -267,7 +267,15 @@ export function createGizmoManager(context: SceneContext) {
     },
     setEnabled,
     setEntity(entity: EcsEntity | null) {
-      if (entity === lastEntity || !isEnabled || areMultipleEntitiesSelected()) return
+      if (
+        entity === lastEntity ||
+        !isEnabled ||
+        areMultipleEntitiesSelected() ||
+        entity?.isHidden() ||
+        entity?.isLocked()
+      ) {
+        return
+      }
       gizmoManager.attachToNode(entity)
       lastEntity = entity
       // fix gizmo rotation/position if necessary

--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -41,7 +41,9 @@ export enum EditorComponentNames {
   Counter = ComponentName.COUNTER,
   Triggers = ComponentName.TRIGGERS,
   States = ComponentName.STATES,
-  TransformConfig = 'inspector::TransformConfig'
+  TransformConfig = 'inspector::TransformConfig',
+  Hide = 'inspector::Hide',
+  Lock = 'inspector::Lock'
 }
 
 export type EditorComponentsTypes = {
@@ -54,6 +56,8 @@ export type EditorComponentsTypes = {
   Triggers: Triggers
   States: States
   Counter: Counter
+  Hide: { value: boolean }
+  Lock: { value: boolean }
 }
 
 export type EditorComponents = {
@@ -66,6 +70,8 @@ export type EditorComponents = {
   Counter: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Counter']>
   Triggers: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Triggers']>
   States: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['States']>
+  Hide: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Hide']>
+  Lock: LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Lock']>
 }
 
 export type SdkComponents = {
@@ -156,11 +162,21 @@ export function createEditorComponents(engine: IEngine): EditorComponents {
     porportionalScaling: Schemas.Optional(Schemas.Boolean)
   })
 
+  const Hide = engine.defineComponent(EditorComponentNames.Hide, {
+    value: Schemas.Boolean
+  })
+
+  const Lock = engine.defineComponent(EditorComponentNames.Lock, {
+    value: Schemas.Boolean
+  })
+
   return {
     Selection,
     Scene,
     Nodes,
     TransformConfig,
+    Hide,
+    Lock,
     ActionTypes: ActionTypes as unknown as LastWriteWinElementSetComponentDefinition<
       EditorComponentsTypes['ActionTypes']
     >,

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-component.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-component.spec.ts
@@ -20,6 +20,7 @@ describe('addComponent', () => {
     describe('and then passing the entity and the component id to the addComponent operation', () => {
       let entity: Entity
       let componentId: number
+      let defaultValue: any
       let addComponentOperation: ReturnType<typeof addComponent>
       const createMock = jest.fn()
       const componentMock = {
@@ -37,8 +38,8 @@ describe('addComponent', () => {
         createMock.mockReset()
       })
       it('should add the component to the entity', () => {
-        addComponentOperation(entity, componentId)
-        expect(createMock).toHaveBeenCalledWith(entity)
+        addComponentOperation(entity, componentId, defaultValue)
+        expect(createMock).toHaveBeenCalledWith(entity, defaultValue)
       })
       describe('and the component is not an LWW component', () => {
         beforeEach(() => {
@@ -48,7 +49,7 @@ describe('addComponent', () => {
           getComponentMock.mockReset()
         })
         it('should throw an error', () => {
-          expect(() => addComponentOperation(entity, componentId)).toThrowError()
+          expect(() => addComponentOperation(entity, componentId, defaultValue)).toThrowError()
         })
       })
     })

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-component.ts
@@ -3,10 +3,10 @@ import { isLastWriteWinComponent } from '../../../hooks/sdk/useComponentValue'
 import { COMPONENTS_WITH_ID, getNextId } from '@dcl/asset-packs'
 
 export function addComponent(engine: IEngine) {
-  return function addComponent(entity: Entity, componentId: number) {
+  return function addComponent(entity: Entity, componentId: number, value?: any) {
     const component = engine.getComponent(componentId)
     if (isLastWriteWinComponent<{ id?: number }>(component)) {
-      component.create(entity)
+      component.create(entity, value)
       if (COMPONENTS_WITH_ID.includes(component.componentName)) {
         const value = component.getMutable(entity)
         value.id = getNextId(engine as any)


### PR DESCRIPTION
This PR adds the `Lock` and `Hide` components to let users `lock` and `hide` entities in the inspector.

https://github.com/decentraland/js-sdk-toolchain/assets/3170051/55d70d77-3795-4e78-a0db-af33ada882fb

Closes: https://github.com/decentraland/sdk/issues/1067