### PR TITLE
fix node spawn process

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -234,7 +234,7 @@ function runTypeChecker(components: BundleComponents, options: CompileOptions) {
   if (options.watch) args.push('--watch')
 
   printProgressStep(components.logger, `Running type checker`, 2, MAX_STEP)
-  const ts = child_process.spawn('node', args, { env: process.env, cwd: options.workingDirectory })
+  const ts = child_process.spawn(process.execPath, args, { env: process.env, cwd: options.workingDirectory })
   const typeCheckerFuture = future<number>()
 
   ts.on('close', (code) => {


### PR DESCRIPTION
Having `node` installed was previously assumed be since the user would be running `npm start` on a scene to preview it.

Since we are now running sdk-commands from within another processes (creator-hub, etc), the OS where we are running those processes might not have `node` installed, so we need to run sub-processes using the bundled node executable (or the original executable caller).