### PR TITLE
fix: Update legacy-ecs package

### DIFF
--- a/packages/@dcl/dcl-rollup/ecs.config.ts
+++ b/packages/@dcl/dcl-rollup/ecs.config.ts
@@ -1,7 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve'
 import { RollupOptions } from 'rollup'
-import { terser } from 'rollup-plugin-terser'
-import typescript from 'rollup-plugin-typescript2'
+import typescript from '@rollup/plugin-typescript'
 import commonjs from '@rollup/plugin-commonjs'
 import { sys } from 'typescript'
 import { apiExtractor } from './api-extractor'
@@ -17,27 +16,7 @@ console.assert(packageJson.main, 'package.json .main must be present')
 console.assert(packageJson.typings, 'package.json .typings must be present')
 
 const plugins = [
-  typescript({
-    verbosity: 2,
-    clean: true,
-    tsconfigDefaults: {
-      include: ['src'],
-      compilerOptions: {
-        module: 'ESNext',
-        sourceMap: true,
-        declaration: true
-      }
-    },
-    tsconfig: 'tsconfig.json',
-    tsconfigOverride: {
-      declaration: true,
-      declarationMap: true,
-      sourceMap: false,
-      inlineSourceMap: true,
-      inlineSources: true
-    },
-    typescript: require('typescript')
-  }),
+  typescript(),
   resolve({
     browser: true,
     preferBuiltins: false
@@ -59,19 +38,10 @@ const config: RollupOptions = {
   output: [
     {
       file: packageJson.main,
-      format: 'iife',
+      format: 'es',
       name: 'self',
       extend: true,
       sourcemap: 'inline'
-    },
-    {
-      file: packageJson.main.replace(/\.js$/, '.min.js'),
-      format: 'iife',
-      name: 'self',
-      extend: true,
-      sourcemap: 'hidden',
-      compact: true,
-      plugins: [terser({})]
     }
   ]
 }

--- a/packages/@dcl/dcl-rollup/ecs.config.ts
+++ b/packages/@dcl/dcl-rollup/ecs.config.ts
@@ -2,6 +2,7 @@ import resolve from '@rollup/plugin-node-resolve'
 import { RollupOptions } from 'rollup'
 import typescript from '@rollup/plugin-typescript'
 import commonjs from '@rollup/plugin-commonjs'
+import terser from '@rollup/plugin-terser'
 import { sys } from 'typescript'
 import { apiExtractor } from './api-extractor'
 
@@ -42,6 +43,15 @@ const config: RollupOptions = {
       name: 'self',
       extend: true,
       sourcemap: 'inline'
+    },
+    {
+      file: packageJson.main.replace(/\.js$/, '.min.js'),
+      format: 'iife',
+      name: 'self',
+      extend: true,
+      sourcemap: 'hidden',
+      compact: true,
+      plugins: [terser({})]
     }
   ]
 }

--- a/packages/@dcl/dcl-rollup/libs.config.ts
+++ b/packages/@dcl/dcl-rollup/libs.config.ts
@@ -1,6 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
-import { terser } from 'rollup-plugin-terser'
+import terser from '@rollup/plugin-terser'
 import typescript from 'rollup-plugin-typescript2'
 import { sys } from 'typescript'
 import { apiExtractor } from './api-extractor'

--- a/packages/@dcl/dcl-rollup/package-lock.json
+++ b/packages/@dcl/dcl-rollup/package-lock.json
@@ -10,11 +10,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/api-extractor": "^7.18.7",
-        "@rollup/plugin-commonjs": "^21.0.1",
-        "@rollup/plugin-node-resolve": "^13.0.4",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
         "glob": "^7.1.7",
-        "rollup": "^2.56.3",
-        "rollup-plugin-terser": "^7.0.2",
+        "rollup": "^4.9.6",
         "rollup-plugin-typescript2": "^0.30.0",
         "typescript": "^4.8.2"
       },
@@ -22,33 +23,10 @@
         "dcl-rollup": "index.js"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dependencies": {
-        "@babel/highlight": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -59,9 +37,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -75,83 +53,83 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.29.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.5.tgz",
-      "integrity": "sha512-+vqO/TAGw9xXANpvTjA4y5ADcaRuYuBoJ9IfoAHubrGuxKG6GoW3P2tfdgwteLz95CnlftBxYp+3NG/mf05P9Q==",
+      "version": "7.39.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.39.4.tgz",
+      "integrity": "sha512-6YvfkpbEqRQ0UPdVBc+lOiq7VlXi9kw8U3w+RcXCFDVc/UljlXU5l9fHEyuBAW1GGO2opUe+yf9OscWhoHANhg==",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.23.3",
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/api-extractor-model": "7.28.7",
+        "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.51.1",
-        "@rushstack/rig-package": "0.3.14",
-        "@rushstack/ts-command-line": "4.12.2",
+        "@rushstack/node-core-library": "3.64.2",
+        "@rushstack/rig-package": "0.5.1",
+        "@rushstack/ts-command-line": "4.17.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "~4.7.4"
+        "typescript": "5.3.3"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.3.tgz",
-      "integrity": "sha512-HpsWzG6jrWHrTlIg53kmp/IVQPBHUZc+8dunnr9VXrmDjVBehaXxp9A6jhTQ/bd7W1m5TYfAvwCmseC1+9FCuA==",
+      "version": "7.28.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.7.tgz",
+      "integrity": "sha512-4gCGGEQGHmbQmarnDcEWS2cjj0LtNuD3D6rh3ZcAyAYTkceAugAk2eyQHGdTcGX8w3qMjWCTU1TPb8xHnMM+Kg==",
       "dependencies": {
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.51.1"
+        "@rushstack/node-core-library": "3.64.2"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
-      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
-      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
       "dependencies": {
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc": "0.14.2",
         "ajv": "~6.12.6",
         "jju": "~1.4.0",
         "resolve": "~1.19.0"
@@ -170,169 +148,348 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
-      "integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+      "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
+        "@rollup/pluginutils": "^5.0.1",
         "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.38.3"
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
-      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.42.0"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dependencies": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-      "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
+      "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
+      "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
+      "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
+      "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
+      "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+      "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
+      "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
+      "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+      "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
+      "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
+      "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
+      "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
+      "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.51.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.51.1.tgz",
-      "integrity": "sha512-xLoUztvGpaT5CphDexDPt2WbBx8D68VS5tYOkwfr98p90y0f/wepgXlTA/q5MUeZGGucASiXKp5ysdD+GPYf9A==",
+      "version": "3.64.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.64.2.tgz",
+      "integrity": "sha512-n1S2VYEklONiwKpUyBq/Fym6yAsfsCXrqFabuOMcCuj4C+zW+HyaspSHXJCKqkMxfjviwe/c9+DUqvRWIvSN9Q==",
       "dependencies": {
-        "@types/node": "12.20.24",
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
         "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.14.tgz",
-      "integrity": "sha512-Ic9EN3kWJCK6iOxEDtwED9nrM146zCDrQaUxbeGOF+q/VLZ/HNHPw+aLqrqmTl0ZT66Sf75Qk6OG+rySjTorvQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
+      "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
       "dependencies": {
-        "resolve": "~1.17.0",
+        "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.12.2.tgz",
-      "integrity": "sha512-poBtnumLuWmwmhCEkVAgynWgtnF9Kygekxyp4qtQUSbBrkuyPQTL85c8Cva1YfoUpOdOXxezMAkUt0n5SNKGqw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz",
+      "integrity": "sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==",
       "dependencies": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -346,19 +503,19 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
-    "node_modules/@types/node": {
-      "version": "12.20.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -379,17 +536,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/argparse": {
@@ -420,41 +566,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtin-modules": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "engines": {
         "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/colors": {
       "version": "1.2.5",
@@ -472,28 +592,25 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -506,9 +623,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -549,12 +666,12 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -565,19 +682,22 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -589,27 +709,19 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
       "dependencies": {
-        "function-bind": "^1.1.1"
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "engines": {
-        "node": ">=4"
+        "node": ">= 0.4"
       }
     },
     "node_modules/import-lazy": {
@@ -623,7 +735,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -634,12 +746,26 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dependencies": {
-        "has": "^1.0.3"
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dependencies": {
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -648,7 +774,7 @@
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -658,47 +784,10 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -708,7 +797,7 @@
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -751,11 +840,14 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.6.tgz",
+      "integrity": "sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==",
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -773,22 +865,17 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -799,7 +886,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
       }
@@ -848,7 +935,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -859,9 +946,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -881,9 +968,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -897,42 +984,50 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
+      "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.9.6",
+        "@rollup/rollup-android-arm64": "4.9.6",
+        "@rollup/rollup-darwin-arm64": "4.9.6",
+        "@rollup/rollup-darwin-x64": "4.9.6",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.6",
+        "@rollup/rollup-linux-arm64-musl": "4.9.6",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-musl": "4.9.6",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.6",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.6",
+        "@rollup/rollup-win32-x64-msvc": "4.9.6",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.0.0"
       }
     },
     "node_modules/rollup-plugin-typescript2": {
@@ -949,6 +1044,18 @@
       "peerDependencies": {
         "rollup": ">=1.26.3",
         "typescript": ">=2.4.0"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
@@ -996,9 +1103,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1010,12 +1117,17 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/smob": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
+      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -1034,20 +1146,15 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "engines": {
         "node": ">=0.6.19"
       }
@@ -1063,24 +1170,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -1097,9 +1204,9 @@
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1125,9 +1232,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -1135,7 +1242,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -1143,9 +1250,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/z-schema": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
-      "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
@@ -1158,38 +1265,24 @@
         "node": ">=8.0.0"
       },
       "optionalDependencies": {
-        "commander": "^2.20.3"
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "requires": {
-        "@babel/highlight": "^7.12.13"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
-    },
-    "@babel/highlight": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      }
-    },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1197,9 +1290,9 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -1207,75 +1300,75 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.29.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.29.5.tgz",
-      "integrity": "sha512-+vqO/TAGw9xXANpvTjA4y5ADcaRuYuBoJ9IfoAHubrGuxKG6GoW3P2tfdgwteLz95CnlftBxYp+3NG/mf05P9Q==",
+      "version": "7.39.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.39.4.tgz",
+      "integrity": "sha512-6YvfkpbEqRQ0UPdVBc+lOiq7VlXi9kw8U3w+RcXCFDVc/UljlXU5l9fHEyuBAW1GGO2opUe+yf9OscWhoHANhg==",
       "requires": {
-        "@microsoft/api-extractor-model": "7.23.3",
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/api-extractor-model": "7.28.7",
+        "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.51.1",
-        "@rushstack/rig-package": "0.3.14",
-        "@rushstack/ts-command-line": "4.12.2",
+        "@rushstack/node-core-library": "3.64.2",
+        "@rushstack/rig-package": "0.5.1",
+        "@rushstack/ts-command-line": "4.17.1",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "~4.7.4"
+        "typescript": "5.3.3"
       },
       "dependencies": {
         "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
         }
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.23.3.tgz",
-      "integrity": "sha512-HpsWzG6jrWHrTlIg53kmp/IVQPBHUZc+8dunnr9VXrmDjVBehaXxp9A6jhTQ/bd7W1m5TYfAvwCmseC1+9FCuA==",
+      "version": "7.28.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.7.tgz",
+      "integrity": "sha512-4gCGGEQGHmbQmarnDcEWS2cjj0LtNuD3D6rh3ZcAyAYTkceAugAk2eyQHGdTcGX8w3qMjWCTU1TPb8xHnMM+Kg==",
       "requires": {
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.51.1"
+        "@rushstack/node-core-library": "3.64.2"
       }
     },
     "@microsoft/tsdoc": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
-      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
     },
     "@microsoft/tsdoc-config": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
-      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
       "requires": {
-        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc": "0.14.2",
         "ajv": "~6.12.6",
         "jju": "~1.4.0",
         "resolve": "~1.19.0"
@@ -1293,144 +1386,195 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz",
-      "integrity": "sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==",
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+      "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
       "requires": {
-        "@rollup/pluginutils": "^3.1.0",
+        "@rollup/pluginutils": "^5.0.1",
         "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
       },
       "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          },
-          "dependencies": {
-            "estree-walker": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-              "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-            }
+            "balanced-match": "^1.0.0"
           }
         },
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
         },
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
         }
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
-      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
       "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
         "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
         "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-          "requires": {
-            "@types/estree": "0.0.39",
-            "estree-walker": "^1.0.1",
-            "picomatch": "^2.2.2"
-          }
-        },
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-        },
-        "@types/resolve": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-          "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        }
+        "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "requires": {
+        "serialize-javascript": "^6.0.1",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      }
+    },
+    "@rollup/plugin-typescript": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+      "requires": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
       }
     },
     "@rollup/pluginutils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-      "integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "requires": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-        }
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
+      "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
+      "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
+      "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
+      "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
+      "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+      "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
+      "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
+      "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+      "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
+      "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
+      "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
+      "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
+      "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
+      "optional": true
+    },
     "@rushstack/node-core-library": {
-      "version": "3.51.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.51.1.tgz",
-      "integrity": "sha512-xLoUztvGpaT5CphDexDPt2WbBx8D68VS5tYOkwfr98p90y0f/wepgXlTA/q5MUeZGGucASiXKp5ysdD+GPYf9A==",
+      "version": "3.64.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.64.2.tgz",
+      "integrity": "sha512-n1S2VYEklONiwKpUyBq/Fym6yAsfsCXrqFabuOMcCuj4C+zW+HyaspSHXJCKqkMxfjviwe/c9+DUqvRWIvSN9Q==",
       "requires": {
-        "@types/node": "12.20.24",
         "colors": "~1.2.1",
         "fs-extra": "~7.0.1",
         "import-lazy": "~4.0.0",
         "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.5.4",
         "z-schema": "~5.0.2"
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.14.tgz",
-      "integrity": "sha512-Ic9EN3kWJCK6iOxEDtwED9nrM146zCDrQaUxbeGOF+q/VLZ/HNHPw+aLqrqmTl0ZT66Sf75Qk6OG+rySjTorvQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
+      "integrity": "sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==",
       "requires": {
-        "resolve": "~1.17.0",
+        "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.12.2.tgz",
-      "integrity": "sha512-poBtnumLuWmwmhCEkVAgynWgtnF9Kygekxyp4qtQUSbBrkuyPQTL85c8Cva1YfoUpOdOXxezMAkUt0n5SNKGqw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.17.1.tgz",
+      "integrity": "sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==",
       "requires": {
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
@@ -1444,19 +1588,19 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
-    "@types/node": {
-      "version": "12.20.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+    "@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -1467,14 +1611,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -1505,32 +1641,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builtin-modules": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="
     },
     "colors": {
       "version": "1.2.5",
@@ -1545,22 +1658,22 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -1573,9 +1686,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "requires": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -1604,49 +1717,44 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "^1.1.2"
       }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "import-lazy": {
       "version": "4.0.0",
@@ -1656,7 +1764,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1667,18 +1775,26 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+    "is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "requires": {
-        "has": "^1.0.3"
+        "builtin-modules": "^3.3.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "requires": {
+        "hasown": "^2.0.0"
       }
     },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
     },
     "is-reference": {
       "version": "1.2.1",
@@ -1688,40 +1804,10 @@
         "@types/estree": "*"
       }
     },
-    "jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "requires": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1731,7 +1817,7 @@
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -1768,11 +1854,11 @@
       }
     },
     "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.30.6",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.6.tgz",
