### PR TITLE
refactor: composite

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
+        "@dcl/asset-packs": "^2.0.0",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -294,9 +294,9 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.20.3-12059736694.commit-f1d4396",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
-      "integrity": "sha512-UjFgGLsWh8itTV2VwKlA3rRCwaOyfDEbhb3KT7Y95QZUsgxgeyYoyYHVAOgcFvRqMTGe8zjGPpfjwFkgUf9Lqg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.0.0.tgz",
+      "integrity": "sha512-RyeSOE8FoZDIjsYddgvWmez7mkv8HSlCSYlfP+QhDRvUs7j50mMoSzHMf6i8xm9IDHm8bCH94AuxHlykdahyeA==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "1.20.2",
+        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -294,12 +294,15 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.20.2.tgz",
-      "integrity": "sha512-mYnRMzrFDzQZb+72uZYnvTVM6WOa3gS9OnAsnemRECM8x2NuM+0XIuAQ8fYT02lQPmi6Jq+zCqHCo60tr/wL0A==",
+      "version": "1.20.3-12059736694.commit-f1d4396",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
+      "integrity": "sha512-UjFgGLsWh8itTV2VwKlA3rRCwaOyfDEbhb3KT7Y95QZUsgxgeyYoyYHVAOgcFvRqMTGe8zjGPpfjwFkgUf9Lqg==",
+      "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",
         "@dcl/js-runtime": "7.5.2",
+        "@types/glob": "^8.1.0",
+        "glob": "^11.0.0",
         "mitt": "^3.0.1"
       }
     },
@@ -465,6 +468,102 @@
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@jest/environment": {
@@ -1180,6 +1279,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
@@ -1236,11 +1345,16 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "18.19.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
       "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1476,7 +1590,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1485,7 +1598,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1586,6 +1698,12 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/balloon-css": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/balloon-css/-/balloon-css-0.5.2.tgz",
@@ -1672,6 +1790,15 @@
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -1840,7 +1967,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1851,8 +1977,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1906,6 +2031,35 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-mediaquery": {
       "version": "0.1.2",
@@ -2478,12 +2632,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2884,6 +3042,22 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3029,6 +3203,29 @@
       "integrity": "sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==",
       "dev": true,
       "license": "zlib"
