### PR TITLE
auto install & import asset-packs for editor scenes

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.12.2",
+        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -285,13 +285,12 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
-      "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
+      "version": "1.12.3-20240301140405.commit-8aef784",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.3-20240301140405.commit-8aef784.tgz",
+      "integrity": "sha512-GRVu44YTmoVB/N7oLQDP8RhzjaHObYEIMmOK83xsNXMRd2wcmIRuYp68k9Jy8nITdvOPSW018pLh2/x2bv5gRg==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.6",
-        "@dcl/js-runtime": "^7.4.2",
-        "@dcl/sdk": "^7.4.2",
+        "@dcl/sdk": "7.4.7",
         "mitt": "^3.0.1"
       }
     },
@@ -451,18 +450,29 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.2.tgz",
-      "integrity": "sha512-7W+/jQtd09n4rCs30XTh/TVv0/z+E0IAtZEKo9JIGwiSXctmpZoN9DNfhvICfZJBiAfJfZUzh+KsRCqj1elH+g==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.7.tgz",
+      "integrity": "sha512-0POwSm4wUvC4Dkuv58UGClEDJhXVpNjceWcuzSjqeDw0x+Aw5zJaLce5Fl9oApt+cEgj6E5xrdsq/NL/HWkHWw==",
       "dependencies": {
-        "@dcl/asset-packs": "^1.11.0",
+        "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
       }
     },
+    "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
+      "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
+      "dependencies": {
+        "@dcl-sdk/utils": "^1.2.6",
+        "@dcl/js-runtime": "^7.4.2",
+        "@dcl/sdk": "^7.4.2",
+        "mitt": "^3.0.1"
+      }
+    },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.2.tgz",
-      "integrity": "sha512-jlmkaLe3lFhCdA8y5+92yKhFhdBoQvoo0GAYLVUqNN8QSSIxAYjO2jmf+fmuM7/mMDVx/ev23PVE1/tzGXJgkg=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.7.tgz",
+      "integrity": "sha512-ZT3QRVPIZV2ASCynoC0Gl/Ix91DL/sUgcFPEXZiBMs8lEmOBTC/ONBuf+nqSKyBPRyKEAqAz4Yea5xasDnc7dg=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -533,19 +543,19 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.2.tgz",
-      "integrity": "sha512-w16WPk6QzkHbGQU9KC2lu/Uim+ITC1sltvhp4swZgBllpiCJR50h41iR2hRvSPvwao8U3N7Uvk5nMBigRp9Tmw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.7.tgz",
+      "integrity": "sha512-7M/kAchsPB41F2YQFi6yjDCmCLTlsXL3cQBmFBsW8KjQszJ/mIHVvCeEdF2uzCoYz9EFfN+AuWSulWWu0q9sgg==",
       "dependencies": {
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
     },
     "node_modules/@dcl/react-ecs/node_modules/@dcl/ecs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-      "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+      "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
     },
     "node_modules/@dcl/rpc": {
       "version": "1.1.2",
@@ -567,28 +577,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.2.tgz",
-      "integrity": "sha512-LaX9dIlQUuX4xU9vwTTc8034UlxJ8Ix+lJeawFTuAcD1rgMgogefZxUShpjNJZQTKDzad80OVr2VA3r0ecWusg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-U2X4PufRpfVDpb2Bz1hcg62d8vefj/2ezSeViF9sqMl4+ACkS0CTNt2RRTuMRpaerq8BNsOun9gOjZ02abPCaA==",
       "dependencies": {
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.2",
-        "@dcl/react-ecs": "7.4.2",
-        "@dcl/sdk-commands": "7.4.2",
+        "@dcl/js-runtime": "7.4.7",
+        "@dcl/react-ecs": "7.4.7",
+        "@dcl/sdk-commands": "7.4.7",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.2.tgz",
-      "integrity": "sha512-pZ7MvRnMwzfhHA49QWaQsS1CRpVY26zzRkXJ/N9miKlBTY+JoMpcXySK8Bwef5LAWQHXOFQgGy9BNXl1IY+p6A==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.7.tgz",
+      "integrity": "sha512-UlaGMT603Q0Yh/XwqNqZbp49zViC0p4lC7WMUzfU+zC+7UgVE8P/w4iQdpruiJuXaZ2qY+EcdzBemBnykf6TdA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.2",
+        "@dcl/inspector": "7.4.7",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
@@ -625,14 +635,14 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/@dcl/ecs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-      "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+      "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
     },
     "node_modules/@dcl/sdk/node_modules/@dcl/ecs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-      "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+      "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
     },
     "node_modules/@dcl/ts-proto": {
       "version": "1.154.0",
@@ -1032,9 +1042,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
@@ -2167,9 +2177,9 @@
       }
     },
     "node_modules/@well-known-components/interfaces/node_modules/@types/node": {
-      "version": "20.11.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7935,13 +7945,12 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "@dcl/asset-packs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
-      "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
+      "version": "1.12.3-20240301140405.commit-8aef784",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.3-20240301140405.commit-8aef784.tgz",
+      "integrity": "sha512-GRVu44YTmoVB/N7oLQDP8RhzjaHObYEIMmOK83xsNXMRd2wcmIRuYp68k9Jy8nITdvOPSW018pLh2/x2bv5gRg==",
       "requires": {
         "@dcl-sdk/utils": "^1.2.6",
-        "@dcl/js-runtime": "^7.4.2",
-        "@dcl/sdk": "^7.4.2",
+        "@dcl/sdk": "7.4.7",
         "mitt": "^3.0.1"
       }
     },
