### PR TITLE
fix: hide GLTFs on entities nested under the Camera or Player

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
@@ -145,6 +145,7 @@ export class EcsEntity extends BABYLON.TransformNode {
   getRoot() {
     const ctx = this.context.deref()
     const nodes = ctx?.editorComponents.Nodes.getOrNull(ctx.engine.RootEntity)?.value || []
+    if (nodes.length === 0) return null
     const root = getRoot(this.entityId, nodes)
     return root
   }


### PR DESCRIPTION
Currently, when an entity is nested under the Player or Camera, it is hidden from the scene renderer (Babylon). That works fine when reparenting, but when the scene is loaded for the first time (like after refreshing the editor), all the GLTFContainers are loaded into the scene, no matter where the entity is nested under.

This PR changes the `loadGltf` function to check the root of the entity tree branch, and if it's not the RootEntity, it hides the model. We still load the model, otherwise if this entity is later nested under the RootEntity, the `entity.setVisibility(true)` whould not work, because the model is not loaded.