### PR TITLE
feat: Export create tween system

### DIFF
--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -302,6 +302,7 @@ export function Engine(options?: IEngineOptions): IEngine {
   }
 
   return {
+    _id: Date.now(),
     addEntity: partialEngine.addEntity,
     removeEntity: partialEngine.removeEntity,
     removeEntityWithChildren: partialEngine.removeEntityWithChildren,

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -78,6 +78,7 @@ export interface IEngineOptions {
  * @public
  */
 export interface IEngine {
+  _id: number
   /**
    * @public
    * Increment the used entity counter and return the next one.

--- a/packages/@dcl/ecs/src/index.ts
+++ b/packages/@dcl/ecs/src/index.ts
@@ -10,6 +10,7 @@ export * from './systems/events'
 export * from './systems/raycast'
 export * from './systems/videoEvents'
 export * from './systems/async-task'
+export * from './systems/tween'
 export * from './engine/entity'
 export * from './components/types'
 

--- a/packages/@dcl/ecs/src/systems/tween.ts
+++ b/packages/@dcl/ecs/src/systems/tween.ts
@@ -9,10 +9,18 @@ export type TweenSystem = {
 }
 
 /**
+ * Avoid creating multiple tween systems
+ */
+const cacheTween: Map<number, TweenSystem> = new Map()
+
+/**
  * @public
  * @returns tween helper to be used on the scene
  */
 export function createTweenSystem(engine: IEngine): TweenSystem {
+  if (cacheTween.has(engine._id)) {
+    return cacheTween.get(engine._id)!
+  }
   const Tween = components.Tween(engine)
   const TweenState = components.TweenState(engine)
   const TweenSequence = components.TweenSequence(engine)
@@ -139,8 +147,11 @@ export function createTweenSystem(engine: IEngine): TweenSystem {
     throw new Error('Invalid tween')
   }
 
-  return {
+  const tweenSystem: TweenSystem = {
     // This event is fired only once per tween
     tweenCompleted: isCompleted
   }
+
+  cacheTween.set(engine._id, tweenSystem)
+  return tweenSystem
 }

--- a/packages/@dcl/ecs/src/systems/tween.ts
+++ b/packages/@dcl/ecs/src/systems/tween.ts
@@ -9,7 +9,7 @@ export type TweenSystem = {
 }
 
 /**
- * @internal
+ * @public
  * @returns tween helper to be used on the scene
  */
 export function createTweenSystem(engine: IEngine): TweenSystem {

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -751,6 +751,9 @@ export function createInputSystem(engine: IEngine): IInputSystem;
 // @public
 export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSystem): PointerEventsSystem;
 
+// @public (undocumented)
+export function createTweenSystem(engine: IEngine): TweenSystem;
+
 // Warning: (tsdoc-code-fence-closing-syntax) Unexpected characters after closing delimiter for code fence
 // Warning: (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@params" is not defined in this configuration

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1161,6 +1161,8 @@ export interface IEngine {
     // @alpha
     getEntityOrNullByName(label: string): Entity | null;
     getEntityState(entity: Entity): EntityState;
+    // (undocumented)
+    _id: number;
     readonly PlayerEntity: Entity;
     registerComponentDefinition<T>(componentName: string, componentDefinition: ComponentDefinition<T>): ComponentDefinition<T>;
     // (undocumented)

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -65,7 +65,7 @@
     "../inspector": {
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
+        "@dcl/asset-packs": "^1.14.0",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -3143,7 +3143,7 @@
         "@babylonjs/inspector": "^6.18.0",
         "@babylonjs/loaders": "^6.18.0",
         "@babylonjs/materials": "^6.18.0",
-        "@dcl/asset-packs": "^1.12.3-20240301140405.commit-8aef784",
+        "@dcl/asset-packs": "^1.14.0",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",

--- a/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/hummingBird.ts
+++ b/test/build-ecs/fixtures/sdk7-humming-birds-sync/src/hummingBird.ts
@@ -17,7 +17,6 @@ import {
 import { myProfile, syncEntity } from '@dcl/sdk//network'
 import { Quaternion } from '@dcl/sdk/math'
 import * as utils from '@dcl-sdk/utils'
-import { gamePaused } from './ui'
 
 export const Bird = engine.defineComponent('bird', {})
 
@@ -82,7 +81,6 @@ export function createHummingBird() {
 // System to shoot birds
 export function shootBirds(userId: string) {
   return function () {
-    if (gamePaused) return
     for (const [entity, _bird, visibleComponent] of engine.getEntitiesWith(Bird, VisibilityComponent, PointerEvents)) {
       if (
         inputSystem.isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN, entity) &&

--- a/test/ecs/events/tween.spec.ts
+++ b/test/ecs/events/tween.spec.ts
@@ -134,4 +134,31 @@ describe('Tween System', () => {
     expect(completed).toBeCalledTimes(2)
     expect(TweenSequence.get(entity).sequence).toMatchObject([tween, rotateTween])
   })
+
+  it('should call the createTweenSystem twice with the same engine and check if the tween system was created just once', async () => {
+    const tweenSystemAlt = createTweenSystem(engine)
+    expect(tweenSystem).toBe(tweenSystemAlt)
+    await mockTween(entity)
+
+    engine.addSystem(() => {
+      if (tweenSystem.tweenCompleted(entity)) {
+        completed()
+      }
+    })
+    expect(completed).toBeCalledTimes(0)
+  })
+
+  it('should call the createTweenSystem twice with different engines and check if both tween systems were created', async () => {
+    const engineAlt = Engine()
+    const tweenSystemAlt = createTweenSystem(engineAlt)
+    expect(tweenSystem).not.toBe(tweenSystemAlt)
+    await mockTween(entity)
+
+    engine.addSystem(() => {
+      if (tweenSystem.tweenCompleted(entity)) {
+        completed()
+      }
+    })
+    expect(completed).toBeCalledTimes(0)
+  })
 })


### PR DESCRIPTION
This PR exports the method: `createTweenSystem` to be used in the `asset-packs` project.