### PR TITLE
feat: Make createReactBasedUiSystem public

### DIFF
--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -847,6 +847,9 @@ export function createInputSystem(engine: IEngine): IInputSystem;
 export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSystem): PointerEventsSystem;
 
 // @public (undocumented)
+export function createReactBasedUiSystem(engine: IEngine, pointerSystem: PointerEventsSystem): ReactBasedUiSystem;
+
+// @public (undocumented)
 export function createTweenSystem(engine: IEngine): TweenSystem;
 
 // Warning: (tsdoc-code-fence-closing-syntax) Unexpected characters after closing delimiter for code fence

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -17,7 +17,7 @@ export interface ReactBasedUiSystem {
 }
 
 /**
- * @internal
+ * @public
  */
 export function createReactBasedUiSystem(engine: IEngine, pointerSystem: PointerEventsSystem): ReactBasedUiSystem {
   const renderer = createReconciler(engine, pointerSystem)

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -64,8 +64,9 @@ ${
   isEditorScene &&
   `
 import { syncEntity } from '@dcl/sdk/network'
+import players from '@dcl/sdk/players'
 import { initAssetPacks, setSyncEntity } from '@dcl/asset-packs/dist/scene-entrypoint'
-initAssetPacks(engine, { syncEntity })
+initAssetPacks(engine, { syncEntity }, players)
 
 // TODO: do we need to do this on runtime ?
 // I think we have that information at build-time and we avoid to do evaluate this on the worker.


### PR DESCRIPTION
This PR updates the access modifier for the class `createReactBasedUiSystem`, allowing us to instantiate the system in another library, such as `@dcl/asset-packs`.

It also passes the playerHelper object as a param to the initializer method: `initAssetPack`, allowing us to access the player data from the lib `@dcl/asset-packs`.