### PR TITLE
fix: Add SyncComponents to Smart Items when using the AdminTools

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
+        "@dcl/asset-packs": "^2.3.0",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -295,9 +295,9 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.2.2-14499191062.commit-22acee0",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
-      "integrity": "sha512-a4A5hJlJQIRMxRPr6FtZhapRqTCbUqi4C391tBwJb26e6Ec+QcnzRVxbKi3pi6JHI1tFJOTADZERAqPOgIOEJQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.3.0.tgz",
+      "integrity": "sha512-wh9LQtsXttiO1LQDHxMmEQ+OzOQ/n69Ltv5WGJ8tkTIlf97I0N1sid7Z2s0+VjCDR+ggCeu7d6fSjlJRXEYPOg==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "^2.3.0",
+        "@dcl/asset-packs": "2.3.0",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
+        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -295,9 +295,9 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.2.2-14449970067.commit-243817e",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
-      "integrity": "sha512-oq+xnCG0KJTkcB/cHVI7GYXyW7UqtyanVd+xdqM+IVn/zPHUXVedDIry6+Pjp5gPmoDcrxca4MjWK7i8jJ2dog==",
+      "version": "2.2.2-14499191062.commit-22acee0",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
+      "integrity": "sha512-a4A5hJlJQIRMxRPr6FtZhapRqTCbUqi4C391tBwJb26e6Ec+QcnzRVxbKi3pi6JHI1tFJOTADZERAqPOgIOEJQ==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
+        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -295,9 +295,9 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.2.2-14388570180.commit-8eaab38",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
-      "integrity": "sha512-0q8cMuKqdax2RlY4v++eoa7rdEEBbUSiwTMYQL+ixvyXT6GJNel75HShuSI/dRTvkvTzXMZoDH/LEihy2rC+GA==",
+      "version": "2.2.2-14449970067.commit-243817e",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
+      "integrity": "sha512-oq+xnCG0KJTkcB/cHVI7GYXyW7UqtyanVd+xdqM+IVn/zPHUXVedDIry6+Pjp5gPmoDcrxca4MjWK7i8jJ2dog==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "2.2.1",
+        "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -295,9 +295,9 @@
       "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.2.1.tgz",
