### PR TITLE
fix: import duplicated file name

### DIFF
--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.css
@@ -119,3 +119,12 @@
   width: 100px;
   height: 100px;
 }
+
+.ImportAsset .warning {
+  color: var(--danger);
+  margin-top: 6px;
+}
+
+.ImportAsset .text {
+  text-align: center;
+}

--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
@@ -151,7 +151,8 @@ const ImportAsset: React.FC<PropTypes> = ({ onSave }) => {
         importAsset({
           content,
           basePath,
-          assetPackageName: ''
+          assetPackageName: '',
+          reload: true
         })
       )
 

--- a/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/ImportAsset.tsx
@@ -1,7 +1,7 @@
 import { GLTFValidation } from '@babylonjs/loaders'
 import React, { useCallback, useEffect, useState } from 'react'
 import { HiOutlineUpload } from 'react-icons/hi'
-import { RxCross2, RxReload } from 'react-icons/rx'
+import { RxCross2 } from 'react-icons/rx'
 import classNames from 'classnames'
 
 import FileInput from '../FileInput'
@@ -14,7 +14,6 @@ import { DIRECTORY, transformBase64ResourceToBinary, withAssetDir } from '../../
 import { importAsset, saveThumbnail } from '../../redux/data-layer'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { selectAssetCatalog, selectUploadFile, updateUploadFile } from '../../redux/app'
-import { getRandomMnemonic } from './utils'
 import { AssetPreview } from '../AssetPreview'
 
 import './ImportAsset.css'
@@ -189,7 +188,7 @@ const ImportAsset: React.FC<PropTypes> = ({ onSave }) => {
     setAssetName(event.target.value)
   }, [])
 
