### PR TITLE
Update global value on Audio Source component

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
@@ -9,22 +9,26 @@ import { AudioSourceInput } from './types'
 export const fromAudioSource =
   (base: string) =>
   (value: PBAudioSource): AudioSourceInput => {
+    debugger
     return {
       audioClipUrl: removeBasePath(base, value.audioClipUrl),
       loop: value.loop,
       playing: value.playing,
-      volume: volumeFromAudioSource(value.volume)
+      volume: volumeFromAudioSource(value.volume),
+      global: value.global
     }
   }
 
 export const toAudioSource =
   (base: string) =>
   (value: AudioSourceInput): PBAudioSource => {
+    debugger
     return {
       audioClipUrl: base ? base + '/' + value.audioClipUrl : value.audioClipUrl,
       loop: value.loop,
       playing: value.playing,
-      volume: volumeToAudioSource(value.volume)
+      volume: volumeToAudioSource(value.volume),
+      global: value.global
     }
   }
 

--- a/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/AudioSourceInspector/utils.ts
@@ -9,7 +9,6 @@ import { AudioSourceInput } from './types'
 export const fromAudioSource =
   (base: string) =>
   (value: PBAudioSource): AudioSourceInput => {
-    debugger
     return {
       audioClipUrl: removeBasePath(base, value.audioClipUrl),
       loop: value.loop,
@@ -22,7 +21,6 @@ export const fromAudioSource =
 export const toAudioSource =
   (base: string) =>
   (value: AudioSourceInput): PBAudioSource => {
-    debugger
     return {
       audioClipUrl: base ? base + '/' + value.audioClipUrl : value.audioClipUrl,
       loop: value.loop,

--- a/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/FileUploadField/FileUploadField.tsx
@@ -176,7 +176,7 @@ const FileUploadField: React.FC<Props> = ({
           label={label}
           onChange={handleChangeTextField}
           value={removeBase(path)}
-          error={hasError}
+          error={!!value && hasError}
           disabled={disabled}
           drop={isHover}
           autoSelect
@@ -188,7 +188,7 @@ const FileUploadField: React.FC<Props> = ({
           </button>
         )}
       </div>
-      {hasError && <Message text={errorMessage} type={MessageType.ERROR} />}
+      {!!value && hasError && <Message text={errorMessage} type={MessageType.ERROR} />}
     </div>
   )
 }


### PR DESCRIPTION
The global property was not being saved on the audio source component. Now we are saving it but only when you select a valid audio source. If not, it does not keep the selection. This issue was already discussed with Ezio and it will be hanlded in another ticket, as it's something that it's happening in more than one component.


https://github.com/user-attachments/assets/5a991bdd-e287-43e4-b333-33ef3c467a87