+      "integrity": "sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==",
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "make-dir": {
@@ -1784,21 +1870,16 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1806,7 +1887,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -1840,7 +1921,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -1848,9 +1929,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -1861,9 +1942,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -1874,30 +1955,35 @@
       }
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "rollup": {
-      "version": "2.56.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
-      "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
+      "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
       "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.9.6",
+        "@rollup/rollup-android-arm64": "4.9.6",
+        "@rollup/rollup-darwin-arm64": "4.9.6",
+        "@rollup/rollup-darwin-x64": "4.9.6",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.6",
+        "@rollup/rollup-linux-arm64-musl": "4.9.6",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-musl": "4.9.6",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.6",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.6",
+        "@rollup/rollup-win32-x64-msvc": "4.9.6",
+        "@types/estree": "1.0.5",
         "fsevents": "~2.3.2"
-      }
-    },
-    "rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
       }
     },
     "rollup-plugin-typescript2": {
@@ -1912,6 +1998,15 @@
         "tslib": "2.1.0"
       },
       "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -1939,20 +2034,25 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
     },
     "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "smob": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
+      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -1968,41 +2068,33 @@
         "source-map": "^0.6.0"
       }
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="
     },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       }
@@ -2013,9 +2105,9 @@
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -2031,14 +2123,14 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ=="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -2046,14 +2138,22 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "z-schema": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
-      "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
       "requires": {
-        "commander": "^2.20.3",
+        "commander": "^9.4.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "validator": "^13.7.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "optional": true
+        }
       }
     }
   }

--- a/packages/@dcl/dcl-rollup/package.json
+++ b/packages/@dcl/dcl-rollup/package.json
@@ -17,11 +17,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@microsoft/api-extractor": "^7.18.7",
-    "@rollup/plugin-commonjs": "^21.0.1",
-    "@rollup/plugin-node-resolve": "^13.0.4",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^11.1.6",
     "glob": "^7.1.7",
-    "rollup": "^2.56.3",
-    "rollup-plugin-terser": "^7.0.2",
+    "rollup": "^4.9.6",
     "rollup-plugin-typescript2": "^0.30.0",
     "typescript": "^4.8.2"
   }

--- a/packages/@dcl/dcl-rollup/tsconfig.json
+++ b/packages/@dcl/dcl-rollup/tsconfig.json
@@ -4,9 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "pretty": true,
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "strictNullChecks": true,

--- a/packages/@dcl/legacy-ecs/package-lock.json
+++ b/packages/@dcl/legacy-ecs/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs-math": "^1.0.1-20211130194043.commit-c994f71",
+        "@dcl/ecs-math": "1.1.0",
         "@dcl/posix": "^1.0.4"
       }
     },
     "node_modules/@dcl/ecs-math": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-1.0.1.tgz",
-      "integrity": "sha512-eTWiJzXlcTSjIHP67hJoumrzV5PUwGpqwgpJjPkvTwaini3/ZLmIricTG7Yn8OP9WEBNpYrKYY4CrImZ1b+w5Q=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-1.1.0.tgz",
+      "integrity": "sha512-MA506f2nw+0ArjCWI3AnUrCKQlJ2bRKQL5az6vnaeKeNnIwU+HeXAPRLLZ8FBBflyzTfEdM+PUOYFIhOrW10SQ=="
     },
     "node_modules/@dcl/posix": {
       "version": "1.0.4",
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@dcl/ecs-math": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-1.0.1.tgz",
-      "integrity": "sha512-eTWiJzXlcTSjIHP67hJoumrzV5PUwGpqwgpJjPkvTwaini3/ZLmIricTG7Yn8OP9WEBNpYrKYY4CrImZ1b+w5Q=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-1.1.0.tgz",
+      "integrity": "sha512-MA506f2nw+0ArjCWI3AnUrCKQlJ2bRKQL5az6vnaeKeNnIwU+HeXAPRLLZ8FBBflyzTfEdM+PUOYFIhOrW10SQ=="
     },
     "@dcl/posix": {
       "version": "1.0.4",

--- a/packages/@dcl/legacy-ecs/package.json
+++ b/packages/@dcl/legacy-ecs/package.json
@@ -4,6 +4,7 @@
   "description": "Decentraland ECS Legacy",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "watch": "tsc -p tsconfig.json --watch",
     "build": "tsc -p tsconfig.json",
@@ -16,7 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "@dcl/ecs-math": "^1.0.1-20211130194043.commit-c994f71",
+    "@dcl/ecs-math": "1.1.0",
     "@dcl/posix": "^1.0.4"
   }
 }