-      "integrity": "sha512-UX5zjlGsKhRcRdJ70XigHmQep6zqgH1m7jViu4Hq3z84GggRgWhyGDzHt2deIlmxj8FCtRH3du3zxKnnUML2xA==",
+      "version": "2.2.2-14388570180.commit-8eaab38",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
+      "integrity": "sha512-0q8cMuKqdax2RlY4v++eoa7rdEEBbUSiwTMYQL+ixvyXT6GJNel75HShuSI/dRTvkvTzXMZoDH/LEihy2rC+GA==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
+    "@dcl/asset-packs": "^2.3.0",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
+    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14449970067.commit-243817e.tgz",
+    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14499191062.commit-22acee0.tgz",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "^2.3.0",
+    "@dcl/asset-packs": "2.3.0",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "2.2.1",
+    "@dcl/asset-packs": "https://sdk-team-cdn.decentraland.org/@dcl/asset-packs/branch/fix/sync-smart-items/dcl-asset-packs-2.2.2-14388570180.commit-8eaab38.tgz",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@dcl/inspector/src/components/EntityInspector/AdminToolkitView/SmartItemControl/SmartItemControl.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AdminToolkitView/SmartItemControl/SmartItemControl.tsx
@@ -21,13 +21,23 @@ type Props = {
 }
 
 const SmartItemControl: React.FC<WithSdkProps & Props> = ({ sdk, entity }) => {
-  const { AdminTools, Actions, Animator, Transform, Tween, VisibilityComponent, VideoPlayer, AudioSource } =
-    sdk.components
+  const {
+    AdminTools,
+    Actions,
+    Animator,
+    Transform,
+    Tween,
+    VisibilityComponent,
+    VideoPlayer,
+    AudioSource,
+    AudioStream
+  } = sdk.components
   const [adminComponent, setAdminComponent] = useComponentValue(entity, AdminTools)
   const entitiesWithAction: Entity[] = useEntitiesWith((components) => components.Actions)
 
   const componentIdsToSync = [
     AudioSource.componentId,
+    AudioStream.componentId,
     Animator.componentId,
     Transform.componentId,
     Tween.componentId,

--- a/packages/@dcl/inspector/src/components/EntityInspector/AdminToolkitView/SmartItemControl/SmartItemControl.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AdminToolkitView/SmartItemControl/SmartItemControl.tsx
@@ -11,6 +11,7 @@ import { Button } from '../../../Button'
 import { AddButton } from '../../AddButton'
 import MoreOptionsMenu from '../../MoreOptionsMenu'
 import { Component } from '../../../../lib/sdk/components'
+import { addSyncComponentsToEntities } from '../../../../lib/sdk/operations/entitySyncUtils'
 import { Block } from '../../../Block'
 
 import './SmartItemControl.css'
@@ -20,9 +21,19 @@ type Props = {
 }
 
 const SmartItemControl: React.FC<WithSdkProps & Props> = ({ sdk, entity }) => {
-  const { AdminTools, Actions } = sdk.components
+  const { AdminTools, Actions, Animator, Transform, Tween, VisibilityComponent, VideoPlayer, AudioSource } =
+    sdk.components
   const [adminComponent, setAdminComponent] = useComponentValue(entity, AdminTools)
   const entitiesWithAction: Entity[] = useEntitiesWith((components) => components.Actions)
+
+  const componentIdsToSync = [
+    AudioSource.componentId,
+    Animator.componentId,
+    Transform.componentId,
+    Tween.componentId,
+    VideoPlayer.componentId,
+    VisibilityComponent.componentId
+  ]
 
   const availableActions: Map<number, { actions: Action[] }> = useMemo(() => {
     const actions = new Map<number, { actions: Action[] }>()
@@ -51,6 +62,12 @@ const SmartItemControl: React.FC<WithSdkProps & Props> = ({ sdk, entity }) => {
         }
       })
     }
+
+    addSyncComponentsToEntities(
+      sdk,
+      validSmartItems.map((item) => item.entity as Entity),
+      componentIdsToSync
+    )
   }, [availableActions, adminComponent, setAdminComponent])
 
   const handleAddSmartItemAction = useCallback(() => {

--- a/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.spec.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.spec.ts
@@ -1,0 +1,234 @@
+import { Engine, Entity, IEngine } from '@dcl/ecs'
+import { ActionType } from '@dcl/asset-packs'
+import { addSyncComponentsToEntities, getEntitiesSyncStatus, removeSyncComponentsFromEntities } from './entitySyncUtils'
+import { createOperations } from './index'
+import { SdkContextValue } from '../context'
+import { createComponents, createEditorComponents, EditorComponents, SdkComponents } from '../components'
+import { createEnumEntityId } from '../enum-entity'
+
+describe('entitySyncUtils', () => {
+  let engine: IEngine
+  let operations: ReturnType<typeof createOperations>
+  let sdk: SdkContextValue
+  let components: EditorComponents & SdkComponents
+  let dispatchMock: jest.Mock
+
+  beforeEach(() => {
+    engine = Engine()
+    // Create components
+    components = {
+      ...createComponents(engine),
+      ...createEditorComponents(engine)
+    }
+    // Create operations
+    dispatchMock = jest.fn().mockResolvedValue(undefined)
+    operations = createOperations(engine)
+    operations.dispatch = dispatchMock
+
+    sdk = {
+      engine,
+      operations,
+      components,
+      enumEntity: createEnumEntityId(engine)
+    } as SdkContextValue
+  })
+
+  describe('addSyncComponentsToEntities', () => {
+    it('should return an empty object for empty entities array', () => {
+      const result = addSyncComponentsToEntities(sdk, [])
+      expect(result).toEqual({})
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('should add SyncComponents and NetworkEntity to entities with valid components', () => {
+      const entities = [512, 513, 514, 515] as Entity[]
+      sdk.components.Animator.create(entities[1])
+      sdk.components.Animator.create(entities[3])
+      const result = addSyncComponentsToEntities(
+        sdk,
+        [entities[0], entities[1], entities[2], entities[3]],
+        [sdk.components.Animator.componentId]
+      )
+
+      // Entity 0 doesn't have Animator, should fail
+      expect(result[entities[0]]).toBe(false)
+
+      // Entity 1 has Animator, should succeed
+      expect(result[entities[1]]).toBe(true)
+
+      // Entity 2 doesn't have Animator, should fail
+      expect(result[entities[2]]).toBe(false)
+
+      // Entity 3 doesn't have Animator directly but has Actions referencing it, should succeed
+      expect(result[entities[3]]).toBe(true)
+
+      // Verify component operations
+      expect(sdk.components.SyncComponents.has(entities[1])).toBe(true)
+      expect(sdk.components.NetworkEntity.has(entities[1])).toBe(true)
+      expect(sdk.components.SyncComponents.has(entities[3])).toBe(true)
+      expect(sdk.components.NetworkEntity.has(entities[3])).toBe(true)
+      // Dispatch should be called once
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should update existing SyncComponents with new component IDs', () => {
+      const entity = 512 as Entity
+      // First create the Animator component
+      sdk.components.Animator.create(entity)
+
+      // Then add SyncComponents with Animator
+      sdk.components.SyncComponents.create(entity, { componentIds: [sdk.components.Animator.componentId] })
+      sdk.components.NetworkEntity.create(entity, { entityId: sdk.enumEntity.getNextEnumEntityId(), networkId: 0 })
+
+      // Then create the States component
+      sdk.components.States.create(entity)
+
+      // Before adding States, check what's in SyncComponents
+      expect(sdk.components.SyncComponents.get(entity).componentIds).toEqual([sdk.components.Animator.componentId])
+
+      // Try to add States
+      const result = addSyncComponentsToEntities(sdk, [entity], [sdk.components.States.componentId])
+
+      // Should add successfully
+      expect(result[entity]).toBe(true)
+
+      // Verify SyncComponents was updated to include both components
+      expect(sdk.components.SyncComponents.get(entity).componentIds).toContain(sdk.components.Animator.componentId)
+      expect(sdk.components.SyncComponents.get(entity).componentIds).toContain(sdk.components.States.componentId)
+
+      // Dispatch should be called once
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not update if component IDs already exist in SyncComponents', () => {
+      const entity = 512 as Entity
+      // First create the Animator component
+      sdk.components.Animator.create(entity)
+
+      // Then add SyncComponents with Animator
+      sdk.components.SyncComponents.create(entity, { componentIds: [sdk.components.Animator.componentId] })
+      sdk.components.NetworkEntity.create(entity, { entityId: sdk.enumEntity.getNextEnumEntityId(), networkId: 0 })
+
+      // Then try to add Animator again
+      const result = addSyncComponentsToEntities(sdk, [entity], [sdk.components.Animator.componentId])
+
+      // Should return false as no changes were made
+      expect(result[entity]).toBe(false)
+
+      // Dispatch should not be called
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('should detect components implied by Actions', () => {
+      const entity = 512 as Entity
+      // Create the Animator and States components first since entitySyncUtils checks for them
+      sdk.components.Animator.create(entity)
+      sdk.components.States.create(entity)
+
+      // Add Actions component that references Animator and States
+      sdk.components.Actions.create(entity, {
+        id: 1,
+        value: [
+          {
+            name: 'Play Walk Animation',
+            type: ActionType.PLAY_ANIMATION,
+            jsonPayload: JSON.stringify({
+              animation: 'walk'
+            })
+          },
+          {
+            name: 'Set On',
+            type: ActionType.SET_STATE,
+            jsonPayload: JSON.stringify({
+              state: 'on'
+            })
+          }
+        ]
+      })
+
+      // Try to sync all components on entity 3 which has Actions referencing Animator and States
+      const result = addSyncComponentsToEntities(
+        sdk,
+        [entity],
+        [sdk.components.Animator.componentId, sdk.components.States.componentId, sdk.components.Tween.componentId]
+      )
+
+      // Should succeed because entity has the components
+      expect(result[entity]).toBe(true)
+
+      // Check that SyncComponents was added with the correct IDs
+      expect(sdk.components.SyncComponents.has(entity)).toBe(true)
+      expect(sdk.components.SyncComponents.get(entity).componentIds).toContain(sdk.components.Animator.componentId)
+      expect(sdk.components.SyncComponents.get(entity).componentIds).toContain(sdk.components.States.componentId)
+
+      // Shouldn't include Tween which isn't on the entity
+      expect(sdk.components.SyncComponents.get(entity).componentIds).not.toContain(sdk.components.Tween.componentId)
+
+      // Dispatch should be called once
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('removeSyncComponentsFromEntities', () => {
+    it('should return an empty object for empty entities array', async () => {
+      const result = await removeSyncComponentsFromEntities(sdk, [])
+      expect(result).toEqual({})
+      expect(dispatchMock).not.toHaveBeenCalled()
+    })
+
+    it('should remove SyncComponents and NetworkEntity from entities', async () => {
+      const entities = [512, 513] as Entity[]
+      // Add SyncComponents and NetworkEntity to entities
+      sdk.components.SyncComponents.create(entities[0], { componentIds: [sdk.components.Animator.componentId] })
+      sdk.components.NetworkEntity.create(entities[0], { entityId: sdk.enumEntity.getNextEnumEntityId(), networkId: 0 })
+
+      // Make sure they exist
+      expect(sdk.components.SyncComponents.has(entities[0])).toBe(true)
+      expect(sdk.components.NetworkEntity.has(entities[0])).toBe(true)
+
+      // Remove them
+      const result = await removeSyncComponentsFromEntities(sdk, [entities[0], entities[1]])
+
+      // Entity 0 had components, should return true
+      expect(result[entities[0]]).toBe(true)
+
+      // Entity 1 didn't have components, should return false
+      expect(result[entities[1]]).toBe(false)
+
+      // Verify components were actually removed
+      expect(sdk.components.SyncComponents.has(entities[0])).toBe(false)
+      expect(sdk.components.NetworkEntity.has(entities[0])).toBe(false)
+
+      // Dispatch should be called once
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getEntitiesSyncStatus', () => {
+    it('should return sync status for entities', () => {
+      const entities = [512, 513] as Entity[]
+      // Add SyncComponents and NetworkEntity to entity 1
+      sdk.components.SyncComponents.create(entities[1], {
+        componentIds: [sdk.components.Animator.componentId, sdk.components.States.componentId]
+      })
+      sdk.components.NetworkEntity.create(entities[1], { entityId: sdk.enumEntity.getNextEnumEntityId(), networkId: 0 })
+
+      // Get status for all entities
+      const result = getEntitiesSyncStatus(sdk, entities)
+
+      // Entity 0 should have no components
+      expect(result[entities[0]]).toEqual({
+        hasSyncComponents: false,
+        hasNetworkEntity: false,
+        syncComponentIds: []
+      })
+
+      // Entity 1 should have both components
+      expect(result[entities[1]]).toEqual({
+        hasSyncComponents: true,
+        hasNetworkEntity: true,
+        syncComponentIds: [sdk.components.Animator.componentId, sdk.components.States.componentId]
+      })
+    })
+  })
+})

--- a/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.ts
@@ -47,16 +47,8 @@ export function addSyncComponentsToEntities(
           case ActionType.STOP_ANIMATION:
             ids.add(sdk.components.Animator.componentId)
             break
-          case ActionType.SET_STATE:
-            ids.add(sdk.components.States.componentId)
-            break
           case ActionType.START_TWEEN:
             ids.add(sdk.components.Tween.componentId)
-            break
-          case ActionType.SET_COUNTER:
-          case ActionType.INCREMENT_COUNTER:
-          case ActionType.DECREASE_COUNTER:
-            ids.add(sdk.components.Counter.componentId)
             break
           case ActionType.PLAY_SOUND:
           case ActionType.STOP_SOUND:

--- a/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/operations/entitySyncUtils.ts
@@ -1,0 +1,199 @@
+import { Entity } from '@dcl/ecs'
+import { SdkContextValue } from '../context'
+import { ActionType } from '@dcl/asset-packs'
+
+type EntitySyncResult = {
+  hasSyncComponents: boolean
+  hasNetworkEntity: boolean
+  syncComponentIds: number[]
+}
+
+/**
+ * Adds SyncComponents to multiple entities.
+ *
+ * @param sdk - The SDK instance
+ * @param entities - Array of entities to add SyncComponents to
+ * @param componentIds - Optional array of component IDs to synchronize
+ * @returns A record of results per entity
+ */
+export function addSyncComponentsToEntities(
+  sdk: SdkContextValue,
+  entities: Entity[],
+  componentIds: number[] = []
+): Record<Entity, boolean> {
+  if (!entities.length) return {}
+
+  const { engine, enumEntity, operations } = sdk
+  const { Actions, NetworkEntity, SyncComponents } = sdk.components
+
+  const results: Record<Entity, boolean> = {}
+  let needsDispatch = false
+
+  // Precompute entity component presence map
+  const getEntityComponentIds = (entity: Entity): Set<number> => {
+    const ids = new Set<number>()
+
+    for (const component of engine.componentsIter()) {
+      if (component.has(entity)) {
+        ids.add(component.componentId)
+      }
+    }
+
+    if (Actions.has(entity)) {
+      const actions = Actions.get(entity)
+      for (const action of actions.value) {
+        switch (action.type) {
+          case ActionType.PLAY_ANIMATION:
+          case ActionType.STOP_ANIMATION:
+            ids.add(sdk.components.Animator.componentId)
+            break
+          case ActionType.SET_STATE:
+            ids.add(sdk.components.States.componentId)
+            break
+          case ActionType.START_TWEEN:
+            ids.add(sdk.components.Tween.componentId)
+            break
+          case ActionType.SET_COUNTER:
+          case ActionType.INCREMENT_COUNTER:
+          case ActionType.DECREASE_COUNTER:
+            ids.add(sdk.components.Counter.componentId)
+            break
+          case ActionType.PLAY_SOUND:
+          case ActionType.STOP_SOUND:
+            ids.add(sdk.components.AudioSource.componentId)
+            break
+          case ActionType.PLAY_AUDIO_STREAM:
+          case ActionType.STOP_AUDIO_STREAM:
+            ids.add(sdk.components.AudioSource.componentId)
+            break
+          case ActionType.PLAY_VIDEO_STREAM:
+          case ActionType.STOP_VIDEO_STREAM:
+            ids.add(sdk.components.VideoPlayer.componentId)
+            break
+        }
+      }
+    }
+
+    return ids
+  }
+
+  for (const entity of entities) {
+    const entityComponentIds = getEntityComponentIds(entity)
+    const validComponentIds = componentIds.filter((id) => entityComponentIds.has(id))
+
+    if (entity === 0 || validComponentIds.length === 0) {
+      results[entity] = false
+      continue
+    }
+
+    const hasSyncComponents = SyncComponents.has(entity)
+
+    if (!hasSyncComponents) {
+      operations.addComponent(entity, SyncComponents.componentId)
+      operations.updateValue(SyncComponents, entity, { componentIds: validComponentIds })
+      results[entity] = true
+      needsDispatch = true
+    } else {
+      const currentValue = SyncComponents.get(entity)
+      const currentIds = new Set(currentValue.componentIds || [])
+      const updatedIds = Array.from(currentIds)
+
+      for (const id of validComponentIds) {
+        if (!currentIds.has(id)) {
+          updatedIds.push(id)
+        }
+      }
+
+      if (currentIds.size !== updatedIds.length) {
+        operations.updateValue(SyncComponents, entity, { componentIds: updatedIds })
+        results[entity] = true
+        needsDispatch = true
+      } else {
+        results[entity] = false
+      }
+    }
+
+    const hasNetworkEntity = NetworkEntity.has(entity)
+
+    if (!hasNetworkEntity) {
+      operations.addComponent(entity, NetworkEntity.componentId)
+      operations.updateValue(NetworkEntity, entity, {
+        entityId: enumEntity.getNextEnumEntityId(),
+        networkId: 0
+      })
+      needsDispatch = true
+    }
+  }
+
+  if (needsDispatch) {
+    void operations.dispatch()
+  }
+
+  return results
+}
+
+/**
+ * Removes SyncComponents and NetworkEntity from multiple entities
+ *
+ * @param sdk - The SDK instance
+ * @param entities - Array of entities to remove components from
+ * @returns A record of results per entity
+ */
+export async function removeSyncComponentsFromEntities(
+  sdk: SdkContextValue,
+  entities: Entity[]
+): Promise<Record<Entity, boolean>> {
+  if (!entities.length) return {}
+
+  const { NetworkEntity, SyncComponents } = sdk.components
+  const results: Record<Entity, boolean> = {}
+  let needsDispatch = false
+
+  entities.forEach((entity) => {
+    const hasSyncComponents = SyncComponents.has(entity)
+    const hasNetworkEntity = NetworkEntity.has(entity)
+
+    if (hasSyncComponents) {
+      sdk.operations.removeComponent(entity, SyncComponents)
+      needsDispatch = true
+    }
+
+    if (hasNetworkEntity) {
+      sdk.operations.removeComponent(entity, NetworkEntity)
+      needsDispatch = true
+    }
+
+    results[entity] = hasSyncComponents || hasNetworkEntity
+  })
+
+  if (needsDispatch) {
+    await sdk.operations.dispatch()
+  }
+
+  return results
+}
+
+/**
+ * Gets the current sync status for multiple entities
+ *
+ * @param sdk - The SDK instance
+ * @param entities - Array of entities to check
+ * @returns A record of sync status per entity
+ */
+export function getEntitiesSyncStatus(sdk: SdkContextValue, entities: Entity[]): Record<Entity, EntitySyncResult> {
+  const results: Record<Entity, EntitySyncResult> = {}
+
+  entities.forEach((entity) => {
+    const hasSyncComponents = sdk.components.SyncComponents.has(entity)
+    const hasNetworkEntity = sdk.components.NetworkEntity.has(entity)
+    const syncComponentsValue = hasSyncComponents ? sdk.components.SyncComponents.get(entity) : null
+
+    results[entity] = {
+      hasSyncComponents,
+      hasNetworkEntity,
+      syncComponentIds: syncComponentsValue?.componentIds || []
+    }
+  })
+
+  return results
+}


### PR DESCRIPTION
This PR adds the following components to be synced when being used by the AdminTools Smart Item: 
- AudioSource (if present or used by an Action)
- Animator (if present or used by an Action)
- Transform
- Tween (if present or used by an Action)
- VideoPlayer (if present or used by an Action)
- VisibilityComponent

Depends on: https://github.com/decentraland/asset-packs/pull/164