### PR TITLE
fix: avoid annoying error message when websocket disconnects

### DIFF
--- a/packages/@dcl/inspector/src/lib/data-layer/host/scene.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/scene.ts
@@ -42,7 +42,7 @@ function augmentDefaults(fs: FileSystemInterface, scene: Scene): SceneWithDefaul
     ...scene,
     display: {
       ...scene.display,
-      title: scene.display?.title || fs.cwd()
+      title: scene.display?.title || ''
     }
   }
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/stream.ts
@@ -36,7 +36,9 @@ export function stream(
 
   // and lastly wire the new messages from the renderer engine
   consumeAllMessagesInto(stream, processMessage).catch((err) => {
-    console.error('Faile to consume stream from data layer ', err)
+    if (err instanceof Error && !err.message.includes('RPC Transport closed')) {
+      console.error('Failed to consume stream from data layer ', err)
+    }
     queue.close()
   })
 


### PR DESCRIPTION
Every time we close the `@dcl/inspector` and it was connected via websocket, the data layer prints the following error:

```
Faile to consume stream from data layer  Error: RPC Transport closed
    at /Users/mostro/Code/test-text-shape/node_modules/@dcl/rpc/dist/stream-protocol.js:65:23
    at /Users/mostro/Code/test-text-shape/node_modules/mitt/dist/mitt.js:1:255
    at Array.map (<anonymous>)
```

This PR ignores that particular error.