### PR TITLE
Improve import emotes 

### DIFF
--- a/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -6,7 +6,7 @@ import { AiFillSound } from 'react-icons/ai'
 import { IoVideocamOutline } from 'react-icons/io5'
 import { FaFile } from 'react-icons/fa'
 
-import { toWearableWithBlobs } from './utils'
+import { toEmoteWithBlobs, toWearableWithBlobs } from './utils'
 import { Props } from './types'
 
 import './AssetPreview.css'
@@ -42,25 +42,43 @@ export function AssetPreview({ value, resources, onScreenshot, onLoad }: Props) 
 
 function GltfPreview({ value, resources, onScreenshot, onLoad }: Props) {
   const [loading, setLoading] = useState(true)
-  const handleLoad = useCallback(() => {
+  const handleLoad = useCallback(async () => {
     onLoad?.()
     const wp = WearablePreview.createController(value.name)
-    void wp.scene.getScreenshot(WIDTH, HEIGHT).then(($) => {
-      setTimeout(() => {
-        onScreenshot($)
-        setLoading(false)
-      }, 1000) // ugly hack to avoid iframe flickering...
+    const length = await wp.emote.getLength()
+    void wp.emote.goTo(length * 0.5).then(() => {
+      void wp.scene.getScreenshot(WIDTH, HEIGHT).then(($) => {
+        setTimeout(() => {
+          onScreenshot($)
+          setLoading(false)
+        }, 1000) // ugly hack to avoid iframe flickering...
+      })
     })
+    // void wp.scene.getScreenshot(WIDTH, HEIGHT).then(($) => {
+    //   setTimeout(() => {
+    //     onScreenshot($)
+    //     setLoading(false)
+    //   }, 1000) // ugly hack to avoid iframe flickering...
+    // })
   }, [onLoad])
+
+  const wearablePreviewExtraOptions = {
+    profile: 'default',
+    disableFace: true,
+    disableDefaultWearables: true,
+    skin: '000000',
+    wheelZoom: 2
+  }
 
   return (
     <>
       <div className={cx('GltfPreview', { hidden: loading })}>
         <WearablePreview
           id={value.name}
-          blob={toWearableWithBlobs(value, resources)}
+          blob={toEmoteWithBlobs(value, resources)}
           disableAutoRotate
           disableBackground
+          {...wearablePreviewExtraOptions}
           projection={PreviewProjection.ORTHOGRAPHIC}
           camera={PreviewCamera.STATIC}
           onLoad={handleLoad}

--- a/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -15,13 +15,21 @@ import { useRef } from 'react'
 const WIDTH = 300
 const HEIGHT = 300
 
-export function AssetPreview({ value, resources, onScreenshot, onLoad }: Props) {
+export function AssetPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props) {
   const preview = useMemo(() => {
     const ext = value.name.split('.').pop()
     switch (ext) {
       case 'gltf':
       case 'glb':
-        return <GltfPreview value={value} resources={resources} onScreenshot={onScreenshot} onLoad={onLoad} />
+        return (
+          <GltfPreview
+            value={value}
+            resources={resources}
+            onScreenshot={onScreenshot}
+            onLoad={onLoad}
+            isEmote={isEmote}
+          />
+        )
       case 'png':
       case 'jpg':
       case 'jpeg':

--- a/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { PreviewCamera, PreviewProjection } from '@dcl/schemas'
 import cx from 'classnames'
 import { WearablePreview } from 'decentraland-ui'
@@ -6,7 +6,7 @@ import { AiFillSound } from 'react-icons/ai'
 import { IoVideocamOutline } from 'react-icons/io5'
 import { FaFile } from 'react-icons/fa'
 
-import { toEmoteWithBlobs, toWearableWithBlobs, isEmote } from './utils'
+import { toEmoteWithBlobs, toWearableWithBlobs } from './utils'
 import { Props } from './types'
 
 import './AssetPreview.css'

--- a/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
+++ b/packages/@dcl/inspector/src/components/AssetPreview/AssetPreview.tsx
@@ -48,17 +48,8 @@ export function AssetPreview({ value, resources, onScreenshot, onLoad, isEmote }
   return <div className="AssetPreview">{preview}</div>
 }
 
-function GltfPreview({ value, resources, onScreenshot, onLoad }: Props) {
+function GltfPreview({ value, resources, onScreenshot, onLoad, isEmote }: Props) {
   const [loading, setLoading] = useState(true)
-  const [isEmoteFile, setIsEmoteFile] = useState(false)
-
-  useEffect(() => {
-    const checkIfEmote = async () => {
-      const isEmoteResult = await isEmote(value)
-      setIsEmoteFile(isEmoteResult)
-    }
-    void checkIfEmote()
-  }, [value])
 
   const handleScreenshot = useCallback(
     (screenshot: string) => {
@@ -73,8 +64,7 @@ function GltfPreview({ value, resources, onScreenshot, onLoad }: Props) {
   const handleLoad = useCallback(async () => {
     onLoad?.()
     const wp = WearablePreview.createController(value.name)
-
-    if (isEmoteFile) {
+    if (isEmote) {
       const length = await wp.emote.getLength()
       //takes a screenshot at the middle of the emote
       void wp.emote.goTo(length * 0.5).then(() => {
@@ -83,9 +73,9 @@ function GltfPreview({ value, resources, onScreenshot, onLoad }: Props) {
     } else {
       void wp.scene.getScreenshot(WIDTH, HEIGHT).then(handleScreenshot)
     }
-  }, [onLoad, value, isEmoteFile, handleScreenshot])
+  }, [onLoad, value, isEmote, handleScreenshot])
 
-  const wearablePreviewExtraOptions = isEmoteFile
+  const wearablePreviewExtraOptions = isEmote
     ? {
         profile: 'default',
         disableFace: true,
@@ -100,7 +90,7 @@ function GltfPreview({ value, resources, onScreenshot, onLoad }: Props) {
       <div className={cx('GltfPreview', { hidden: loading })}>
         <WearablePreview
           id={value.name}
-          blob={isEmoteFile ? toEmoteWithBlobs(value, resources) : toWearableWithBlobs(value, resources)}
+          blob={isEmote ? toEmoteWithBlobs(value, resources) : toWearableWithBlobs(value, resources)}
           disableAutoRotate
           disableBackground
           {...wearablePreviewExtraOptions}

--- a/packages/@dcl/inspector/src/components/AssetPreview/types.ts
+++ b/packages/@dcl/inspector/src/components/AssetPreview/types.ts
@@ -3,4 +3,5 @@ export interface Props {
   resources?: File[]
   onScreenshot: (value: string) => void
   onLoad?: () => void
+  isEmote?: boolean
 }

--- a/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
+++ b/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
@@ -1,4 +1,4 @@
-import { BodyShape, WearableCategory, WearableWithBlobs } from '@dcl/schemas'
+import { BodyShape, EmoteCategory, EmoteWithBlobs, WearableCategory, WearableWithBlobs } from '@dcl/schemas'
 
 export function toWearableWithBlobs(file: File, resources: File[] = []): WearableWithBlobs {
   return {
@@ -31,6 +31,38 @@ export function toWearableWithBlobs(file: File, resources: File[] = []): Wearabl
           overrideReplaces: []
         }
       ]
+    }
+  }
+}
+
+export function toEmoteWithBlobs(file: File, resources: File[] = []): EmoteWithBlobs {
+  return {
+    id: file.name,
+    name: file.name,
+    description: '',
+    image: '',
+    thumbnail: '',
+    i18n: [],
+    emoteDataADR74: {
+      category: EmoteCategory.DANCE,
+      tags: [],
+      representations: [
+        {
+          bodyShapes: [BodyShape.MALE, BodyShape.FEMALE],
+          mainFile: file.name || 'model.glb',
+          contents: [
+            {
+              key: file.name,
+              blob: file
+            },
+            ...resources?.map((resource) => ({
+              key: resource.name,
+              blob: resource
+            }))
+          ]
+        }
+      ],
+      loop: false
     }
   }
 }

--- a/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
+++ b/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
@@ -90,8 +90,8 @@ export async function isEmote(file: File): Promise<boolean> {
     if (!armature) return false
 
     const hasAvatarChildren = armature.getChildren().some((child) => child.name.startsWith('Avatar_'))
-
-    return hasAvatarChildren
+    const hasProp = armature.getChildren().some((child) => child.name.startsWith('Armature_Prop'))
+    return hasAvatarChildren || hasProp
   } catch (err) {
     console.error('Error checking if file is emote:', err)
     return false

--- a/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
+++ b/packages/@dcl/inspector/src/components/AssetPreview/utils.ts
@@ -1,4 +1,8 @@
 import { BodyShape, EmoteCategory, EmoteWithBlobs, WearableCategory, WearableWithBlobs } from '@dcl/schemas'
+import { Engine } from '@babylonjs/core/Engines/engine'
+import { Scene } from '@babylonjs/core/scene'
+import { SceneLoader } from '@babylonjs/core/Loading/sceneLoader'
+import '@babylonjs/loaders/glTF'
 
 export function toWearableWithBlobs(file: File, resources: File[] = []): WearableWithBlobs {
   return {
@@ -64,5 +68,36 @@ export function toEmoteWithBlobs(file: File, resources: File[] = []): EmoteWithB
       ],
       loop: false
     }
+  }
+}
+
+export async function isEmote(file: File): Promise<boolean> {
+  const url = URL.createObjectURL(file)
+  const canvas = document.createElement('canvas')
+  const engine = new Engine(canvas, false)
+  const scene = new Scene(engine)
+
+  try {
+    const result = await SceneLoader.LoadAssetContainerAsync(
+      '',
+      url,
+      scene,
+      undefined,
+      file.name.endsWith('.gltf') ? '.gltf' : '.glb'
+    )
+
+    const armature = result.transformNodes.find((node) => node.name === 'Armature')
+    if (!armature) return false
+
+    const hasAvatarChildren = armature.getChildren().some((child) => child.name.startsWith('Avatar_'))
+
+    return hasAvatarChildren
+  } catch (err) {
+    console.error('Error checking if file is emote:', err)
+    return false
+  } finally {
+    URL.revokeObjectURL(url)
+    scene.dispose()
+    engine.dispose()
   }
 }

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io'
 import cx from 'classnames'
 
@@ -8,10 +8,10 @@ import { Loading } from '../../Loading'
 
 import { getAssetSize, getAssetResources } from '../utils'
 import { Asset } from '../types'
-import { Thumbnails } from './types'
+import { AssetWithEmote, Thumbnails } from './types'
 
 interface AssetSlidesProps {
-  uploadedAssets: Asset[]
+  uploadedAssets: AssetWithEmote[]
   currentSlide: number
   screenshots: Thumbnails
   onSlideChange: (newSlide: number) => void
@@ -40,19 +40,6 @@ export function AssetSlides({
   const manyAssets = uploadedAssets.length > 1
   const leftArrowDisabled = currentSlide <= 0
   const rightArrowDisabled = currentSlide >= uploadedAssets.length - 1
-
-  const hasEmoteName = (asset: Asset) => {
-    return asset.name.endsWith('_emote')
-  }
-
-  useEffect(() => {
-    uploadedAssets.forEach((asset, index) => {
-      if (asset.isEmote && !hasEmoteName(asset)) {
-        const newName = `${asset.name}_emote`
-        onNameChange(index)(newName)
-      }
-    })
-  }, [])
 
   return (
     <div className="content">

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
@@ -41,6 +41,10 @@ export function AssetSlides({
   const leftArrowDisabled = currentSlide <= 0
   const rightArrowDisabled = currentSlide >= uploadedAssets.length - 1
 
+  const hasEmoteName = (asset: Asset) => {
+    return asset.name.endsWith('_emote')
+  }
+
   return (
     <div className="content">
       {manyAssets && (
@@ -52,14 +56,25 @@ export function AssetSlides({
         {uploadedAssets.map(($, i) => (
           <div className={cx('asset', { active: currentSlide === i })} key={i}>
             <div>
-              <AssetPreview value={$.blob} resources={getAssetResources($)} onScreenshot={onScreenshot($)} />
+              <AssetPreview
+                value={$.blob}
+                resources={getAssetResources($)}
+                onScreenshot={onScreenshot($)}
+                isEmote={$.isEmote}
+              />
               {screenshots[$.blob.name] ? (
                 <div className="thumbnail" style={{ backgroundImage: `url(${screenshots[$.blob.name]})` }}></div>
               ) : (
                 <Loading dimmer={false} />
               )}
               <Input value={$.name} onChange={onNameChange(i)} />
-              {!isNameUnique($) && <span className="name-error">Filename already exists</span>}
+              {$.isEmote && !hasEmoteName($) ? (
+                <span className="name-error">
+                  If you’re trying to upload an emote, please make sure the file name ends in _emote
+                </span>
+              ) : !isNameUnique($) ? (
+                <span className="name-error">Filename already exists</span>
+              ) : null}
             </div>
             <span className="size">{getAssetSize($)}</span>
           </div>

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/AssetSlides.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io'
 import cx from 'classnames'
 
@@ -45,6 +45,15 @@ export function AssetSlides({
     return asset.name.endsWith('_emote')
   }
 
+  useEffect(() => {
+    uploadedAssets.forEach((asset, index) => {
+      if (asset.isEmote && !hasEmoteName(asset)) {
+        const newName = `${asset.name}_emote`
+        onNameChange(index)(newName)
+      }
+    })
+  }, [])
+
   return (
     <div className="content">
       {manyAssets && (
@@ -68,13 +77,7 @@ export function AssetSlides({
                 <Loading dimmer={false} />
               )}
               <Input value={$.name} onChange={onNameChange(i)} />
-              {$.isEmote && !hasEmoteName($) ? (
-                <span className="name-error">
-                  If you’re trying to upload an emote, please make sure the file name ends in _emote
-                </span>
-              ) : !isNameUnique($) ? (
-                <span className="name-error">Filename already exists</span>
-              ) : null}
+              {!isNameUnique($) && <span className="name-error">Filename already exists</span>}
             </div>
             <span className="size">{getAssetSize($)}</span>
           </div>

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/Slider.tsx
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/Slider.tsx
@@ -10,6 +10,7 @@ import { PropTypes, Thumbnails } from './types'
 import './Slider.css'
 import { Error } from '../Error'
 import { Button } from '../../Button'
+import { useSliderAssets } from './useSliderAssets'
 
 enum ImportStep {
   UPLOAD = 'upload',
@@ -17,7 +18,7 @@ enum ImportStep {
 }
 
 export function Slider({ assets, onSubmit, isNameValid }: PropTypes) {
-  const [uploadedAssets, setUploadedAssets] = useState(assets)
+  const { assets: uploadedAssets, setAssets: setUploadedAssets } = useSliderAssets(assets)
   const [slide, setSlide] = useState(0)
   const [screenshots, setScreenshots] = useState<Thumbnails>({})
   const [step, setStep] = useState<ImportStep>(ImportStep.UPLOAD)

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/types.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/types.ts
@@ -1,9 +1,11 @@
 import { Asset } from '../types'
 
 export type PropTypes = {
-  assets: Asset[]
+  assets: AssetWithEmote[]
   onSubmit(assets: Asset[]): void
   isNameValid(asset: Asset, newName: string): boolean
 }
+
+export type AssetWithEmote = Asset & { isEmote?: boolean }
 
 export type Thumbnails = Record<string, string>

--- a/packages/@dcl/inspector/src/components/ImportAsset/Slider/useSliderAssets.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/Slider/useSliderAssets.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { isEmote } from '../../AssetPreview/utils'
+import { Asset } from '../types'
+import { AssetWithEmote } from './types'
+
+export function useSliderAssets(_assets: Asset[]) {
+  const [assets, setAssets] = useState<AssetWithEmote[]>([])
+
+  const hasEmoteName = (asset: Asset) => {
+    return asset.name.endsWith('_emote')
+  }
+
+  const processAssets = async (assetsToProcess: Asset[]) => {
+    try {
+      const newAssets = await Promise.all(
+        assetsToProcess.map(async (asset) => {
+          const isEmoteFile = await isEmote(asset.blob)
+          return {
+            ...asset,
+            isEmote: isEmoteFile,
+            name: isEmoteFile && !hasEmoteName(asset) ? `${asset.name}_emote` : asset.name
+          }
+        })
+      )
+      setAssets(newAssets)
+    } catch (error) {
+      console.error('Error processing assets:', error)
+      setAssets([])
+    }
+  }
+
+  useEffect(() => {
+    void processAssets(_assets)
+  }, [_assets])
+
+  return { assets, setAssets }
+}

--- a/packages/@dcl/inspector/src/components/ImportAsset/types.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/types.ts
@@ -4,6 +4,7 @@ export type BaseAsset = {
   extension: string
   error?: ValidationError
   thumbnail?: string
+  isEmote?: boolean
 }
 
 export type ModelAsset = BaseAsset & {

--- a/packages/@dcl/inspector/src/components/ImportAsset/types.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/types.ts
@@ -4,7 +4,6 @@ export type BaseAsset = {
   extension: string
   error?: ValidationError
   thumbnail?: string
-  isEmote?: boolean
 }
 
 export type ModelAsset = BaseAsset & {

--- a/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
@@ -2,7 +2,6 @@
 const validator = require('gltf-validator')
 
 import { BaseAsset, ModelAsset, ValidationError, Asset, isModelAsset, Gltf, AssetType } from './types'
-import { isEmote } from '../AssetPreview/utils'
 
 const sampleIndex = (list: any[]) => Math.floor(Math.random() * list.length)
 

--- a/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
@@ -176,14 +176,11 @@ async function processFile(file: File): Promise<BaseAsset> {
     return { blob: file, name, extension, error: extensionError }
   }
 
-  const isEmoteFile = await isEmote(file)
-
   const sizeError = validateFileSize(file.size)
   if (sizeError) {
-    return { blob: file, name, extension, error: sizeError, isEmote: isEmoteFile }
+    return { blob: file, name, extension, error: sizeError }
   }
-
-  return { blob: file, name, extension, isEmote: isEmoteFile }
+  return { blob: file, name, extension }
 }
 
 async function validateModelWithDependencies(model: ModelAsset): Promise<ValidationError> {

--- a/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
+++ b/packages/@dcl/inspector/src/components/ImportAsset/utils.ts
@@ -2,6 +2,7 @@
 const validator = require('gltf-validator')
 
 import { BaseAsset, ModelAsset, ValidationError, Asset, isModelAsset, Gltf, AssetType } from './types'
+import { isEmote } from '../AssetPreview/utils'
 
 const sampleIndex = (list: any[]) => Math.floor(Math.random() * list.length)
 
@@ -175,12 +176,14 @@ async function processFile(file: File): Promise<BaseAsset> {
     return { blob: file, name, extension, error: extensionError }
   }
 
+  const isEmoteFile = await isEmote(file)
+
   const sizeError = validateFileSize(file.size)
   if (sizeError) {
-    return { blob: file, name, extension, error: sizeError }
+    return { blob: file, name, extension, error: sizeError, isEmote: isEmoteFile }
   }
 
-  return { blob: file, name, extension }
+  return { blob: file, name, extension, isEmote: isEmoteFile }
 }
 
 async function validateModelWithDependencies(model: ModelAsset): Promise<ValidationError> {


### PR DESCRIPTION
- Detecting whether a GLB/GLTF file is an emote or a regular model to show the correct preview and UI behavior.
- Ensures that emotes have filenames ending with _emote. If not, the suffix is automatically appended to the name during processing.

To test:
- Import a model, check that it's uploaded correctly
- Import an emote, check that the preview is working and that it's uploaded correctly
- If the emote has the _emote at the end of the name, it will be uploaded directly. Otherwise, it will be automatically added to the emote name

<img width="542" alt="Screenshot 2025-06-25 at 17 29 42" src="https://github.com/user-attachments/assets/71112a84-32ec-42e6-a8e8-3af1192e11b8" />
