### PR TITLE
fix: config issues

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/SmartItemBasicView/SmartItemBasicView.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SmartItemBasicView/SmartItemBasicView.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import { BsFillLightningChargeFill as SmartItemIcon } from 'react-icons/bs'
 import { withSdk } from '../../../hoc/withSdk'
-import { useHasComponent } from '../../../hooks/sdk/useHasComponent'
 import { ConfigComponent } from '../../../lib/sdk/components'
 import { Container } from '../../Container'
 import { NftView } from './NftView'
@@ -17,7 +16,6 @@ import './SmartItemBasicView.css'
 
 const SmartItemBasicView = withSdk<Props>(({ sdk, entity }) => {
   const { Config } = sdk.components
-  const hasConfig = useHasComponent(entity, Config)
 
   const renderField = useCallback(
     (field: ConfigComponent['fields'][0], idx: number) => {
@@ -52,11 +50,11 @@ const SmartItemBasicView = withSdk<Props>(({ sdk, entity }) => {
     )
   }, [])
 
-  if (!hasConfig) return null
-
   const config = useMemo(() => {
-    return Config.get(entity)
+    return Config.getOrNull(entity)
   }, [entity])
+
+  if (!config) return null
 
   return (
     <Container

--- a/packages/@dcl/inspector/src/hooks/sdk/useHasComponent.ts
+++ b/packages/@dcl/inspector/src/hooks/sdk/useHasComponent.ts
@@ -1,5 +1,5 @@
 import { Entity } from '@dcl/ecs'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Component } from '../../lib/sdk/components'
 import { useChange } from './useChange'
@@ -12,6 +12,10 @@ export const useHasComponent = (entity: Entity, component: Component) => {
       setHasComponent(component.has(entity))
     }
   })
+
+  useEffect(() => {
+    setHasComponent(component.has(entity))
+  }, [entity, component])
 
   return hasComponent
 }


### PR DESCRIPTION
This PR fixes two unrelated issues that have been introduced on this commit: https://github.com/decentraland/js-sdk-toolchain/commit/cf41aed618c96b2b4bfc60c7a7a6e42dfb89c701

1) The `SmartItemBasicView` was using a `useMemo` that was not being called on every render, due to an early return if the entity had no Config component. Hooks need to be called allways on every render to work properly, so this was causing runtime errors. I refactored it to instead of using `useHasComponent` to return early, it just checks for a null config.

2) The `useHasComponent` hook would cache values when switching between different entities. I added an effect to refresh the value if the entity changes. This caused the issue where switching from a smart item to a regular item, it would keep the 'Enable Advanced Mode' option on the dropdown even though the currently selected entity was not a smart item (same for the other way around, going from a non-smart entity to a smart one would cache the value and would not show the 'Enable Advanced Mode' option).