### PR TITLE
chore: move alpha_texture from PBRMaterial to UnlitMaterial

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-10955038136.commit-7fe9554",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
-      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
+      "version": "1.0.0-11377135224.commit-2d27fb7",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
+      "integrity": "sha512-R02wTHj+aPIItDjKi9TH+REJkurzJ/n8or33Ml/JO82BEw4nXlotfm+B1Ri84G1HY8/fmPeWZlzDA91N/yAv8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
@@ -8233,9 +8233,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-10955038136.commit-7fe9554",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
-      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
+      "integrity": "sha512-R02wTHj+aPIItDjKi9TH+REJkurzJ/n8or33Ml/JO82BEw4nXlotfm+B1Ri84G1HY8/fmPeWZlzDA91N/yAv8A==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
+        "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,10 +577,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11377135224.commit-2d27fb7",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
-      "integrity": "sha512-R02wTHj+aPIItDjKi9TH+REJkurzJ/n8or33Ml/JO82BEw4nXlotfm+B1Ri84G1HY8/fmPeWZlzDA91N/yAv8A==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-11406954347.commit-ba19c4f",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
+      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -8233,8 +8232,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
-      "integrity": "sha512-R02wTHj+aPIItDjKi9TH+REJkurzJ/n8or33Ml/JO82BEw4nXlotfm+B1Ri84G1HY8/fmPeWZlzDA91N/yAv8A==",
+      "version": "1.0.0-11406954347.commit-ba19c4f",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
+      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
+        "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
+    "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
+    "@dcl/protocol": "^1.0.0-11406954347.commit-ba19c4f",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11377135224.commit-2d27fb7.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -2418,6 +2418,7 @@ export namespace PBMaterial {
 export interface PBMaterial_PbrMaterial {
     albedoColor?: PBColor4 | undefined;
     alphaTest?: number | undefined;
+    // @deprecated (undocumented)
     alphaTexture?: TextureUnion | undefined;
     bumpTexture?: TextureUnion | undefined;
     castShadows?: boolean | undefined;
@@ -2444,6 +2445,7 @@ export namespace PBMaterial_PbrMaterial {
 // @public (undocumented)
 export interface PBMaterial_UnlitMaterial {
     alphaTest?: number | undefined;
+    alphaTexture?: TextureUnion | undefined;
     castShadows?: boolean | undefined;
     diffuseColor?: PBColor4 | undefined;
     texture?: TextureUnion | undefined;

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -15,7 +15,7 @@
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
+        "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -239,10 +239,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-10955038136.commit-7fe9554",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
-      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-11406954347.commit-ba19c4f",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
+      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -3229,9 +3228,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-10955038136.commit-7fe9554",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-10955038136.commit-7fe9554.tgz",
-      "integrity": "sha512-0BcRTJxFhxpX1k4oN8ErL+HiJYDmd98aDh6Kti54zoCph3SlJqkq0r1KshHAeMaXLSKNRtljjgkf4KkB8MriKA==",
+      "version": "1.0.0-11406954347.commit-ba19c4f",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
+      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -13,7 +13,7 @@
     "@dcl/inspector": "file:../inspector",
     "@dcl/linker-dapp": "^0.14.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-10955038136.commit-7fe9554",
+    "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/ecs/components/Material.spec.ts
+++ b/test/ecs/components/Material.spec.ts
@@ -48,16 +48,7 @@ describe('Generated Material ProtoBuf', () => {
             }
           }
         },
-        alphaTexture: {
-          tex: {
-            $case: 'texture',
-            texture: {
-              filterMode: undefined,
-              wrapMode: undefined,
-              src: 'not-casla'
-            }
-          }
-        },
+        alphaTexture: undefined,
         castShadows: true,
         metallic: 1,
         roughness: 1,
@@ -79,16 +70,7 @@ describe('Generated Material ProtoBuf', () => {
       createPbrMaterial({
         albedoColor: { r: 0, g: 1, b: 1, a: 1 },
         alphaTest: 1,
-        alphaTexture: {
-          tex: {
-            $case: 'texture',
-            texture: {
-              wrapMode: TextureWrapMode.TWM_CLAMP,
-              filterMode: TextureFilterMode.TFM_BILINEAR,
-              src: 'not-casla'
-            }
-          }
-        },
+        alphaTexture: undefined,
         bumpTexture: {
           tex: {
             $case: 'texture',
@@ -136,6 +118,7 @@ describe('Generated Material ProtoBuf', () => {
       createUnlitMaterial({
         castShadows: true,
         diffuseColor: { r: 0, g: 1, b: 1, a: 1 },
+        alphaTexture: undefined,
         alphaTest: undefined,
         texture: undefined
       })


### PR DESCRIPTION
Addresses the SDK part of [issue #240](https://github.com/decentraland/creator-hub/issues/240)

Related PRs:
E@: https://github.com/decentraland/unity-explorer/pull/2482
Protocol: https://github.com/decentraland/protocol/pull/223