### PR TITLE
fix required params

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -4,12 +4,6 @@ import { CliComponents } from '../../components'
 
 const isWindows = /^win/.test(process.platform)
 
-// Helper function to convert string to boolean
-function stringToBoolean(value: string | undefined, defaultValue: boolean = true): boolean {
-  if (!value) return defaultValue
-  return value.toLowerCase() === 'true'
-}
-
 export async function runExplorerAlpha(
   components: CliComponents,
   opts: {
@@ -48,27 +42,37 @@ async function runApp(
   const cmd = isWindows ? 'start' : 'open'
   const position = args['--position'] ?? `${baseCoords.x},${baseCoords.y}`
   const realm = args['--realm'] ?? realmValue
-  const localScene = stringToBoolean(args['--local-scene'], true)
-  const debug = stringToBoolean(args['--debug'], true)
+  const localScene = !!args['--local-scene']
+  const debug = !!args['--debug']
   const dclenv = args['--dclenv'] ?? 'org'
-  const skipAuthScreen = stringToBoolean(args['--skip-auth-screen'], true)
-  const landscapeTerrainEnabled = stringToBoolean(args['--landscape-terrain-enabled'], true)
-  const openDeeplinkInNewInstance = args['-n']
+  const skipAuthScreen = !!args['--skip-auth-screen']
+  const landscapeTerrainEnabled = !!args['--landscape-terrain-enabled']
+  const openDeeplinkInNewInstance = !!args['-n']
 
   try {
     const params = new URLSearchParams()
 
     params.set('realm', realm)
     params.set('position', position)
-    params.set('local-scene', localScene.toString())
-    params.set('debug', debug.toString())
-    params.set('hub', isHub.toString())
     params.set('dclenv', dclenv)
-    params.set('skip-auth-screen', skipAuthScreen.toString())
-    params.set('landscape-terrain-enabled', landscapeTerrainEnabled.toString())
 
+    if (localScene) {
+      params.set('local-scene', 'true')
+    }
+    if (debug) {
+      params.set('debug', 'true')
+    }
+    if (isHub) {
+      params.set('hub', 'true')
+    }
+    if (skipAuthScreen) {
+      params.set('skip-auth-screen', 'true')
+    }
+    if (landscapeTerrainEnabled) {
+      params.set('landscape-terrain-enabled', 'true')
+    }
     if (openDeeplinkInNewInstance) {
-      params.set('open-deeplink-in-new-instance', openDeeplinkInNewInstance.toString())
+      params.set('open-deeplink-in-new-instance', 'true')
     }
 
     const queryParams = params.toString()

--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -42,8 +42,6 @@ async function runApp(
   const cmd = isWindows ? 'start' : 'open'
   const position = args['--position'] ?? `${baseCoords.x},${baseCoords.y}`
   const realm = args['--realm'] ?? realmValue
-  const localScene = !!args['--local-scene']
-  const debug = !!args['--debug']
   const dclenv = args['--dclenv'] ?? 'org'
   const skipAuthScreen = !!args['--skip-auth-screen']
   const landscapeTerrainEnabled = !!args['--landscape-terrain-enabled']
@@ -56,12 +54,9 @@ async function runApp(
     params.set('position', position)
     params.set('dclenv', dclenv)
 
-    if (localScene) {
-      params.set('local-scene', 'true')
-    }
-    if (debug) {
-      params.set('debug', 'true')
-    }
+    params.set('local-scene', 'true')
+    params.set('debug', 'true')
+
     if (isHub) {
       params.set('hub', 'true')
     }

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -53,13 +53,13 @@ export const args = declareArgs({
   '--explorer-alpha': Boolean,
   '--hub': Boolean,
   // Params related to the explorer-alpha
-  '--debug': String,
+  '--debug': Boolean,
   '--dclenv': String,
   '--realm': String,
-  '--local-scene': String,
+  '--local-scene': Boolean,
   '--position': String,
-  '--skip-auth-screen': String,
-  '--landscape-terrain-enabled': String,
+  '--skip-auth-screen': Boolean,
+  '--landscape-terrain-enabled': Boolean,
   '-n': Boolean
 })
 

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -33,7 +33,7 @@ describe('explorer-alpha', () => {
   })
 
   describe('boolean parameters', () => {
-    it('should include boolean parameters only when they are true', async () => {
+    it('should always include local-scene and debug parameters', async () => {
       const args: any = {
         '--local-scene': true,
         '--debug': true,
@@ -57,7 +57,7 @@ describe('explorer-alpha', () => {
       )
     })
 
-    it('should not include boolean parameters when they are false', async () => {
+    it('should always include local-scene and debug even when they are false', async () => {
       const args: any = {
         '--local-scene': false,
         '--debug': false,
@@ -76,12 +76,12 @@ describe('explorer-alpha', () => {
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
-        expect.arrayContaining([expect.not.stringContaining('local-scene')]),
+        expect.arrayContaining([expect.stringContaining('local-scene=true')]),
         { silent: true }
       )
     })
 
-    it('should not include boolean parameters when they are undefined', async () => {
+    it('should always include local-scene and debug even when they are undefined', async () => {
       const args: any = {}
 
       await runExplorerAlpha(mockComponents, {
@@ -95,7 +95,7 @@ describe('explorer-alpha', () => {
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
-        expect.arrayContaining([expect.not.stringContaining('local-scene')]),
+        expect.arrayContaining([expect.stringContaining('local-scene=true')]),
         { silent: true }
       )
     })
@@ -177,12 +177,12 @@ describe('explorer-alpha', () => {
       expect(callArgs).toContain('position=10%2C20')
       expect(callArgs).toContain('dclenv=zone')
       expect(callArgs).toContain('local-scene=true')
+      expect(callArgs).toContain('debug=true')
       expect(callArgs).toContain('hub=true')
       expect(callArgs).toContain('skip-auth-screen=true')
       expect(callArgs).toContain('open-deeplink-in-new-instance=true')
 
       // Check that false parameters are not present
-      expect(callArgs).not.toContain('debug=true')
       expect(callArgs).not.toContain('landscape-terrain-enabled=true')
     })
 
@@ -201,7 +201,9 @@ describe('explorer-alpha', () => {
         '/test',
         'open',
         expect.arrayContaining([
-          expect.stringMatching(/decentraland:\/\/.*realm=default-realm.*position=5%2C10.*dclenv=org/)
+          expect.stringMatching(
+            /decentraland:\/\/.*realm=default-realm.*position=5%2C10.*dclenv=org.*local-scene=true.*debug=true/
+          )
         ]),
         { silent: true }
       )


### PR DESCRIPTION
# Fix boolean parameter handling in explorer-alpha command

## Problem

When running the `dcl start` command with boolean flags like `--landscape-terrain-enabled` without providing a value, the command would fail. This happened because the code was treating these parameters as strings and trying to convert them to booleans, but when no value was provided, the conversion would fail.

And the creator-hub sometimes use that flag without a value so some users where having issues to preview their scenes.

Example of the failing command:
```bash
npm start -- --explorer-alpha --landscape-terrain-enabled
```
