### PR TITLE
fix: remove magic cube

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/TextShapeInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/TextShapeInspector/utils.spec.ts
@@ -1,4 +1,4 @@
-import { PBTextShape, Font, TextAlignMode } from '@dcl/ecs'
+import { PBTextShape, TextAlignMode } from '@dcl/ecs'
 import { fromTextShape, toTextShape, isValidInput } from './utils'
 import { TextShapeInput } from './types'
 

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -27,23 +27,12 @@ export function createTempEngineContext() {
 type TempEngine = ReturnType<typeof createTempEngineContext>
 
 export function generateMinimalComposite({ engine, components }: TempEngine) {
-  // custom component
-  const cubeIdComponent = engine.defineComponent('cube-id', {})
-
-  // main box
-  const entity = engine.addEntity()
-  components.Transform.create(entity, { position: { x: 8, y: 1, z: 8 }, parent: engine.RootEntity })
-  components.MeshRenderer.setBox(entity)
-  cubeIdComponent.create(entity)
-  components.Name.create(entity, { value: 'Magic Cube' })
-
   // nodes
   components.Nodes.create(engine.RootEntity, {
     value: [
-      { entity: engine.RootEntity, children: [entity], open: true },
+      { entity: engine.RootEntity, children: [], open: true },
       { entity: engine.PlayerEntity, children: [] },
-      { entity: engine.CameraEntity, children: [] },
-      { entity, children: [] }
+      { entity: engine.CameraEntity, children: [] }
     ]
   })
 

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/build-nodes-hierarchy.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/build-nodes-hierarchy.ts
@@ -36,6 +36,9 @@ export function buildNodesHierarchy(engine: IEngine): Node[] {
   hierarchy.set(engine.PlayerEntity, { entity: engine.PlayerEntity, children: [] })
   hierarchy.set(engine.CameraEntity, { entity: engine.CameraEntity, children: [] })
 
+  const root = hierarchy.get(engine.RootEntity)!
+  hierarchy.set(engine.RootEntity, { ...root, open: true })
+
   return Array.from(hierarchy.values())
 }
 


### PR DESCRIPTION
Remove "Magic Cube" from autogenerated `main.composite` on workspaces that don't have a composite when using the `@dcl/inspector`

This caused an issue that if you open a non-Editor project with the Editor, and then open the Visual Editor, the inspector would autogenerate a composite with the Magic Cube for that project.