### PR TITLE
move ts own process to use chokidar

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -218,15 +218,15 @@ function runTypeChecker(components: BundleComponents, options: CompileOptions) {
   const typeCheckerFuture = future<number>()
 
   function runTsc() {
-    const args = [
-      require.resolve('typescript/lib/tsc'),
-      '-p',
-      'tsconfig.json',
-      options.emitDeclaration ? '--emitDeclarationOnly' : '--noEmit'
-    ]
+    const tsBin = require.resolve('typescript/lib/tsc')
+    const args = ['-p', 'tsconfig.json', options.emitDeclaration ? '--emitDeclarationOnly' : '--noEmit']
 
     printProgressStep(components.logger, `Running type checker`, 2, MAX_STEP)
-    const ts = child_process.spawn(process.execPath, args, { env: process.env, cwd: options.workingDirectory })
+    const ts = child_process.fork(tsBin, args, {
+      stdio: 'pipe',
+      env: process.env,
+      cwd: options.workingDirectory
+    })
 
     return new Promise<number>((resolve, reject) => {
       ts.on('close', (code) => {
@@ -238,8 +238,8 @@ function runTypeChecker(components: BundleComponents, options: CompileOptions) {
         }
       })
 
-      ts.stdout.pipe(process.stdout)
-      ts.stderr.pipe(process.stderr)
+      ts.stdout?.pipe(process.stdout)
+      ts.stderr?.pipe(process.stderr)
     })
   }
 

--- a/packages/@dcl/sdk-commands/src/logic/typescript.ts
+++ b/packages/@dcl/sdk-commands/src/logic/typescript.ts
@@ -1,0 +1,41 @@
+import ts from 'typescript'
+import path from 'path'
+
+export function getTypeScriptWatchPatterns(tsconfigPath: string): string[] {
+  const configPath = ts.findConfigFile(tsconfigPath, ts.sys.fileExists, 'tsconfig.json')
+
+  if (!configPath) {
+    throw new Error('Could not find tsconfig.json')
+  }
+
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
+  if (configFile.error) {
+    throw new Error(`Error reading tsconfig.json: ${configFile.error.messageText}`)
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, path.dirname(configPath))
+
+  const patterns: string[] = []
+
+  if (parsedConfig.raw.include) {
+    patterns.push(...parsedConfig.raw.include)
+  } else {
+    // Default TypeScript patterns if no includes specified
+    patterns.push('**/*.ts', '**/*.tsx', '**/*.d.ts')
+  }
+
+  if (parsedConfig.raw.files) {
+    patterns.push(...parsedConfig.raw.files)
+  }
+
+  // Convert excludes to negative patterns
+  const excludePatterns = []
+  if (parsedConfig.raw.exclude) {
+    excludePatterns.push(...parsedConfig.raw.exclude.map((p: string) => `!${p}`))
+  }
+
+  // Add default TypeScript excludes
+  excludePatterns.push('!**/node_modules/**', '!**/dist/**', '!**/*.js', '!**/*.jsx')
+
+  return [...patterns, ...excludePatterns]
+}


### PR DESCRIPTION
Since we are now using `sdk-commands` as child process of other apps (creator-hub, etc), creating child processes of child processes seems to be having problems maintaining them alive when needed.
This avoids creating a new keepalive process when running `tsc` on the user's scene by using `chokidar`. The only gotcha is having to parse the `tsconfig.json` file so we can obtain the proper files to watch, so that's what the new `getTypeScriptWatchPatterns` function is doing.

Tested it inside and outside Electron app, having different configs inside the `tsconfig.json` file and seems to be doing a proper work.