### PR TITLE
remove install of asset-pack

### DIFF
--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -65,7 +65,7 @@
     "../inspector": {
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "1.20.0",
+        "@dcl/asset-packs": "1.20.1",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -3138,7 +3138,7 @@
         "@babylonjs/inspector": "~6.18.0",
         "@babylonjs/loaders": "~6.18.0",
         "@babylonjs/materials": "~6.18.0",
-        "@dcl/asset-packs": "1.20.0",
+        "@dcl/asset-packs": "1.20.1",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/mini-rpc": "^1.0.7",

--- a/packages/@dcl/sdk-commands/src/commands/build/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/build/index.ts
@@ -1,14 +1,7 @@
 import path from 'path'
 import { CliComponents } from '../../components'
 import { declareArgs } from '../../logic/args'
-import {
-  installAssetPack,
-  installDependencies,
-  isEditorScene,
-  needsDependencies,
-  SceneProject,
-  WearableProject
-} from '../../logic/project-validations'
+import { installDependencies, needsDependencies, SceneProject, WearableProject } from '../../logic/project-validations'
 import { getBaseCoords } from '../../logic/scene-validations'
 import { b64HashingFunction } from '../../logic/project-files'
 import { bundleProject } from '../../logic/bundle'
@@ -69,10 +62,6 @@ export async function buildScene(options: Options, project: SceneProject | Weara
   if (canInstall) {
     if (await needsDependencies(options.components, project.workingDirectory)) {
       await installDependencies(options.components, project.workingDirectory)
-    }
-
-    if (await isEditorScene(options.components, project.workingDirectory)) {
-      await installAssetPack(options.components, project.workingDirectory)
     }
   }
 

--- a/packages/@dcl/sdk-commands/src/logic/project-validations.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-validations.ts
@@ -2,10 +2,10 @@ import { Scene } from '@dcl/schemas'
 import path from 'path'
 import { CliComponents } from '../components'
 import { colors } from '../components/log'
-import { printProgressInfo, printSuccess, printWarning } from './beautiful-logs'
+import { printProgressInfo } from './beautiful-logs'
 import { CliError } from './error'
 import { getSceneFilePath, getValidSceneJson } from './scene-validations'
-import { getInstalledPackageVersion, getInstalledPackageVersionInsidePackage } from './config'
+import { getInstalledPackageVersion } from './config'
 import { getSmartWearableFile, getValidWearableJson } from './portable-experience-sw-validations'
 import { getPackageJson } from './project-files'
 
@@ -72,29 +72,6 @@ export async function installDependencies(
   // TODO: test in windows
   await components.spawner.exec(workingDirectory, npmBin, ['install'])
   printProgressInfo(components.logger, colors.white('✅ Installing dependencies...'))
-}
-
-/*
- * Runs "npm install" for desired project
- */
-export async function installAssetPack(
-  components: Pick<CliComponents, 'logger' | 'spawner' | 'fs'>,
-  workingDirectory: string
-): Promise<void> {
-  const assetPack = '@dcl/asset-packs' as const
-  let assetPackVersion: string = ''
-  try {
-    assetPackVersion = await getInstalledPackageVersionInsidePackage(
-      components,
-      assetPack,
-      '@dcl/inspector',
-      workingDirectory
-    )
-    await components.spawner.exec(workingDirectory, npmBin, ['install', `${assetPack}@${assetPackVersion}`, '-D'])
-    printSuccess(components.logger, `${assetPack}@${assetPackVersion} installed`, '')
-  } catch (e: any) {
-    printWarning(components.logger, `Failed to install ${assetPack}@${assetPackVersion}' \n ${e.message}`)
-  }
 }
 
 /**


### PR DESCRIPTION
@dcl/asset-packs is already installed inside the @dcl/inspector.
@dcl/inspector is installed via @dcl/sdk-commands
@dcl/sdk-commands is installed via @dcl/sdk

So there is no need to install the asset-packs again, is already there. 
Also it fixes the unlink of npm packages every time you run `npm start`.
