### PR TITLE
fix: sync main to experiment CI action error interruption

### DIFF
--- a/.github/workflows/sync-main-to-experimental.yml
+++ b/.github/workflows/sync-main-to-experimental.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     permissions:
       contents: write


### PR DESCRIPTION
Added continue-on-error instruction in YAML