### PR TITLE
fix: Refactor get bounding box info and outside layout material generation

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.spec.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.spec.ts
@@ -194,14 +194,14 @@ describe('EcsEntity', () => {
     expect(entity.boundingInfoMesh).toBeDefined()
     const boundingInfoMesh = entity.boundingInfoMesh!
     expect(boundingInfoMesh.name).toBe(`BoundingMesh-${entity.id}`)
-    expect(boundingInfoMesh.position).toEqual(entity.absolutePosition)
-    expect(boundingInfoMesh.rotationQuaternion).toEqual(entity.absoluteRotationQuaternion)
-    expect(boundingInfoMesh.scaling).toEqual(entity.absoluteScaling)
+    expect(boundingInfoMesh.absolutePosition).toEqual(entity.absolutePosition)
+    expect(boundingInfoMesh.absoluteRotationQuaternion).toEqual(entity.absoluteRotationQuaternion)
+    expect(boundingInfoMesh.absoluteScaling).toEqual(entity.absoluteScaling)
     expect(boundingInfoMesh.getBoundingInfo().boundingBox.minimumWorld).toEqual(
-      mesh1.getBoundingInfo().boundingBox.minimumWorld
+      entity.getGroupMeshesBoundingBox()!.boundingBox.minimumWorld
     )
     expect(boundingInfoMesh.getBoundingInfo().boundingBox.maximumWorld).toEqual(
-      mesh2.getBoundingInfo().boundingBox.maximumWorld
+      entity.getGroupMeshesBoundingBox()!.boundingBox.maximumWorld
     )
   })
 })

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
@@ -143,8 +143,8 @@ export class EcsEntity extends BABYLON.TransformNode {
       return null // No children to calculate the bounding box
     }
 
-    let groupMin = new BABYLON.Vector3(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE)
-    let groupMax = new BABYLON.Vector3(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE)
+    let groupMin = new BABYLON.Vector3(Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    let groupMax = new BABYLON.Vector3(Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER)
 
     for (const child of children) {
       if (!child.material) continue

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/sdkComponents/gltf-container.ts
@@ -162,7 +162,7 @@ async function tryLoadGltfAsync(sceneId: string, entity: EcsEntity, filePath: st
       */
       const prevChildren = entity.getChildren()
       for (const child of prevChildren) {
-        if (child instanceof EcsEntity) continue // skip EcsEntity nodes, only remove gltf related stuff
+        if (child instanceof EcsEntity || child.id.startsWith('BoundingMesh')) continue // skip EcsEntity nodes, only remove gltf related stuff
         child.setEnabled(false)
         child.dispose(false, true)
       }
@@ -174,9 +174,10 @@ async function tryLoadGltfAsync(sceneId: string, entity: EcsEntity, filePath: st
           mesh.parent = entity
           entity.setGltfContainer(mesh)
         })
-      entity.generateBoundingBox()
+
       entity.setGltfAssetContainer(assetContainer)
       entity.resolveGltfPathLoading(filePath)
+      entity.generateBoundingBox()
       loadAssetFuture.resolve()
     },
     undefined,

--- a/packages/@dcl/inspector/src/lib/babylon/setup/setup.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/setup/setup.ts
@@ -94,10 +94,6 @@ export function setupEngine(engine: BABYLON.Engine, canvas: HTMLCanvasElement, p
   // Set bounding box color = red
   scene.getBoundingBoxRenderer().frontColor.set(1, 0, 0)
   scene.getBoundingBoxRenderer().backColor.set(1, 0, 0)
-  // Material for entity outside layout
-  const entityOutsideLayoutMaterial = new BABYLON.StandardMaterial('entity_outside_layout', scene)
-  entityOutsideLayoutMaterial.diffuseColor = new BABYLON.Color3(1, 0, 0)
-  entityOutsideLayoutMaterial.backFaceCulling = false
 
   BABYLON.Database.IDBStorageEnabled = true
   engine.enableOfflineSupport = true

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -150,7 +150,7 @@
       "dependencies": {
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.162830-20240429195817.commit-25498a3",
+        "@dcl/explorer": "1.0.163667-20240612172815.commit-85b23a7",
         "@dcl/js-runtime": "file:../js-runtime",
         "@dcl/react-ecs": "file:../react-ecs",
         "@dcl/sdk-commands": "file:../sdk-commands",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -168,7 +168,7 @@
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-9115457439.commit-926ebd1",
+        "@dcl/protocol": "1.0.0-9466805132.commit-365e0bb",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",


### PR DESCRIPTION
This PR refactors the bounding box info and the outside layout material generation to avoid cases when nested entities behave unexpectedly.

Closes: https://github.com/decentraland/sdk/issues/1119
Closes: https://github.com/decentraland/sdk/issues/1101