### PR TITLE
feat: pointer event toggle highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,9 +577,10 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "1.0.0-11593429245.commit-6dd6863",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -8232,9 +8233,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+        "@dcl/protocol": "1.0.0-11599848164.commit-ef74edc",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,10 +577,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11593429245.commit-6dd6863",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
-      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
-      "license": "Apache-2.0",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -8233,8 +8232,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
-      "integrity": "sha512-2MEa2+Q9Qd5l0TYlPjIUVBspnEyFvkTOqfHyJGwejxiiE0kIfdo29b5fUtKkMpcBS1VRfkJmsEiD1kOVzDSSlg==",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-11593429245.commit-6dd6863.tgz",
+    "@dcl/protocol": "1.0.0-11599848164.commit-ef74edc",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -111,20 +111,17 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
   }
 
   function setPointerEvent(entity: Entity, type: PointerEventType, opts: EventSystemOptions) {
-    if (opts.hoverText || opts.showFeedback || opts.showHighlight) {
-      const pointerEvent = PointerEvents.getMutableOrNull(entity) || PointerEvents.create(entity)
-
-      pointerEvent.pointerEvents.push({
-        eventType: type,
-        eventInfo: {
-          button: opts.button,
-          showFeedback: opts.showFeedback,
-          showHighlight: opts.showHighlight,
-          hoverText: opts.hoverText,
-          maxDistance: opts.maxDistance
-        }
-      })
-    }
+    const pointerEvent = PointerEvents.getMutableOrNull(entity) || PointerEvents.create(entity)
+    pointerEvent.pointerEvents.push({
+      eventType: type,
+      eventInfo: {
+        button: opts.button,
+        showFeedback: opts.showFeedback,
+        showHighlight: opts.showHighlight,
+        hoverText: opts.hoverText,
+        maxDistance: opts.maxDistance
+      }
+    })
   }
 
   function removePointerEvent(entity: Entity, type: PointerEventType, button: InputAction) {

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -23,6 +23,11 @@ export type EventSystemOptions = {
   showHighlight?: boolean
 }
 
+export const getDefaultOpts = (opts: Partial<EventSystemOptions> = {}): EventSystemOptions => ({
+  button: InputAction.IA_ANY,
+  ...opts
+})
+
 /**
  * @public
  */
@@ -98,11 +103,6 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     Up
   }
   type EventMapType = Map<EventType, { cb: EventSystemCallback; opts: EventSystemOptions }>
