### PR TITLE
Fix for circular dependency in `npm` scripts

### DIFF
--- a/packages/@dcl/ecs/package.json
+++ b/packages/@dcl/ecs/package.json
@@ -26,6 +26,7 @@
     "start": "tsc -p tsconfig.json --watch"
   },
   "dependencies": {
+    "arg": "^5.0.0",
     "protobufjs": "^7.2.4"
   },
   "typedoc": {

--- a/packages/@dcl/ecs/package.json
+++ b/packages/@dcl/ecs/package.json
@@ -25,6 +25,9 @@
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
     "start": "tsc -p tsconfig.json --watch"
   },
+  "dependencies": {
+    "protobufjs": "^7.2.4"
+  },
   "typedoc": {
     "entryPoint": "./src/index.ts",
     "readmeFile": "./README.md",

--- a/packages/@dcl/sdk/package.json
+++ b/packages/@dcl/sdk/package.json
@@ -9,7 +9,6 @@
     "@dcl/explorer": "1.0.164182-20240702173148.commit-d4a0e99",
     "@dcl/js-runtime": "file:../js-runtime",
     "@dcl/react-ecs": "file:../react-ecs",
-    "@dcl/sdk-commands": "file:../sdk-commands",
     "text-encoding": "0.7.0"
   },
   "keywords": [],


### PR DESCRIPTION
As reported on https://feedback.decentraland.org/creator-tools-sdk/p/circular-dependency-in-npm-scripts.

```
💲 mkdir empty && cd empty
💲 npx @dcl/sdk-commands init
💲 npm ls @dcl/sdk-commands
dcl-project@1.0.0 ~\empty
├─┬ @dcl/asset-packs@1.20.0
│ └─┬ @dcl/sdk@7.5.2
│   └─┬ @dcl/sdk-commands@7.5.2
│     └─┬ @dcl/inspector@7.5.2
│       └─┬ @dcl/asset-packs@1.19.0
│         └─┬ @dcl/sdk@7.4.15
│           └─┬ @dcl/sdk-commands@7.4.15
│             └─┬ @dcl/inspector@7.4.15
│               └─┬ @dcl/asset-packs@1.16.0
│                 └─┬ @dcl/sdk@7.4.10
│                   └── @dcl/sdk-commands@7.4.10
└─┬ @dcl/sdk@7.5.6
  └── @dcl/sdk-commands@7.5.6
```