--- a/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
+++ b/packages/@dcl/legacy-ecs/src/decentraland/Components.ts
@@ -1,11 +1,4 @@
-import {
-  Vector3,
-  Quaternion,
-  Matrix,
-  MathTmp,
-  Color3,
-  Color4
-} from '@dcl/ecs-math'
+import { Vector3, Quaternion, Matrix, Color3, Color4 } from '@dcl/ecs-math'
 
 import {
   Component,
@@ -161,7 +154,10 @@ export class Transform extends ObservableComponent {
    * @public
    * Rotates the transform so the forward vector points at target's current position.
    */
-  lookAt(target: Vector3, worldUp: Vector3 = MathTmp.staticUp) {
+  lookAt(
+    target: Vector3,
+    worldUp: Vector3 = Vector3.Up() as Readonly<Vector3>
+  ) {
     const result = new Matrix()
     Matrix.LookAtLHToRef(this.position, target, worldUp, result)
     result.invert()
@@ -1071,7 +1067,7 @@ export class OnAnimationEnd extends OnUUIDEvent<'onAnimationEnd'> {
 }
 
 /**
- * @internal
+ * @public
  */
 @Component('engine.smartItem', CLASS_ID.SMART_ITEM)
 export class SmartItem extends ObservableComponent {}

--- a/packages/@dcl/legacy-ecs/src/ecs/Component.ts
+++ b/packages/@dcl/legacy-ecs/src/ecs/Component.ts
@@ -113,7 +113,7 @@ export function Component(componentName: string, classId?: number) {
 
     const RegisteredComponent: any = function RegisteredComponent() {
       // eslint-disable-next-line prefer-rest-params
-      const args = Array.prototype.slice.call(arguments)
+      const args: any = Array.prototype.slice.call(arguments)
       const ret = new extendedClass(...args)
 
       Object.defineProperty(ret, componentSymbol, {
@@ -295,9 +295,7 @@ export type ObservableComponentSubscription = (
  * @public
  */
 export class ObservableComponent {
-  // @internal
   dirty: boolean = false
-  // @internal
   data: any = {}
   private subscriptions: Array<ObservableComponentSubscription> = []
 

--- a/packages/@dcl/legacy-ecs/src/ecs/Engine.ts
+++ b/packages/@dcl/legacy-ecs/src/ecs/Engine.ts
@@ -338,7 +338,7 @@ export class Engine implements IEngine {
     }
 
     // Otherwise create and store it
-    componentGroup = new ComponentGroup(...requires)
+    componentGroup = new ComponentGroup(...(requires as any))
 
     componentGroup.active = true
 

--- a/packages/@dcl/legacy-ecs/src/ecs/Observable.ts
+++ b/packages/@dcl/legacy-ecs/src/ecs/Observable.ts
@@ -133,7 +133,7 @@ export class MultiObserver<T> {
     result._observers = new Array<Observer<T>>()
     result._observables = observables
 
-    for (const observable of observables) {
+    for (const observable of observables as any) {
       const observer = observable.add(callback, mask, false, scope)
       if (observer) {
         result._observers.push(observer)
@@ -303,7 +303,7 @@ export class Observable<T> {
     state.skipNextObservers = false
     state.lastReturnValue = eventData
 
-    for (const obs of this._observers) {
+    for (const obs of this._observers as any) {
       if (obs._willBeUnregistered) {
         continue
       }
@@ -446,7 +446,7 @@ export class Observable<T> {
    * @returns whether or not one observer registered with the given mask is handeled
    */
   public hasSpecificMask(mask: number = -1): boolean {
-    for (const obs of this._observers) {
+    for (const obs of this._observers as any) {
       if (obs.mask & mask || obs.mask === mask) {
         return true
       }

--- a/packages/@dcl/legacy-ecs/src/ecs/helpers.ts
+++ b/packages/@dcl/legacy-ecs/src/ecs/helpers.ts
@@ -9,9 +9,9 @@ declare let console: any
  */
 export function log(...args: any[]) {
   if (typeof dcl !== 'undefined') {
-    dcl.log(...args)
+    dcl.log(...(args as any))
   } else {
-    console.log('DEBUG:', ...args)
+    console.log('DEBUG:', ...(args as any))
   }
 }
 

--- a/packages/@dcl/legacy-ecs/tsconfig.json
+++ b/packages/@dcl/legacy-ecs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "esnext",
+    "target": "es6",
+    "module": "es6",
     "moduleResolution": "node",
     "pretty": true,
     "outDir": "dist",

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.29.5",
-    "schemaVersion": 1009,
+    "toolVersion": "7.39.4",
+    "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -182,6 +182,7 @@
               "text": "export declare enum ActionButton "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
           "name": "ActionButton",
           "preserveMemberOrder": false,
@@ -492,7 +493,9 @@
               "text": "export declare class Angle "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Angle.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Angle",
           "preserveMemberOrder": false,
           "members": [
@@ -592,6 +595,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "BetweenTwoPoints"
             },
             {
@@ -622,6 +626,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "degrees"
             },
             {
@@ -670,6 +675,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromDegrees"
             },
             {
@@ -718,6 +724,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromRadians"
             },
             {
@@ -748,6 +755,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "radians"
             }
           ],
@@ -760,7 +768,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type AnimationParams = "
+              "text": "export type AnimationParams = "
             },
             {
               "kind": "Content",
@@ -771,6 +779,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/AnimationState.d.ts",
           "releaseTag": "Public",
           "name": "AnimationParams",
           "typeTokenRange": {
@@ -797,7 +806,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/AnimationState.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AnimationState",
           "preserveMemberOrder": false,
           "members": [
@@ -877,7 +888,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -906,7 +918,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -935,7 +948,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -965,6 +979,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "pause"
             },
             {
@@ -1012,6 +1027,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "play"
             },
             {
@@ -1041,7 +1057,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -1071,6 +1088,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "reset"
             },
             {
@@ -1119,6 +1137,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setParams"
             },
             {
@@ -1148,7 +1167,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1177,7 +1197,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -1207,6 +1228,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "stop"
             },
             {
@@ -1237,6 +1259,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             },
             {
@@ -1266,7 +1289,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -1294,7 +1318,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Animator",
           "preserveMemberOrder": false,
           "members": [
@@ -1344,6 +1370,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addClip"
             },
             {
@@ -1392,6 +1419,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClip"
             },
             {
@@ -1440,6 +1468,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "pause"
             },
             {
@@ -1504,6 +1533,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "play"
             },
             {
@@ -1552,6 +1582,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "stop"
             }
           ],
@@ -1571,7 +1602,9 @@
               "text": "export declare class Arc2 "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Arc2.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Arc2",
           "preserveMemberOrder": false,
           "members": [
@@ -1670,7 +1703,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1700,7 +1734,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1730,7 +1765,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1760,7 +1796,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1790,7 +1827,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1819,7 +1857,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1849,7 +1888,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1879,7 +1919,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -1891,7 +1932,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type Area = "
+              "text": "export type Area = "
             },
             {
               "kind": "Content",
@@ -1911,6 +1952,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "Area",
           "typeTokenRange": {
@@ -1928,7 +1970,9 @@
               "text": "export declare abstract class Attachable "
             }
           ],
+          "fileUrlPath": "dist/ecs/Attachable.d.ts",
           "releaseTag": "Public",
+          "isAbstract": true,
           "name": "Attachable",
           "preserveMemberOrder": false,
           "members": [
@@ -1960,7 +2004,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -1990,7 +2035,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -2014,7 +2060,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AttachToAvatar",
           "preserveMemberOrder": false,
           "members": [
@@ -2079,7 +2127,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2108,7 +2157,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2137,7 +2187,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -2156,6 +2207,7 @@
               "text": "export declare enum AttachToAvatarAnchorPointId "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "AttachToAvatarAnchorPointId",
           "preserveMemberOrder": false,
@@ -2211,7 +2263,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type AttachToAvatarConstructorArgs = "
+              "text": "export type AttachToAvatarConstructorArgs = "
             },
             {
               "kind": "Content",
@@ -2231,6 +2283,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "AttachToAvatarConstructorArgs",
           "typeTokenRange": {
@@ -2257,7 +2310,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Audio.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AudioClip",
           "preserveMemberOrder": false,
           "members": [
@@ -2320,7 +2375,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2349,7 +2405,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2378,7 +2435,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -2406,7 +2464,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Audio.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AudioSource",
           "preserveMemberOrder": false,
           "members": [
@@ -2471,7 +2531,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2500,7 +2561,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2529,7 +2591,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2558,7 +2621,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2587,7 +2651,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2616,7 +2681,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -2646,6 +2712,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "playOnce"
             },
             {
@@ -2675,7 +2742,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -2703,7 +2771,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Audio.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AudioStream",
           "preserveMemberOrder": false,
           "members": [
@@ -2766,7 +2836,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2795,7 +2866,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -2824,7 +2896,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -2840,7 +2913,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type AvatarForRenderer = "
+              "text": "export type AvatarForRenderer = "
             },
             {
               "kind": "Content",
@@ -2896,6 +2969,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "AvatarForRenderer",
           "typeTokenRange": {
@@ -2922,7 +2996,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AvatarModifierArea",
           "preserveMemberOrder": false,
           "members": [
@@ -3004,7 +3080,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3033,7 +3110,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3067,7 +3145,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -3086,6 +3165,7 @@
               "text": "export declare enum AvatarModifiers "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "AvatarModifiers",
           "preserveMemberOrder": false,
@@ -3153,7 +3233,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/AvatarShape.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AvatarShape",
           "preserveMemberOrder": false,
           "members": [
@@ -3185,7 +3267,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -3216,6 +3299,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Dummy"
             },
             {
@@ -3245,7 +3329,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3274,7 +3359,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3303,7 +3389,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3333,7 +3420,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3363,7 +3451,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3392,7 +3481,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3421,7 +3511,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3451,7 +3542,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3480,7 +3572,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3509,7 +3602,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3543,7 +3637,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -3571,7 +3666,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "AvatarTexture",
           "preserveMemberOrder": false,
           "members": [
@@ -3673,7 +3770,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3702,7 +3800,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3731,7 +3830,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3760,7 +3860,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -3779,7 +3880,9 @@
               "text": "export declare class Axis "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Axis.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Axis",
           "preserveMemberOrder": false,
           "members": [
@@ -3811,7 +3914,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3841,7 +3945,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -3871,7 +3976,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -3886,6 +3992,7 @@
               "text": "export interface BasicAvatarInfo "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "BasicAvatarInfo",
           "preserveMemberOrder": false,
@@ -3966,7 +4073,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "BasicMaterial",
           "preserveMemberOrder": false,
           "members": [
@@ -3997,7 +4106,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4026,7 +4136,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4074,7 +4185,8 @@
                 "endIndex": 6
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -4093,7 +4205,9 @@
               "text": "export declare class BezierCurve "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/BezierCurve.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "BezierCurve",
           "preserveMemberOrder": false,
           "members": [
@@ -4206,6 +4320,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Interpolate"
             }
           ],
@@ -4230,7 +4345,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Billboard",
           "preserveMemberOrder": false,
           "members": [
@@ -4325,7 +4442,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4354,7 +4472,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4383,7 +4502,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -4399,7 +4519,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type BodyShapeRespresentation = "
+              "text": "export type BodyShapeRespresentation = "
             },
             {
               "kind": "Content",
@@ -4419,6 +4539,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "BodyShapeRespresentation",
           "typeTokenRange": {
@@ -4445,7 +4566,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "BoxShape",
           "preserveMemberOrder": false,
           "members": [
@@ -4476,7 +4599,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -4495,7 +4619,9 @@
               "text": "export declare class Camera "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Camera.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Camera",
           "preserveMemberOrder": false,
           "members": [
@@ -4542,7 +4668,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4572,7 +4699,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4602,7 +4730,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4631,7 +4760,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4661,7 +4791,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4691,7 +4822,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4721,7 +4853,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -4736,6 +4869,7 @@
               "text": "export declare enum CameraMode "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "CameraMode",
           "preserveMemberOrder": false,
@@ -4803,7 +4937,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "CameraModeArea",
           "preserveMemberOrder": false,
           "members": [
@@ -4885,7 +5021,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -4915,7 +5052,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -4943,7 +5081,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "CircleShape",
           "preserveMemberOrder": false,
           "members": [
@@ -4974,7 +5114,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -5003,7 +5144,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -5022,6 +5164,7 @@
               "text": "export declare enum CLASS_ID "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "CLASS_ID",
           "preserveMemberOrder": false,
@@ -5983,7 +6126,9 @@
               "text": "export declare class Color3 "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Color3.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Color3",
           "preserveMemberOrder": false,
           "members": [
@@ -6098,6 +6243,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -6164,6 +6310,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToRef"
             },
             {
@@ -6194,6 +6341,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -6223,7 +6371,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -6254,6 +6403,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Black"
             },
             {
@@ -6285,6 +6435,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Blue"
             },
             {
@@ -6366,6 +6517,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clampToRef"
             },
             {
@@ -6397,6 +6549,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -6446,6 +6599,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -6526,6 +6680,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -6574,6 +6729,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -6653,6 +6809,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsFloats"
             },
             {
@@ -6722,6 +6879,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -6770,6 +6928,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromHexString"
             },
             {
@@ -6850,6 +7009,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromInts"
             },
             {
@@ -6879,7 +7039,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -6909,6 +7070,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -6939,6 +7101,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -6970,6 +7133,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Gray"
             },
             {
@@ -7001,6 +7165,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Green"
             },
             {
@@ -7083,6 +7248,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -7181,6 +7347,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LerpToRef"
             },
             {
@@ -7212,6 +7379,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Magenta"
             },
             {
@@ -7261,6 +7429,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -7327,6 +7496,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -7358,6 +7528,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Purple"
             },
             {
@@ -7387,7 +7558,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -7418,6 +7590,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Random"
             },
             {
@@ -7449,6 +7622,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Red"
             },
             {
@@ -7497,6 +7671,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -7562,6 +7737,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -7627,6 +7803,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -7707,6 +7884,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -7756,6 +7934,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -7822,6 +8001,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractToRef"
             },
             {
@@ -7853,6 +8033,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Teal"
             },
             {
@@ -7918,6 +8099,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -7966,6 +8148,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toColor4"
             },
             {
@@ -7997,6 +8180,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toGammaSpace"
             },
             {
@@ -8046,6 +8230,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toGammaSpaceToRef"
             },
             {
@@ -8076,6 +8261,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toHexString"
             },
             {
@@ -8106,6 +8292,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             },
             {
@@ -8137,6 +8324,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toLinearSpace"
             },
             {
@@ -8186,6 +8374,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toLinearSpaceToRef"
             },
             {
@@ -8216,6 +8405,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toLuminance"
             },
             {
@@ -8246,6 +8436,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -8277,6 +8468,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "White"
             },
             {
@@ -8308,6 +8500,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Yellow"
             }
           ],
@@ -8323,7 +8516,9 @@
               "text": "export declare class Color4 "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Color4.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Color4",
           "preserveMemberOrder": false,
           "members": [
@@ -8434,7 +8629,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -8483,6 +8679,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -8532,6 +8729,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addInPlace"
             },
             {
@@ -8562,6 +8760,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -8591,7 +8790,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -8622,6 +8822,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Black"
             },
             {
@@ -8653,6 +8854,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Blue"
             },
             {
@@ -8716,6 +8918,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CheckColors4"
             },
             {
@@ -8797,6 +9000,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clampToRef"
             },
             {
@@ -8828,6 +9032,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Clear"
             },
             {
@@ -8859,6 +9064,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -8908,6 +9114,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -9004,6 +9211,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -9073,6 +9281,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -9138,6 +9347,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromColor3"
             },
             {
@@ -9186,6 +9396,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromHexString"
             },
             {
@@ -9282,6 +9493,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromInts"
             },
             {
@@ -9311,7 +9523,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -9341,6 +9554,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -9371,6 +9585,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -9402,6 +9617,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Gray"
             },
             {
@@ -9433,6 +9649,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Green"
             },
             {
@@ -9515,6 +9732,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -9613,6 +9831,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LerpToRef"
             },
             {
@@ -9644,6 +9863,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Magenta"
             },
             {
@@ -9693,6 +9913,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -9759,6 +9980,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -9790,6 +10012,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Purple"
             },
             {
@@ -9819,7 +10042,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -9850,6 +10074,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Red"
             },
             {
@@ -9898,6 +10123,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -9963,6 +10189,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -10028,6 +10255,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -10124,6 +10352,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -10173,6 +10402,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -10239,6 +10469,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractToRef"
             },
             {
@@ -10270,6 +10501,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Teal"
             },
             {
@@ -10334,6 +10566,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -10365,6 +10598,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toGammaSpace"
             },
             {
@@ -10414,6 +10648,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toGammaSpaceToRef"
             },
             {
@@ -10444,6 +10679,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toHexString"
             },
             {
@@ -10475,6 +10711,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toLinearSpace"
             },
             {
@@ -10524,6 +10761,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toLinearSpaceToRef"
             },
             {
@@ -10554,6 +10792,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -10585,6 +10824,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "White"
             },
             {
@@ -10616,6 +10856,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Yellow"
             }
           ],
@@ -10664,6 +10905,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 5,
             "endIndex": 8
@@ -10700,7 +10942,9 @@
               "text": "export declare class ComponentAdded "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ComponentAdded",
           "preserveMemberOrder": false,
           "members": [
@@ -10796,7 +11040,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -10825,7 +11070,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -10855,7 +11101,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -10879,6 +11126,7 @@
               "text": "> "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -11006,7 +11254,9 @@
               "text": "export declare class ComponentGroup "
             }
           ],
+          "fileUrlPath": "dist/ecs/ComponentGroup.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ComponentGroup",
           "preserveMemberOrder": false,
           "members": [
@@ -11074,7 +11324,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11117,7 +11368,8 @@
                 "endIndex": 5
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -11165,6 +11417,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasEntity"
             },
             {
@@ -11208,7 +11461,8 @@
                 "endIndex": 5
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11242,7 +11496,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -11257,6 +11512,7 @@
               "text": "export interface ComponentLike "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
           "name": "ComponentLike",
           "preserveMemberOrder": false,
@@ -11273,7 +11529,9 @@
               "text": "export declare class ComponentRemoved "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ComponentRemoved",
           "preserveMemberOrder": false,
           "members": [
@@ -11371,7 +11629,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11400,7 +11659,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11430,7 +11690,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -11454,7 +11715,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ConeShape",
           "preserveMemberOrder": false,
           "members": [
@@ -11485,7 +11748,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11514,7 +11778,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11543,7 +11808,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11572,7 +11838,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11601,7 +11868,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11630,7 +11898,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -11659,7 +11928,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -11678,7 +11948,9 @@
               "text": "export declare class Curve3 "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Curve3d.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Curve3",
           "preserveMemberOrder": false,
           "members": [
@@ -11766,6 +12038,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "continue"
             },
             {
@@ -11851,6 +12124,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CreateCatmullRomSpline"
             },
             {
@@ -11967,6 +12241,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CreateCubicBezier"
             },
             {
@@ -12083,6 +12358,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CreateHermiteSpline"
             },
             {
@@ -12182,6 +12458,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CreateQuadraticBezier"
             },
             {
@@ -12217,6 +12494,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getPoints"
             },
             {
@@ -12247,6 +12525,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "length"
             }
           ],
@@ -12271,7 +12550,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "CylinderShape",
           "preserveMemberOrder": false,
           "members": [
@@ -12302,7 +12583,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12331,7 +12613,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12360,7 +12643,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12389,7 +12673,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12418,7 +12703,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12447,7 +12733,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12476,7 +12763,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -12499,6 +12787,7 @@
               "text": "number"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "DEG2RAD",
@@ -12550,6 +12839,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 5,
             "endIndex": 8
@@ -12595,6 +12885,7 @@
               "text": "> "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -12749,7 +13040,9 @@
               "text": "export declare class DisposableComponentCreated "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "DisposableComponentCreated",
           "preserveMemberOrder": false,
           "members": [
@@ -12844,7 +13137,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12873,7 +13167,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -12902,7 +13197,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -12926,6 +13222,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
           "name": "DisposableComponentLike",
           "preserveMemberOrder": false,
@@ -12976,7 +13273,9 @@
               "text": "export declare class DisposableComponentRemoved "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "DisposableComponentRemoved",
           "preserveMemberOrder": false,
           "members": [
@@ -13039,7 +13338,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -13054,7 +13354,9 @@
               "text": "export declare class DisposableComponentUpdated "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "DisposableComponentUpdated",
           "preserveMemberOrder": false,
           "members": [
@@ -13135,7 +13437,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -13164,7 +13467,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -13187,6 +13491,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "double",
           "typeTokenRange": {
@@ -13212,6 +13517,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Quaternion.d.ts",
           "releaseTag": "Public",
           "name": "EcsMathReadOnlyQuaternion",
           "typeTokenRange": {
@@ -13237,6 +13543,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector2.d.ts",
           "releaseTag": "Public",
           "name": "EcsMathReadOnlyVector2",
           "typeTokenRange": {
@@ -13262,6 +13569,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector3.d.ts",
           "releaseTag": "Public",
           "name": "EcsMathReadOnlyVector3",
           "typeTokenRange": {
@@ -13287,6 +13595,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector4.d.ts",
           "releaseTag": "Public",
           "name": "EcsMathReadOnlyVector4",
           "typeTokenRange": {
@@ -13313,7 +13622,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/ecs/Engine.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Engine",
           "preserveMemberOrder": false,
           "members": [
@@ -13397,6 +13708,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addEntity"
             },
             {
@@ -13462,6 +13774,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addSystem"
             },
             {
@@ -13492,7 +13805,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -13544,7 +13858,8 @@
                 "endIndex": 7
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -13592,6 +13907,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "disposeComponent"
             },
             {
@@ -13644,7 +13960,8 @@
                 "endIndex": 7
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -13674,7 +13991,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -13704,7 +14022,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -13757,6 +14076,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponentGroup"
             },
             {
@@ -13809,6 +14129,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getEntitiesWithComponent"
             },
             {
@@ -13875,6 +14196,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getEntitiesWithComponent"
             },
             {
@@ -13923,6 +14245,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "registerComponent"
             },
             {
@@ -13971,6 +14294,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeComponentGroup"
             },
             {
@@ -14019,6 +14343,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeEntity"
             },
             {
@@ -14067,6 +14392,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeSystem"
             },
             {
@@ -14097,7 +14423,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -14144,6 +14471,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "update"
             },
             {
@@ -14192,6 +14520,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "updateComponent"
             }
           ],
@@ -14217,6 +14546,7 @@
               "canonicalReference": "@dcl/legacy-ecs!Engine:class"
             }
           ],
+          "fileUrlPath": "dist/0.6289080540469796index.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "engine",
@@ -14244,7 +14574,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/ecs/Entity.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Entity",
           "preserveMemberOrder": false,
           "members": [
@@ -14346,6 +14678,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addComponent"
             },
             {
@@ -14414,6 +14747,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addComponentOrReplace"
             },
             {
@@ -14443,7 +14777,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -14486,7 +14821,8 @@
                 "endIndex": 5
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -14520,7 +14856,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -14554,7 +14891,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -14622,6 +14960,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponent"
             },
             {
@@ -14696,6 +15035,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponent"
             },
             {
@@ -14770,6 +15110,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponentOrCreate"
             },
             {
@@ -14838,6 +15179,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponentOrNull"
             },
             {
@@ -14912,6 +15254,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getComponentOrNull"
             },
             {
@@ -14947,6 +15290,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getParent"
             },
             {
@@ -15015,6 +15359,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasComponent"
             },
             {
@@ -15089,6 +15434,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasComponent"
             },
             {
@@ -15157,6 +15503,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasComponent"
             },
             {
@@ -15187,6 +15534,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "isAddedToEngine"
             },
             {
@@ -15216,7 +15564,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -15279,6 +15628,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeComponent"
             },
             {
@@ -15363,6 +15713,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeComponent"
             },
             {
@@ -15431,6 +15782,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeComponent"
             },
             {
@@ -15493,6 +15845,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setParent"
             },
             {
@@ -15522,7 +15875,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": [
@@ -15546,6 +15900,7 @@
               "text": "0.000001"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "initializerTokenRange": {
             "startIndex": 1,
             "endIndex": 2
@@ -15597,6 +15952,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/helpers.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 6,
             "endIndex": 7
@@ -15642,6 +15998,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/EventManager.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 1,
             "endIndex": 2
@@ -15661,7 +16018,9 @@
               "text": "export declare class EventManager "
             }
           ],
+          "fileUrlPath": "dist/ecs/EventManager.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "EventManager",
           "preserveMemberOrder": false,
           "members": [
@@ -15771,6 +16130,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addListener"
             },
             {
@@ -15839,6 +16199,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "fireEvent"
             },
             {
@@ -15920,6 +16281,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeListener"
             }
           ],
@@ -15965,6 +16327,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Task.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 5,
             "endIndex": 7
@@ -16003,7 +16366,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type FileAndHash = "
+              "text": "export type FileAndHash = "
             },
             {
               "kind": "Content",
@@ -16014,6 +16377,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "FileAndHash",
           "typeTokenRange": {
@@ -16039,6 +16403,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "float",
           "typeTokenRange": {
@@ -16064,6 +16429,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "FloatArray",
           "typeTokenRange": {
@@ -16090,7 +16456,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Font",
           "preserveMemberOrder": false,
           "members": [
@@ -16153,7 +16521,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -16172,6 +16541,7 @@
               "text": "export declare enum Fonts "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "Fonts",
           "preserveMemberOrder": false,
@@ -16356,7 +16726,9 @@
               "text": "export declare class Frustum "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Furstum.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Frustum",
           "preserveMemberOrder": false,
           "members": [
@@ -16423,6 +16795,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetBottomPlaneToRef"
             },
             {
@@ -16488,6 +16861,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetFarPlaneToRef"
             },
             {
@@ -16553,6 +16927,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetLeftPlaneToRef"
             },
             {
@@ -16618,6 +16993,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetNearPlaneToRef"
             },
             {
@@ -16671,6 +17047,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetPlanes"
             },
             {
@@ -16740,6 +17117,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetPlanesToRef"
             },
             {
@@ -16805,6 +17183,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetRightPlaneToRef"
             },
             {
@@ -16870,6 +17249,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetTopPlaneToRef"
             }
           ],
@@ -16931,6 +17311,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 10,
             "endIndex": 11
@@ -16997,6 +17378,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 5,
             "endIndex": 6
@@ -17084,6 +17466,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 10,
             "endIndex": 11
@@ -17125,6 +17508,7 @@
               "text": "export declare enum Gizmo "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Gizmos.d.ts",
           "releaseTag": "Public",
           "name": "Gizmo",
           "preserveMemberOrder": false,
@@ -17234,7 +17618,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Gizmos.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Gizmos",
           "preserveMemberOrder": false,
           "members": [
@@ -17265,7 +17651,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -17294,7 +17681,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -17323,7 +17711,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -17352,7 +17741,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -17381,7 +17771,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -17411,7 +17802,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -17439,7 +17831,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "GlobalPointerDown",
           "preserveMemberOrder": false,
           "members": [],
@@ -17468,7 +17862,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "GlobalPointerUp",
           "preserveMemberOrder": false,
           "members": [],
@@ -17497,7 +17893,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "GLTFShape",
           "preserveMemberOrder": false,
           "members": [
@@ -17560,7 +17958,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -17579,6 +17978,7 @@
               "text": "export interface HitEntityInfo "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "HitEntityInfo",
           "preserveMemberOrder": false,
@@ -17677,6 +18077,7 @@
               "text": "export interface IEngine "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
           "name": "IEngine",
           "preserveMemberOrder": false,
@@ -18028,6 +18429,7 @@
               "text": "export interface IEntity "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
           "name": "IEntity",
           "preserveMemberOrder": false,
@@ -19499,6 +19901,7 @@
               "text": "export interface IEventConstructor<T> "
             }
           ],
+          "fileUrlPath": "dist/ecs/EventManager.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -19572,7 +19975,9 @@
               "text": "export declare class Input "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Input",
           "preserveMemberOrder": false,
           "members": [
@@ -19604,6 +20009,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ensureInstance"
             },
             {
@@ -19652,6 +20058,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "handlePointerEvent"
             },
             {
@@ -19682,7 +20089,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -19730,6 +20138,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "isButtonPressed"
             },
             {
@@ -19836,6 +20245,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subscribe"
             },
             {
@@ -19935,6 +20345,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "unsubscribe"
             }
           ],
@@ -19947,7 +20358,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type InputEventKind = "
+              "text": "export type InputEventKind = "
             },
             {
               "kind": "Content",
@@ -19958,6 +20369,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
           "name": "InputEventKind",
           "typeTokenRange": {
@@ -19975,6 +20387,7 @@
               "text": "export declare enum InputEventType "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "InputEventType",
           "preserveMemberOrder": false,
@@ -20030,7 +20443,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type InputState = "
+              "text": "export type InputState = "
             },
             {
               "kind": "Reference",
@@ -20055,6 +20468,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
           "name": "InputState",
           "typeTokenRange": {
@@ -20072,6 +20486,7 @@
               "text": "export interface IPhysicsCast "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "IPhysicsCast",
           "preserveMemberOrder": false,
@@ -20280,6 +20695,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 3,
             "endIndex": 4
@@ -20308,6 +20724,7 @@
               "text": "export interface ISize "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "ISize",
           "preserveMemberOrder": false,
@@ -20379,6 +20796,7 @@
               "text": "export interface ISystem "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
           "name": "ISystem",
           "preserveMemberOrder": false,
@@ -20634,6 +21052,7 @@
               "text": "export declare enum LandRole "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "LandRole",
           "preserveMemberOrder": false,
@@ -20689,7 +21108,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type LocalActionButtonEvent = "
+              "text": "export type LocalActionButtonEvent = "
             },
             {
               "kind": "Reference",
@@ -20768,6 +21187,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
           "name": "LocalActionButtonEvent",
           "typeTokenRange": {
@@ -20801,6 +21221,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/helpers.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 3,
             "endIndex": 4
@@ -20838,7 +21259,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Material",
           "preserveMemberOrder": false,
           "members": [
@@ -20879,7 +21302,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -20927,7 +21351,8 @@
                 "endIndex": 6
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -20956,7 +21381,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21004,7 +21430,8 @@
                 "endIndex": 6
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21043,7 +21470,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21072,7 +21500,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21101,7 +21530,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21131,7 +21561,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21160,7 +21591,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21208,7 +21640,8 @@
                 "endIndex": 6
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21237,7 +21670,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21266,7 +21700,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21296,7 +21731,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21325,7 +21761,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21354,7 +21791,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -21384,7 +21822,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -21403,7 +21842,9 @@
               "text": "export declare class Matrix "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Matrix.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Matrix",
           "preserveMemberOrder": false,
           "members": [
@@ -21469,6 +21910,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -21533,6 +21975,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addAtIndex"
             },
             {
@@ -21599,6 +22042,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToRef"
             },
             {
@@ -21648,6 +22092,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToSelf"
             },
             {
@@ -21692,6 +22137,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -21723,6 +22169,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -21806,6 +22253,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Compose"
             },
             {
@@ -21905,6 +22353,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ComposeToRef"
             },
             {
@@ -21967,6 +22416,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -22032,6 +22482,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyToArray"
             },
             {
@@ -22114,6 +22565,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "decompose"
             },
             {
@@ -22196,6 +22648,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DecomposeLerp"
             },
             {
@@ -22294,6 +22747,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DecomposeLerpToRef"
             },
             {
@@ -22324,6 +22778,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "determinant"
             },
             {
@@ -22372,6 +22827,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -22441,6 +22897,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -22526,6 +22983,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArrayToRef"
             },
             {
@@ -22623,6 +23081,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatArrayToRefScaled"
             },
             {
@@ -22688,6 +23147,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromQuaternionToRef"
             },
             {
@@ -22976,6 +23436,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromValues"
             },
             {
@@ -23280,6 +23741,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromValuesToRef"
             },
             {
@@ -23379,6 +23841,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromXYZAxesToRef"
             },
             {
@@ -23428,6 +23891,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetAsMatrix2x2"
             },
             {
@@ -23477,6 +23941,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetAsMatrix3x3"
             },
             {
@@ -23507,6 +23972,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -23537,6 +24003,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -23568,6 +24035,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getRotationMatrix"
             },
             {
@@ -23617,6 +24085,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getRotationMatrixToRef"
             },
             {
@@ -23678,6 +24147,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getRow"
             },
             {
@@ -23709,6 +24179,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getTranslation"
             },
             {
@@ -23758,6 +24229,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getTranslationToRef"
             },
             {
@@ -23789,6 +24261,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Identity"
             },
             {
@@ -23832,7 +24305,8 @@
                 "endIndex": 5
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -23880,6 +24354,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "IdentityToRef"
             },
             {
@@ -23911,6 +24386,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "invert"
             },
             {
@@ -23960,6 +24436,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Invert"
             },
             {
@@ -24009,6 +24486,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "invertToRef"
             },
             {
@@ -24039,6 +24517,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "isIdentity"
             },
             {
@@ -24069,6 +24548,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "isIdentityAs3x2"
             },
             {
@@ -24151,6 +24631,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -24249,6 +24730,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LerpToRef"
             },
             {
@@ -24332,6 +24814,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LookAtLH"
             },
             {
@@ -24431,6 +24914,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LookAtLHToRef"
             },
             {
@@ -24514,6 +24998,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LookAtRH"
             },
             {
@@ -24613,6 +25098,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LookAtRHToRef"
             },
             {
@@ -24656,7 +25142,8 @@
                 "endIndex": 5
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -24718,6 +25205,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -24782,6 +25270,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyAtIndex"
             },
             {
@@ -24877,6 +25366,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToArray"
             },
             {
@@ -24956,6 +25446,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -25052,6 +25543,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoLH"
             },
             {
@@ -25164,6 +25656,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoLHToRef"
             },
             {
@@ -25292,6 +25785,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoOffCenterLH"
             },
             {
@@ -25436,6 +25930,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoOffCenterLHToRef"
             },
             {
@@ -25564,6 +26059,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoOffCenterRH"
             },
             {
@@ -25708,6 +26204,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "OrthoOffCenterRHToRef"
             },
             {
@@ -25804,6 +26301,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveFovLH"
             },
             {
@@ -25932,6 +26430,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveFovLHToRef"
             },
             {
@@ -26028,6 +26527,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveFovRH"
             },
             {
@@ -26156,6 +26656,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveFovRHToRef"
             },
             {
@@ -26268,6 +26769,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveFovWebVRToRef"
             },
             {
@@ -26364,6 +26866,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PerspectiveLH"
             },
             {
@@ -26413,6 +26916,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Reflection"
             },
             {
@@ -26478,6 +26982,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ReflectionToRef"
             },
             {
@@ -26509,6 +27014,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeRotationAndScaling"
             },
             {
@@ -26540,6 +27046,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "reset"
             },
             {
@@ -26605,6 +27112,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAxis"
             },
             {
@@ -26686,6 +27194,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAxisToRef"
             },
             {
@@ -26734,6 +27243,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationX"
             },
             {
@@ -26798,6 +27308,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationXToRef"
             },
             {
@@ -26846,6 +27357,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationY"
             },
             {
@@ -26926,6 +27438,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationYawPitchRoll"
             },
             {
@@ -27022,6 +27535,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationYawPitchRollToRef"
             },
             {
@@ -27086,6 +27600,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationYToRef"
             },
             {
@@ -27134,6 +27649,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationZ"
             },
             {
@@ -27198,6 +27714,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationZToRef"
             },
             {
@@ -27246,6 +27763,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -27311,6 +27829,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -27376,6 +27895,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -27456,6 +27976,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Scaling"
             },
             {
@@ -27552,6 +28073,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ScalingToRef"
             },
             {
@@ -27617,6 +28139,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setRow"
             },
             {
@@ -27729,6 +28252,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setRowFromFloats"
             },
             {
@@ -27778,6 +28302,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setTranslation"
             },
             {
@@ -27858,6 +28383,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setTranslationFromFloats"
             },
             {
@@ -27902,6 +28428,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -27932,6 +28459,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toggleModelMatrixHandInPlace"
             },
             {
@@ -27962,6 +28490,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toggleProjectionMatrixHandInPlace"
             },
             {
@@ -28010,6 +28539,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toNormalMatrix"
             },
             {
@@ -28090,6 +28620,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Translation"
             },
             {
@@ -28186,6 +28717,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TranslationToRef"
             },
             {
@@ -28217,6 +28749,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "transpose"
             },
             {
@@ -28266,6 +28799,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Transpose"
             },
             {
@@ -28315,6 +28849,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "transposeToRef"
             },
             {
@@ -28380,6 +28915,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransposeToRef"
             },
             {
@@ -28409,7 +28945,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -28440,6 +28977,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -28455,7 +28993,9 @@
               "text": "export declare class MessageBus "
             }
           ],
+          "fileUrlPath": "dist/decentraland/MessageBus.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "MessageBus",
           "preserveMemberOrder": false,
           "members": [
@@ -28540,6 +29080,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "emit"
             },
             {
@@ -28617,6 +29158,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "on"
             }
           ],
@@ -28629,7 +29171,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type MinimapSceneInfo = "
+              "text": "export type MinimapSceneInfo = "
             },
             {
               "kind": "Content",
@@ -28640,6 +29182,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "MinimapSceneInfo",
           "typeTokenRange": {
@@ -28657,6 +29200,7 @@
               "text": "export declare class MultiObserver<T> "
             }
           ],
+          "fileUrlPath": "dist/ecs/Observable.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -28671,6 +29215,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "MultiObserver",
           "preserveMemberOrder": false,
           "members": [
@@ -28702,6 +29247,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "dispose"
             },
             {
@@ -28829,6 +29375,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Watch"
             }
           ],
@@ -28860,6 +29407,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/helpers.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 3,
             "endIndex": 4
@@ -28897,7 +29445,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "NFTShape",
           "preserveMemberOrder": false,
           "members": [
@@ -29059,7 +29609,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -29088,7 +29639,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -29118,7 +29670,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -29134,7 +29687,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type NFTShapeConstructorArgs = "
+              "text": "export type NFTShapeConstructorArgs = "
             },
             {
               "kind": "Content",
@@ -29163,6 +29716,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "NFTShapeConstructorArgs",
           "typeTokenRange": {
@@ -29188,6 +29742,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "Nullable",
           "typeParameters": [
@@ -29227,7 +29782,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OBJShape",
           "preserveMemberOrder": false,
           "members": [
@@ -29290,7 +29847,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -29309,6 +29867,7 @@
               "text": "export declare class Observable<T> "
             }
           ],
+          "fileUrlPath": "dist/ecs/Observable.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -29323,6 +29882,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "Observable",
           "preserveMemberOrder": false,
           "members": [
@@ -29494,6 +30054,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -29559,6 +30120,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addOnce"
             },
             {
@@ -29589,6 +30151,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clear"
             },
             {
@@ -29624,6 +30187,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -29654,6 +30218,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasObservers"
             },
             {
@@ -29701,6 +30266,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hasSpecificMask"
             },
             {
@@ -29785,6 +30351,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "notifyObserver"
             },
             {
@@ -29880,6 +30447,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "notifyObservers"
             },
             {
@@ -29980,6 +30548,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "notifyObserversWithPromise"
             },
             {
@@ -30036,6 +30605,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "remove"
             },
             {
@@ -30108,6 +30678,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "removeCallback"
             }
           ],
@@ -30123,7 +30694,9 @@
               "text": "export declare class ObservableComponent "
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ObservableComponent",
           "preserveMemberOrder": false,
           "members": [
@@ -30189,7 +30762,68 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "component"
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@dcl/legacy-ecs!ObservableComponent#data:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "data: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "data",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@dcl/legacy-ecs!ObservableComponent#dirty:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "dirty: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "dirty",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -30253,6 +30887,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "field"
             },
             {
@@ -30301,6 +30936,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "onChange"
             },
             {
@@ -30365,6 +31001,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "readonly"
             },
             {
@@ -30395,6 +31032,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             },
             {
@@ -30459,6 +31097,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "uiValue"
             }
           ],
@@ -30471,7 +31110,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type ObservableComponentSubscription = "
+              "text": "export type ObservableComponentSubscription = "
             },
             {
               "kind": "Content",
@@ -30482,6 +31121,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Component.d.ts",
           "releaseTag": "Public",
           "name": "ObservableComponentSubscription",
           "typeTokenRange": {
@@ -30499,6 +31139,7 @@
               "text": "export declare class Observer<T> "
             }
           ],
+          "fileUrlPath": "dist/ecs/Observable.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -30513,6 +31154,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "Observer",
           "preserveMemberOrder": false,
           "members": [
@@ -30543,7 +31185,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Constructor",
@@ -30654,7 +31297,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -30683,7 +31327,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -30712,7 +31357,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -30741,7 +31387,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -30756,7 +31403,9 @@
               "text": "export declare class ObserverEventState "
             }
           ],
+          "fileUrlPath": "dist/ecs/Observable.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ObserverEventState",
           "preserveMemberOrder": false,
           "members": [
@@ -30867,7 +31516,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -30963,6 +31613,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "initalize"
             },
             {
@@ -30992,7 +31643,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -31021,7 +31673,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -31050,7 +31703,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -31079,7 +31733,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -31107,7 +31762,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnAnimationEnd",
           "preserveMemberOrder": false,
           "members": [
@@ -31138,7 +31795,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31170,7 +31828,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnBlur",
           "preserveMemberOrder": false,
           "members": [
@@ -31242,7 +31902,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31270,6 +31931,7 @@
               "text": "<{\n    cameraMode: 0 | 1 | 2;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onCameraModeChangedObservable",
@@ -31301,7 +31963,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnChanged",
           "preserveMemberOrder": false,
           "members": [
@@ -31373,7 +32037,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31405,7 +32070,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnClick",
           "preserveMemberOrder": false,
           "members": [
@@ -31535,7 +32202,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31567,7 +32235,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnEnter",
           "preserveMemberOrder": false,
           "members": [
@@ -31639,7 +32309,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31667,6 +32338,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onEnterScene",
@@ -31694,6 +32366,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onEnterSceneObservable",
@@ -31725,7 +32398,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnFocus",
           "preserveMemberOrder": false,
           "members": [
@@ -31797,7 +32472,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31829,7 +32505,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Gizmos.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnGizmoEvent",
           "preserveMemberOrder": false,
           "members": [
@@ -31860,7 +32538,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -31888,6 +32567,7 @@
               "text": "<{\n    isIdle: boolean;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onIdleStateChangedObservable",
@@ -31915,6 +32595,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onLeaveScene",
@@ -31942,6 +32623,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onLeaveSceneObservable",
@@ -31987,6 +32669,7 @@
               "text": ";\n        distance: number;\n    };\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onPlayerClickedObservable",
@@ -32014,6 +32697,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onPlayerConnectedObservable",
@@ -32041,6 +32725,7 @@
               "text": "<{\n    userId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onPlayerDisconnectedObservable",
@@ -32068,6 +32753,7 @@
               "text": "<{\n    expressionId: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onPlayerExpressionObservable",
@@ -32099,7 +32785,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnPointerDown",
           "preserveMemberOrder": false,
           "members": [
@@ -32229,7 +32917,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -32261,7 +32950,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnPointerHoverEnter",
           "preserveMemberOrder": false,
           "members": [
@@ -32391,7 +33082,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -32407,7 +33099,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type OnPointerHoverEnterUUIDEventOptions = "
+              "text": "export type OnPointerHoverEnterUUIDEventOptions = "
             },
             {
               "kind": "Content",
@@ -32418,6 +33110,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
           "name": "OnPointerHoverEnterUUIDEventOptions",
           "typeTokenRange": {
@@ -32448,7 +33141,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnPointerHoverExit",
           "preserveMemberOrder": false,
           "members": [
@@ -32520,7 +33215,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -32548,6 +33244,7 @@
               "text": "<{\n    locked?: boolean | undefined;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onPointerLockedStateChange",
@@ -32579,7 +33276,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnPointerUp",
           "preserveMemberOrder": false,
           "members": [
@@ -32709,7 +33408,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -32754,6 +33454,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -32768,6 +33469,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "OnPointerUUIDEvent",
           "preserveMemberOrder": false,
           "members": [
@@ -32799,7 +33501,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -32828,7 +33531,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -32857,7 +33561,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -32886,7 +33591,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -32925,6 +33631,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             }
           ],
@@ -32941,7 +33648,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type OnPointerUUIDEventOptions = "
+              "text": "export type OnPointerUUIDEventOptions = "
             },
             {
               "kind": "Content",
@@ -32961,6 +33668,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
           "name": "OnPointerUUIDEventOptions",
           "typeTokenRange": {
@@ -32987,6 +33695,7 @@
               "text": "<{\n    ethAddress: string;\n    version: number;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onProfileChanged",
@@ -33014,6 +33723,7 @@
               "text": "<{\n    domain: string;\n    room: string;\n    serverName: string;\n    displayName: string;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onRealmChangedObservable",
@@ -33041,6 +33751,7 @@
               "text": "<{}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onSceneReadyObservable",
@@ -33072,7 +33783,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIEvents.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "OnTextSubmit",
           "preserveMemberOrder": false,
           "members": [
@@ -33144,7 +33857,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -33185,6 +33899,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -33199,6 +33914,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "OnUUIDEvent",
           "preserveMemberOrder": false,
           "members": [
@@ -33270,7 +33986,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -33300,6 +34017,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             },
             {
@@ -33364,6 +34082,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "uuidEvent"
             }
           ],
@@ -33392,6 +34111,7 @@
               "text": "<{\n    componentId: string;\n    videoClipId: string;\n    videoStatus: number;\n    currentOffset: number;\n    totalVideoLength: number;\n}>"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "onVideoEvent",
@@ -33426,6 +34146,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/helpers.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 3,
             "endIndex": 4
@@ -33478,6 +34199,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/helpers.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 5,
             "endIndex": 6
@@ -33514,6 +34236,7 @@
               "text": "export declare enum Orientation "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "Orientation",
           "preserveMemberOrder": false,
@@ -33569,7 +34292,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type ParcelsWithAccess = "
+              "text": "export type ParcelsWithAccess = "
             },
             {
               "kind": "Reference",
@@ -33594,6 +34317,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "ParcelsWithAccess",
           "typeTokenRange": {
@@ -33611,7 +34335,9 @@
               "text": "export declare class ParentChanged "
             }
           ],
+          "fileUrlPath": "dist/ecs/IEntity.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "ParentChanged",
           "preserveMemberOrder": false,
           "members": [
@@ -33697,7 +34423,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -33731,7 +34458,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -33746,7 +34474,9 @@
               "text": "export declare class Path2 "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Path2d.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Path2",
           "preserveMemberOrder": false,
           "members": [
@@ -33908,6 +34638,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addArcTo"
             },
             {
@@ -33972,6 +34703,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addLineTo"
             },
             {
@@ -34003,6 +34735,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "close"
             },
             {
@@ -34032,7 +34765,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -34080,6 +34814,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getPointAtLengthPosition"
             },
             {
@@ -34115,6 +34850,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getPoints"
             },
             {
@@ -34145,6 +34881,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "length"
             },
             {
@@ -34209,6 +34946,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "StartingAt"
             }
           ],
@@ -34224,7 +34962,9 @@
               "text": "export declare class Path3D "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Path3d.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Path3D",
           "preserveMemberOrder": false,
           "members": [
@@ -34344,6 +35084,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getBinormals"
             },
             {
@@ -34379,6 +35120,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getCurve"
             },
             {
@@ -34409,6 +35151,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getDistances"
             },
             {
@@ -34444,6 +35187,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getNormals"
             },
             {
@@ -34479,6 +35223,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getTangents"
             },
             {
@@ -34513,7 +35258,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -34596,6 +35342,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "update"
             }
           ],
@@ -34620,7 +35367,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "PhysicsCast",
           "preserveMemberOrder": false,
           "members": [
@@ -34652,6 +35401,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ensureInstance"
             },
             {
@@ -34700,6 +35450,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getRayFromCamera"
             },
             {
@@ -34766,6 +35517,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getRayFromPositions"
             },
             {
@@ -34827,6 +35579,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "handleRaycastHitAllResponse"
             },
             {
@@ -34888,6 +35641,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "handleRaycastHitFirstResponse"
             },
             {
@@ -34977,6 +35731,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hitAll"
             },
             {
@@ -35050,6 +35805,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hitAllAvatars"
             },
             {
@@ -35139,6 +35895,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hitFirst"
             },
             {
@@ -35212,6 +35969,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "hitFirstAvatar"
             },
             {
@@ -35242,7 +36000,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": [
@@ -35262,6 +36021,7 @@
               "text": "export declare enum PictureFrameStyle "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "PictureFrameStyle",
           "preserveMemberOrder": false,
@@ -35761,7 +36521,9 @@
               "text": "export declare class Plane "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Plane.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Plane",
           "preserveMemberOrder": false,
           "members": [
@@ -35873,6 +36635,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -35904,6 +36667,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -35987,6 +36751,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromPoints"
             },
             {
@@ -36016,7 +36781,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -36064,6 +36830,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "dotCoordinate"
             },
             {
@@ -36117,6 +36884,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -36200,6 +36968,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromPoints"
             },
             {
@@ -36266,6 +37035,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromPositionAndNormal"
             },
             {
@@ -36296,6 +37066,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -36326,6 +37097,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -36390,6 +37162,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "isFrontFacingTo"
             },
             {
@@ -36420,7 +37193,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -36451,6 +37225,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalize"
             },
             {
@@ -36499,6 +37274,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "signedDistanceTo"
             },
             {
@@ -36581,6 +37357,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "SignedDistanceToPlaneFromPositionAndNormal"
             },
             {
@@ -36630,6 +37407,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "transform"
             }
           ],
@@ -36654,7 +37432,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "PlaneShape",
           "preserveMemberOrder": false,
           "members": [
@@ -36685,7 +37465,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -36714,7 +37495,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -36743,7 +37525,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -36762,6 +37545,7 @@
               "text": "export declare class PointerEvent<GlobalInputEventResult> "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -36776,6 +37560,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "PointerEvent",
           "preserveMemberOrder": false,
           "members": [
@@ -36838,7 +37623,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -36853,7 +37639,9 @@
               "text": "export declare class PointerEventComponent "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "PointerEventComponent",
           "preserveMemberOrder": false,
           "members": [
@@ -36934,7 +37722,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -36958,7 +37747,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Systems.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "PointerEventSystem",
           "preserveMemberOrder": false,
           "members": [
@@ -37008,6 +37799,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "activate"
             },
             {
@@ -37038,6 +37830,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "deactivate"
             }
           ],
@@ -37055,7 +37848,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type ProfileForRenderer = "
+              "text": "export type ProfileForRenderer = "
             },
             {
               "kind": "Content",
@@ -37084,6 +37877,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "ProfileForRenderer",
           "typeTokenRange": {
@@ -37110,7 +37904,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Quaternion.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Quaternion",
           "preserveMemberOrder": false,
           "members": [
@@ -37257,6 +38053,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Angle"
             },
             {
@@ -37322,6 +38119,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "angleAxis"
             },
             {
@@ -37387,6 +38185,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "AreClose"
             },
             {
@@ -37417,6 +38216,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -37448,6 +38248,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -37479,6 +38280,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "conjugate"
             },
             {
@@ -37510,6 +38312,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "conjugateInPlace"
             },
             {
@@ -37559,6 +38362,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "conjugateToRef"
             },
             {
@@ -37608,6 +38412,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -37704,6 +38509,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -37769,6 +38575,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Dot"
             },
             {
@@ -37817,6 +38624,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -37897,6 +38705,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Euler"
             },
             {
@@ -37927,7 +38736,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -37996,6 +38806,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -38092,6 +38903,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromEulerAnglesRef"
             },
             {
@@ -38141,6 +38953,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "fromRotationMatrix"
             },
             {
@@ -38190,6 +39003,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromRotationMatrix"
             },
             {
@@ -38255,6 +39069,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromRotationMatrixToRef"
             },
             {
@@ -38338,6 +39153,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromToRotation"
             },
             {
@@ -38368,6 +39184,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -38398,6 +39215,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -38514,6 +39332,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Hermite"
             },
             {
@@ -38544,7 +39363,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -38593,6 +39413,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Inverse"
             },
             {
@@ -38641,6 +39462,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "IsIdentity"
             },
             {
@@ -38670,7 +39492,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -38699,7 +39522,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -38765,6 +39589,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LookRotation"
             },
             {
@@ -38814,6 +39639,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -38863,6 +39689,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyInPlace"
             },
             {
@@ -38929,6 +39756,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -38960,6 +39788,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalize"
             },
             {
@@ -38990,7 +39819,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -39072,6 +39902,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotateTowards"
             },
             {
@@ -39152,6 +39983,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAlphaBetaGamma"
             },
             {
@@ -39248,6 +40080,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAlphaBetaGammaToRef"
             },
             {
@@ -39313,6 +40146,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAxis"
             },
             {
@@ -39395,6 +40229,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationAxisToRef"
             },
             {
@@ -39478,6 +40313,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationQuaternionFromAxis"
             },
             {
@@ -39577,6 +40413,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationQuaternionFromAxisToRef"
             },
             {
@@ -39657,6 +40494,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationYawPitchRoll"
             },
             {
@@ -39753,6 +40591,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationYawPitchRollToRef"
             },
             {
@@ -39801,6 +40640,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -39866,6 +40706,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -39914,6 +40755,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleInPlace"
             },
             {
@@ -39979,6 +40821,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -40075,6 +40918,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -40155,6 +40999,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setEuler"
             },
             {
@@ -40237,6 +41082,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setFromToRotation"
             },
             {
@@ -40319,6 +41165,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Slerp"
             },
             {
@@ -40417,6 +41264,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "SlerpToRef"
             },
             {
@@ -40466,6 +41314,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -40515,6 +41364,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toRotationMatrix"
             },
             {
@@ -40545,6 +41395,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -40574,7 +41425,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -40603,7 +41455,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -40632,7 +41485,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -40661,7 +41515,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -40692,6 +41547,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -40709,7 +41565,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type QueryType = "
+              "text": "export type QueryType = "
             },
             {
               "kind": "Content",
@@ -40720,6 +41576,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "QueryType",
           "typeTokenRange": {
@@ -40741,6 +41598,7 @@
               "text": "number"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "RAD2DEG",
@@ -40759,6 +41617,7 @@
               "text": "export interface Ray "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "Ray",
           "preserveMemberOrder": false,
@@ -40868,7 +41727,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Systems.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "RaycastEventSystem",
           "preserveMemberOrder": false,
           "members": [
@@ -40918,6 +41779,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "activate"
             },
             {
@@ -40948,6 +41810,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "deactivate"
             }
           ],
@@ -40968,6 +41831,7 @@
               "text": "export interface RaycastHit "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "RaycastHit",
           "preserveMemberOrder": false,
@@ -41105,6 +41969,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "RaycastHitAvatar",
           "preserveMemberOrder": false,
@@ -41164,6 +42029,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "RaycastHitAvatars",
           "preserveMemberOrder": false,
@@ -41227,6 +42093,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "RaycastHitEntities",
           "preserveMemberOrder": false,
@@ -41290,6 +42157,7 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/PhysicsCast.d.ts",
           "releaseTag": "Public",
           "name": "RaycastHitEntity",
           "preserveMemberOrder": false,
@@ -41340,6 +42208,7 @@
               "text": "export declare class RaycastResponse<T> "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -41354,6 +42223,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "RaycastResponse",
           "preserveMemberOrder": false,
           "members": [
@@ -41426,7 +42296,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -41449,6 +42320,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Color4.d.ts",
           "releaseTag": "Public",
           "name": "ReadOnlyColor4",
           "typeTokenRange": {
@@ -41466,7 +42338,9 @@
               "text": "export declare class Scalar "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Scalar.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Scalar",
           "preserveMemberOrder": false,
           "members": [
@@ -41547,6 +42421,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Clamp"
             },
             {
@@ -41610,6 +42485,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DeltaAngle"
             },
             {
@@ -41689,6 +42565,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Denormalize"
             },
             {
@@ -41800,6 +42677,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Hermite"
             },
             {
@@ -41879,6 +42757,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "InverseLerp"
             },
             {
@@ -41958,6 +42837,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -42037,6 +42917,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LerpAngle"
             },
             {
@@ -42084,6 +42965,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Log2"
             },
             {
@@ -42163,6 +43045,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "MoveTowards"
             },
             {
@@ -42242,6 +43125,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "MoveTowardsAngle"
             },
             {
@@ -42321,6 +43205,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Normalize"
             },
             {
@@ -42368,6 +43253,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "NormalizeRadians"
             },
             {
@@ -42447,6 +43333,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PercentToRange"
             },
             {
@@ -42510,6 +43397,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PingPong"
             },
             {
@@ -42573,6 +43461,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RandomRange"
             },
             {
@@ -42652,6 +43541,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RangeToPercent"
             },
             {
@@ -42715,6 +43605,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Repeat"
             },
             {
@@ -42762,6 +43653,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Sign"
             },
             {
@@ -42841,6 +43733,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "SmoothStep"
             },
             {
@@ -42888,6 +43781,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ToHex"
             },
             {
@@ -42917,7 +43811,8 @@
                 "endIndex": 2
               },
               "isStatic": true,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -42996,6 +43891,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "WithinEpsilon"
             }
           ],
@@ -43020,7 +43916,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Shape",
           "preserveMemberOrder": false,
           "members": [
@@ -43051,7 +43949,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -43080,7 +43979,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -43109,7 +44009,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -43137,7 +44038,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Size.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Size",
           "preserveMemberOrder": false,
           "members": [
@@ -43236,6 +44139,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -43267,6 +44171,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -43315,6 +44220,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -43379,6 +44285,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -43427,6 +44334,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -43457,6 +44365,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -43487,6 +44396,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -43516,7 +44426,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -43598,6 +44509,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -43662,6 +44574,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyByFloats"
             },
             {
@@ -43726,6 +44639,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -43775,6 +44689,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -43804,7 +44719,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -43834,6 +44750,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -43863,7 +44780,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -43894,6 +44812,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -43905,6 +44824,37 @@
           ]
         },
         {
+          "kind": "Class",
+          "canonicalReference": "@dcl/legacy-ecs!SmartItem:class",
+          "docComment": "/**\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class SmartItem extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "ObservableComponent",
+              "canonicalReference": "@dcl/legacy-ecs!ObservableComponent:class"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
+          "releaseTag": "Public",
+          "isAbstract": false,
+          "name": "SmartItem",
+          "preserveMemberOrder": false,
+          "members": [],
+          "extendsTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
+          "implementsTokenRanges": []
+        },
+        {
           "kind": "Enum",
           "canonicalReference": "@dcl/legacy-ecs!Space:enum",
           "docComment": "/**\n * Defines supported spaces\n *\n * @public\n */\n",
@@ -43914,6 +44864,7 @@
               "text": "export declare enum Space "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "releaseTag": "Public",
           "name": "Space",
           "preserveMemberOrder": false,
@@ -44002,7 +44953,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "SphereShape",
           "preserveMemberOrder": false,
           "members": [],
@@ -44022,7 +44975,9 @@
               "text": "export declare class Subscription "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Input.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Subscription",
           "preserveMemberOrder": false,
           "members": [
@@ -44119,7 +45074,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44148,7 +45104,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -44160,7 +45117,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type TaskResult<T> = "
+              "text": "export type TaskResult<T> = "
             },
             {
               "kind": "Reference",
@@ -44185,6 +45142,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/Task.d.ts",
           "releaseTag": "Public",
           "name": "TaskResult",
           "typeParameters": [
@@ -44231,6 +45189,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/ecs/UserActions.d.ts",
           "returnTypeTokenRange": {
             "startIndex": 3,
             "endIndex": 4
@@ -44268,7 +45227,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "TextShape",
           "preserveMemberOrder": false,
           "members": [
@@ -44331,7 +45292,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44361,7 +45323,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44391,7 +45354,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44420,7 +45384,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44449,7 +45414,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44478,7 +45444,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44507,7 +45474,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44536,7 +45504,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44565,7 +45534,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44595,7 +45565,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44624,7 +45595,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44653,7 +45625,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44682,7 +45655,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44711,7 +45685,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44740,7 +45715,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44769,7 +45745,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44799,7 +45776,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44828,7 +45806,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44857,7 +45836,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44886,7 +45866,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44915,7 +45896,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44944,7 +45926,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -44973,7 +45956,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45002,7 +45986,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -45030,7 +46015,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Texture",
           "preserveMemberOrder": false,
           "members": [
@@ -45132,7 +46119,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45161,7 +46149,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45190,7 +46179,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45219,7 +46209,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -45242,6 +46233,7 @@
               "text": "number"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "ToGammaSpace",
@@ -45264,6 +46256,7 @@
               "text": "2.2"
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/types.d.ts",
           "initializerTokenRange": {
             "startIndex": 1,
             "endIndex": 2
@@ -45283,7 +46276,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type TranformConstructorArgs = "
+              "text": "export type TranformConstructorArgs = "
             },
             {
               "kind": "Reference",
@@ -45295,6 +46288,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "TranformConstructorArgs",
           "typeTokenRange": {
@@ -45321,7 +46315,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Transform",
           "preserveMemberOrder": false,
           "members": [
@@ -45386,7 +46382,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -45451,6 +46448,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "lookAt"
             },
             {
@@ -45481,7 +46479,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -45545,6 +46544,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "rotate"
             },
             {
@@ -45575,7 +46575,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45605,7 +46606,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -45653,6 +46655,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "translate"
             }
           ],
@@ -45669,7 +46672,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type TransformConstructorArgs = "
+              "text": "export type TransformConstructorArgs = "
             },
             {
               "kind": "Content",
@@ -45707,6 +46710,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "TransformConstructorArgs",
           "typeTokenRange": {
@@ -45724,6 +46728,7 @@
               "text": "export declare enum TransparencyMode "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "TransparencyMode",
           "preserveMemberOrder": false,
@@ -45854,7 +46859,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIButton",
           "preserveMemberOrder": false,
           "members": [
@@ -45886,7 +46893,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45916,7 +46924,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45945,7 +46954,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -45974,7 +46984,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46003,7 +47014,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46032,7 +47044,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46061,7 +47074,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46090,7 +47104,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46119,7 +47134,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46148,7 +47164,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46178,7 +47195,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46207,7 +47225,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46236,7 +47255,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46265,7 +47285,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46294,7 +47315,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -46322,7 +47344,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UICanvas",
           "preserveMemberOrder": false,
           "members": [
@@ -46367,7 +47391,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIContainerRect",
           "preserveMemberOrder": false,
           "members": [
@@ -46398,7 +47424,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46428,7 +47455,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46457,7 +47485,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -46485,7 +47514,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIContainerStack",
           "preserveMemberOrder": false,
           "members": [
@@ -46516,7 +47547,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46545,7 +47577,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46575,7 +47608,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46604,7 +47638,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46634,7 +47669,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -46662,7 +47698,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIImage",
           "preserveMemberOrder": false,
           "members": [
@@ -46757,7 +47795,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46786,7 +47825,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46815,7 +47855,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46844,7 +47885,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46873,7 +47915,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46902,7 +47945,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46941,7 +47985,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46970,7 +48015,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -46999,7 +48045,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47028,7 +48075,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47057,7 +48105,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -47085,7 +48134,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIInputText",
           "preserveMemberOrder": false,
           "members": [
@@ -47154,7 +48205,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47184,7 +48236,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47214,7 +48267,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47243,7 +48297,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47272,7 +48327,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47301,7 +48357,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47335,7 +48392,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47369,7 +48427,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47403,7 +48462,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47437,7 +48497,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47467,7 +48528,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47496,7 +48558,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47525,7 +48588,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47554,7 +48618,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47583,7 +48648,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47612,7 +48678,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47641,7 +48708,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47670,7 +48738,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47700,7 +48769,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47729,7 +48799,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47758,7 +48829,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47787,7 +48859,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47816,7 +48889,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47845,7 +48919,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -47873,7 +48948,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIScrollRect",
           "preserveMemberOrder": false,
           "members": [
@@ -47905,7 +48982,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47934,7 +49012,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47963,7 +49042,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -47997,7 +49077,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48026,7 +49107,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48055,7 +49137,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48084,7 +49167,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48113,7 +49197,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48142,7 +49227,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48171,7 +49257,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -48199,7 +49286,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": true,
           "name": "UIShape",
           "preserveMemberOrder": false,
           "members": [
@@ -48267,7 +49356,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48296,7 +49386,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48325,7 +49416,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48354,7 +49446,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48383,7 +49476,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48417,7 +49511,8 @@
                 "endIndex": 3
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48446,7 +49541,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48475,7 +49571,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48504,7 +49601,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48533,7 +49631,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48562,7 +49661,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -48581,6 +49681,7 @@
               "text": "export declare enum UIStackOrientation "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
           "name": "UIStackOrientation",
           "preserveMemberOrder": false,
@@ -48648,7 +49749,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/UIShapes.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIText",
           "preserveMemberOrder": false,
           "members": [
@@ -48679,7 +49782,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48708,7 +49812,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48738,7 +49843,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48768,7 +49874,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48797,7 +49904,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48826,7 +49934,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48855,7 +49964,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48884,7 +49994,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48913,7 +50024,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48943,7 +50055,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -48972,7 +50085,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49001,7 +50115,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49030,7 +50145,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49059,7 +50175,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49088,7 +50205,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49117,7 +50235,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49147,7 +50266,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49176,7 +50296,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49205,7 +50326,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49234,7 +50356,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49263,7 +50386,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49292,7 +50416,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -49311,7 +50436,9 @@
               "text": "export declare class UIValue "
             }
           ],
+          "fileUrlPath": "dist/ecs/UIValue.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UIValue",
           "preserveMemberOrder": false,
           "members": [
@@ -49375,6 +50502,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -49405,7 +50533,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49434,7 +50563,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -49449,6 +50579,7 @@
               "text": "export declare enum UIValueType "
             }
           ],
+          "fileUrlPath": "dist/ecs/UIValue.d.ts",
           "releaseTag": "Public",
           "name": "UIValueType",
           "preserveMemberOrder": false,
@@ -49515,6 +50646,7 @@
               "text": "> "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Events.d.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -49529,6 +50661,7 @@
               }
             }
           ],
+          "isAbstract": false,
           "name": "UUIDEvent",
           "preserveMemberOrder": false,
           "members": [
@@ -49607,7 +50740,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -49636,7 +50770,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "implementsTokenRanges": []
@@ -49660,7 +50795,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Systems.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "UUIDEventSystem",
           "preserveMemberOrder": false,
           "members": [
@@ -49710,6 +50847,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "activate"
             },
             {
@@ -49740,6 +50878,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "deactivate"
             },
             {
@@ -49778,7 +50917,8 @@
                 "endIndex": 4
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -49826,6 +50966,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "onAddEntity"
             },
             {
@@ -49874,6 +51015,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "onRemoveEntity"
             }
           ],
@@ -49903,7 +51045,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector2.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Vector2",
           "preserveMemberOrder": false,
           "members": [
@@ -50002,6 +51146,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -50068,6 +51213,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Add"
             },
             {
@@ -50117,6 +51263,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addInPlace"
             },
             {
@@ -50183,6 +51330,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToRef"
             },
             {
@@ -50232,6 +51380,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addVector3"
             },
             {
@@ -50262,6 +51411,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -50378,6 +51528,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CatmullRom"
             },
             {
@@ -50444,6 +51595,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Center"
             },
             {
@@ -50527,6 +51679,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Clamp"
             },
             {
@@ -50558,6 +51711,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -50607,6 +51761,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -50671,6 +51826,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -50736,6 +51892,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Distance"
             },
             {
@@ -50818,6 +51975,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DistanceOfPointFromSegment"
             },
             {
@@ -50883,6 +52041,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DistanceSquared"
             },
             {
@@ -50932,6 +52091,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divide"
             },
             {
@@ -50981,6 +52141,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideInPlace"
             },
             {
@@ -51047,6 +52208,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideToRef"
             },
             {
@@ -51112,6 +52274,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Dot"
             },
             {
@@ -51160,6 +52323,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -51224,6 +52388,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsWithEpsilon"
             },
             {
@@ -51255,6 +52420,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "floor"
             },
             {
@@ -51286,6 +52452,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "fract"
             },
             {
@@ -51355,6 +52522,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -51440,6 +52608,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArrayToRef"
             },
             {
@@ -51470,6 +52639,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -51500,6 +52670,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -51616,6 +52787,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Hermite"
             },
             {
@@ -51646,6 +52818,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "length"
             },
             {
@@ -51676,6 +52849,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "lengthSquared"
             },
             {
@@ -51758,6 +52932,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -51824,6 +52999,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Maximize"
             },
             {
@@ -51890,6 +53066,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Minimize"
             },
             {
@@ -51939,6 +53116,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -52003,6 +53181,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyByFloats"
             },
             {
@@ -52052,6 +53231,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyInPlace"
             },
             {
@@ -52118,6 +53298,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -52149,6 +53330,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "negate"
             },
             {
@@ -52180,6 +53362,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalize"
             },
             {
@@ -52229,6 +53412,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Normalize"
             },
             {
@@ -52260,6 +53444,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "One"
             },
             {
@@ -52359,6 +53544,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "PointInTriangle"
             },
             {
@@ -52407,6 +53593,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -52472,6 +53659,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -52520,6 +53708,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleInPlace"
             },
             {
@@ -52585,6 +53774,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -52649,6 +53839,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -52698,6 +53889,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -52747,6 +53939,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractInPlace"
             },
             {
@@ -52813,6 +54006,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractToRef"
             },
             {
@@ -52878,6 +54072,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -52908,6 +54103,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -52974,6 +54170,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Transform"
             },
             {
@@ -53056,6 +54253,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformToRef"
             },
             {
@@ -53085,7 +54283,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -53114,7 +54313,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -53145,6 +54345,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -53174,7 +54375,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector3.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Vector3",
           "preserveMemberOrder": false,
           "members": [
@@ -53289,6 +54492,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -53355,6 +54559,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Add"
             },
             {
@@ -53404,6 +54609,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addInPlace"
             },
             {
@@ -53484,6 +54690,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addInPlaceFromFloats"
             },
             {
@@ -53550,6 +54757,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToRef"
             },
             {
@@ -53598,6 +54806,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "applyMatrix4"
             },
             {
@@ -53664,6 +54873,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "applyMatrix4ToRef"
             },
             {
@@ -53694,6 +54904,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -53725,6 +54936,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Backward"
             },
             {
@@ -53841,6 +55053,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CatmullRom"
             },
             {
@@ -53907,6 +55120,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Center"
             },
             {
@@ -53990,6 +55204,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Clamp"
             },
             {
@@ -54089,6 +55304,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "ClampToRef"
             },
             {
@@ -54120,6 +55336,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -54169,6 +55386,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -54249,6 +55467,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -54315,6 +55534,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Cross"
             },
             {
@@ -54397,6 +55617,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "CrossToRef"
             },
             {
@@ -54462,6 +55683,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Distance"
             },
             {
@@ -54527,6 +55749,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DistanceSquared"
             },
             {
@@ -54576,6 +55799,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divide"
             },
             {
@@ -54625,6 +55849,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideInPlace"
             },
             {
@@ -54691,6 +55916,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideToRef"
             },
             {
@@ -54756,6 +55982,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Dot"
             },
             {
@@ -54787,6 +56014,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Down"
             },
             {
@@ -54835,6 +56063,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -54914,6 +56143,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsToFloats"
             },
             {
@@ -54978,6 +56208,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsWithEpsilon"
             },
             {
@@ -55009,6 +56240,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "floor"
             },
             {
@@ -55040,6 +56272,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Forward"
             },
             {
@@ -55071,6 +56304,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "fract"
             },
             {
@@ -55140,6 +56374,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -55225,6 +56460,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArrayToRef"
             },
             {
@@ -55290,6 +56526,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatArray"
             },
             {
@@ -55371,6 +56608,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatArrayToRef"
             },
             {
@@ -55467,6 +56705,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatsToRef"
             },
             {
@@ -55549,6 +56788,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetAngleBetweenVectors"
             },
             {
@@ -55579,6 +56819,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -55677,6 +56918,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "GetClipFactor"
             },
             {
@@ -55707,6 +56949,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -55823,6 +57066,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Hermite"
             },
             {
@@ -55852,7 +57096,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -55883,6 +57128,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Left"
             },
             {
@@ -55913,6 +57159,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "length"
             },
             {
@@ -55943,6 +57190,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "lengthSquared"
             },
             {
@@ -56025,6 +57273,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Lerp"
             },
             {
@@ -56123,6 +57372,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "LerpToRef"
             },
             {
@@ -56189,6 +57439,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Maximize"
             },
             {
@@ -56238,6 +57489,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "maximizeInPlace"
             },
             {
@@ -56318,6 +57570,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "maximizeInPlaceFromFloats"
             },
             {
@@ -56384,6 +57637,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Minimize"
             },
             {
@@ -56433,6 +57687,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "minimizeInPlace"
             },
             {
@@ -56513,6 +57768,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "minimizeInPlaceFromFloats"
             },
             {
@@ -56562,6 +57818,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -56642,6 +57899,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyByFloats"
             },
             {
@@ -56691,6 +57949,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyInPlace"
             },
             {
@@ -56757,6 +58016,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -56788,6 +58048,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "negate"
             },
             {
@@ -56819,6 +58080,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalize"
             },
             {
@@ -56868,6 +58130,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Normalize"
             },
             {
@@ -56916,6 +58179,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalizeFromLength"
             },
             {
@@ -56947,6 +58211,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalizeToNew"
             },
             {
@@ -56996,6 +58261,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalizeToRef"
             },
             {
@@ -57061,6 +58327,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "NormalizeToRef"
             },
             {
@@ -57092,6 +58359,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "One"
             },
             {
@@ -57123,6 +58391,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Right"
             },
             {
@@ -57172,6 +58441,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "rotate"
             },
             {
@@ -57238,6 +58508,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "rotateToRef"
             },
             {
@@ -57321,6 +58592,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationFromAxis"
             },
             {
@@ -57420,6 +58692,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "RotationFromAxisToRef"
             },
             {
@@ -57468,6 +58741,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -57533,6 +58807,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -57581,6 +58856,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleInPlace"
             },
             {
@@ -57646,6 +58922,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -57726,6 +59003,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -57774,6 +59052,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setAll"
             },
             {
@@ -57823,6 +59102,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -57903,6 +59183,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractFromFloats"
             },
             {
@@ -58000,6 +59281,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractFromFloatsToRef"
             },
             {
@@ -58049,6 +59331,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractInPlace"
             },
             {
@@ -58115,6 +59398,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractToRef"
             },
             {
@@ -58180,6 +59464,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -58211,6 +59496,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toQuaternion"
             },
             {
@@ -58241,6 +59527,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -58307,6 +59594,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformCoordinates"
             },
             {
@@ -58433,6 +59721,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformCoordinatesFromFloatsToRef"
             },
             {
@@ -58528,6 +59817,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformCoordinatesToRef"
             },
             {
@@ -58594,6 +59884,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormal"
             },
             {
@@ -58720,6 +60011,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormalFromFloatsToRef"
             },
             {
@@ -58815,6 +60107,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormalToRef"
             },
             {
@@ -58846,6 +60139,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Up"
             },
             {
@@ -58875,7 +60169,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -58904,7 +60199,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -58933,7 +60229,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -58964,6 +60261,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -58993,7 +60291,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "node_modules/@dcl/ecs-math/dist/Vector4.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "Vector4",
           "preserveMemberOrder": false,
           "members": [
@@ -59124,6 +60424,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "add"
             },
             {
@@ -59190,6 +60491,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Add"
             },
             {
@@ -59239,6 +60541,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addInPlace"
             },
             {
@@ -59305,6 +60608,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "addToRef"
             },
             {
@@ -59335,6 +60639,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "asArray"
             },
             {
@@ -59401,6 +60706,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Center"
             },
             {
@@ -59432,6 +60738,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "clone"
             },
             {
@@ -59481,6 +60788,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFrom"
             },
             {
@@ -59577,6 +60885,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "copyFromFloats"
             },
             {
@@ -59642,6 +60951,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Distance"
             },
             {
@@ -59707,6 +61017,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "DistanceSquared"
             },
             {
@@ -59756,6 +61067,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divide"
             },
             {
@@ -59805,6 +61117,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideInPlace"
             },
             {
@@ -59871,6 +61184,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "divideToRef"
             },
             {
@@ -59919,6 +61233,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equals"
             },
             {
@@ -60014,6 +61329,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsToFloats"
             },
             {
@@ -60078,6 +61394,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "equalsWithEpsilon"
             },
             {
@@ -60109,6 +61426,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "floor"
             },
             {
@@ -60140,6 +61458,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "fract"
             },
             {
@@ -60209,6 +61528,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArray"
             },
             {
@@ -60294,6 +61614,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromArrayToRef"
             },
             {
@@ -60375,6 +61696,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatArrayToRef"
             },
             {
@@ -60487,6 +61809,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "FromFloatsToRef"
             },
             {
@@ -60517,6 +61840,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getClassName"
             },
             {
@@ -60547,6 +61871,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "getHashCode"
             },
             {
@@ -60577,6 +61902,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "length"
             },
             {
@@ -60607,6 +61933,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "lengthSquared"
             },
             {
@@ -60673,6 +62000,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Maximize"
             },
             {
@@ -60722,6 +62050,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "maximizeInPlace"
             },
             {
@@ -60788,6 +62117,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Minimize"
             },
             {
@@ -60837,6 +62167,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "minimizeInPlace"
             },
             {
@@ -60886,6 +62217,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiply"
             },
             {
@@ -60982,6 +62314,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyByFloats"
             },
             {
@@ -61031,6 +62364,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyInPlace"
             },
             {
@@ -61097,6 +62431,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "multiplyToRef"
             },
             {
@@ -61128,6 +62463,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "negate"
             },
             {
@@ -61159,6 +62495,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "normalize"
             },
             {
@@ -61208,6 +62545,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Normalize"
             },
             {
@@ -61273,6 +62611,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "NormalizeToRef"
             },
             {
@@ -61304,6 +62643,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "One"
             },
             {
@@ -61352,6 +62692,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scale"
             },
             {
@@ -61417,6 +62758,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleAndAddToRef"
             },
             {
@@ -61465,6 +62807,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleInPlace"
             },
             {
@@ -61530,6 +62873,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "scaleToRef"
             },
             {
@@ -61626,6 +62970,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "set"
             },
             {
@@ -61674,6 +63019,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "setAll"
             },
             {
@@ -61723,6 +63069,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtract"
             },
             {
@@ -61819,6 +63166,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractFromFloats"
             },
             {
@@ -61932,6 +63280,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractFromFloatsToRef"
             },
             {
@@ -61981,6 +63330,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractInPlace"
             },
             {
@@ -62047,6 +63397,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "subtractToRef"
             },
             {
@@ -62112,6 +63463,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toArray"
             },
             {
@@ -62142,6 +63494,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toString"
             },
             {
@@ -62173,6 +63526,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toVector3"
             },
             {
@@ -62239,6 +63593,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormal"
             },
             {
@@ -62368,6 +63723,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormalFromFloatsToRef"
             },
             {
@@ -62450,6 +63806,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "TransformNormalToRef"
             },
             {
@@ -62479,7 +63836,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -62508,7 +63866,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -62537,7 +63896,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -62566,7 +63926,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -62597,6 +63958,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "Zero"
             }
           ],
@@ -62626,7 +63988,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "VideoClip",
           "preserveMemberOrder": false,
           "members": [
@@ -62689,7 +64053,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -62708,6 +64073,7 @@
               "text": "export declare enum VideoStatus "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
           "name": "VideoStatus",
           "preserveMemberOrder": false,
@@ -62859,7 +64225,9 @@
               "text": " "
             }
           ],
+          "fileUrlPath": "dist/decentraland/Components.d.ts",
           "releaseTag": "Public",
+          "isAbstract": false,
           "name": "VideoTexture",
           "preserveMemberOrder": false,
           "members": [
@@ -62962,7 +64330,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -62992,6 +64361,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "pause"
             },
             {
@@ -63022,6 +64392,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "play"
             },
             {
@@ -63051,7 +64422,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63080,7 +64452,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63109,7 +64482,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -63139,6 +64513,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "reset"
             },
             {
@@ -63168,7 +64543,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63197,7 +64573,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -63244,6 +64621,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "seekTime"
             },
             {
@@ -63274,7 +64652,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Method",
@@ -63304,6 +64683,7 @@
               "overloadIndex": 1,
               "parameters": [],
               "isOptional": false,
+              "isAbstract": false,
               "name": "toJSON"
             },
             {
@@ -63356,6 +64736,7 @@
                 }
               ],
               "isOptional": false,
+              "isAbstract": false,
               "name": "update"
             },
             {
@@ -63385,7 +64766,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63414,7 +64796,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63443,7 +64826,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             },
             {
               "kind": "Property",
@@ -63472,7 +64856,8 @@
                 "endIndex": 2
               },
               "isStatic": false,
-              "isProtected": false
+              "isProtected": false,
+              "isAbstract": false
             }
           ],
           "extendsTokenRange": {
@@ -63488,7 +64873,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type Wearable = "
+              "text": "export type Wearable = "
             },
             {
               "kind": "Content",
@@ -63517,6 +64902,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "Wearable",
           "typeTokenRange": {
@@ -63531,7 +64917,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type WearableId = "
+              "text": "export type WearableId = "
             },
             {
               "kind": "Content",
@@ -63542,6 +64928,7 @@
               "text": ";"
             }
           ],
+          "fileUrlPath": "dist/decentraland/Types.d.ts",
           "releaseTag": "Public",
           "name": "WearableId",
           "typeTokenRange": {

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.json
@@ -14546,7 +14546,7 @@
               "canonicalReference": "@dcl/legacy-ecs!Engine:class"
             }
           ],
-          "fileUrlPath": "dist/0.6289080540469796index.d.ts",
+          "fileUrlPath": "dist/0.16640530207844217index.d.ts",
           "isReadonly": true,
           "releaseTag": "Public",
           "name": "engine",

--- a/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
+++ b/packages/decentraland-ecs/types/dcl/decentraland-ecs.api.md
@@ -1313,6 +1313,10 @@ export class ObservableComponent {
     // (undocumented)
     static component(target: ObservableComponent, propertyKey: string): void;
     // (undocumented)
+    data: any;
+    // (undocumented)
+    dirty: boolean;
+    // (undocumented)
     static field(target: ObservableComponent, propertyKey: string): void;
     // (undocumented)
     onChange(fn: ObservableComponentSubscription): this;
@@ -1973,6 +1977,10 @@ export class Size implements ISize {
     toString(): string;
     width: number;
     static Zero(): Size;
+}
+
+// @public (undocumented)
+export class SmartItem extends ObservableComponent {
 }
 
 // @public

--- a/packages/decentraland-ecs/types/dcl/index-beta.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-beta.d.ts
@@ -2999,6 +2999,8 @@ export declare class Observable<T> {
  * @public
  */
 export declare class ObservableComponent {
+    dirty: boolean;
+    data: any;
     private subscriptions;
     static component(target: ObservableComponent, propertyKey: string): void;
     static field(target: ObservableComponent, propertyKey: string): void;
@@ -4533,6 +4535,12 @@ export declare class Size implements ISize {
      * @returns a new Size set as the subtraction result of  the given one from the current Size.
      */
     subtract(otherSize: Size): Size;
+}
+
+/**
+ * @public
+ */
+export declare class SmartItem extends ObservableComponent {
 }
 
 /**

--- a/packages/decentraland-ecs/types/dcl/index-full.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index-full.d.ts
@@ -3001,6 +3001,8 @@ export declare class Observable<T> {
  * @public
  */
 export declare class ObservableComponent {
+    dirty: boolean;
+    data: any;
     private subscriptions;
     static component(target: ObservableComponent, propertyKey: string): void;
     static field(target: ObservableComponent, propertyKey: string): void;
@@ -4547,6 +4549,12 @@ export declare class Size implements ISize {
      * @returns a new Size set as the subtraction result of  the given one from the current Size.
      */
     subtract(otherSize: Size): Size;
+}
+
+/**
+ * @public
+ */
+export declare class SmartItem extends ObservableComponent {
 }
 
 /**

--- a/packages/decentraland-ecs/types/dcl/index.d.ts
+++ b/packages/decentraland-ecs/types/dcl/index.d.ts
@@ -2999,6 +2999,8 @@ declare class Observable<T> {
  * @public
  */
 declare class ObservableComponent {
+    dirty: boolean;
+    data: any;
     private subscriptions;
     static component(target: ObservableComponent, propertyKey: string): void;
     static field(target: ObservableComponent, propertyKey: string): void;
@@ -4533,6 +4535,12 @@ declare class Size implements ISize {
      * @returns a new Size set as the subtraction result of  the given one from the current Size.
      */
     subtract(otherSize: Size): Size;
+}
+
+/**
+ * @public
+ */
+declare class SmartItem extends ObservableComponent {
 }
 
 /**

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -89,7 +89,7 @@ flow('build-all', () => {
 
 function copyLegacyEcs() {
   it('copy legacy ecs iife to decentraland-ecs', () => {
-    const filesToCopy = ['index.js']
+    const filesToCopy = ['index.js', 'index.min.js']
     for (const file of filesToCopy) {
       const filePath = ensureFileExists(`dist/${file}`, LEGACY_ECS_PATH)
       copyFile(filePath, `${ECS_PATH}/dist/src/${file}`)

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -89,7 +89,7 @@ flow('build-all', () => {
 
 function copyLegacyEcs() {
   it('copy legacy ecs iife to decentraland-ecs', () => {
-    const filesToCopy = ['index.js', 'index.min.js', 'index.min.js.map']
+    const filesToCopy = ['index.js']
     for (const file of filesToCopy) {
       const filePath = ensureFileExists(`dist/${file}`, LEGACY_ECS_PATH)
       copyFile(filePath, `${ECS_PATH}/dist/src/${file}`)

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -32,6 +32,7 @@ export const LEGACY_ECS_PATH = resolve(
   process.cwd(),
   './packages/@dcl/legacy-ecs'
 )
+export const SCRIPTS_PATH = resolve(process.cwd(), './scripts')
 
 export function commonChecks() {
   test('tooling is installed', () => {

--- a/scripts/prepare.spec.ts
+++ b/scripts/prepare.spec.ts
@@ -1,3 +1,4 @@
+import { copySync } from 'fs-extra'
 import {
   flow,
   commonChecks,
@@ -5,7 +6,8 @@ import {
   BUILD_ECS_PATH,
   DECENTRALAND_AMD_PATH,
   ROLLUP_CONFIG_PATH,
-  LEGACY_ECS_PATH
+  LEGACY_ECS_PATH,
+  SCRIPTS_PATH
 } from './common'
 import {
   itExecutes,
@@ -25,6 +27,9 @@ flow('build-all', () => {
   })
 
   flow('pack every package', () => {
+    copySync(`${SCRIPTS_PATH}/resources/artifacts`, `${ECS_PATH}/artifacts`, {
+      recursive: true
+    })
     itExecutes('npm pack', ECS_PATH)
     itExecutes('npm pack', LEGACY_ECS_PATH)
     itExecutes('npm pack', DECENTRALAND_AMD_PATH)


### PR DESCRIPTION
This PR updates the `legacy-ecs` package to be transpiled as an ESM module.