### PR TITLE
feat: change shortcut for rotating camera

### DIFF
--- a/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.css
+++ b/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.css
@@ -63,7 +63,7 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  width: 350px;
+  width: 365px;
   overflow-y: auto;
   right: 0;
   bottom: calc(var(--shortcuts-bottom) + var(--shortcuts-button-height) + 8px);

--- a/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.tsx
+++ b/packages/@dcl/inspector/src/components/Renderer/Shortcuts/Shortcuts.tsx
@@ -83,7 +83,7 @@ const Shortcuts: React.FC<Props> = ({ canvas, onResetCamera, onZoomIn, onZoomOut
             <div className="Item">
               <div className="Title">Rotate Camera</div>
               <div className="Description">
-                <span className="Key">Left Mouse Button</span>+<span className="Key">Drag</span>
+                <span className="Key">Right Mouse Button</span>+<span className="Key">Drag</span>
               </div>
             </div>
             <div className="Item">


### PR DESCRIPTION
Close: https://github.com/decentraland/creator-hub/issues/553
- Update rotate camera shortcut copy
- Change shortcut window width to fit the new text

<img width="437" alt="Screenshot 2025-05-05 at 11 42 08" src="https://github.com/user-attachments/assets/1fb7e02d-9e90-4a55-a49d-618272c318bf" />
 
