### PR TITLE
fix: check if scene component is null

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Metrics/Metrics.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Metrics/Metrics.tsx
@@ -67,8 +67,10 @@ const Metrics = withSdk<WithSdkProps>(({ sdk }) => {
   }, [sdk])
 
   const handleUpdateSceneLayout = useCallback(() => {
-    const scene = sdk.components.Scene.get(ROOT)
-    setSceneLayout({ ...(scene.layout as Layout) })
+    const scene = sdk.components.Scene.getOrNull(ROOT)
+    if (scene) {
+      setSceneLayout({ ...(scene.layout as Layout) })
+    }
   }, [sdk, setSceneLayout])
 
   useEffect(() => {


### PR DESCRIPTION
Use `getOrNull` to get `Scene` component and check it is not null. This was throwing an error on the VSCode extension, because the `<Metrics />` react component was being rendered and the `handleUpdateSceneLayout` was being called before the data layer was initialized, resulting in an Error.