+    },
+    "node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/global-modules": {
       "version": "0.2.3",
@@ -3448,8 +3645,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3615,8 +3810,22 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/jest-dev-server": {
       "version": "9.0.2",
@@ -4222,6 +4431,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4281,6 +4499,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -4288,6 +4521,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -4536,6 +4778,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parallax-js": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
@@ -4603,6 +4851,31 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-type": {
@@ -5546,6 +5819,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -5568,7 +5862,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -5725,8 +6018,21 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5740,8 +6046,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6117,8 +6434,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -6352,6 +6668,24 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "1.20.2",
+    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/refactor/composite/dcl-asset-packs-1.20.3-12059736694.commit-f1d4396.tgz",
+    "@dcl/asset-packs": "^2.0.0",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/src/components/AssetsCatalog/Asset/Asset.tsx
+++ b/packages/@dcl/inspector/src/components/AssetsCatalog/Asset/Asset.tsx
@@ -11,7 +11,7 @@ import { fetchImage, resizeImage } from '../../../lib/utils/img'
 import { useIsMounted } from '../../../hooks/useIsMounted'
 
 const Asset: React.FC<{ value: Asset }> = ({ value }) => {
-  const [, drag, preview] = useDrag(() => ({ type: 'builder-asset', item: { value } }), [value])
+  const [, drag, preview] = useDrag(() => ({ type: 'catalog-asset', item: { value } }), [value])
   const isSmartItem = isSmart(value)
   const isGroundItem = isGround(value)
   const imgSrc = getContentsUrl(value.contents['thumbnail.png'])

--- a/packages/@dcl/inspector/src/components/EntityInspector/SmartItemBasicView/VideoView/VideoView.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SmartItemBasicView/VideoView/VideoView.tsx
@@ -5,7 +5,7 @@ import { Entity } from '@dcl/ecs'
 import { withSdk, WithSdkProps } from '../../../../hoc/withSdk'
 import { useHasComponent } from '../../../../hooks/sdk/useHasComponent'
 import { useComponentInput } from '../../../../hooks/sdk/useComponentInput'
-import { ProjectAssetDrop, getNode } from '../../../../lib/sdk/drag-drop'
+import { LocalAssetDrop, getNode } from '../../../../lib/sdk/drag-drop'
 import { withAssetDir } from '../../../../lib/data-layer/host/fs-utils'
 import { useAppSelector } from '../../../../redux/hooks'
 import { selectAssetCatalog } from '../../../../redux/app'
@@ -13,7 +13,7 @@ import { Block } from '../../../Block'
 import { TextField, CheckboxField, RangeField, InfoTooltip } from '../../../ui'
 import { fromVideoPlayer, toVideoPlayer, isValidInput, isVideo, isValidVolume } from '../../VideoPlayerInspector/utils'
 
-const DROP_TYPES = ['project-asset']
+const DROP_TYPES = ['local-asset']
 
 export default React.memo(
   withSdk<WithSdkProps & { entity: Entity }>(({ sdk, entity }) => {
@@ -44,13 +44,13 @@ export default React.memo(
     const [{ isHover }, drop] = useDrop(
       () => ({
         accept: DROP_TYPES,
-        drop: ({ value, context }: ProjectAssetDrop, monitor) => {
+        drop: ({ value, context }: LocalAssetDrop, monitor) => {
           if (monitor.didDrop()) return
           const node = context.tree.get(value)!
           const model = getNode(node, context.tree, isVideo)
           if (model) void handleDrop(withAssetDir(model.asset.src))
         },
-        canDrop: ({ value, context }: ProjectAssetDrop) => {
+        canDrop: ({ value, context }: LocalAssetDrop) => {
           const node = context.tree.get(value)!
           return !!getNode(node, context.tree, isVideo)
         },

--- a/packages/@dcl/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/VideoPlayerInspector/VideoPlayerInspector.tsx
@@ -9,7 +9,7 @@ import { getComponentValue } from '../../../hooks/sdk/useComponentValue'
 import { analytics, Event } from '../../../lib/logic/analytics'
 import { getAssetByModel } from '../../../lib/logic/catalog'
 import { CoreComponents } from '../../../lib/sdk/components'
-import { ProjectAssetDrop, getNode } from '../../../lib/sdk/drag-drop'
+import { LocalAssetDrop, getNode } from '../../../lib/sdk/drag-drop'
 import { withAssetDir } from '../../../lib/data-layer/host/fs-utils'
 import { useAppSelector } from '../../../redux/hooks'
 import { selectAssetCatalog } from '../../../redux/app'
@@ -19,7 +19,7 @@ import { TextField, CheckboxField, RangeField, InfoTooltip } from '../../ui'
 import { fromVideoPlayer, toVideoPlayer, isValidInput, isVideo, isValidVolume } from './utils'
 import type { Props } from './types'
 
-const DROP_TYPES = ['project-asset']
+const DROP_TYPES = ['local-asset']
 
 export default withSdk<Props>(({ sdk, entity }) => {
   const files = useAppSelector(selectAssetCatalog)
@@ -56,13 +56,13 @@ export default withSdk<Props>(({ sdk, entity }) => {
   const [{ isHover }, drop] = useDrop(
     () => ({
       accept: DROP_TYPES,
-      drop: ({ value, context }: ProjectAssetDrop, monitor) => {
+      drop: ({ value, context }: LocalAssetDrop, monitor) => {
         if (monitor.didDrop()) return
         const node = context.tree.get(value)!
         const model = getNode(node, context.tree, isVideo)
         if (model) void handleDrop(withAssetDir(model.asset.src))
       },
-      canDrop: ({ value, context }: ProjectAssetDrop) => {
+      canDrop: ({ value, context }: LocalAssetDrop) => {
         const node = context.tree.get(value)!
         return !!getNode(node, context.tree, isVideo)
       },

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/ProjectView.tsx
@@ -30,7 +30,7 @@ interface ModalState {
 
 export const ROOT = 'File System'
 
-export const DRAG_N_DROP_ASSET_KEY = 'project-asset'
+export const DRAG_N_DROP_ASSET_KEY = 'local-asset'
 
 export type TreeNode = Omit<AssetNode, 'children'> & { children?: string[]; matches?: string[] }
 

--- a/packages/@dcl/inspector/src/components/ProjectAssetExplorer/types.ts
+++ b/packages/@dcl/inspector/src/components/ProjectAssetExplorer/types.ts
@@ -1,5 +1,4 @@
-import { ComponentName } from '@dcl/asset-packs'
-import { CoreComponents } from '../../lib/sdk/components'
+import { AssetData } from '../../lib/logic/catalog'
 
 export interface IAsset {
   src: string
@@ -20,7 +19,7 @@ export interface AssetCellProp {
 export type AssetNodeBase = {
   name: string
   parent: AssetNodeFolder | null
-  components?: Partial<Record<ComponentName | CoreComponents, any>>
+  composite?: AssetData['composite']
 }
 
 export type AssetNodeItem = AssetNodeBase & {

--- a/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -8,7 +8,7 @@ import { selectAssetCatalog, selectUploadFile, updateUploadFile } from '../../..
 import { selectAssetsTab } from '../../../redux/ui'
 import { AssetsTab } from '../../../redux/ui/types'
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks'
-import { DropTypesEnum, ProjectAssetDrop, getNode } from '../../../lib/sdk/drag-drop'
+import { DropTypesEnum, LocalAssetDrop, getNode } from '../../../lib/sdk/drag-drop'
 import { EXTENSIONS, withAssetDir } from '../../../lib/data-layer/host/fs-utils'
 
 import { isModel } from '../../EntityInspector/GltfInspector/utils'
@@ -98,7 +98,7 @@ const FileUploadField: React.FC<Props> = ({
   const [{ isHover, canDrop }, drop] = useDrop(
     () => ({
       accept: [DropTypesEnum.ProjectAsset],
-      drop: ({ value, context }: ProjectAssetDrop, monitor) => {
+      drop: ({ value, context }: LocalAssetDrop, monitor) => {
         if (monitor.didDrop()) return
         const node = context.tree.get(value)!
         const element = getNode(node, context.tree, isValid)
@@ -109,7 +109,7 @@ const FileUploadField: React.FC<Props> = ({
           setDropError(true)
         }
       },
-      canDrop: ({ value, context }: ProjectAssetDrop) => {
+      canDrop: ({ value, context }: LocalAssetDrop) => {
         const node = context.tree.get(value)!
         return !!getNode(node, context.tree, isValid)
       },

--- a/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -97,7 +97,7 @@ const FileUploadField: React.FC<Props> = ({
 
   const [{ isHover, canDrop }, drop] = useDrop(
     () => ({
-      accept: [DropTypesEnum.ProjectAsset],
+      accept: [DropTypesEnum.LocalAsset],
       drop: ({ value, context }: LocalAssetDrop, monitor) => {
         if (monitor.didDrop()) return
         const node = context.tree.get(value)!

--- a/packages/@dcl/inspector/src/lib/logic/catalog.ts
+++ b/packages/@dcl/inspector/src/lib/logic/catalog.ts
@@ -1,11 +1,13 @@
-import { ComponentName } from '@dcl/asset-packs'
-import * as _catalog from '@dcl/asset-packs/catalog.json'
+import { Catalog, AssetPack, Asset, AssetData } from '@dcl/asset-packs'
 import { CoreComponents } from '../sdk/components'
 import { getConfig } from './config'
+import * as _catalog from '@dcl/asset-packs/catalog.json'
 
-export const catalog = _catalog.assetPacks as unknown as AssetPack[]
+export const catalog = (_catalog as unknown as Catalog).assetPacks
 
-// categories obtained from "builder.decentraland.org" catalog
+export { Catalog, AssetPack, Asset, AssetData }
+
+// categories obtained from "builder-items.decentraland.org" catalog
 export const CATEGORIES = [
   'ground',
   'utils',
@@ -26,22 +28,6 @@ export const CATEGORIES = [
   'health'
 ]
 
-export type AssetPack = {
-  id: string
-  name: string
-  thumbnail: string
-  assets: Asset[]
-}
-
-export type Asset = {
-  id: string
-  name: string
-  category: string
-  tags: string[]
-  contents: Record<string, string>
-  components: Partial<Record<ComponentName | CoreComponents, any>>
-}
-
 export function getContentsUrl(hash: string) {
   const config = getConfig()
   return `${config.contentUrl}/contents/${hash}`
@@ -57,12 +43,12 @@ export function getAssetsByCategory(assets: Asset[]) {
 }
 
 export function isSmart(asset: Partial<Asset>) {
-  const components = Object.keys(asset?.components ?? {})
+  const components = asset?.composite?.components ?? []
   // when the item has more than one component, it is smart
   if (components.length > 1) {
     return true
-    // when the item has a single component but it's not a GltfContainer, then it's also smart (NFTShape, TextShape, MeshRenderers, etc...)
-  } else if (components.length === 1 && components[0] !== CoreComponents.GLTF_CONTAINER) {
+    // when the item has a single component but it's not a GltfContainer, then it's also smart
+  } else if (components.length === 1 && components[0].name !== CoreComponents.GLTF_CONTAINER) {
     return true
   }
   // when the item only has a GltfContainer then it's not smart

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.spec.ts
@@ -2,9 +2,9 @@ import * as dnd from './drag-drop'
 
 describe('sdk drag and drop', () => {
   it('should return true when identifier equals type', () => {
-    const drop = { value: 'project-asset', context: { tree: new Map() } }
-    expect(dnd.isDropType(drop, 'project-asset', 'project-asset')).toBe(true)
-    expect(dnd.isDropType(drop, 'invalid', 'project-asset')).toBe(false)
+    const drop = { value: 'local-asset', context: { tree: new Map() } }
+    expect(dnd.isDropType(drop, 'local-asset', 'local-asset')).toBe(true)
+    expect(dnd.isDropType(drop, 'invalid', 'local-asset')).toBe(false)
   })
   it('should return all drop types list', () => {
     expect(dnd.DROP_TYPES).toStrictEqual(expect.arrayContaining(Object.values(dnd.DropTypesEnum)))

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
@@ -14,7 +14,7 @@ export type CatalogAssetDrop = Drop<Asset>
 export type IDrop = LocalAssetDrop | CatalogAssetDrop
 
 export enum DropTypesEnum {
-  ProjectAsset = 'local-asset',
+  LocalAsset = 'local-asset',
   CatalogAsset = 'catalog-asset'
 }
 

--- a/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/drag-drop.ts
@@ -8,14 +8,14 @@ interface Drop<T, K = object> {
   context: K
 }
 
-export type ProjectAssetDrop = Drop<string, { tree: Map<string, TreeNode> }>
-export type BuilderAsset = Drop<Asset>
+export type LocalAssetDrop = Drop<string, { tree: Map<string, TreeNode> }>
+export type CatalogAssetDrop = Drop<Asset>
 
-export type IDrop = ProjectAssetDrop | BuilderAsset
+export type IDrop = LocalAssetDrop | CatalogAssetDrop
 
 export enum DropTypesEnum {
-  ProjectAsset = 'project-asset',
-  BuilderAsset = 'builder-asset'
+  ProjectAsset = 'local-asset',
+  CatalogAsset = 'catalog-asset'
 }
 
 export type DropTypes = `${DropTypesEnum}`

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-asset/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-asset/index.ts
@@ -95,7 +95,6 @@ export function addAsset(engine: IEngine) {
       }
 
       const mapId = (id: string | number) => {
-        debugger
         if (typeof id === 'string') {
           const match = id.match(/{self:(.+)}/)
           if (match) {
@@ -185,7 +184,6 @@ export function addAsset(engine: IEngine) {
                 }))
               }))
               componentValue = { ...componentValue, value: newValue }
-              debugger
               break
             }
             case CoreComponents.SYNC_COMPONENTS: {

--- a/packages/@dcl/inspector/src/lib/sdk/operations/add-asset/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/add-asset/index.ts
@@ -3,12 +3,8 @@ import {
   IEngine,
   Transform as TransformEngine,
   GltfContainer as GltfEngine,
-  PBGltfContainer,
   Vector3Type,
-  PBAudioSource,
   LastWriteWinElementSetComponentDefinition,
-  PBVideoPlayer,
-  PBMaterial,
   NetworkEntity as NetworkEntityEngine
 } from '@dcl/ecs'
 import {
@@ -16,7 +12,6 @@ import {
   Actions,
   COMPONENTS_WITH_ID,
   ComponentName,
-  Triggers,
   getJson,
   getNextId,
   getPayload
@@ -27,6 +22,7 @@ import updateSelectedEntity from '../update-selected-entity'
 import { addChild } from '../add-child'
 import { isSelf, parseMaterial, parseSyncComponents } from './utils'
 import { EnumEntity } from '../../enum-entity'
+import { AssetData } from '../../../logic/catalog'
 
 export function addAsset(engine: IEngine) {
   return function addAsset(
@@ -36,156 +32,197 @@ export function addAsset(engine: IEngine) {
     position: Vector3Type,
     base: string,
     enumEntityId: EnumEntity,
-    components?: Partial<Record<CoreComponents | ComponentName | EditorComponentNames.Config, any>>,
+    composite?: AssetData['composite'],
     assetId?: string
   ): Entity {
-    const child = addChild(engine)(parent, name)
     const Transform = engine.getComponent(TransformEngine.componentId) as typeof TransformEngine
     const GltfContainer = engine.getComponent(GltfEngine.componentId) as typeof GltfEngine
     const NetworkEntity = engine.getComponent(NetworkEntityEngine.componentId) as typeof NetworkEntityEngine
 
-    Transform.createOrReplace(child, { parent, position })
-
-    if (components) {
-      // values
-      const values = new Map<string, any>()
-
-      // generate ids
-      const ids = new Map<string, number>()
-      for (const componentName in components) {
-        const key = componentName as keyof typeof components
-        const componentValue = components[key] ? { ...components[key] } : {}
-        if (COMPONENTS_WITH_ID.includes(componentName) && isSelf(componentValue.id)) {
-          componentValue.id = getNextId(engine as any)
-          ids.set(componentName, componentValue.id)
-        }
-        values.set(componentName, componentValue)
+    if (composite) {
+      // Get all unique entity IDs from components
+      const entityIds = new Set<string>()
+      for (const component of composite.components) {
+        Object.keys(component.data).forEach((id) => entityIds.add(id))
       }
 
-      // map paths, ids, and modify values if needed
-      const mapId = (id: string | number | undefined) => {
-        if (typeof id === 'string') {
-          if (/{self:(.+)}/.test(id)) {
-            const result = id.match(/{self:(.+)}/)
-            if (result) {
-              const componentName = result[1] as ComponentName
-              const mappedId = ids.get(componentName)
-              if (mappedId) {
-                return mappedId
-              }
-            }
+      // Track all created entities
+      const entities = new Map<string, Entity>()
+
+      // If there's only one entity, it becomes the main entity
+      // If there are multiple entities, create a new main entity as parent
+      const mainEntity =
+        entityIds.size === 1 ? addChild(engine)(parent, name) : addChild(engine)(parent, `${name}_root`)
+
+      Transform.createOrReplace(mainEntity, { parent, position })
+
+      // Set up entity hierarchy based on number of entities
+      const parentForChildren = entityIds.size === 1 ? parent : mainEntity
+
+      // Create all entities
+      for (const entityId of entityIds) {
+        if (entityIds.size === 1) {
+          // Single entity case: use the main entity
+          entities.set(entityId, mainEntity)
+        } else {
+          // Multiple entities case: create child entities
+          const entity = entityId === '0' ? mainEntity : addChild(engine)(parentForChildren, `${name}_${entityId}`)
+
+          if (entityId !== '0') {
+            Transform.createOrReplace(entity, {
+              parent: parentForChildren,
+              position: { x: 0, y: 0, z: 0 }
+            })
           }
-          return parseInt(id)
+          entities.set(entityId, entity)
+        }
+      }
+
+      const values = new Map<string, any>()
+
+      // Generate ids for components that need them BEFORE processing components
+      const ids = new Map<string, number>()
+      for (const component of composite.components) {
+        const componentName = component.name
+        for (const [_entityId, data] of Object.entries(component.data)) {
+          const componentValue = { ...data.json }
+          if (COMPONENTS_WITH_ID.includes(componentName) && isSelf(componentValue.id)) {
+            ids.set(componentName, getNextId(engine as any))
+            componentValue.id = ids.get(componentName)
+          }
+          values.set(componentName, componentValue)
+        }
+      }
+
+      const mapId = (id: string | number) => {
+        debugger
+        if (typeof id === 'string') {
+          const match = id.match(/{self:(.+)}/)
+          if (match) {
+            const componentName = match[1]
+            return ids.get(componentName)
+          }
         }
         return id
       }
-      for (const componentName in components) {
-        switch (componentName) {
-          case CoreComponents.GLTF_CONTAINER: {
-            const gltfContainer = values.get(componentName) as PBGltfContainer
-            gltfContainer.visibleMeshesCollisionMask ??= 1
-            gltfContainer.invisibleMeshesCollisionMask ??= 2
-            values.set(componentName, { ...gltfContainer, src: gltfContainer.src.replace('{assetPath}', base) })
-            break
-          }
-          case CoreComponents.AUDIO_SOURCE: {
-            const audioSource = values.get(componentName) as PBAudioSource
-            values.set(componentName, { ...audioSource, src: audioSource.audioClipUrl.replace('{assetPath}', base) })
-            break
-          }
-          case CoreComponents.VIDEO_PLAYER: {
-            const videoPlayer = values.get(componentName) as PBVideoPlayer
-            values.set(componentName, { ...videoPlayer, src: videoPlayer.src.replace('{assetPath}', base) })
-            break
-          }
-          case CoreComponents.MATERIAL: {
-            const material = values.get(componentName) as PBMaterial
-            values.set(componentName, parseMaterial(base, material))
-            break
-          }
-          case ComponentName.ACTIONS: {
-            const actions = values.get(componentName) as Actions
-            const newValue: Actions['value'] = []
-            for (const action of actions.value) {
-              switch (action.type) {
-                case ActionType.PLAY_SOUND: {
-                  const payload = getPayload<ActionType.PLAY_SOUND>(action)
-                  newValue.push({
-                    ...action,
-                    jsonPayload: getJson<ActionType.PLAY_SOUND>({
-                      ...payload,
-                      src: payload.src.replace('{assetPath}', base)
-                    })
-                  })
-                  break
-                }
-                case ActionType.PLAY_CUSTOM_EMOTE: {
-                  const payload = getPayload<ActionType.PLAY_CUSTOM_EMOTE>(action)
-                  newValue.push({
-                    ...action,
-                    jsonPayload: getJson<ActionType.PLAY_CUSTOM_EMOTE>({
-                      ...payload,
-                      src: payload.src.replace('{assetPath}', base)
-                    })
-                  })
-                  break
-                }
-                default:
-                  newValue.push(action)
-                  break
-              }
+
+      // Process and create components for each entity
+      for (const component of composite.components) {
+        const componentName = component.name
+        for (const [entityId] of Object.entries(component.data)) {
+          const targetEntity = entities.get(entityId)!
+          let componentValue = values.get(componentName)
+
+          switch (componentName) {
+            case CoreComponents.GLTF_CONTAINER: {
+              componentValue.visibleMeshesCollisionMask ??= 1
+              componentValue.invisibleMeshesCollisionMask ??= 2
+              componentValue.src = componentValue.src.replace('{assetPath}', base)
+              break
             }
-            values.set(componentName, { ...actions, value: newValue })
-            break
-          }
-          case ComponentName.TRIGGERS: {
-            const triggers = values.get(componentName) as Triggers
-            const newValue = triggers.value.map((trigger) => ({
-              ...trigger,
-              conditions: (trigger.conditions || []).map((condition) => ({
-                ...condition,
-                id: mapId(condition.id)
-              })),
-              actions: trigger.actions.map((action) => ({
-                ...action,
-                id: mapId(action.id)
+            case EditorComponentNames.Config: {
+              if (assetId) {
+                componentValue = { ...componentValue, assetId }
+              }
+              break
+            }
+            case CoreComponents.AUDIO_SOURCE: {
+              componentValue.src = componentValue.audioClipUrl.replace('{assetPath}', base)
+              break
+            }
+            case CoreComponents.VIDEO_PLAYER: {
+              componentValue.src = componentValue.src.replace('{assetPath}', base)
+              break
+            }
+            case CoreComponents.MATERIAL: {
+              componentValue = parseMaterial(base, componentValue)
+              break
+            }
+            case ComponentName.ACTIONS: {
+              const newValue: Actions['value'] = []
+              for (const action of componentValue.value) {
+                switch (action.type) {
+                  case ActionType.PLAY_SOUND: {
+                    const payload = getPayload<ActionType.PLAY_SOUND>(action)
+                    newValue.push({
+                      ...action,
+                      jsonPayload: getJson<ActionType.PLAY_SOUND>({
+                        ...payload,
+                        src: payload.src.replace('{assetPath}', base)
+                      })
+                    })
+                    break
+                  }
+                  case ActionType.PLAY_CUSTOM_EMOTE: {
+                    const payload = getPayload<ActionType.PLAY_CUSTOM_EMOTE>(action)
+                    newValue.push({
+                      ...action,
+                      jsonPayload: getJson<ActionType.PLAY_CUSTOM_EMOTE>({
+                        ...payload,
+                        src: payload.src.replace('{assetPath}', base)
+                      })
+                    })
+                    break
+                  }
+                  default:
+                    newValue.push(action)
+                    break
+                }
+              }
+              componentValue = { ...componentValue, value: newValue }
+              break
+            }
+            case ComponentName.TRIGGERS: {
+              const newValue = componentValue.value.map((trigger: any) => ({
+                ...trigger,
+                conditions: (trigger.conditions || []).map((condition: any) => ({
+                  ...condition,
+                  id: mapId(condition.id)
+                })),
+                actions: trigger.actions.map((action: any) => ({
+                  ...action,
+                  id: mapId(action.id)
+                }))
               }))
-            }))
-            values.set(componentName, { ...triggers, value: newValue })
-            break
+              componentValue = { ...componentValue, value: newValue }
+              debugger
+              break
+            }
+            case CoreComponents.SYNC_COMPONENTS: {
+              const componentIds = parseSyncComponents(engine, componentValue.value)
+              componentValue = { componentIds }
+              const NetworkEntityComponent = engine.getComponent(NetworkEntity.componentId) as typeof NetworkEntity
+              NetworkEntityComponent.create(targetEntity, {
+                entityId: enumEntityId.getNextEnumEntityId(),
+                networkId: 0
+              })
+              break
+            }
           }
-          case CoreComponents.SYNC_COMPONENTS: {
-            const componentNames = values.get(componentName) as { value: string[] }
-            const componentIds = parseSyncComponents(engine, componentNames.value)
-            values.set(componentName, { componentIds })
-            values.set(NetworkEntity.componentName, { entityId: enumEntityId.getNextEnumEntityId(), networkId: 0 })
-            break
-          }
-          case EditorComponentNames.Config: {
-            values.set(componentName, { ...components[componentName], assetId })
-            break
-          }
+
+          const Component = engine.getComponent(componentName) as LastWriteWinElementSetComponentDefinition<unknown>
+          Component.create(targetEntity, componentValue)
         }
       }
 
-      // create components
-      for (const [componentName, componentValue] of values) {
-        const Component = engine.getComponent(componentName) as LastWriteWinElementSetComponentDefinition<unknown>
-        Component.create(child, componentValue)
-      }
+      // update selection
+      updateSelectedEntity(engine)(mainEntity)
+      return mainEntity
     } else {
-      // if the asset is just a path to a model, create a gltf container for it (this is the case for assets dropped from the local files tab)
-      GltfContainer.create(child, {
+      // Handle non-composite case
+      const mainEntity = addChild(engine)(parent, name)
+      Transform.createOrReplace(mainEntity, { parent, position })
+
+      GltfContainer.create(mainEntity, {
         src: `${base}/${src}`,
         visibleMeshesCollisionMask: 1,
         invisibleMeshesCollisionMask: 2
       })
+
+      // update selection
+      updateSelectedEntity(engine)(mainEntity)
+      return mainEntity
     }
-
-    // update selection
-    updateSelectedEntity(engine)(child)
-
-    return child
   }
 }
 


### PR DESCRIPTION
This PR refactor the `addAsset` operation to work with the new `@dcl/asset-packs` asset format, which uses composites instead of the custom format.

It also adds support for multiple entities per item, since the composite supports multiple entities. When multiple entities are present, a main entity will be created (this one will have the Transform in the position the user selected) and the item's entities will be added as children of that main entity. When a single entity is used and it's id is 0, then those components will be added to the main entities (to avoid having the main entity with a single child when only 1 entity is needed. which is the case of the current smart items).

Finally, it refactors the ProjectAssets and BuilderAssets into LocalAssets and CatalogAssets, which match better the current nomenclatures.