### PR TITLE
fix: upgrade decentraland-ui

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -36,7 +36,7 @@
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "@well-known-components/pushable-channel": "^1.0.3",
         "classnames": "^2.3.2",
-        "decentraland-ui": "^4.10.0",
+        "decentraland-ui": "^6.5.3",
         "dotenv": "^16.3.1",
         "esbuild": "^0.18.17",
         "ethereum-cryptography": "^2.1.2",
@@ -878,6 +878,12 @@
       "bin": {
         "protoc-gen-dcl_ts_proto": "protoc-gen-dcl_ts_proto"
       }
+    },
+    "node_modules/@dcl/ui-env": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@dcl/ui-env/-/ui-env-1.5.1.tgz",
+      "integrity": "sha512-03cPMH3wrNK5bdDEoidnXIr0ZpGPe0ly8ObDNwik6PjXF+g2YBAbo5/jDUN0panddL6N6YnCJROP8NkZl/ThnQ==",
+      "dev": true
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -3352,6 +3358,12 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
+      "dev": true
+    },
     "node_modules/dayzed": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/dayzed/-/dayzed-3.2.3.tgz",
@@ -3415,19 +3427,21 @@
       }
     },
     "node_modules/decentraland-ui": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-4.10.0.tgz",
-      "integrity": "sha512-vRUeTMa9q4dOrkKlNrlh+n0dyedXw27ckT/DE6Ia7vkwfDAgGREP1RYoJOadGZ2bM1hgOFWH6rlmZ8deInCzfQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-6.5.3.tgz",
+      "integrity": "sha512-45+jS8DJP9GZ4/VN5NInKYD9uJPWWfLJMEtreuiy+SH4E5BhhB+o9Q1E7/5ETirQIqLPkjGgzYdZZpuxzbmaAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@dcl/schemas": "^9.4.1",
+        "@dcl/schemas": "^11.9.0",
+        "@dcl/ui-env": "^1.5.1",
         "balloon-css": "^0.5.0",
         "classnames": "^2.3.2",
+        "dayjs": "^1.11.10",
         "deep-equal": "^2.0.5",
         "ethereum-blockies": "^0.1.1",
         "events": "^3.3.0",
         "fp-future": "^1.0.1",
+        "mitt": "^3.0.1",
         "parallax-js": "^3.1.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0",
@@ -3436,7 +3450,11 @@
         "react-tile-map": "^0.4.1",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
-        "semantic-ui-react": "^2.0.3"
+        "semantic-ui-react": "^2.0.3",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "18"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
@@ -3452,15 +3470,15 @@
       }
     },
     "node_modules/decentraland-ui/node_modules/@dcl/schemas": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
-      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
+      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0"
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/decentraland-ui/node_modules/react": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -30,7 +30,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "@well-known-components/pushable-channel": "^1.0.3",
     "classnames": "^2.3.2",
-    "decentraland-ui": "^4.10.0",
+    "decentraland-ui": "^6.5.3",
     "dotenv": "^16.3.1",
     "esbuild": "^0.18.17",
     "ethereum-cryptography": "^2.1.2",


### PR DESCRIPTION
This upgrades to `decentraland-ui` to `v6.5.3` which contains the following fixed dependency: https://github.com/decentraland/ui-env/pull/10