@@ -8068,18 +8077,31 @@
       }
     },
     "@dcl/inspector": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.2.tgz",
-      "integrity": "sha512-7W+/jQtd09n4rCs30XTh/TVv0/z+E0IAtZEKo9JIGwiSXctmpZoN9DNfhvICfZJBiAfJfZUzh+KsRCqj1elH+g==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.7.tgz",
+      "integrity": "sha512-0POwSm4wUvC4Dkuv58UGClEDJhXVpNjceWcuzSjqeDw0x+Aw5zJaLce5Fl9oApt+cEgj6E5xrdsq/NL/HWkHWw==",
       "requires": {
-        "@dcl/asset-packs": "^1.11.0",
+        "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
+      },
+      "dependencies": {
+        "@dcl/asset-packs": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
+          "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
+          "requires": {
+            "@dcl-sdk/utils": "^1.2.6",
+            "@dcl/js-runtime": "^7.4.2",
+            "@dcl/sdk": "^7.4.2",
+            "mitt": "^3.0.1"
+          }
+        }
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.2.tgz",
-      "integrity": "sha512-jlmkaLe3lFhCdA8y5+92yKhFhdBoQvoo0GAYLVUqNN8QSSIxAYjO2jmf+fmuM7/mMDVx/ev23PVE1/tzGXJgkg=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.7.tgz",
+      "integrity": "sha512-ZT3QRVPIZV2ASCynoC0Gl/Ix91DL/sUgcFPEXZiBMs8lEmOBTC/ONBuf+nqSKyBPRyKEAqAz4Yea5xasDnc7dg=="
     },
     "@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -8152,19 +8174,19 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "@dcl/react-ecs": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.2.tgz",
-      "integrity": "sha512-w16WPk6QzkHbGQU9KC2lu/Uim+ITC1sltvhp4swZgBllpiCJR50h41iR2hRvSPvwao8U3N7Uvk5nMBigRp9Tmw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.7.tgz",
+      "integrity": "sha512-7M/kAchsPB41F2YQFi6yjDCmCLTlsXL3cQBmFBsW8KjQszJ/mIHVvCeEdF2uzCoYz9EFfN+AuWSulWWu0q9sgg==",
       "requires": {
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       },
       "dependencies": {
         "@dcl/ecs": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-          "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+          "version": "7.4.7",
+          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+          "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
         }
       }
     },
