### PR TITLE
chore: remove debug param for explorer alpha

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -55,7 +55,6 @@ async function runApp(
     params.set('dclenv', dclenv)
 
     params.set('local-scene', 'true')
-    params.set('debug', 'true')
 
     if (isHub) {
       params.set('hub', 'true')


### PR DESCRIPTION
Removed `--debug` app param injection when opening explorer alpha.

Since `v0.80` Explorer Alpha shows only creator [pertinent sections in the debug panel](https://github.com/decentraland/unity-explorer/pull/4689) while in Local Scene Dev mode unless the `--debug` app param is there.