### PR TITLE
feat: add type safe entity names file

### DIFF
--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -197,6 +197,11 @@ function preEngine(options?: IEngineOptions): PreEngine {
     return null
   }
 
+  function getEntityByName<T = never, K = T>(value: K & (T extends never ? never : string)): Entity {
+    const entity = getEntityOrNullByName(value)
+    return entity!
+  }
+
   function* getComponentDefGroup<T extends ComponentDefinition<any>[]>(...args: T): Iterable<[Entity, ...T]> {
     const [firstComponentDef, ...componentDefinitions] = args
     for (const [entity] of firstComponentDef.iterator()) {
@@ -252,6 +257,7 @@ function preEngine(options?: IEngineOptions): PreEngine {
     getComponent,
     getComponentOrNull: getComponentOrNull as IEngine['getComponentOrNull'],
     getEntityOrNullByName,
+    getEntityByName,
     removeComponentDefinition,
     registerComponentDefinition,
     entityContainer,
@@ -313,6 +319,7 @@ export function Engine(options?: IEngineOptions): IEngine {
     componentsIter: partialEngine.componentsIter,
     seal: partialEngine.seal,
     getEntityOrNullByName: partialEngine.getEntityOrNullByName,
+    getEntityByName: partialEngine.getEntityByName,
 
     update,
 

--- a/packages/@dcl/ecs/src/engine/index.ts
+++ b/packages/@dcl/ecs/src/engine/index.ts
@@ -189,7 +189,7 @@ function preEngine(options?: IEngineOptions): PreEngine {
     }
   }
 
-  function getEntityOrNullByName(value: string) {
+  function getEntityOrNullByName<T = string>(value: T) {
     const NameComponent = components.Name({ defineComponent })
     for (const [entity, name] of getEntitiesWith(NameComponent)) {
       if (name.value === value) return entity

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -62,6 +62,7 @@ export type PreEngine = Pick<
   | 'seal'
   | 'entityContainer'
   | 'getEntityOrNullByName'
+  | 'getEntityByName'
 > & {
   getSystems: () => SystemItem[]
 }
@@ -246,6 +247,14 @@ export interface IEngine {
    * @param value - Name value string
    */
   getEntityOrNullByName<T = string>(label: T): Entity | null
+
+  /**
+   * @public
+   * Search for the entity that matches de label string defined in the editor.
+   * @param value - Name value string
+   * @typeParam T - The type of the entity name value
+   */
+  getEntityByName<T = never, K = T>(value: K & (T extends never ? never : string)): Entity
 
   /**
    * @public

--- a/packages/@dcl/ecs/src/engine/types.ts
+++ b/packages/@dcl/ecs/src/engine/types.ts
@@ -245,7 +245,7 @@ export interface IEngine {
    * Search for the entity that matches de label string defined in the editor.
    * @param value - Name value string
    */
-  getEntityOrNullByName(label: string): Entity | null
+  getEntityOrNullByName<T = string>(label: T): Entity | null
 
   /**
    * @public

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/composite-dirty.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/composite-dirty.ts
@@ -9,7 +9,7 @@ import {
 } from '@dcl/ecs'
 import { initComponents } from '@dcl/asset-packs'
 import { EditorComponentNames, EditorComponents } from '../../../sdk/components'
-import { dumpEngineToComposite, dumpEngineToCrdtCommands } from './engine-to-composite'
+import { dumpEngineToComposite, dumpEngineToCrdtCommands, generateEntityNamesType } from './engine-to-composite'
 import { FileSystemInterface } from '../../types'
 import { CompositeManager, createFsCompositeProvider } from './fs-composite-provider'
 import { getMinimalComposite } from '../../client/feeded-local-fs'
@@ -21,6 +21,7 @@ import { toSceneComponent } from './component'
 import { addNodesComponentsToPlayerAndCamera } from './migrations/add-nodes-to-player-and-camera'
 import { fixNetworkEntityValues } from './migrations/fix-network-entity-values'
 import { selectSceneEntity } from './migrations/select-scene-entity'
+import { DIRECTORY, withAssetDir } from '../fs-utils'
 
 enum DirtyEnum {
   // No changes
@@ -107,6 +108,9 @@ export async function compositeAndDirty(
       const mainCrdt = dumpEngineToCrdtCommands(engine)
       await fs.writeFile('main.crdt', Buffer.from(mainCrdt))
       await compositeProvider.save({ src: compositePath, composite }, 'json')
+
+      // Generate entity names type file
+      await generateEntityNamesType(engine, withAssetDir(DIRECTORY.SCENE + '/entity-names.ts'), 'EntityNames', fs)
 
       return composite
     } catch (e) {

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -8,9 +8,12 @@ import {
   IEngine,
   LastWriteWinElementSetComponentDefinition,
   PutComponentOperation,
-  getCompositeRootComponent
+  getCompositeRootComponent,
+  Name,
+  NameType
 } from '@dcl/ecs'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist/serialization/ByteBuffer'
+import { FileSystemInterface } from '../../types'
 
 function componentToCompositeComponentData<T>(
   $case: 'json' | 'binary',
@@ -127,4 +130,86 @@ export function dumpEngineToCrdtCommands(engine: IEngine): Uint8Array {
   }
 
   return crdtBuffer.toBinary()
+}
+
+/**
+ * Generate a TypeScript declaration file with a string literal union type containing all entity names in the scene.
+ * This allows for type-safe references to entities by name in scene scripts.
+ *
+ * @param engine The ECS engine instance
+ * @param outputPath The path where the .d.ts file should be written
+ * @param typeName The name for the generated type (default: "SceneEntityNames")
+ * @param fs FileSystem interface for writing the file
+ * @returns Promise that resolves when the file has been written
+ */
+export async function generateEntityNamesType(
+  engine: IEngine,
+  outputPath: string = 'scene-entity-names.d.ts',
+  typeName: string = 'SceneEntityNames',
+  fs: FileSystemInterface
+): Promise<void> {
+  try {
+    // Find the Name component definition
+
+    const NameComponent: typeof Name = engine.getComponentOrNull(Name.componentId) as typeof Name
+
+    if (!NameComponent) {
+      throw new Error('Name component not found in engine')
+    }
+
+    // Collect all names from entities
+    const names: string[] = []
+    for (const [_, nameValue] of engine.getEntitiesWith(NameComponent)) {
+      if (nameValue.value) {
+        names.push(nameValue.value)
+      }
+    }
+
+    // Sort names for consistency
+    names.sort()
+
+    // Remove duplicates
+    const uniqueNames = Array.from(new Set(names))
+
+    // Generate valid TypeScript identifiers
+    const validNames = uniqueNames.map((name) => {
+      // Create a valid TypeScript identifier
+      const validName = name
+        .replace(/[^a-zA-Z0-9_]/g, '_') // Replace non-alphanumeric chars with underscore
+        .replace(/^[0-9]/, '_$&') // Prepend underscore if starts with number
+
+      // Ensure no duplicate keys after validation
+      return { original: name, valid: validName }
+    })
+
+    // Generate the .d.ts file content
+    let fileContent = `// Auto-generated entity names from the scene\n\n`
+    fileContent += `/**\n * Union type containing all entity names in the scene.\n * Use for type-safe references to entities by name.\n */\n`
+    fileContent += `export type I${typeName} = `
+
+    if (uniqueNames.length === 0) {
+      fileContent += `never\n`
+    } else {
+      fileContent += `\n`
+      for (const key in uniqueNames) {
+        const isLast = Number(key) === uniqueNames.length - 1
+        fileContent += `  | "${uniqueNames[key]}"${isLast ? '\n' : '\n'}`
+      }
+    }
+
+    // Add a constant object with name keys for IDE autocompletion
+    fileContent += `\n/**\n * Object containing all entity names in the scene for autocomplete support.\n */\n`
+    fileContent += `export const ${typeName} = {\n`
+
+    for (const { original, valid } of validNames) {
+      fileContent += `  ${valid}: "${original}",\n`
+    }
+
+    fileContent += `} as const\n`
+
+    // Write to file
+    await fs.writeFile(outputPath, Buffer.from(fileContent, 'utf-8'))
+  } catch (e) {
+    console.error('Faield to generate entity names types', e)
+  }
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -9,8 +9,7 @@ import {
   LastWriteWinElementSetComponentDefinition,
   PutComponentOperation,
   getCompositeRootComponent,
-  Name,
-  NameType
+  Name
 } from '@dcl/ecs'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist/serialization/ByteBuffer'
 import { FileSystemInterface } from '../../types'

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1248,7 +1248,7 @@ export interface IEngine {
     getComponentOrNull<T>(componentId: number | string): ComponentDefinition<T> | null;
     getEntitiesWith<T extends [ComponentDefinition<any>, ...ComponentDefinition<any>[]]>(...components: T): Iterable<[Entity, ...ReadonlyComponentSchema<T>]>;
     // @alpha
-    getEntityOrNullByName(label: string): Entity | null;
+    getEntityOrNullByName<T = string>(label: T): Entity | null;
     getEntityState(entity: Entity): EntityState;
     // (undocumented)
     _id: number;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1247,6 +1247,7 @@ export interface IEngine {
     getComponent<T>(componentId: number | string): ComponentDefinition<T>;
     getComponentOrNull<T>(componentId: number | string): ComponentDefinition<T> | null;
     getEntitiesWith<T extends [ComponentDefinition<any>, ...ComponentDefinition<any>[]]>(...components: T): Iterable<[Entity, ...ReadonlyComponentSchema<T>]>;
+    getEntityByName<T = never, K = T>(value: K & (T extends never ? never : string)): Entity;
     // @alpha
     getEntityOrNullByName<T = string>(label: T): Entity | null;
     getEntityState(entity: Entity): EntityState;

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -65,7 +65,7 @@
     "../inspector": {
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "2.2.1",
+        "@dcl/asset-packs": "2.3.1",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -3141,7 +3141,7 @@
         "@babylonjs/inspector": "~6.18.0",
         "@babylonjs/loaders": "~6.18.0",
         "@babylonjs/materials": "~6.18.0",
-        "@dcl/asset-packs": "2.2.1",
+        "@dcl/asset-packs": "2.3.1",
         "@dcl/ecs": "file:../ecs",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/mini-rpc": "^1.0.7",

--- a/test/ecs/components/Name.spec.ts
+++ b/test/ecs/components/Name.spec.ts
@@ -12,5 +12,8 @@ describe('Generated Raycast ProtoBuf', () => {
 
     expect(newEngine.getEntityOrNullByName('CASLA')).toBeDefined()
     expect(newEngine.getEntityOrNullByName('Boedo')).toBe(null)
+
+    expect(newEngine.getEntityByName<string>('CASLA')).toBeDefined()
+    expect(newEngine.getEntityByName<string>('Boedo')).toBe(null)
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=462.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=462.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 54k
-  MALLOC_COUNT = 13727
+  MALLOC_COUNT = 13735
   ALIVE_OBJS_DELTA ~= 2.70k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1209.35k bytes
+  MEMORY_USAGE_COUNT ~= 1209.94k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=463.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=463.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 63k
-  MALLOC_COUNT = 14248
+  MALLOC_COUNT = 14260
   ALIVE_OBJS_DELTA ~= 2.85k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -64,4 +64,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1217.97k bytes
+  MEMORY_USAGE_COUNT ~= 1218.62k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=463.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=463.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 63k
-  MALLOC_COUNT = 14248
+  MALLOC_COUNT = 14260
   ALIVE_OBJS_DELTA ~= 2.85k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -64,4 +64,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1217.97k bytes
+  MEMORY_USAGE_COUNT ~= 1218.63k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=203k bytes
+SCENE_COMPILED_JS_SIZE_PROD=203.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 65k
-  MALLOC_COUNT = 12773
+  MALLOC_COUNT = 12784
   ALIVE_OBJS_DELTA ~= 2.85k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 14k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 909.46k bytes
+  MEMORY_USAGE_COUNT ~= 909.93k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=236k bytes
+SCENE_COMPILED_JS_SIZE_PROD=236.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 66k
-  MALLOC_COUNT = 14885
+  MALLOC_COUNT = 14892
   ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
@@ -77,4 +77,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 10k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1051.90k bytes
+  MEMORY_USAGE_COUNT ~= 1052.22k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=199.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=199.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 55k
-  MALLOC_COUNT = 11927
+  MALLOC_COUNT = 11935
   ALIVE_OBJS_DELTA ~= 2.63k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 872.22k bytes
+  MEMORY_USAGE_COUNT ~= 872.62k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=199.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=199.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 55k
-  MALLOC_COUNT = 11900
+  MALLOC_COUNT = 11908
   ALIVE_OBJS_DELTA ~= 2.62k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 862.13k bytes
+  MEMORY_USAGE_COUNT ~= 862.53k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=236.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=236.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 105k
-  MALLOC_COUNT = 18228
+  MALLOC_COUNT = 18235
   ALIVE_OBJS_DELTA ~= 4.53k
 CALL onStart()
   OPCODES ~= 0k
@@ -1652,4 +1652,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 693k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1187.85k bytes
+  MEMORY_USAGE_COUNT ~= 1188.17k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 56k
-  MALLOC_COUNT = 12186
+  MALLOC_COUNT = 12195
   ALIVE_OBJS_DELTA ~= 2.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 879.86k bytes
+  MEMORY_USAGE_COUNT ~= 880.28k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 59k
-  MALLOC_COUNT = 12027
+  MALLOC_COUNT = 12035
   ALIVE_OBJS_DELTA ~= 2.65k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 864.55k bytes
+  MEMORY_USAGE_COUNT ~= 864.95k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=357.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=358k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 65k
-  MALLOC_COUNT = 19552
+  MALLOC_COUNT = 19559
   ALIVE_OBJS_DELTA ~= 3.88k
 CALL onStart()
   OPCODES ~= 0k
@@ -65,4 +65,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 65k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1708.08k bytes
+  MEMORY_USAGE_COUNT ~= 1708.45k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=199.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=199.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,8 +9,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 55k
-  MALLOC_COUNT = 12056
-  ALIVE_OBJS_DELTA ~= 2.65k
+  MALLOC_COUNT = 12064
+  ALIVE_OBJS_DELTA ~= 2.66k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -37,4 +37,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 877.68k bytes
+  MEMORY_USAGE_COUNT ~= 878.07k bytes


### PR DESCRIPTION
# Entity Names Type Generation

## Description
This PR introduces a new feature to automatically generate TypeScript definitions for entity names in the scene. It simplifies referencing scene entities by name with full type safety and IDE autocompletion support.

## Implementation Details
- Added a new function `generateEntityNamesType` to create a TypeScript file with string literal types for entity names
- Automatically generates this file whenever the scene composite is saved
- Creates both a string literal union type and a constant object for better developer experience
- Entity names are properly sanitized for valid TypeScript identifiers

## Benefits
- Type safety when referencing entities by name in code
- Autocomplete support in IDE for all named entities in the scene
- Prevents runtime errors from typos in entity name strings
- Makes refactoring entity names easier as TypeScript will catch all references

## Example Usage
```typescript
import { EntityNames } from '../assets/scene/entity-names'

// Auto-completion support via constant object
const GroundBoedoOrNull = engine.getEntityOrNullByName(EntityNames.Ground_Boedo1) 
const GroundBoedo = engine.getEntityByName<EntityNames>(EntityNames.Ground_Boedo1)
console.log(GroundBoedo)

```

This implementation helps reduce runtime errors and improves the developer experience when working with named entities in Decentraland scenes.
