### PR TITLE
fix: added ts-deepmerge to dependencies to fix entrypoint

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.8.0"
+        "@dcl/asset-packs": "^1.8.0",
+        "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
         "@babylonjs/core": "^6.18.0",
@@ -56,7 +57,6 @@
         "react-resizable-panels": "^0.0.48",
         "redux-saga": "^1.2.3",
         "redux-saga-test-plan": "^4.0.6",
-        "ts-deepmerge": "^7.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.2",
         "uuid": "^9.0.1"
@@ -7157,7 +7157,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
       "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
-      "dev": true,
       "engines": {
         "node": ">=14.13.1"
       }
@@ -12973,8 +12972,7 @@
     "ts-deepmerge": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
-      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
-      "dev": true
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA=="
     },
     "ts-node": {
       "version": "10.9.1",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,8 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^1.8.0"
+    "@dcl/asset-packs": "^1.8.0",
+    "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {
     "@babylonjs/core": "^6.18.0",
@@ -50,7 +51,6 @@
     "react-resizable-panels": "^0.0.48",
     "redux-saga": "^1.2.3",
     "redux-saga-test-plan": "^4.0.6",
-    "ts-deepmerge": "^7.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
     "uuid": "^9.0.1"


### PR DESCRIPTION
This needs to be a dependency because it's used by the entrypoint of the `@dcl/inspector` used by the `@dcl/sdk-commands` package (to configure the RPC of the CLI)