-  const isValidName = useCallback((name: string, ext: string) => {
+  const isNameUnique = useCallback((name: string, ext: string) => {
     return !assets.find((asset) => {
       const [packageName, otherAssetName] = removeBasePath(basePath, asset.path).split('/')
       if (packageName === 'builder') return false
@@ -197,15 +196,7 @@ const ImportAsset: React.FC<PropTypes> = ({ onSave }) => {
     })
   }, [])
 
-  const invalidName = !isValidName(assetName, assetExtension)
-
-  const generateAssetName = useCallback(() => {
-    let name: string = assetName
-    while (!isValidName(name, assetExtension)) {
-      name = getRandomMnemonic()
-    }
-    setAssetName(name)
-  }, [assetName])
+  const isNameRepeated = !isNameUnique(assetName, assetExtension)
 
   const handleScreenshot = useCallback(
     (value: string) => {
@@ -222,7 +213,7 @@ const ImportAsset: React.FC<PropTypes> = ({ onSave }) => {
             <div className="upload-icon">
               <HiOutlineUpload />
             </div>
-            <span>
+            <span className="text">
               To import an asset drag and drop a single GLB/GLTF/PNG/MP3/MP4 file
               <br /> or click to select a file.
             </span>
@@ -237,22 +228,20 @@ const ImportAsset: React.FC<PropTypes> = ({ onSave }) => {
               <AssetPreview value={file} onScreenshot={handleScreenshot} />
               <div className="file-title">{file.name}</div>
             </Container>
-            <div className={classNames({ error: invalidName })}>
+            <div className={classNames({ error: isNameRepeated })}>
               <Block label="Asset name">
                 <TextField value={assetName} onChange={handleNameChange} />
-                {invalidName && (
-                  <div onClick={generateAssetName}>
-                    <RxReload />
-                  </div>
-                )}
               </Block>
-              <Button disabled={invalidName || !!validationError} onClick={handleSave}>
+              <Button disabled={!!validationError} onClick={handleSave}>
                 Import
               </Button>
             </div>
           </div>
         )}
         <span className="error">{validationError}</span>
+        {isNameRepeated && (
+          <span className="warning">There's a file with this name already, you will overwrite it if you continue</span>
+        )}
       </FileInput>
     </div>
   )

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -7,7 +7,7 @@ import { Entity } from '@dcl/ecs'
 
 import { DIRECTORY, withAssetDir } from '../../lib/data-layer/host/fs-utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { getLastImportedAssetRequest, importAsset, saveThumbnail } from '../../redux/data-layer'
+import { getReloadImportAssetRequest, importAsset, saveThumbnail } from '../../redux/data-layer'
 import { getNode, BuilderAsset, DROP_TYPES, IDrop, ProjectAssetDrop, isDropType } from '../../lib/sdk/drag-drop'
 import { useRenderer } from '../../hooks/sdk/useRenderer'
 import { useSdk } from '../../hooks/sdk/useSdk'
@@ -70,7 +70,7 @@ const Renderer: React.FC = () => {
   const [placeSingleTile, setPlaceSingleTile] = useState(false)
   const [showSingleTileHint, setShowSingleTileHint] = useState(false)
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
-  const lastImportAssetRequest = useAppSelector(getLastImportedAssetRequest)
+  const reloadImportAssetRequest = useAppSelector(getReloadImportAssetRequest)
 
   useEffect(() => {
     if (sdk && init) {
@@ -83,7 +83,7 @@ const Renderer: React.FC = () => {
         if (!fileSet.has(value.src)) {
           removeGltf(sceneEntity)
         } else {
-          const paths = lastImportAssetRequest ? Array.from(lastImportAssetRequest.content.keys()) : []
+          const paths = reloadImportAssetRequest ? Array.from(reloadImportAssetRequest.content.keys()) : []
           const needsReload = paths.some((path) => value.src.includes(path))
           if (needsReload) {
             void loadGltf(sceneEntity, value.src)
@@ -91,7 +91,7 @@ const Renderer: React.FC = () => {
         }
       }
     }
-  }, [files, lastImportAssetRequest])
+  }, [files, reloadImportAssetRequest])
 
   useEffect(() => {
     if (sdk) {

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDrop } from 'react-dnd'
 import cx from 'classnames'
@@ -79,8 +80,11 @@ const Renderer: React.FC = () => {
         const sceneEntity = sdk.sceneContext.getEntityOrNull(entity)
         if (!sceneEntity) continue
 
-        if (!fileSet.has(value.src)) removeGltf(sceneEntity)
-        else void loadGltf(sceneEntity, value.src)
+        let shoudReload = true
+        if (!fileSet.has(value.src)) {
+          removeGltf(sceneEntity)
+          shoudReload = false
+        } else void loadGltf(sceneEntity, value.src, shoudReload)
       }
     }
   }, [files])

--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -7,7 +7,7 @@ import { Entity } from '@dcl/ecs'
 
 import { DIRECTORY, withAssetDir } from '../../lib/data-layer/host/fs-utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { getReloadImportAssetRequest, importAsset, saveThumbnail } from '../../redux/data-layer'
+import { getReloadAssets, importAsset, saveThumbnail } from '../../redux/data-layer'
 import { getNode, BuilderAsset, DROP_TYPES, IDrop, ProjectAssetDrop, isDropType } from '../../lib/sdk/drag-drop'
 import { useRenderer } from '../../hooks/sdk/useRenderer'
 import { useSdk } from '../../hooks/sdk/useSdk'
@@ -70,7 +70,7 @@ const Renderer: React.FC = () => {
   const [placeSingleTile, setPlaceSingleTile] = useState(false)
   const [showSingleTileHint, setShowSingleTileHint] = useState(false)
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
-  const reloadImportAssetRequest = useAppSelector(getReloadImportAssetRequest)
+  const reloadAssets = useAppSelector(getReloadAssets)
 
   useEffect(() => {
     if (sdk && init) {
@@ -83,15 +83,14 @@ const Renderer: React.FC = () => {
         if (!fileSet.has(value.src)) {
           removeGltf(sceneEntity)
         } else {
-          const paths = reloadImportAssetRequest ? Array.from(reloadImportAssetRequest.content.keys()) : []
-          const needsReload = paths.some((path) => value.src.includes(path))
+          const needsReload = reloadAssets.some((asset) => value.src.includes(asset))
           if (needsReload) {
             void loadGltf(sceneEntity, value.src)
           }
         }
       }
     }
-  }, [files, reloadImportAssetRequest])
+  }, [files, reloadAssets])
 
   useEffect(() => {
     if (sdk) {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -135,13 +135,7 @@ async function tryLoadGltfAsync(sceneId: string, entity: EcsEntity, filePath: st
   }
 
   if (entity.isGltfPathLoading()) {
-    const loadingFilePath = await entity.getGltfPathLoading()
-    if (loadingFilePath === filePath) {
-      console.warn(
-        `Asset ${filePath} for entity ${entity.entityId} is already being loaded. This call will be dismissed`
-      )
-      return
-    }
+    await entity.getGltfPathLoading()
   }
 
   entity.setGltfPathLoading()

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -68,9 +68,13 @@ export const updateGltfForEntity = (entity: EcsEntity, newValue: PBGltfContainer
   if (shouldLoadGltf) void loadGltf(entity, newValue.src)
 }
 
-export async function loadGltf(entity: EcsEntity, value: string) {
+export async function loadGltf(entity: EcsEntity, value: string, reload?: boolean) {
   const context = entity.context.deref()
-  if (!context || !!entity.gltfContainer) return
+  if (!context || (!!entity.gltfContainer && !reload)) return
+
+  if (entity.gltfContainer && reload) {
+    removeGltf(entity)
+  }
 
   // store a WeakRef to the sceneContext to enable file resolver
   if (!sceneContext) {

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -68,11 +68,11 @@ export const updateGltfForEntity = (entity: EcsEntity, newValue: PBGltfContainer
   if (shouldLoadGltf) void loadGltf(entity, newValue.src)
 }
 
-export async function loadGltf(entity: EcsEntity, value: string, reload?: boolean) {
+export async function loadGltf(entity: EcsEntity, value: string) {
   const context = entity.context.deref()
-  if (!context || (!!entity.gltfContainer && !reload)) return
+  if (!context) return
 
-  if (entity.gltfContainer && reload) {
+  if (entity.gltfContainer) {
     removeGltf(entity)
   }
 

--- a/packages/@dcl/inspector/src/redux/data-layer/index.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/index.ts
@@ -31,14 +31,14 @@ export interface DataLayerState {
   reconnectAttempts: number
   error: ErrorType | undefined
   removingAsset: Record<string, boolean>
-  reloadImportAssetRequest: ImportAssetRequest | null
+  reloadAssets: string[]
 }
 
 export const initialState: DataLayerState = {
   reconnectAttempts: 0,
   error: undefined,
   removingAsset: {},
-  reloadImportAssetRequest: null
+  reloadAssets: []
 }
 
 export const dataLayer = createSlice({
@@ -72,7 +72,7 @@ export const dataLayer = createSlice({
     redo: () => {},
     importAsset: (state, payload: PayloadAction<ImportAssetRequest & { reload?: boolean }>) => {
       const { reload, ...importAssetRequest } = payload.payload
-      state.reloadImportAssetRequest = reload ? importAssetRequest : null
+      state.reloadAssets = reload ? Array.from(importAssetRequest.content.keys()) : []
     },
     removeAsset: (state, payload: PayloadAction<Asset>) => {
       state.removingAsset[payload.payload.path] = true
@@ -108,7 +108,7 @@ export const {
 export const selectDataLayerError = (state: RootState) => state.dataLayer.error
 export const selectDataLayerReconnectAttempts = (state: RootState) => state.dataLayer.reconnectAttempts
 export const selectDataLayerRemovingAsset = (state: RootState) => state.dataLayer.removingAsset
-export const getReloadImportAssetRequest = (state: RootState) => state.dataLayer.reloadImportAssetRequest
+export const getReloadAssets = (state: RootState) => state.dataLayer.reloadAssets
 
 // Reducer
 export default dataLayer.reducer

--- a/packages/@dcl/inspector/src/redux/data-layer/index.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/index.ts
@@ -31,14 +31,14 @@ export interface DataLayerState {
   reconnectAttempts: number
   error: ErrorType | undefined
   removingAsset: Record<string, boolean>
-  lastImportAssetRequest: ImportAssetRequest | null
+  reloadImportAssetRequest: ImportAssetRequest | null
 }
 
 export const initialState: DataLayerState = {
   reconnectAttempts: 0,
   error: undefined,
   removingAsset: {},
-  lastImportAssetRequest: null
+  reloadImportAssetRequest: null
 }
 
 export const dataLayer = createSlice({
@@ -70,8 +70,9 @@ export const dataLayer = createSlice({
     getAssetCatalog: () => {},
     undo: () => {},
     redo: () => {},
-    importAsset: (state, payload: PayloadAction<ImportAssetRequest>) => {
-      state.lastImportAssetRequest = payload.payload
+    importAsset: (state, payload: PayloadAction<ImportAssetRequest & { reload?: boolean }>) => {
+      const { reload, ...importAssetRequest } = payload.payload
+      state.reloadImportAssetRequest = reload ? importAssetRequest : null
     },
     removeAsset: (state, payload: PayloadAction<Asset>) => {
       state.removingAsset[payload.payload.path] = true
@@ -107,7 +108,7 @@ export const {
 export const selectDataLayerError = (state: RootState) => state.dataLayer.error
 export const selectDataLayerReconnectAttempts = (state: RootState) => state.dataLayer.reconnectAttempts
 export const selectDataLayerRemovingAsset = (state: RootState) => state.dataLayer.removingAsset
-export const getLastImportedAssetRequest = (state: RootState) => state.dataLayer.lastImportAssetRequest
+export const getReloadImportAssetRequest = (state: RootState) => state.dataLayer.reloadImportAssetRequest
 
 // Reducer
 export default dataLayer.reducer

--- a/packages/@dcl/inspector/src/redux/data-layer/index.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/index.ts
@@ -31,12 +31,14 @@ export interface DataLayerState {
   reconnectAttempts: number
   error: ErrorType | undefined
   removingAsset: Record<string, boolean>
+  lastImportAssetRequest: ImportAssetRequest | null
 }
 
 export const initialState: DataLayerState = {
   reconnectAttempts: 0,
   error: undefined,
-  removingAsset: {}
+  removingAsset: {},
+  lastImportAssetRequest: null
 }
 
 export const dataLayer = createSlice({
@@ -68,7 +70,9 @@ export const dataLayer = createSlice({
     getAssetCatalog: () => {},
     undo: () => {},
     redo: () => {},
-    importAsset: (_state, _payload: PayloadAction<ImportAssetRequest>) => {},
+    importAsset: (state, payload: PayloadAction<ImportAssetRequest>) => {
+      state.lastImportAssetRequest = payload.payload
+    },
     removeAsset: (state, payload: PayloadAction<Asset>) => {
       state.removingAsset[payload.payload.path] = true
     },
@@ -103,6 +107,7 @@ export const {
 export const selectDataLayerError = (state: RootState) => state.dataLayer.error
 export const selectDataLayerReconnectAttempts = (state: RootState) => state.dataLayer.reconnectAttempts
 export const selectDataLayerRemovingAsset = (state: RootState) => state.dataLayer.removingAsset
+export const getLastImportedAssetRequest = (state: RootState) => state.dataLayer.lastImportAssetRequest
 
 // Reducer
 export default dataLayer.reducer

--- a/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
@@ -26,7 +26,7 @@ describe('WebSocket Connection Saga', () => {
         error: undefined,
         reconnectAttempts: 0,
         removingAsset: {},
-        reloadImportAssetRequest: null
+        reloadAssets: []
       })
       .run()
     expect(getDataLayerInterface()).toBe(dataLayer)

--- a/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
@@ -25,7 +25,8 @@ describe('WebSocket Connection Saga', () => {
       .hasFinalState({
         error: undefined,
         reconnectAttempts: 0,
-        removingAsset: {}
+        removingAsset: {},
+        lastImportAssetRequest: null
       })
       .run()
     expect(getDataLayerInterface()).toBe(dataLayer)

--- a/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/sagas/connect.spec.ts
@@ -26,7 +26,7 @@ describe('WebSocket Connection Saga', () => {
         error: undefined,
         reconnectAttempts: 0,
         removingAsset: {},
-        lastImportAssetRequest: null
+        reloadImportAssetRequest: null
       })
       .run()
     expect(getDataLayerInterface()).toBe(dataLayer)


### PR DESCRIPTION
Fixes https://github.com/decentraland/dapps-issues/issues/140

This PR changes the ImportAsset modal to allow importing assets with a name that already exists. 
If a file with that name exists, it will show a warning letting the user know that they will override that file.

This PR also changes the Renderer so when the files change, it will ONLY reload the gltf models that have been updated, instead of every gltf container in the scene.