### PR TITLE
fix: handle new categories without breaking

### DIFF
--- a/packages/@dcl/inspector/src/lib/logic/catalog.ts
+++ b/packages/@dcl/inspector/src/lib/logic/catalog.ts
@@ -30,7 +30,11 @@ export const CATEGORIES = [
   'nature',
   'tiles',
   'year of the pig',
-  'health'
+  'health',
+  'sounds',
+  'primitives',
+  'pillars',
+  'other'
 ]
 
 export function getContentsUrl(hash: string) {
@@ -41,7 +45,16 @@ export function getContentsUrl(hash: string) {
 export function getAssetsByCategory(assets: Asset[]) {
   const categories = new Map<Asset['category'], Asset[]>(CATEGORIES.map(($) => [$, []]))
   for (const asset of assets) {
-    categories.get(asset.category)!.push(asset)
+    const list = categories.get(asset.category)
+    if (list) {
+      list.push(asset)
+    } else {
+      if (asset.category) {
+        categories.set(asset.category, [asset])
+      } else {
+        categories.set('other', [asset])
+      }
+    }
   }
 
   return categories


### PR DESCRIPTION
This PR adds the new categories added by https://github.com/decentraland/asset-packs/pull/133

Also it will support new categories without breaking, and a catch-all "Other" category for assets without a category.