### PR TITLE
fix: add legacy schema for retrocompat

### DIFF
--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -203,6 +203,15 @@ export function createEditorComponents(engine: IEngine): EditorComponents {
     y: Schemas.Int
   })
 
+  // legacy component
+  // we define the schema of the legacy component for retrocompat purposes
+  engine.defineComponent('inspector::Scene', {
+    layout: Schemas.Map({
+      base: Coords,
+      parcels: Schemas.Array(Coords)
+    })
+  })
+
   const Scene = engine.defineComponent(EditorComponentNames.Scene, {
     // everything but layout is set as optional for retrocompat purposes
     name: Schemas.Optional(Schemas.String),


### PR DESCRIPTION
Fixes the issue with old scenes throwing `Error: inspector::Scene is not defined and there is no schema to define it.`