@@ -8188,35 +8210,35 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.2.tgz",
-      "integrity": "sha512-LaX9dIlQUuX4xU9vwTTc8034UlxJ8Ix+lJeawFTuAcD1rgMgogefZxUShpjNJZQTKDzad80OVr2VA3r0ecWusg==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-U2X4PufRpfVDpb2Bz1hcg62d8vefj/2ezSeViF9sqMl4+ACkS0CTNt2RRTuMRpaerq8BNsOun9gOjZ02abPCaA==",
       "requires": {
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.2",
-        "@dcl/react-ecs": "7.4.2",
-        "@dcl/sdk-commands": "7.4.2",
+        "@dcl/js-runtime": "7.4.7",
+        "@dcl/react-ecs": "7.4.7",
+        "@dcl/sdk-commands": "7.4.7",
         "text-encoding": "0.7.0"
       },
       "dependencies": {
         "@dcl/ecs": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-          "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+          "version": "7.4.7",
+          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+          "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
         }
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.2.tgz",
-      "integrity": "sha512-pZ7MvRnMwzfhHA49QWaQsS1CRpVY26zzRkXJ/N9miKlBTY+JoMpcXySK8Bwef5LAWQHXOFQgGy9BNXl1IY+p6A==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.7.tgz",
+      "integrity": "sha512-UlaGMT603Q0Yh/XwqNqZbp49zViC0p4lC7WMUzfU+zC+7UgVE8P/w4iQdpruiJuXaZ2qY+EcdzBemBnykf6TdA==",
       "requires": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.2",
+        "@dcl/ecs": "7.4.7",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.2",
+        "@dcl/inspector": "7.4.7",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
@@ -8250,9 +8272,9 @@
       },
       "dependencies": {
         "@dcl/ecs": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.2.tgz",
-          "integrity": "sha512-m3YPodzQudjopIR8WfE3bE5i5Imsr1C6KwdzkqE/0wpJ8BLRrFA3XfypcAZfq78YCYOUiXvvlqzab+7q6GgwsQ=="
+          "version": "7.4.7",
+          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+          "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
         }
       }
     },
@@ -8448,9 +8470,9 @@
       "optional": true
     },
     "@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
     },
     "@fluentui/react-component-event-listener": {
       "version": "0.63.1",
@@ -9362,9 +9384,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.11.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-          "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+          "version": "20.11.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+          "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
           "requires": {
             "undici-types": "~5.26.4"
           }

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
+        "@dcl/asset-packs": "^1.13.0",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -285,9 +285,9 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.12.3-20240301140405.commit-8aef784",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.3-20240301140405.commit-8aef784.tgz",
-      "integrity": "sha512-GRVu44YTmoVB/N7oLQDP8RhzjaHObYEIMmOK83xsNXMRd2wcmIRuYp68k9Jy8nITdvOPSW018pLh2/x2bv5gRg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.13.0.tgz",
+      "integrity": "sha512-StD+ug9h0LKXSVD2mOqLjkxhu7VggykevLw3Vno8WPXH3HwjjEcrqIMFTSslAe87NEiqkFr76s2eAC2USdiANg==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.6",
         "@dcl/sdk": "7.4.7",
@@ -456,17 +456,6 @@
       "dependencies": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
-      }
-    },
-    "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
-      "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
-      "dependencies": {
-        "@dcl-sdk/utils": "^1.2.6",
-        "@dcl/js-runtime": "^7.4.2",
-        "@dcl/sdk": "^7.4.2",
-        "mitt": "^3.0.1"
       }
     },
     "node_modules/@dcl/js-runtime": {
@@ -7945,9 +7934,9 @@
       "integrity": "sha512-PePRsdXfs4vZCDm/1awBAakCsqgM1R0AyyizA0qG+S5AHgQm+kN2+SjFOJ6HEi94Vy91EU3TES3/NpY7L3+SCA=="
     },
     "@dcl/asset-packs": {
-      "version": "1.12.3-20240301140405.commit-8aef784",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.3-20240301140405.commit-8aef784.tgz",
-      "integrity": "sha512-GRVu44YTmoVB/N7oLQDP8RhzjaHObYEIMmOK83xsNXMRd2wcmIRuYp68k9Jy8nITdvOPSW018pLh2/x2bv5gRg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.13.0.tgz",
+      "integrity": "sha512-StD+ug9h0LKXSVD2mOqLjkxhu7VggykevLw3Vno8WPXH3HwjjEcrqIMFTSslAe87NEiqkFr76s2eAC2USdiANg==",
       "requires": {
         "@dcl-sdk/utils": "^1.2.6",
         "@dcl/sdk": "7.4.7",
@@ -8083,19 +8072,6 @@
       "requires": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
-      },
-      "dependencies": {
-        "@dcl/asset-packs": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.12.2.tgz",
-          "integrity": "sha512-jIkXrsfeG1zL52Opyz5hvqbeBL0Pjt6B/oPnXfNbc0+AwmiSnsR4+jMbpaOd5OQMClgr1vReik3buirm+JoEDg==",
-          "requires": {
-            "@dcl-sdk/utils": "^1.2.6",
-            "@dcl/js-runtime": "^7.4.2",
-            "@dcl/sdk": "^7.4.2",
-            "mitt": "^3.0.1"
-          }
-        }
       }
     },
     "@dcl/js-runtime": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^1.12.2",
