### PR TITLE
chore: added analytics for custom items

### DIFF
--- a/packages/@dcl/inspector/src/components/CustomAssets/ContextMenu/ContextMenu.ts
+++ b/packages/@dcl/inspector/src/components/CustomAssets/ContextMenu/ContextMenu.ts
@@ -1,5 +1,6 @@
 import { contextMenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
+import { analytics, Event } from '../../../lib/logic/analytics'
 
 export const CUSTOM_ASSETS_CONTEXT_MENU_ID = 'custom-assets-context-menu'
 
@@ -17,9 +18,15 @@ export function openCustomAssetContextMenu(event: React.MouseEvent, props: Custo
     props: {
       ...props,
       onDelete: (assetId: string) => {
+        analytics.track(Event.DELETE_CUSTOM_ITEM, {
+          itemId: assetId
+        })
         props.onDelete(assetId)
       },
       onRename: (assetId: string) => {
+        analytics.track(Event.RENAME_CUSTOM_ITEM, {
+          itemId: assetId
+        })
         props.onRename(assetId)
       }
     }

--- a/packages/@dcl/inspector/src/components/CustomAssets/ContextMenu/ContextMenu.ts
+++ b/packages/@dcl/inspector/src/components/CustomAssets/ContextMenu/ContextMenu.ts
@@ -14,6 +14,14 @@ export function openCustomAssetContextMenu(event: React.MouseEvent, props: Custo
   contextMenu.show({
     id: CUSTOM_ASSETS_CONTEXT_MENU_ID,
     event,
-    props
+    props: {
+      ...props,
+      onDelete: (assetId: string) => {
+        props.onDelete(assetId)
+      },
+      onRename: (assetId: string) => {
+        props.onRename(assetId)
+      }
+    }
   })
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/rpc-methods.ts
@@ -212,7 +212,15 @@ export async function initRpcMethods(
         }
       ])
 
-      return {}
+      const asset: AssetData = {
+        id: data.id,
+        name: data.name,
+        category: data.category,
+        tags: data.tags,
+        composite: JSON.parse(new TextDecoder().decode(composite))
+      }
+
+      return { asset: { data: Buffer.from(JSON.stringify(asset)) } }
     },
     async getCustomAssets() {
       const paths = await getFilesInDirectory(fs, `${DIRECTORY.CUSTOM}`, [], true)

--- a/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
+++ b/packages/@dcl/inspector/src/lib/data-layer/proto/data-layer.proto
@@ -73,6 +73,10 @@ message CreateCustomAssetRequest {
   optional bytes thumbnail = 4;
 }
 
+message CreateCustomAssetResponse {
+  AssetData asset = 1;
+}
+
 message GetCustomAssetsResponse {
   repeated AssetData assets = 1;
 }
@@ -102,7 +106,7 @@ service DataService {
   rpc SetInspectorPreferences(InspectorPreferencesMessage) returns (Empty) {}
   rpc CopyFile(CopyFileRequest) returns (Empty) {}
   rpc GetFile(GetFileRequest) returns (GetFileResponse) {}
-  rpc CreateCustomAsset(CreateCustomAssetRequest) returns (Empty) {}
+  rpc CreateCustomAsset(CreateCustomAssetRequest) returns (CreateCustomAssetResponse) {}
   rpc GetCustomAssets(Empty) returns (GetCustomAssetsResponse) {}
   rpc DeleteCustomAsset(DeleteCustomAssetRequest) returns (Empty) {}
   rpc RenameCustomAsset(RenameCustomAssetRequest) returns (Empty) {}

--- a/packages/@dcl/inspector/src/lib/logic/analytics.ts
+++ b/packages/@dcl/inspector/src/lib/logic/analytics.ts
@@ -10,7 +10,10 @@ export enum Event {
   SWITCH_BUILDER_MODE = 'Switch Builder Mode',
   SET_GROUND = 'Set Ground',
   LOCK = 'Lock',
-  HIDE = 'Hide'
+  HIDE = 'Hide',
+  CREATE_CUSTOM_ITEM = 'Create Custom Item',
+  DELETE_CUSTOM_ITEM = 'Delete Custom Item',
+  RENAME_CUSTOM_ITEM = 'Rename Custom Item'
 }
 
 export type Events = {
@@ -51,6 +54,20 @@ export type Events = {
   }
   [Event.HIDE]: {
     value: boolean
+  }
+  [Event.CREATE_CUSTOM_ITEM]: {
+    itemId: string
+    itemName: string
+    resourceCount: number
+    isSmart: boolean
+  }
+  [Event.DELETE_CUSTOM_ITEM]: {
+    itemId: string
+    itemName: string
+  }
+  [Event.RENAME_CUSTOM_ITEM]: {
+    itemId: string
+    newName: string
   }
 }
 

--- a/packages/@dcl/inspector/src/lib/logic/analytics.ts
+++ b/packages/@dcl/inspector/src/lib/logic/analytics.ts
@@ -63,11 +63,9 @@ export type Events = {
   }
   [Event.DELETE_CUSTOM_ITEM]: {
     itemId: string
-    itemName: string
   }
   [Event.RENAME_CUSTOM_ITEM]: {
     itemId: string
-    newName: string
   }
 }
 

--- a/packages/@dcl/inspector/src/redux/data-layer/sagas/create-custom-asset.ts
+++ b/packages/@dcl/inspector/src/redux/data-layer/sagas/create-custom-asset.ts
@@ -2,11 +2,13 @@ import { PayloadAction } from '@reduxjs/toolkit'
 import { call, put } from 'redux-saga/effects'
 import { IDataLayer, error, getAssetCatalog, getDataLayerInterface } from '../index'
 import { ErrorType } from '../index'
-import { AssetData } from '../../../lib/logic/catalog'
+import { AssetData, isSmart } from '../../../lib/logic/catalog'
 import { selectAssetsTab } from '../../ui'
 import { AssetsTab } from '../../ui/types'
 import { getResourcesFromModels } from '../../../lib/babylon/decentraland/get-resources'
 import { transformBase64ResourceToBinary } from '../../../lib/data-layer/host/fs-utils'
+import { analytics, Event } from '../../../lib/logic/analytics'
+import { CreateCustomAssetResponse } from '../../../tooling-entrypoint'
 
 export function* createCustomAssetSaga(
   action: PayloadAction<{
@@ -24,12 +26,23 @@ export function* createCustomAssetSaga(
     )
     const resourcesFromModels: string[] = yield call(getResourcesFromModels, models)
     const resources = [...action.payload.resources, ...resourcesFromModels]
-    yield call(dataLayer.createCustomAsset, {
+    const result: CreateCustomAssetResponse = yield call(dataLayer.createCustomAsset, {
       name: action.payload.name,
       composite: Buffer.from(JSON.stringify(action.payload.composite)),
       resources,
       thumbnail: action.payload.thumbnail ? transformBase64ResourceToBinary(action.payload.thumbnail) : undefined
     })
+
+    const asset = JSON.parse(new TextDecoder().decode(result.asset?.data)) as AssetData
+
+    // Track custom item creation
+    analytics.track(Event.CREATE_CUSTOM_ITEM, {
+      itemId: asset.id,
+      itemName: action.payload.name,
+      resourceCount: resources.length,
+      isSmart: isSmart(asset)
+    })
+
     // Fetch asset catalog again
     yield put(getAssetCatalog())
     yield put(selectAssetsTab({ tab: AssetsTab.CustomAssets }))


### PR DESCRIPTION
This PR adds analytics tracking for custom item operations in the Inspector package, including creation, deletion, and renaming of custom items.

### Analytics Events
Added new event types in `analytics.ts`:
- `CREATE_CUSTOM_ITEM`: Tracks when a custom item is created
- `DELETE_CUSTOM_ITEM`: Tracks when a custom item is deleted  
- `RENAME_CUSTOM_ITEM`: Tracks when a custom item is renamed

### Event Metadata
Each event includes relevant metadata:
- `CREATE_CUSTOM_ITEM`: 
  - `itemId`: Unique identifier for the item
  - `itemName`: Name of the item
  - `resourceCount`: Number of resources in the item
  - `isSmart`: Whether the item is a smart item
- `DELETE_CUSTOM_ITEM`:
  - `itemId`: Unique identifier for the item
- `RENAME_CUSTOM_ITEM`:
  - `itemId`: Unique identifier for the item
