### PR TITLE
avoid bundle of index.js if there is a change that is not a .ts file.

### DIFF
--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/gizmo-manager.ts
@@ -18,6 +18,7 @@ import { SceneContext } from './SceneContext'
 import { PatchedGizmoManager } from './gizmo-patch'
 import { ROOT } from '../../sdk/tree'
 import { LEFT_BUTTON } from './mouse-utils'
+import { recursiveCheck } from 'jest-matcher-deep-close-to/lib/recursiveCheck'
 
 const GIZMO_DUMMY_NODE = 'GIZMO_DUMMY_NODE'
 
@@ -160,12 +161,16 @@ export function createGizmoManager(context: SceneContext) {
 
   function updateEntityTransform(entity: Entity, newTransform: TransformType) {
     const { position, scale, rotation, parent } = newTransform
-    context.operations.updateValue(context.Transform, entity, {
+    const transform = {
       position: DclVector3.create(position.x, position.y, position.z),
       rotation: DclQuaternion.create(rotation.x, rotation.y, rotation.z, rotation.w),
       scale: DclVector3.create(scale.x, scale.y, scale.z),
       parent
-    })
+    }
+    if (!recursiveCheck(context.Transform.get(entity), transform, 2)) {
+      return
+    }
+    context.operations.updateValue(context.Transform, entity, transform)
   }
 
   /**

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -170,6 +170,7 @@ export async function generateEntityNamesType(
     const namesSet = new Set(names)
 
     if (namesSet.difference(__ENTITY_NAMES_CACHE).size === 0) {
+      console.log('[BOEDO]: Same content 1')
       return
     }
 
@@ -221,6 +222,7 @@ export async function generateEntityNamesType(
     if (fileExists) {
       const existingContent = (await fs.readFile(outputPath)).toString('utf-8')
       if (existingContent === fileContent) {
+        console.log('[BOEDO]: Same content 2')
         // Content is identical, no need to write
         return
       }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -149,7 +149,6 @@ export async function generateEntityNamesType(
 ): Promise<void> {
   try {
     // Find the Name component definition
-
     const NameComponent: typeof Name = engine.getComponentOrNull(Name.componentId) as typeof Name
 
     if (!NameComponent) {
@@ -208,7 +207,17 @@ export async function generateEntityNamesType(
 
     fileContent += `} \n`
 
-    // Write to file
+    // Check if file exists and compare content before writing
+    const fileExists = await fs.existFile(outputPath)
+    if (fileExists) {
+      const existingContent = (await fs.readFile(outputPath)).toString('utf-8')
+      if (existingContent === fileContent) {
+        // Content is identical, no need to write
+        return
+      }
+    }
+
+    // Write to file only if content is different or file doesn't exist
     await fs.writeFile(outputPath, Buffer.from(fileContent, 'utf-8'))
   } catch (e) {
     console.error('Fail to generate entity names types', e)

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -141,6 +141,8 @@ export function dumpEngineToCrdtCommands(engine: IEngine): Uint8Array {
  * @param fs FileSystem interface for writing the file
  * @returns Promise that resolves when the file has been written
  */
+
+let __ENTITY_NAMES_CACHE: Set<string> = new Set()
 export async function generateEntityNamesType(
   engine: IEngine,
   outputPath: string = 'scene-entity-names.d.ts',
@@ -165,9 +167,16 @@ export async function generateEntityNamesType(
 
     // Sort names for consistency
     names.sort()
+    const namesSet = new Set(names)
+
+    if (namesSet.difference(__ENTITY_NAMES_CACHE).size === 0) {
+      return
+    }
+
+    __ENTITY_NAMES_CACHE = namesSet
 
     // Remove duplicates
-    const uniqueNames = Array.from(new Set(names))
+    const uniqueNames = Array.from(namesSet)
 
     // Generate valid TypeScript identifiers and handle duplicates in a single pass
     const validNameMap = new Map<string, string>()
@@ -220,6 +229,6 @@ export async function generateEntityNamesType(
     // Write to file only if content is different or file doesn't exist
     await fs.writeFile(outputPath, Buffer.from(fileContent, 'utf-8'))
   } catch (e) {
-    console.error('Fail to generate entity names types', e)
+    console.error(`Fail to generate entity names types: ${e}\n`)
   }
 }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/engine-to-composite.ts
@@ -170,7 +170,6 @@ export async function generateEntityNamesType(
     const namesSet = new Set(names)
 
     if (namesSet.difference(__ENTITY_NAMES_CACHE).size === 0) {
-      console.log('[BOEDO]: Same content 1')
       return
     }
 
@@ -222,7 +221,6 @@ export async function generateEntityNamesType(
     if (fileExists) {
       const existingContent = (await fs.readFile(outputPath)).toString('utf-8')
       if (existingContent === fileContent) {
-        console.log('[BOEDO]: Same content 2')
         // Content is identical, no need to write
         return
       }

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -44,7 +44,7 @@ export async function wireFileWatcherToWebSockets(
       'all',
       debounce(async (a, file) => {
         if (desktopClient) {
-          updateScene(sceneId, file, components.logger)
+          updateScene(sceneId, file)
         }
         return __LEGACY__updateScene(projectRoot, sceneUpdateClients, projectKind)
       }, 800)
@@ -56,10 +56,7 @@ function isGLTFModel(file: string) {
   return file.toLowerCase().endsWith('.glb') || file.toLowerCase().endsWith('.gltf')
 }
 
-type Logger = Pick<PreviewComponents, 'logger'>['logger']
-
-function updateScene(sceneId: string, file: string, logger: Logger) {
-  logger.info('[updateScene]: ', { file })
+function updateScene(sceneId: string, file: string) {
   let message: WsSceneMessage['message']
   if (isGLTFModel(file)) {
     message = {

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -11,14 +11,8 @@ import {
   WsSceneMessage,
   UpdateModelType
 } from '@dcl/protocol/out-js/decentraland/sdk/development/local_development.gen'
+import { debounce } from '../../../logic/debounce'
 
-function debounce<T extends (...args: any[]) => void>(callback: T, delay: number) {
-  let debounceTimer: NodeJS.Timeout
-  return (...args: Parameters<T>) => {
-    clearTimeout(debounceTimer)
-    debounceTimer = setTimeout(() => callback(...args), delay)
-  }
-}
 /**
  * This function gets file modification events and sends them to all the connected
  * websockets, it is used to hot-reload assets of the scene.

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -16,6 +16,7 @@ import { printProgressInfo, printProgressStep, printWarning } from './beautiful-
 import { CliError } from './error'
 import { getAllComposites } from './composite'
 import { isEditorScene } from './project-validations'
+import { watch } from 'chokidar'
 
 export type BundleComponents = Pick<CliComponents, 'logger' | 'fs'>
 
@@ -197,9 +198,28 @@ export async function bundleSingleProject(components: BundleComponents, options:
 
   /* istanbul ignore if */
   if (options.watch) {
-    await context.watch({})
+    // Instead of using esbuild's watch, we create our own watcher
+    const watcher = watch('**/*.{ts,tsx,js,jsx}', {
+      ignored: ['**/dist/**', '**/*.crdt', '**/*.composite', path.dirname(options.outputFile) + '/**'],
+      ignoreInitial: true,
+      cwd: options.workingDirectory
+    })
 
+    watcher.on('all', async (event, path) => {
+      try {
+        printProgressInfo(components.logger, `File ${path} changed, rebuilding...`)
+        await context.rebuild()
+        printProgressInfo(components.logger, `Bundle saved ${colors.bold(options.outputFile)}`)
+      } catch (err: any) {
+        /* istanbul ignore next */
+        components.logger.error(err.toString())
+      }
+    })
+
+    // Do initial build
+    await context.rebuild()
     printProgressInfo(components.logger, `Bundle saved ${colors.bold(options.outputFile)}`)
+    printProgressInfo(components.logger, `The compiler is watching for changes`)
   } else {
     try {
       await context.rebuild()

--- a/packages/@dcl/sdk-commands/src/logic/debounce.ts
+++ b/packages/@dcl/sdk-commands/src/logic/debounce.ts
@@ -1,0 +1,7 @@
+export function debounce<T extends (...args: any[]) => void>(callback: T, delay: number) {
+  let debounceTimer: NodeJS.Timeout
+  return (...args: Parameters<T>) => {
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => callback(...args), delay)
+  }
+}

--- a/scripts/prepare.spec.ts
+++ b/scripts/prepare.spec.ts
@@ -129,26 +129,3 @@ function installCrossDependencies(...paths: string[]) {
     }
   }
 }
-
-function checkNoLocalPackages(...paths: string[]) {
-  for (const path of paths) {
-    const packageJson = resolve(path, 'package.json')
-    it('checking ' + packageJson, async () => {
-      const { dependencies, devDependencies } = JSON.parse(await readFile(packageJson, 'utf-8'))
-      const errors: string[] = []
-      for (const [key, value] of Object.entries({ ...dependencies, ...devDependencies } as Record<string, string>)) {
-        if (
-          value.startsWith('file:') ||
-          value.startsWith('http:') ||
-          value.startsWith('https:') ||
-          value.startsWith('git:')
-        ) {
-          errors.push(`Dependency ${key} is not pointing to a published version: ${value}`)
-        }
-      }
-      if (errors.length) {
-        throw new Error(errors.join('\n'))
-      }
-    })
-  }
-}


### PR DESCRIPTION
## Inspector Changes 
- avoid doing a Hot reload every time you click on the editor canvas.

## Entity-Names file
EntityNames was being updated every time there was a change on the editor, and this was generating a re-build of the index.js file so we were doing unnecessary builds of the code, causing sometimes another hot-reload.
Add a mechanism of cache to check if we need to re-write the file, this way we ensure that if we do an update its really necessary.

## Watcher
Every time there was a change in a model, or a file that is not a code file, we were generating a re-build of the bin/index.js  file. If the build took some time it can cause another hot-reload.
Now we use a custom watch to only watch the chagnes in the .ts files.

Also add a debounce in the watcher to avoid running the re-build on every change. This was sometimes generating the explorer to crash
