### PR TITLE
chore: remove compile_apis call in 'make update-protocol' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ update-protocol:
 	echo "Using protocol tag: $$PROTO_TAG"; \
 	npm i --save-exact @dcl/protocol@$$PROTO_TAG; \
 	(cd packages/@dcl/sdk-commands && npm i --save-exact @dcl/protocol@$$PROTO_TAG); \
-	$(MAKE) sync-deps compile_apis
+	$(MAKE) sync-deps
 
 %:
 	@:


### PR DESCRIPTION
removed unneeded 'make compile_apis' step in 'make update-protocol' command.