### PR TITLE
chore: fix sync main to experimental when branches diverge

### DIFF
--- a/.github/workflows/sync-main-to-experimental.yml
+++ b/.github/workflows/sync-main-to-experimental.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase false  # Always merge, never rebase
 
       - name: Sync main into experimental branch
         run: |


### PR DESCRIPTION
This PR updates the sync workflow to explicitly use a merge strategy (git pull --no-rebase) when pulling changes from main into experimental.
This prevents workflow failures caused by divergent branches and ensures consistent behavior when syncing changes.