+    "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
+    "@dcl/asset-packs": "^1.13.0",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -65,7 +65,7 @@
     "../inspector": {
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.12.2",
+        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -3143,7 +3143,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^1.12.2",
+        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",

--- a/packages/@dcl/sdk-commands/src/commands/build/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/build/index.ts
@@ -1,7 +1,14 @@
 import path from 'path'
 import { CliComponents } from '../../components'
 import { declareArgs } from '../../logic/args'
-import { installDependencies, needsDependencies, SceneProject, WearableProject } from '../../logic/project-validations'
+import {
+  installAssetPack,
+  installDependencies,
+  isEditorScene,
+  needsDependencies,
+  SceneProject,
+  WearableProject
+} from '../../logic/project-validations'
 import { getBaseCoords } from '../../logic/scene-validations'
 import { b64HashingFunction } from '../../logic/project-files'
 import { bundleProject } from '../../logic/bundle'
@@ -57,10 +64,16 @@ export async function main(options: Options) {
 }
 
 export async function buildScene(options: Options, project: SceneProject | WearableProject) {
-  const shouldInstallDeps = await needsDependencies(options.components, project.workingDirectory)
+  const canInstall = !options.args['--skip-install']
 
-  if (shouldInstallDeps && !options.args['--skip-install']) {
-    await installDependencies(options.components, project.workingDirectory)
+  if (canInstall) {
+    if (await needsDependencies(options.components, project.workingDirectory)) {
+      await installDependencies(options.components, project.workingDirectory)
+    }
+
+    if (await isEditorScene(options.components, project.workingDirectory)) {
+      await installAssetPack(options.components, project.workingDirectory)
+    }
   }
 
   const watch = !!options.args['--watch']

--- a/test/sdk-commands/commands/build/index.spec.ts
+++ b/test/sdk-commands/commands/build/index.spec.ts
@@ -55,7 +55,7 @@ describe('build command', () => {
     try {
       await build.main({ args: { _: [], '--skip-install': true }, components })
     } catch (_) {}
-    expect(needsDependenciesSpy).toBeCalledWith(components, process.cwd())
+    expect(needsDependenciesSpy).not.toBeCalled()
     expect(installDependenciesSpy).not.toBeCalled()
   })
 


### PR DESCRIPTION
With this PR is not mandatory to import and install the @dcl/asset-pack lib for the editor scenes.
The sdk-commands does all this at build-time in the background using the asset-pack version that the inspector used to build the scene.
So this way we don't have mismatched of @dcl/asset-packs version. (The inspector already has the asset-packs lib, and the scene could have another version that could lead into mysterious bugs )

## Before (game.ts scene): 
```ts
import { engine } from '@dcl/sdk/ecs'
import { initAssetPacks } from '@dcl/asset-packs/dist/scene-entrypoint'

initAssetPacks(engine)

function main() {}
```

## Now
```ts
import { engine } from '@dcl/sdk/ecs'
function main() {}
```