-
-  const getDefaultOpts = (opts: Partial<EventSystemOptions> = {}): EventSystemOptions => ({
-    button: InputAction.IA_ANY,
-    ...opts
-  })
 
   const eventsMap = new Map<Entity, EventMapType>()
 

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -20,6 +20,7 @@ export type EventSystemOptions = {
   hoverText?: string
   maxDistance?: number
   showFeedback?: boolean
+  showHighlight?: boolean
 }
 
 /**
@@ -110,7 +111,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
   }
 
   function setPointerEvent(entity: Entity, type: PointerEventType, opts: EventSystemOptions) {
-    if (opts.hoverText || opts.showFeedback) {
+    if (opts.hoverText || opts.showFeedback || opts.showHighlight) {
       const pointerEvent = PointerEvents.getMutableOrNull(entity) || PointerEvents.create(entity)
 
       pointerEvent.pointerEvents.push({
@@ -118,6 +119,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
         eventInfo: {
           button: opts.button,
           showFeedback: opts.showFeedback,
+          showHighlight: opts.showHighlight,
           hoverText: opts.hoverText,
           maxDistance: opts.maxDistance
         }

--- a/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/PointerEventsInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/PointerEventsInspector.tsx
@@ -115,6 +115,12 @@ export default withSdk<Props>(({ sdk, entity: entityId }) => {
               onChange={(e) => handleEventInfoChange({ showFeedback: !!e.target.checked }, idx)}
             />
           </Block>
+          <Block label="Show highlight">
+            <CheckboxField
+              checked={!!$.eventInfo?.showHighlight ?? DEFAULTS.eventInfo.showHighlight}
+              onChange={(e) => handleEventInfoChange({ showHighlight: !!e.target.checked }, idx)}
+            />
+          </Block>
           <AddButton onClick={() => handleRemove(idx)}>Remove Pointer Event</AddButton>
         </React.Fragment>
       ))}

--- a/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/utils.spec.ts
@@ -23,7 +23,8 @@ describe('InputUtils', () => {
           button: InputAction.IA_ANY,
           hoverText: 'Interact',
           maxDistance: 10,
-          showFeedback: true
+          showFeedback: true,
+          showHighlight: true
         }
       }
       expect(result).toEqual(expected)
@@ -36,7 +37,8 @@ describe('InputUtils', () => {
           button: InputAction.IA_PRIMARY,
           hoverText: 'Custom Interaction',
           maxDistance: 15,
-          showFeedback: false
+          showFeedback: false,
+          showHighlight: false
         }
       })
       const expected = {
@@ -45,7 +47,8 @@ describe('InputUtils', () => {
           button: InputAction.IA_PRIMARY,
           hoverText: 'Custom Interaction',
           maxDistance: 15,
-          showFeedback: false
+          showFeedback: false,
+          showHighlight: false
         }
       }
       expect(result).toEqual(expected)
@@ -68,7 +71,8 @@ describe('InputUtils', () => {
           button: InputAction.IA_ANY,
           hoverText: 'Interact',
           maxDistance: 10,
-          showFeedback: true
+          showFeedback: true,
+          showHighlight: true
         }
       }
       expect(DEFAULTS).toEqual(expected)

--- a/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/PointerEventsInspector/utils.ts
@@ -18,6 +18,7 @@ export function getDefaultPointerEvent(
       hoverText: 'Interact',
       maxDistance: 10,
       showFeedback: true,
+      showHighlight: true,
       ...def?.eventInfo
     }
   }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -2677,6 +2677,7 @@ export interface PBPointerEvents_Info {
     hoverText?: string | undefined;
     maxDistance?: number | undefined;
     showFeedback?: boolean | undefined;
+    showHighlight?: boolean | undefined;
 }
 
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1168,6 +1168,11 @@ export function getComponentEntityTree<T>(engine: Pick<IEngine, 'getEntitiesWith
 // @public @deprecated (undocumented)
 export function getCompositeRootComponent(engine: IEngine): LastWriteWinElementSetComponentDefinition<CompositeRootType>;
 
+// Warning: (ae-missing-release-tag) "getDefaultOpts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const getDefaultOpts: (opts?: Partial<EventSystemOptions>) => EventSystemOptions;
+
 // Warning: (ae-missing-release-tag) "GlobalDirectionRaycastOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1130,6 +1130,7 @@ export type EventSystemOptions = {
     hoverText?: string;
     maxDistance?: number;
     showFeedback?: boolean;
+    showHighlight?: boolean;
 };
 
 // @public

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -15,7 +15,7 @@
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
+        "@dcl/protocol": "1.0.0-11599848164.commit-ef74edc",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -3228,9 +3228,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-11406954347.commit-ba19c4f",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11406954347.commit-ba19c4f.tgz",
-      "integrity": "sha512-oMoq5IKAe1gout5SbP2w3Jq3Im+tbUiREW70BC+aVwwOly0YDtTWTZG9FyjeF36RDhyCg7z6jwtHL/rbWp0skw==",
+      "version": "1.0.0-11599848164.commit-ef74edc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-11599848164.commit-ef74edc.tgz",
+      "integrity": "sha512-XSUOA0LbchlBUk5/BMJFBl0+qOm4UOIxwMGp38A1n4LQAatGO/RXjzReJRveqiFma+X7eq3e6+KCDqTLwepN0w==",
       "requires": {
         "@dcl/ts-proto": "1.154.0"
       }

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -13,7 +13,7 @@
     "@dcl/inspector": "file:../inspector",
     "@dcl/linker-dapp": "^0.14.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-11406954347.commit-ba19c4f",
+    "@dcl/protocol": "1.0.0-11599848164.commit-ef74edc",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/ecs/components/PointerEvents.spec.ts
+++ b/test/ecs/components/PointerEvents.spec.ts
@@ -14,7 +14,8 @@ describe('Generated OnPointerDown ProtoBuf', () => {
             button: 1,
             hoverText: 'Tap to run',
             maxDistance: 10,
-            showFeedback: true
+            showFeedback: true,
+            showHighlight: true
           }
         }
       ]
@@ -28,7 +29,8 @@ describe('Generated OnPointerDown ProtoBuf', () => {
             button: InputAction.IA_ACTION_4,
             hoverText: 'Run to tap',
             maxDistance: 5,
-            showFeedback: false
+            showFeedback: false,
+            showHighlight: false
           }
         }
       ]
@@ -51,7 +53,8 @@ describe('Generated OnPointerDown ProtoBuf', () => {
             button: InputAction.IA_ACTION_4,
             hoverText: 'Run to tap',
             maxDistance: 5,
-            showFeedback: false
+            showFeedback: false,
+            showHighlight: false
           }
         }
       ]

--- a/test/ecs/events/system.spec.ts
+++ b/test/ecs/events/system.spec.ts
@@ -1,6 +1,6 @@
 import { Engine, Entity, IEngine, components, PointerEventType, InputAction } from '../../../packages/@dcl/ecs/src'
 import { createInputSystem } from '../../../packages/@dcl/ecs/src/engine/input'
-import { createPointerEventsSystem, PointerEventsSystem } from '../../../packages/@dcl/ecs/src/systems/events'
+import { createPointerEventsSystem, getDefaultOpts, PointerEventsSystem } from '../../../packages/@dcl/ecs/src/systems/events'
 import { createTestPointerDownCommand } from './utils'
 
 let engine: IEngine
@@ -69,7 +69,6 @@ describe('Events System', () => {
     expect(counter).toBe(1)
     const removedFeedback = PointerEvents.getOrNull(entity)?.pointerEvents
     expect(removedFeedback?.length).toBe(0)
-
     // Update tick and verify we didnt increment the counter again
     await engine.update(1)
     expect(counter).toBe(1)
@@ -83,13 +82,17 @@ describe('Events System', () => {
       entity,
       () => {
         counter += 1
-      },
-      { hoverText: '' }
+      }
     )
     fakePointer(entity, PointerEventType.PET_DOWN)
     await engine.update(1)
     expect(counter).toBe(1)
-    expect(PointerEvents.getOrNull(entity)).toBe(null)
+    expect(PointerEvents.getOrNull(entity)).toMatchObject({
+      'pointerEvents': [{
+        'eventInfo': getDefaultOpts(),
+        'eventType': 1
+      }]
+    })
   })
 
   it('should remove pointer down', async () => {

--- a/test/ecs/events/system.spec.ts
+++ b/test/ecs/events/system.spec.ts
@@ -1,6 +1,10 @@
 import { Engine, Entity, IEngine, components, PointerEventType, InputAction } from '../../../packages/@dcl/ecs/src'
 import { createInputSystem } from '../../../packages/@dcl/ecs/src/engine/input'
-import { createPointerEventsSystem, getDefaultOpts, PointerEventsSystem } from '../../../packages/@dcl/ecs/src/systems/events'
+import {
+  createPointerEventsSystem,
+  getDefaultOpts,
+  PointerEventsSystem
+} from '../../../packages/@dcl/ecs/src/systems/events'
 import { createTestPointerDownCommand } from './utils'
 
 let engine: IEngine
@@ -78,20 +82,19 @@ describe('Events System', () => {
     const entity = engine.addEntity()
     const PointerEvents = components.PointerEvents(engine)
     let counter = 0
-    EventsSystem.onPointerDown(
-      entity,
-      () => {
-        counter += 1
-      }
-    )
+    EventsSystem.onPointerDown(entity, () => {
+      counter += 1
+    })
     fakePointer(entity, PointerEventType.PET_DOWN)
     await engine.update(1)
     expect(counter).toBe(1)
     expect(PointerEvents.getOrNull(entity)).toMatchObject({
-      'pointerEvents': [{
-        'eventInfo': getDefaultOpts(),
-        'eventType': 1
-      }]
+      pointerEvents: [
+        {
+          eventInfo: getDefaultOpts(),
+          eventType: 1
+        }
+      ]
     })
   })
 

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -168,7 +168,7 @@
         "@dcl/inspector": "file:../inspector",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-10704143848.commit-a0c6d86",
+        "@dcl/protocol": "1.0.0-11599848164.commit-ef74edc",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",


### PR DESCRIPTION
* Implements support for new `PointerEvents` `showHighlight` property
* Fixed bug existent bug for the case of using `pointerEventsSystem.onPointerDown()` without any of the pointer event optional properties (those entities weren't clickable before this PR)

Related PRs:
- https://github.com/decentraland/protocol/pull/224
- https://github.com/decentraland/unity-explorer/pull/2651