### PR TITLE
feat: Update animations after changing GLTF

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -145,7 +145,6 @@ export default withSdk<Props>(({ sdk, entity: entityId }) => {
   )
 
   useEffect(() => {
-    debugger
     if (entity && gltfValue) {
       const currentGltfSrc = entity.ecsComponentValues.gltfContainer?.src
       const isChangingGltf = currentGltfSrc !== gltfValue.src

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -145,8 +145,15 @@ export default withSdk<Props>(({ sdk, entity: entityId }) => {
   )
 
   useEffect(() => {
+    debugger
     if (entity && gltfValue) {
-      entity.resetGltfAssetContainerLoading()
+      const currentGltfSrc = entity.ecsComponentValues.gltfContainer?.src
+      const isChangingGltf = currentGltfSrc !== gltfValue.src
+
+      if (isChangingGltf) {
+        entity.resetGltfAssetContainerLoading()
+      }
+
       updateGltfForEntity(entity, gltfValue)
       entity
         .onGltfContainerLoaded()

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -22,6 +22,7 @@ import { useArrayState } from '../../../hooks/useArrayState'
 import { analytics, Event } from '../../../lib/logic/analytics'
 import { EditorComponentsTypes } from '../../../lib/sdk/components'
 import { getAssetByModel } from '../../../lib/logic/catalog'
+import { updateGltfForEntity } from '../../../lib/babylon/decentraland/sdkComponents/gltf-container'
 
 import { Block } from '../../Block'
 import { Container } from '../../Container'
@@ -59,7 +60,6 @@ import { getDefaultPayload, getPartialPayload, isStates } from './utils'
 import { Props } from './types'
 
 import './ActionInspector.css'
-import { updateGltfForEntity } from '../../../lib/babylon/decentraland/sdkComponents/gltf-container'
 
 const ActionMapOption: Record<string, string> = {
   [ActionType.PLAY_ANIMATION]: 'Play Animation',

--- a/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/ActionInspector/ActionInspector.tsx
@@ -146,7 +146,6 @@ export default withSdk<Props>(({ sdk, entity: entityId }) => {
 
   useEffect(() => {
     if (entity && gltfValue) {
-      debugger
       entity.resetGltfAssetContainerLoading()
       updateGltfForEntity(entity, gltfValue)
       entity

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/EcsEntity.ts
@@ -128,6 +128,10 @@ export class EcsEntity extends BABYLON.TransformNode {
     return this.#gltfAssetContainerLoading
   }
 
+  resetGltfAssetContainerLoading() {
+    this.#gltfAssetContainerLoading = future()
+  }
+
   setGltfAssetContainer(gltfAssetContainer: BABYLON.AssetContainer) {
     this.gltfAssetContainer = gltfAssetContainer
     this.#gltfAssetContainerLoading.resolve(gltfAssetContainer)


### PR DESCRIPTION
Reset gltfAssetContainerLoading future to ensure new animations  are loaded when switching between different GLTF models

https://github.com/user-attachments/assets/a4ac955e-2e24-4d7d-88ae-552e067c15f1

