### PR TITLE
send initial state when the player joins the scene

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-10884114018.commit-31410eb",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,9 +577,10 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-10884114018.commit-31410eb",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10884114018.commit-31410eb.tgz",
-      "integrity": "sha512-hLNhiC64uUF2CZxLNx5I8uksEu/JC9n26G2f7yT/MTaBB140/ZjLJDJPUXQ12TFLhdlaKYQJ02bM56LWXCIFhA==",
+      "version": "1.0.0-10836146432.commit-5ce9fe7",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
+      "integrity": "sha512-VCINW1VF9mI93OFLBI9Lg3a/lFwXbNxMIbg6mGF87RiaI/YAwMkFKiVymls+i0DsPUgVayY+tnsIFoQ32YFapw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -8232,9 +8233,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-10884114018.commit-31410eb",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10884114018.commit-31410eb.tgz",
-      "integrity": "sha512-hLNhiC64uUF2CZxLNx5I8uksEu/JC9n26G2f7yT/MTaBB140/ZjLJDJPUXQ12TFLhdlaKYQJ02bM56LWXCIFhA==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
+      "integrity": "sha512-VCINW1VF9mI93OFLBI9Lg3a/lFwXbNxMIbg6mGF87RiaI/YAwMkFKiVymls+i0DsPUgVayY+tnsIFoQ32YFapw==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
+        "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-10836146432.commit-5ce9fe7",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
-      "integrity": "sha512-VCINW1VF9mI93OFLBI9Lg3a/lFwXbNxMIbg6mGF87RiaI/YAwMkFKiVymls+i0DsPUgVayY+tnsIFoQ32YFapw==",
+      "version": "1.0.0-10955038136.commit-7fe9554",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
+      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
@@ -8233,8 +8233,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
-      "integrity": "sha512-VCINW1VF9mI93OFLBI9Lg3a/lFwXbNxMIbg6mGF87RiaI/YAwMkFKiVymls+i0DsPUgVayY+tnsIFoQ32YFapw==",
+      "version": "1.0.0-10955038136.commit-7fe9554",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
+      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
+    "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-10884114018.commit-31410eb",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-10836146432.commit-5ce9fe7.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -356,6 +356,10 @@ export const CameraModeArea: LastWriteWinElementSetComponentDefinition<PBCameraM
 // @public (undocumented)
 export interface CameraTransition {
     // (undocumented)
+    fromEntity?: number | undefined;
+    // (undocumented)
+    toEntity?: number | undefined;
+    // (undocumented)
     transitionMode?: {
         $case: "time";
         time: number;
@@ -2383,7 +2387,7 @@ export namespace PBInputModifier_StandardInput {
 
 // @public (undocumented)
 export interface PBMainCamera {
-    virtualCameraEntity?: number | undefined;
+    virtualCameraEntity: number;
 }
 
 // @public (undocumented)
@@ -3214,7 +3218,7 @@ export namespace PBVideoPlayer {
 // @public (undocumented)
 export interface PBVirtualCamera {
     // (undocumented)
-    defaultTransition?: CameraTransition | undefined;
+    defaultTransition: CameraTransition | undefined;
     // (undocumented)
     lookAtEntity?: number | undefined;
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -2812,6 +2812,8 @@ export interface PBRealmInfo {
     // (undocumented)
     commsAdapter: string;
     // (undocumented)
+    isConnectedSceneRoom?: boolean | undefined;
+    // (undocumented)
     isPreview: boolean;
     // (undocumented)
     networkId: number;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -356,10 +356,6 @@ export const CameraModeArea: LastWriteWinElementSetComponentDefinition<PBCameraM
 // @public (undocumented)
 export interface CameraTransition {
     // (undocumented)
-    fromEntity?: number | undefined;
-    // (undocumented)
-    toEntity?: number | undefined;
-    // (undocumented)
     transitionMode?: {
         $case: "time";
         time: number;
@@ -2387,7 +2383,7 @@ export namespace PBInputModifier_StandardInput {
 
 // @public (undocumented)
 export interface PBMainCamera {
-    virtualCameraEntity: number;
+    virtualCameraEntity?: number | undefined;
 }
 
 // @public (undocumented)
@@ -3218,7 +3214,7 @@ export namespace PBVideoPlayer {
 // @public (undocumented)
 export interface PBVirtualCamera {
     // (undocumented)
-    defaultTransition: CameraTransition | undefined;
+    defaultTransition?: CameraTransition | undefined;
     // (undocumented)
     lookAtEntity?: number | undefined;
 }

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -15,7 +15,7 @@
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-10884114018.commit-31410eb",
+        "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -239,9 +239,10 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-10884114018.commit-31410eb",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10884114018.commit-31410eb.tgz",
-      "integrity": "sha512-hLNhiC64uUF2CZxLNx5I8uksEu/JC9n26G2f7yT/MTaBB140/ZjLJDJPUXQ12TFLhdlaKYQJ02bM56LWXCIFhA==",
+      "version": "1.0.0-10955038136.commit-7fe9554",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
+      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -3228,9 +3229,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-10884114018.commit-31410eb",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10884114018.commit-31410eb.tgz",
-      "integrity": "sha512-hLNhiC64uUF2CZxLNx5I8uksEu/JC9n26G2f7yT/MTaBB140/ZjLJDJPUXQ12TFLhdlaKYQJ02bM56LWXCIFhA==",
+      "version": "1.0.0-10955038136.commit-7fe9554",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
+      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -13,7 +13,7 @@
     "@dcl/inspector": "file:../inspector",
     "@dcl/linker-dapp": "^0.14.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-10884114018.commit-31410eb",
+    "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk/src/network/entities.ts
+++ b/packages/@dcl/sdk/src/network/entities.ts
@@ -8,23 +8,7 @@ import {
   SyncComponents as _SyncComponents,
   INetowrkParent,
   TransformComponent,
-  ISyncComponents,
-  VideoEvent,
-  TweenState,
-  AudioEvent,
-  AudioSource,
-  EngineInfo,
-  GltfContainerLoadingState,
-  PointerEventsResult,
-  RaycastResult,
-  RealmInfo,
-  VideoPlayer,
-  UiDropdown,
-  UiDropdownResult,
-  UiInput,
-  UiInputResult,
-  UiText,
-  UiTransform
+  ISyncComponents
 } from '@dcl/ecs'
 import { IProfile } from './message-bus-sync'
 import { NOT_SYNC_COMPONENTS } from './state'

--- a/packages/@dcl/sdk/src/network/entities.ts
+++ b/packages/@dcl/sdk/src/network/entities.ts
@@ -27,6 +27,7 @@ import {
   UiTransform
 } from '@dcl/ecs'
 import { IProfile } from './message-bus-sync'
+import { NOT_SYNC_COMPONENTS } from './state'
 
 export type SyncEntity = (entityId: Entity, componentIds: number[], entityEnumId?: number) => void
 
@@ -64,24 +65,6 @@ export function entityUtils(engine: IEngine, profile: IProfile) {
       }
     }
 
-    const NOT_SYNC_COMPONENTS = [
-      VideoEvent,
-      VideoPlayer,
-      TweenState,
-      AudioEvent,
-      AudioSource,
-      EngineInfo,
-      GltfContainerLoadingState,
-      PointerEventsResult,
-      RaycastResult,
-      RealmInfo,
-      UiDropdown,
-      UiDropdownResult,
-      UiInput,
-      UiInputResult,
-      UiTransform,
-      UiText
-    ]
     for (const component of NOT_SYNC_COMPONENTS) {
       if (componentsIdsMutable.includes(component.componentId)) {
         console.log(`⚠️ ${component.componentName} can't be sync through the network!`)

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -1,4 +1,4 @@
-import { IEngine, PlayerIdentityData, Transport } from '@dcl/ecs'
+import { IEngine, Transport } from '@dcl/ecs'
 import type { SendBinaryRequest, SendBinaryResponse } from '~system/CommunicationsController'
 
 import { syncFilter } from './filter'
@@ -56,8 +56,8 @@ export function addSyncTransport(
   // If we dont have any state initialized, and recieve a state message.
   binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, (value) => {
     const { sender, data } = decodeCRDTState(value)
-    console.log('[RES_CRDT_STATE]', sender, data)
     if (sender !== myProfile.userId) return
+    console.log('[Received CRDT State]', data.byteLength)
     setInitialized()
     transport.onmessage!(data)
   })
@@ -73,6 +73,7 @@ export function addSyncTransport(
       await wait(2000)
       // if the user is still in the scene
       if (players.getPlayer({ userId })) {
+        console.log('[SEND CRDT STATE] to:', userId)
         binaryMessageBus.emit(CommsMessage.RES_CRDT_STATE, encodeCRDTState(userId, engineToCrdt(engine)))
       }
     }

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -64,12 +64,9 @@ export function addSyncTransport(
   })
 
   binaryMessageBus.on(CommsMessage.REQ_CRDT_STATE, (_, userId) => {
-    console.log('CommsMessage.REQ_CRDT_STATE', userId)
-    if (players.getPlayer({ userId })) {
-      console.log('[Emiting State to]', userId)
-      binaryMessageBus.emit(CommsMessage.RES_CRDT_STATE, encodeCRDTState(userId, engineToCrdt(engine)))
-    }
+    binaryMessageBus.emit(CommsMessage.RES_CRDT_STATE, encodeCRDTState(userId, engineToCrdt(engine)))
   })
+
   const players = definePlayerHelper(engine)
 
   let requestCrdtStateWhenConnected = false

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -63,27 +63,6 @@ export function addSyncTransport(
   })
   const players = definePlayerHelper(engine)
 
-  let connectedPlayers: Set<string> = new Set()
-
-  async function logPlayers() {
-    let dirty = false
-    const players = new Set<string>()
-    const component = engine.getComponent(PlayerIdentityData.componentId) as typeof PlayerIdentityData
-    for (const[entity, player] of engine.getEntitiesWith(component)) {
-      if (!connectedPlayers.has(player.address)) {
-        dirty = true
-      }
-      players.add(player.address)
-    }
-    if (dirty || players.size !== connectedPlayers.size) {
-      console.log(...Array.from(players))
-    }
-    connectedPlayers = players
-    await wait(1000)
-    logPlayers()
-  }
-  logPlayers()
-
   players.onEnterScene((player) => {
     console.log('[onEnterScene]', player.userId)
 

--- a/packages/@dcl/sdk/src/network/state.ts
+++ b/packages/@dcl/sdk/src/network/state.ts
@@ -9,8 +9,45 @@ import {
   SyncComponents as _SyncComponents,
   NetworkEntity as _NetworkEntity,
   ISyncComponents,
-  INetowrkEntity
+  INetowrkEntity,
+  VideoEvent,
+  AudioEvent,
+  AudioSource,
+  EngineInfo,
+  GltfContainerLoadingState,
+  PointerEventsResult,
+  RaycastResult,
+  RealmInfo,
+  TweenState,
+  UiDropdown,
+  UiDropdownResult,
+  UiInput,
+  UiInputResult,
+  UiText,
+  UiTransform,
+  VideoPlayer
 } from '@dcl/ecs'
+
+export const NOT_SYNC_COMPONENTS = [
+  VideoEvent,
+  VideoPlayer,
+  TweenState,
+  AudioEvent,
+  AudioSource,
+  EngineInfo,
+  GltfContainerLoadingState,
+  PointerEventsResult,
+  RaycastResult,
+  RealmInfo,
+  UiDropdown,
+  UiDropdownResult,
+  UiInput,
+  UiInputResult,
+  UiTransform,
+  UiText
+]
+
+const NOT_SYNC_COMPONENTS_IDS = NOT_SYNC_COMPONENTS.map(($) => $.componentId)
 
 export function engineToCrdt(engine: IEngine): Uint8Array {
   const crdtBuffer = new ReadWriteByteBuffer()
@@ -19,6 +56,9 @@ export function engineToCrdt(engine: IEngine): Uint8Array {
   const NetworkEntity = engine.getComponent(_NetworkEntity.componentId) as INetowrkEntity
 
   for (const itComponentDefinition of engine.componentsIter()) {
+    if (NOT_SYNC_COMPONENTS_IDS.includes(itComponentDefinition.componentId)) {
+      continue
+    }
     itComponentDefinition.dumpCrdtStateToBuffer(crdtBuffer, (entity) => {
       const isNetworkEntity = NetworkEntity.has(entity)
       if (!isNetworkEntity) {

--- a/packages/@dcl/sdk/src/network/state.ts
+++ b/packages/@dcl/sdk/src/network/state.ts
@@ -8,7 +8,6 @@ import {
   PutNetworkComponentOperation,
   SyncComponents as _SyncComponents,
   NetworkEntity as _NetworkEntity,
-  ISyncComponents,
   INetowrkEntity,
   VideoEvent,
   AudioEvent,
@@ -52,7 +51,6 @@ const NOT_SYNC_COMPONENTS_IDS = NOT_SYNC_COMPONENTS.map(($) => $.componentId)
 export function engineToCrdt(engine: IEngine): Uint8Array {
   const crdtBuffer = new ReadWriteByteBuffer()
   const networkBuffer = new ReadWriteByteBuffer()
-  const SyncComponents = engine.getComponent(_SyncComponents.componentId) as ISyncComponents
   const NetworkEntity = engine.getComponent(_NetworkEntity.componentId) as INetowrkEntity
 
   for (const itComponentDefinition of engine.componentsIter()) {
@@ -61,17 +59,7 @@ export function engineToCrdt(engine: IEngine): Uint8Array {
     }
     itComponentDefinition.dumpCrdtStateToBuffer(crdtBuffer, (entity) => {
       const isNetworkEntity = NetworkEntity.has(entity)
-      if (!isNetworkEntity) {
-        return false
-      }
-      return true
-      // const isDynamicEntity = NetworkEntity.get(entity).networkId
-      // if (isDynamicEntity) {
-      //   return true
-      // }
-      // // For the static entities we only send the updates of the SyncComponents
-      // // TODO: what about static entities that are created on runtime ?
-      // return SyncComponents.get(entity).componentIds.includes(itComponentDefinition.componentId)
+      return isNetworkEntity
     })
   }
 

--- a/packages/@dcl/sdk/src/network/state.ts
+++ b/packages/@dcl/sdk/src/network/state.ts
@@ -69,6 +69,7 @@ export function engineToCrdt(engine: IEngine): Uint8Array {
         return true
       }
       // For the static entities we only send the updates of the SyncComponents
+      // TODO: what about static entities that are created on runtime ?
       return SyncComponents.get(entity).componentIds.includes(itComponentDefinition.componentId)
     })
   }

--- a/packages/@dcl/sdk/src/network/state.ts
+++ b/packages/@dcl/sdk/src/network/state.ts
@@ -64,13 +64,14 @@ export function engineToCrdt(engine: IEngine): Uint8Array {
       if (!isNetworkEntity) {
         return false
       }
-      const isDynamicEntity = NetworkEntity.get(entity).networkId
-      if (isDynamicEntity) {
-        return true
-      }
-      // For the static entities we only send the updates of the SyncComponents
-      // TODO: what about static entities that are created on runtime ?
-      return SyncComponents.get(entity).componentIds.includes(itComponentDefinition.componentId)
+      return true
+      // const isDynamicEntity = NetworkEntity.get(entity).networkId
+      // if (isDynamicEntity) {
+      //   return true
+      // }
+      // // For the static entities we only send the updates of the SyncComponents
+      // // TODO: what about static entities that are created on runtime ?
+      // return SyncComponents.get(entity).componentIds.includes(itComponentDefinition.componentId)
     })
   }
 

--- a/packages/@dcl/sdk/src/network/utils.ts
+++ b/packages/@dcl/sdk/src/network/utils.ts
@@ -3,7 +3,6 @@ import {
   Entity,
   IEngine,
   NetworkEntity as _NetworkEntity,
-  Schemas,
   LastWriteWinElementSetComponentDefinition,
   PBEngineInfo
 } from '@dcl/ecs'
@@ -13,22 +12,14 @@ import type { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdenti
 import { SyncEntity } from './entities'
 import { IProfile } from './message-bus-sync'
 
-// Component to track all the players and when they enter to the scene.
-// Know who is in charge of sending the initial state (oldest one)
-export const definePlayersInScene = (engine: IEngine) =>
-  engine.defineComponent('players-scene', {
-    timestamp: Schemas.Number,
-    userId: Schemas.String
-  })
-
 // Already initialized my state. Ignore new states messages.
 export let stateInitialized = false
 
 // My player entity to check if I'm the oldest player in the scend
 export let playerSceneEntity: Entity
 
-export function setInitialized() {
-  stateInitialized = true
+export function setInitialized(value = true) {
+  stateInitialized = value
 }
 
 // Flag to avoid sending over the wire all the initial messages that the engine add's to the rendererTransport
@@ -50,37 +41,6 @@ export function fetchProfile(
       throw new Error(`Couldn't fetch profile data`)
     }
   })
-}
-
-/**
- * Add's the user information about when he joined the scene.
- * It's used to check who is the oldest one, to sync the state
- */
-export function createPlayerTimestampData(engine: IEngine, profile: IProfile, syncEntity: SyncEntity) {
-  if (!profile?.userId) return undefined
-  const PlayersInScene = definePlayersInScene(engine)
-  const entity = engine.addEntity()
-  PlayersInScene.create(entity, { timestamp: Date.now(), userId: profile.userId })
-  syncEntity(entity, [PlayersInScene.componentId])
-  playerSceneEntity = entity
-  return playerSceneEntity
-}
-
-/**
- * Check if I'm the older user to send the initial state
- */
-export function oldestUser(engine: IEngine, profile: IProfile, syncEntity: SyncEntity): boolean {
-  const PlayersInScene = definePlayersInScene(engine)
-  // When the user leaves the scene but it's still connected.
-  if (!PlayersInScene.has(playerSceneEntity)) {
-    createPlayerTimestampData(engine, profile, syncEntity)
-    return oldestUser(engine, profile, syncEntity)
-  }
-  const { timestamp } = PlayersInScene.get(playerSceneEntity)
-  for (const [_, player] of engine.getEntitiesWith(PlayersInScene)) {
-    if (player.timestamp < timestamp) return false
-  }
-  return true
 }
 
 /**
@@ -111,35 +71,11 @@ export function stateInitializedChecker(engine: IEngine, _profile: IProfile, _sy
   const EngineInfo = engine.getComponent(_EngineInfo.componentId) as typeof _EngineInfo
   // const NetworkEntity = engine.getComponent(_NetworkEntity.componentId) as INetowrkEntity
   async function enterScene() {
-    // if (!playerSceneEntity) {
-    //   createPlayerTimestampData(engine, profile, syncEntity)
-    // }
-
-    /**
-     * Keeps PlayersInScene up-to-date with the current players.
-     */
-    // const connectedPlayers = await getConnectedPlayers({})
-    // for (const [entity, player] of engine.getEntitiesWith(PlayersInScene)) {
-    //   if (!connectedPlayers.players.find(($) => $.userId === player.userId)) {
-    //     PlayersInScene.deleteFrom(entity)
-    //   }
-    // }
-
     // Wait for comms to be ready ?? ~3000ms
     if ((EngineInfo.getOrNull(engine.RootEntity)?.tickNumber ?? 0) > 100) {
       setInitialized()
       return
     }
-
-    // If we already have data from players, dont send the heartbeat messages
-    // if (connectedPlayers.players.length) return
-
-    // if (!stateInitialized && playerSceneEntity) {
-    //   // Send this data to all the players connected (new and old)
-    //   // So everyone can decide if it's the oldest one or no.
-    //   // It's for the case that multiple users enters ~ at the same time.
-    //   PlayersInScene.getMutable(playerSceneEntity)
-    // }
   }
   void enterScene()
 }

--- a/packages/@dcl/sdk/src/players/index.ts
+++ b/packages/@dcl/sdk/src/players/index.ts
@@ -22,7 +22,7 @@ type GetPlayerDataRes = {
   position: TransformType['position'] | undefined
 }
 
-function definePlayerHelper(engine: IEngine) {
+export function definePlayerHelper(engine: IEngine) {
   const Transform = defineTransform(engine)
   const PlayerIdentityData = definePlayerIdenityData(engine)
   const AvatarEquippedData = defineAvatarEquippedData(engine)

--- a/test/ecs/components/RealmInfo.spec.ts
+++ b/test/ecs/components/RealmInfo.spec.ts
@@ -12,7 +12,8 @@ describe('Generated RealmInfo ProtoBuf', () => {
       networkId: 1,
       realmName: 'boedo',
       room: 'casla',
-      isPreview: false
+      isPreview: false,
+      isConnectedSceneRoom: false
     })
 
     testComponentSerialization(RealmInfo, {
@@ -21,7 +22,8 @@ describe('Generated RealmInfo ProtoBuf', () => {
       networkId: 1,
       realmName: 'boedo',
       room: 'casla',
-      isPreview: false
+      isPreview: false,
+      isConnectedSceneRoom: false
     })
   })
 })


### PR DESCRIPTION
Send CRDT State when a player enters the scene. _Before was done the first time the scene started._

Send the CRDT State with the userId that needs to receive that message. So if a player recieces a CRDT state that is not mean to him, it can ignore it.
_Before the user that enters requested the crdt state, and everyone answer to that request. Now we send it without the REQ from the user._

~Add a delay of 2s when the player enters the scene to wait till comms is initalized (TODO: add a component or API for this)~

Use the PBRealmInfo component to know when the user is connected to comms, and then ask for the state

If a player leaves the scene, but the scene is still running in the background (because of hte load of radius), mark the scene as not initialized, so when the player enters again the scene and receives the CRDT State it can be processed, and it updates the running scene. 

