### PR TITLE
feat: Add Rotate camera shortcut help

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.css
+++ b/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.css
@@ -63,7 +63,7 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  width: 298px;
+  width: 350px;
   overflow-y: auto;
   right: 0;
   bottom: calc(var(--shortcuts-bottom) + var(--shortcuts-button-height) + 8px);

--- a/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.tsx
@@ -77,6 +77,12 @@ const Shortcuts: React.FC<Props> = ({ canvas, onResetCamera, onZoomIn, onZoomOut
               </div>
             </div>
             <div className="Item">
+              <div className="Title">Rotate Camera</div>
+              <div className="Description">
+                <span className="Key">Left Mouse Button</span>+<span className="Key">Drag</span>
+              </div>
+            </div>
+            <div className="Item">
               <div className="Title">Select Multiple Items</div>
               <div className="Description">
                 Hold<span className="Key">ctrl</span>and click
@@ -154,7 +160,8 @@ const Shortcuts: React.FC<Props> = ({ canvas, onResetCamera, onZoomIn, onZoomOut
             <div className="Item">
               <div className="Title">Delete</div>
               <div className="Description">
-                <span className="Key">del</span>or<span className="Key">backspace</span>
+                <span className="Key">del</span>or
+                <span className="Key">backspace</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR adds a new item to the shortcuts help guide.

- Roate Camera | `Left Mouse Buton` + `Drag`

![image](https://github.com/decentraland/js-sdk-toolchain/assets/3170051/b03765c8-2f8c-47a9-b9b1-5e5deff6b4f4)
