### PR TITLE
fix: prevent race condition between loading Nodes component and GLTFs

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -75,7 +75,7 @@ const Renderer: React.FC = () => {
         if (!sceneEntity) continue
 
         if (!fileSet.has(value.src)) removeGltf(sceneEntity)
-        else loadGltf(sceneEntity, value.src)
+        else void loadGltf(sceneEntity, value.src)
       }
     }
   }, [files])

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -78,8 +78,9 @@ export async function loadGltf(entity: EcsEntity, value: string) {
   }
 
   let root = entity.getRoot()
+  let attempts = 0
 
-  while (root === null) {
+  while (root === null && attempts++ < 10) {
     // waiting for nodes to be loaded...
     await new Promise((resolve) => setTimeout(resolve, 100))
     root = entity.getRoot()

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -65,10 +65,10 @@ export const updateGltfForEntity = (entity: EcsEntity, newValue: PBGltfContainer
   const shouldRemoveGltf = !newValue || shouldLoadGltf
 
   if (shouldRemoveGltf) removeGltf(entity)
-  if (shouldLoadGltf) loadGltf(entity, newValue.src)
+  if (shouldLoadGltf) void loadGltf(entity, newValue.src)
 }
 
-export function loadGltf(entity: EcsEntity, value: string) {
+export async function loadGltf(entity: EcsEntity, value: string) {
   const context = entity.context.deref()
   if (!context || !!entity.gltfContainer) return
 
@@ -77,23 +77,29 @@ export function loadGltf(entity: EcsEntity, value: string) {
     sceneContext = entity.context
   }
 
-  const root = entity.getRoot()
+  let root = entity.getRoot()
 
-  const shouldHide = root === PLAYER || root === CAMERA || root === null
+  while (root === null) {
+    // waiting for nodes to be loaded...
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    root = entity.getRoot()
+  }
+
+  const shouldHide = root === PLAYER || root === CAMERA
 
   const loadingSpinner: BABYLON.Mesh | null = shouldHide ? null : createLoadingSpinner(entity, context.scene)
 
-  tryLoadGltfAsync(context.loadableScene.id, entity, value)
-    .catch((err) => {
-      console.error('Error trying to load gltf ' + value, err)
-    })
-    .finally(() => {
-      if (shouldHide) {
-        entity.setVisibility(false)
-      } else {
-        loadingSpinner?.dispose(false, true)
-      }
-    })
+  try {
+    await tryLoadGltfAsync(context.loadableScene.id, entity, value)
+  } catch (error) {
+    console.error('Error trying to load gltf ' + value, error)
+  } finally {
+    if (shouldHide) {
+      entity.setVisibility(false)
+    } else {
+      loadingSpinner?.dispose(false, true)
+    }
+  }
 }
 
 export function removeGltf(entity: EcsEntity) {


### PR DESCRIPTION
The previous implementation was assuming that when the root could not be determined (ie. it was `null`) the model should be hidden. 

This was because when refreshing a scene, the `loadGLTF` method is called from two places: the `Renderer.tsx` and the `putGltfContainerComponent`, and the calls from the `Renderer.tsx` where prior to the composite being instantiated, thus the root could not be determined due to the Nodes component not being loaded into the engine, and the calls from the `putGltfContainerComponent` happend after the Nodes component was already loaded.

But that assumption was wrong, and sometimes the `putGltfContainerComponent` is called also before the Nodes component is loaded, so the root is never able to be determined (this depends on the order of the component keys in the composite file).

So this PR changes the `loadGLTF` to instead of hidding the models when the root can't be determined, it waits 100ms and tries again, until the Nodes are loaded and the root can be determined.