### PR TITLE
fix: Load assets when importing from the catalog

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Renderer.tsx
@@ -273,7 +273,8 @@ const Renderer: React.FC = () => {
         importAsset({
           content,
           basePath: withAssetDir(destFolder),
-          assetPackageName
+          assetPackageName,
+          reload: true
         })
       )
     }


### PR DESCRIPTION
This PR fixes the loading assets when importing from the catalog.

Closes: https://github.com/decentraland/sdk/issues/1124