### PR TITLE
feat: Add spinner when loading assets

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -251,7 +251,12 @@ const Renderer: React.FC = () => {
   drop(canvasRef)
 
   return (
-    <div className={cx('Renderer', { 'is-loaded': !isLoading, 'is-loading': isLoading })}>
+    <div
+      className={cx('Renderer', {
+        'is-loaded': !isLoading,
+        'is-loading': isLoading
+      })}
+    >
       {isLoading && <Loading />}
       <Warnings />
       <CameraSpeed />

--- a/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
+++ b/packages/@dcl/inspector/src/components/Toolbar/Gizmos/Gizmos.tsx
@@ -45,6 +45,10 @@ export const Gizmos = withSdk(({ sdk }) => {
   useHotkey(['R'], handleRotationGizmo)
   useHotkey(['X'], handleScaleGizmo)
 
+  useHotkey(['M'], handlePositionGizmo)
+  useHotkey(['R'], handleRotationGizmo)
+  useHotkey(['X'], handleScaleGizmo)
+
   const {
     isPositionGizmoWorldAligned,
     isRotationGizmoWorldAligned,


### PR DESCRIPTION
This PR adds a spinner while the entity is loaded from the rpc-layer.


https://github.com/decentraland/js-sdk-toolchain/assets/3170051/3f3e6c31-0128-4a63-a56f-cf74b0d5ca59

Closes: https://github.com/decentraland/sdk/issues/1073
