### PR TITLE
chore: Creator Hub analytics

### DIFF
--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -1,9 +1,10 @@
 import { ComponentDefinition, CompositeDefinition, DeepReadonlyObject, Entity } from '@dcl/ecs'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist/serialization/ByteBuffer'
 import { dataCompare } from '@dcl/ecs/dist/systems/crdt/utils'
+import { Scene } from '@dcl/schemas'
 
 import { EditorComponentsTypes, SceneAgeRating, SceneCategory, SceneComponent } from '../../../sdk/components'
-import { Scene } from '@dcl/schemas'
+import { getConfig } from '../../../logic/config'
 
 export function isEqual(component: ComponentDefinition<unknown>, prevValue: unknown, newValue: unknown) {
   if (prevValue === newValue || (!prevValue && !newValue)) return true
@@ -40,6 +41,7 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
     const sanitizedTag = tag.trim()
     if (sanitizedTag && !tags.includes(sanitizedTag)) tags.push(sanitizedTag)
   }
+  const config = getConfig()
   const scene: Partial<SceneWithRating> = {
     display: {
       title: value.name || '',
@@ -72,6 +74,14 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
       portableExperiences: value.disablePortableExperiences ? 'disabled' : 'enabled'
     },
     rating: value.ageRating
+  }
+
+  if (config.segmentAppId && config.projectId) {
+    // add analytics source
+    scene.source = {
+      origin: config.segmentAppId,
+      projectId: config.projectId
+    }
   }
 
   return scene

--- a/packages/@dcl/sdk-commands/src/components/analytics.ts
+++ b/packages/@dcl/sdk-commands/src/components/analytics.ts
@@ -140,6 +140,8 @@ export async function createAnalyticsComponent(components: Pick<CliComponents, '
     isCI: isCI(),
     isEditor: isEditor(),
     devId: anonId,
+    projectId: process.env.ANALYTICS_PROJECT_ID || null,
+    appId: process.env.ANALYTICS_APP_ID || null,
     ecs: {
       ecsVersion: 'ecs7',
       packageVersion: sdkVersion

--- a/test/sdk-commands/utils/analytics.spec.ts
+++ b/test/sdk-commands/utils/analytics.spec.ts
@@ -81,6 +81,8 @@ describe('Analytics Component', () => {
           isCI: isCI(),
           isEditor: false,
           devId: 'fb3f84b2-4ddc-4a7e-96bf-1e8992c294dd',
+          appId: null,
+          projectId: null,
           ecs: {
             ecsVersion: 'ecs7',
             packageVersion: 'unknown'


### PR DESCRIPTION
Added `appId` and `projectId` properties to events from the CLI, so we can identify when they come from the Creator Hub.

I also made the inspector save in the `scene.json` the `source` property if it has the appId and projectId set in the config, so the deployed scene can also be identified as created with the creator-hub (or other apps that use the inspector).