### PR TITLE
Fix corruption of Transform data (NetworkParent + Tween)

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -161,14 +161,6 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
 
         /* istanbul ignore else */
         if (component) {
-          if (
-            msg.type === CrdtMessageType.PUT_COMPONENT &&
-            component.componentId === Transform.componentId &&
-            NetworkEntity.has(entityId) &&
-            NetworkParent.has(entityId)
-          ) {
-            msg.data = networkUtils.fixTransformParent(msg)
-          }
           const [conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
           if (!conflictMessage) {
             // Add message to transport queue to be processed by others transports


### PR DESCRIPTION
This PR fixes **Transform** misaligned data reading (all data is shifted by 4 bytes) when entity has **NetworkParent**.

This bug appears as incorrect data produced by `Transform.get`, and causes more impact when one is using `Transform.getMutable` (or recurrent `parentEntity` as well, because it implies the former internally) after network parent was initially assigned - this way incorrect data is forwarded back to engine, and on the next step it will be shifted again.

It occurs only when engine sends **Transform** updates to a scene (i.e. when using **Tween**, but perhaps other cases exist), and doesn't show up if only scene is updating the data.