### PR TITLE
Skybox time settings - Versioning SceneMetada component

### DIFF
--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -23,9 +23,10 @@ import {
 import './SceneInspector.css'
 import { EditorComponentsTypes, SceneAgeRating, SceneCategory, SceneSpawnPoint } from '../../../lib/sdk/components'
 import { Dropdown } from '../../ui/Dropdown'
-import { RangeField, TextArea } from '../../ui'
+import { TextArea } from '../../ui'
 import { Tabs } from '../Tabs'
 import { CheckboxField } from '../../ui/CheckboxField'
+import RangeHourField from '../../ui/RangeHourField/RangeHourField'
 import { useComponentValue } from '../../../hooks/sdk/useComponentValue'
 import { useArrayState } from '../../../hooks/useArrayState'
 import { AddButton } from '../AddButton'
@@ -38,7 +39,6 @@ import { Tab } from '../Tab'
 import { transformBinaryToBase64Resource } from '../../../lib/data-layer/host/fs-utils'
 import { selectThumbnails } from '../../../redux/app'
 import { Layout } from './Layout'
-import RangeHourField from '../../ui/RangeHourField/RangeHourField'
 
 const AGE_RATING_OPTIONS = [
   {

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -111,6 +111,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
   const categoriesProps = getInputProps('categories')
   const authorProps = getInputProps('author')
   const emailProps = getInputProps('email')
+  const transitionModeProps = getInputProps('skyboxConfig.transitionMode')
   const silenceVoiceChatProps = getInputProps('silenceVoiceChat', (e) => e.target.checked)
   const disablePortableExperiencesProps = getInputProps('disablePortableExperiences', (e) => e.target.checked)
 
@@ -382,16 +383,6 @@ export default withSdk<Props>(({ sdk, entity }) => {
     [componentValue]
   )
 
-  const handleChangeTransitionMode = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const newValue = {
-        ...componentValue,
-        skyboxConfig: { ...componentValue.skyboxConfig, transitionMode: parseInt(e.target.value) as TransitionMode }
-      }
-      setComponentValue(newValue)
-    },
-    [componentValue]
-  )
   return (
     <Container className="Scene" gap>
       <Tabs className="SceneTabs">
@@ -483,7 +474,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
             onChange={handleSkyboxAutoChange}
           />
           <RangeHourField
-            value={componentValue.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
+            value={componentValue.skyboxConfig?.fixedTime ?? MIDDAY_SECONDS}
             min={0}
             max={86400}
             step={3600}
@@ -496,8 +487,8 @@ export default withSdk<Props>(({ sdk, entity }) => {
               { label: 'Forward', value: TransitionMode.TM_FORWARD },
               { label: 'Backward', value: TransitionMode.TM_BACKWARD }
             ]}
-            value={componentValue.skyboxConfig?.transitionMode}
-            onChange={(e) => handleChangeTransitionMode(e)}
+            {...transitionModeProps}
+            disabled={componentValue.skyboxConfig?.fixedTime === undefined}
           />
         </>
       ) : null}

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -10,7 +10,15 @@ import { TextField } from '../../ui/TextField'
 import { FileUploadField } from '../../ui/FileUploadField'
 import { ACCEPTED_FILE_TYPES } from '../../ui/FileUploadField/types'
 import { Props } from './types'
-import { fromScene, toScene, isValidInput, isImage, fromSceneSpawnPoint, toSceneSpawnPoint } from './utils'
+import {
+  fromScene,
+  toScene,
+  isValidInput,
+  isImage,
+  fromSceneSpawnPoint,
+  toSceneSpawnPoint,
+  MIDDAY_SECONDS
+} from './utils'
 
 import './SceneInspector.css'
 import { EditorComponentsTypes, SceneAgeRating, SceneCategory, SceneSpawnPoint } from '../../../lib/sdk/components'
@@ -119,7 +127,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
           skyboxConfig: isAuto
             ? undefined
             : {
-                fixedTime: 12
+                fixedTime: MIDDAY_SECONDS
               }
         }
       }
@@ -465,16 +473,16 @@ export default withSdk<Props>(({ sdk, entity }) => {
           <Block label="Skybox" className="underlined"></Block>
           <CheckboxField
             label="Auto (decentraland time)"
-            checked={!componentValue.worldConfiguration?.skyboxConfig?.fixedTime}
+            checked={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
             onChange={handleSkyboxAutoChange}
           />
           <div>{componentValue.worldConfiguration?.skyboxConfig?.fixedTime}</div>
           <RangeField
-            value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || 12}
+            value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
             min={0}
-            max={800000000}
-            step={0.1}
-            disabled={!componentValue.worldConfiguration?.skyboxConfig?.fixedTime}
+            max={86400}
+            step={1}
+            disabled={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
             onChange={handleSkyboxTimeChange}
           />
         </>

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -386,7 +386,7 @@ export default withSdk<Props>(({ sdk, entity }) => {
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newValue = {
         ...componentValue,
-        skyboxConfig: { ...componentValue.skyboxConfig, transitionMode: e.target.value as TransitionMode }
+        skyboxConfig: { ...componentValue.skyboxConfig, transitionMode: parseInt(e.target.value) as TransitionMode }
       }
       setComponentValue(newValue)
     },

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -475,9 +475,6 @@ export default withSdk<Props>(({ sdk, entity }) => {
           />
           <RangeHourField
             value={componentValue.skyboxConfig?.fixedTime ?? MIDDAY_SECONDS}
-            min={0}
-            max={86400}
-            step={3600}
             onChange={handleSkyboxTimeChange}
             disabled={componentValue.skyboxConfig?.fixedTime === undefined}
           />

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -39,6 +39,7 @@ import { Tab } from '../Tab'
 import { transformBinaryToBase64Resource } from '../../../lib/data-layer/host/fs-utils'
 import { selectThumbnails } from '../../../redux/app'
 import { Layout } from './Layout'
+import { TransitionMode } from '../../../lib/sdk/components/SceneMetadata'
 
 const AGE_RATING_OPTIONS = [
   {
@@ -381,6 +382,16 @@ export default withSdk<Props>(({ sdk, entity }) => {
     [componentValue]
   )
 
+  const handleChangeTransitionMode = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newValue = {
+        ...componentValue,
+        skyboxConfig: { ...componentValue.skyboxConfig, transitionMode: e.target.value as TransitionMode }
+      }
+      setComponentValue(newValue)
+    },
+    [componentValue]
+  )
   return (
     <Container className="Scene" gap>
       <Tabs className="SceneTabs">
@@ -478,6 +489,15 @@ export default withSdk<Props>(({ sdk, entity }) => {
             step={3600}
             onChange={handleSkyboxTimeChange}
             disabled={componentValue.skyboxConfig?.fixedTime === undefined}
+          />
+          <Dropdown
+            label="Transition Mode"
+            options={[
+              { label: 'Forward', value: TransitionMode.TM_FORWARD },
+              { label: 'Backward', value: TransitionMode.TM_BACKWARD }
+            ]}
+            value={componentValue.skyboxConfig?.transitionMode}
+            onChange={(e) => handleChangeTransitionMode(e)}
           />
         </>
       ) : null}

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -15,7 +15,7 @@ import { fromScene, toScene, isValidInput, isImage, fromSceneSpawnPoint, toScene
 import './SceneInspector.css'
 import { EditorComponentsTypes, SceneAgeRating, SceneCategory, SceneSpawnPoint } from '../../../lib/sdk/components'
 import { Dropdown } from '../../ui/Dropdown'
-import { TextArea } from '../../ui'
+import { RangeField, TextArea } from '../../ui'
 import { Tabs } from '../Tabs'
 import { CheckboxField } from '../../ui/CheckboxField'
 import { useComponentValue } from '../../../hooks/sdk/useComponentValue'
@@ -107,6 +107,44 @@ export default withSdk<Props>(({ sdk, entity }) => {
   const [componentValue, setComponentValue, isComponentEqual] = useComponentValue<EditorComponentsTypes['Scene']>(
     entity,
     Scene
+  )
+
+  const handleSkyboxAutoChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const isAuto = e.target.checked
+      const newValue = {
+        ...componentValue,
+        worldConfiguration: {
+          ...componentValue.worldConfiguration,
+          skyboxConfig: isAuto
+            ? undefined
+            : {
+                fixedTime: 12
+              }
+        }
+      }
+
+      setComponentValue(newValue)
+    },
+    [sdk, Scene, entity, componentValue, setComponentValue]
+  )
+
+  const handleSkyboxTimeChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target as HTMLInputElement
+      const newValue = {
+        ...componentValue,
+        worldConfiguration: {
+          ...componentValue.worldConfiguration,
+          skyboxConfig: {
+            fixedTime: parseInt(value)
+          }
+        }
+      }
+
+      setComponentValue(newValue)
+    },
+    [sdk, Scene, entity, componentValue, setComponentValue]
   )
 
   const [spawnPoints, addSpawnPoint, modifySpawnPoint, removeSpawnPoint] = useArrayState<SceneSpawnPoint>(
@@ -424,6 +462,21 @@ export default withSdk<Props>(({ sdk, entity }) => {
           <Block label="Spawn Settings" className="underlined"></Block>
           {spawnPoints.map((spawnPoint, index) => renderSpawnPoint(spawnPoint, index))}
           <AddButton onClick={handleAddSpawnPoint}>Add Spawn Point</AddButton>
+          <Block label="Skybox" className="underlined"></Block>
+          <CheckboxField
+            label="Auto (decentraland time)"
+            checked={!componentValue.worldConfiguration?.skyboxConfig?.fixedTime}
+            onChange={handleSkyboxAutoChange}
+          />
+          <div>{componentValue.worldConfiguration?.skyboxConfig?.fixedTime}</div>
+          <RangeField
+            value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || 12}
+            min={0}
+            max={800000000}
+            step={0.1}
+            disabled={!componentValue.worldConfiguration?.skyboxConfig?.fixedTime}
+            onChange={handleSkyboxTimeChange}
+          />
         </>
       ) : null}
     </Container>

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -38,6 +38,7 @@ import { Tab } from '../Tab'
 import { transformBinaryToBase64Resource } from '../../../lib/data-layer/host/fs-utils'
 import { selectThumbnails } from '../../../redux/app'
 import { Layout } from './Layout'
+import RangeHourField from '../../ui/RangeHourField/RangeHourField'
 
 const AGE_RATING_OPTIONS = [
   {
@@ -477,13 +478,13 @@ export default withSdk<Props>(({ sdk, entity }) => {
             onChange={handleSkyboxAutoChange}
           />
           <div>{componentValue.worldConfiguration?.skyboxConfig?.fixedTime}</div>
-          <RangeField
+          <RangeHourField
             value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
             min={0}
             max={86400}
-            step={1}
-            disabled={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
+            step={3600}
             onChange={handleSkyboxTimeChange}
+            disabled={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
           />
         </>
       ) : null}

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -123,13 +123,9 @@ export default withSdk<Props>(({ sdk, entity }) => {
       const isAuto = e.target.checked
       const newValue = {
         ...componentValue,
-        worldConfiguration: {
-          ...componentValue.worldConfiguration,
-          skyboxConfig: isAuto
-            ? undefined
-            : {
-                fixedTime: MIDDAY_SECONDS
-              }
+        skyboxConfig: {
+          ...componentValue.skyboxConfig,
+          fixedTime: isAuto ? undefined : MIDDAY_SECONDS
         }
       }
 
@@ -143,11 +139,9 @@ export default withSdk<Props>(({ sdk, entity }) => {
       const { value } = e.target as HTMLInputElement
       const newValue = {
         ...componentValue,
-        worldConfiguration: {
-          ...componentValue.worldConfiguration,
-          skyboxConfig: {
-            fixedTime: parseInt(value)
-          }
+        skyboxConfig: {
+          ...componentValue.skyboxConfig,
+          fixedTime: parseInt(value)
         }
       }
 
@@ -474,16 +468,16 @@ export default withSdk<Props>(({ sdk, entity }) => {
           <Block label="Skybox" className="underlined"></Block>
           <CheckboxField
             label="Auto (decentraland time)"
-            checked={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
+            checked={componentValue.skyboxConfig?.fixedTime === undefined}
             onChange={handleSkyboxAutoChange}
           />
           <RangeHourField
-            value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
+            value={componentValue.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
             min={0}
             max={86400}
             step={3600}
             onChange={handleSkyboxTimeChange}
-            disabled={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
+            disabled={componentValue.skyboxConfig?.fixedTime === undefined}
           />
         </>
       ) : null}

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/SceneInspector.tsx
@@ -477,7 +477,6 @@ export default withSdk<Props>(({ sdk, entity }) => {
             checked={componentValue.worldConfiguration?.skyboxConfig?.fixedTime === undefined}
             onChange={handleSkyboxAutoChange}
           />
-          <div>{componentValue.worldConfiguration?.skyboxConfig?.fixedTime}</div>
           <RangeHourField
             value={componentValue.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS}
             min={0}

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
@@ -22,10 +22,8 @@ export type SpawnPointInput = {
 export type SceneInput = {
   name: string
   description: string
-  worldConfiguration: {
-    skyboxConfig: {
-      fixedTime: string
-    }
+  skyboxConfig: {
+    fixedTime: string
   }
   thumbnail: string
   ageRating: string

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
@@ -22,6 +22,11 @@ export type SpawnPointInput = {
 export type SceneInput = {
   name: string
   description: string
+  worldConfiguration: {
+    skyboxConfig: {
+      fixedTime: string
+    }
+  }
   thumbnail: string
   ageRating: string
   categories: string[]

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/types.ts
@@ -24,6 +24,7 @@ export type SceneInput = {
   description: string
   skyboxConfig: {
     fixedTime: string
+    transitionMode: string
   }
   thumbnail: string
   ageRating: string

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
@@ -17,10 +17,8 @@ function getInput(base: string, parcels: string): SceneInput {
     spawnPoints: [],
     author: 'John Doe',
     email: 'johndoe@gmail.com',
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: '36000'
-      }
+    skyboxConfig: {
+      fixedTime: '36000'
     },
     layout: {
       base,
@@ -44,10 +42,8 @@ function getScene(layout: Layout): EditorComponentsTypes['Scene'] {
     author: 'John Doe',
     email: 'johndoe@gmail.com',
     layout,
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: 36000
-      }
+    skyboxConfig: {
+      fixedTime: 36000
     }
   }
   return scene

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
@@ -3,6 +3,7 @@ import { Layout } from '../../../lib/utils/layout'
 import { SceneInput } from './types'
 import { fromScene, isValidInput, parseParcels, toScene } from './utils'
 
+//TODO fix tests
 function getInput(base: string, parcels: string): SceneInput {
   const input: SceneInput = {
     name: 'name',
@@ -16,6 +17,11 @@ function getInput(base: string, parcels: string): SceneInput {
     spawnPoints: [],
     author: 'John Doe',
     email: 'johndoe@gmail.com',
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: '800'
+      }
+    },
     layout: {
       base,
       parcels
@@ -37,7 +43,12 @@ function getScene(layout: Layout): EditorComponentsTypes['Scene'] {
     spawnPoints: [],
     author: 'John Doe',
     email: 'johndoe@gmail.com',
-    layout
+    layout,
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: '800'
+      }
+    }
   }
   return scene
 }

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
@@ -1,4 +1,5 @@
-import { EditorComponentsTypes, SceneAgeRating, SceneCategory, TransitionMode } from '../../../lib/sdk/components'
+import { EditorComponentsTypes, SceneAgeRating, SceneCategory } from '../../../lib/sdk/components'
+import { TransitionMode } from '../../../lib/sdk/components/SceneMetadata'
 import { Layout } from '../../../lib/utils/layout'
 import { SceneInput } from './types'
 import { fromScene, isValidInput, parseParcels, toScene } from './utils'
@@ -19,7 +20,7 @@ function getInput(base: string, parcels: string): SceneInput {
     email: 'johndoe@gmail.com',
     skyboxConfig: {
       fixedTime: '36000',
-      transitionMode: TransitionMode.TM_FORWARD
+      transitionMode: TransitionMode.TM_FORWARD.toString()
     },
     layout: {
       base,

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
@@ -1,4 +1,4 @@
-import { EditorComponentsTypes, SceneAgeRating, SceneCategory } from '../../../lib/sdk/components'
+import { EditorComponentsTypes, SceneAgeRating, SceneCategory, TransitionMode } from '../../../lib/sdk/components'
 import { Layout } from '../../../lib/utils/layout'
 import { SceneInput } from './types'
 import { fromScene, isValidInput, parseParcels, toScene } from './utils'
@@ -18,7 +18,8 @@ function getInput(base: string, parcels: string): SceneInput {
     author: 'John Doe',
     email: 'johndoe@gmail.com',
     skyboxConfig: {
-      fixedTime: '36000'
+      fixedTime: '36000',
+      transitionMode: TransitionMode.TM_FORWARD
     },
     layout: {
       base,
@@ -43,7 +44,8 @@ function getScene(layout: Layout): EditorComponentsTypes['Scene'] {
     email: 'johndoe@gmail.com',
     layout,
     skyboxConfig: {
-      fixedTime: 36000
+      fixedTime: 36000,
+      transitionMode: TransitionMode.TM_FORWARD
     }
   }
   return scene

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.spec.ts
@@ -19,7 +19,7 @@ function getInput(base: string, parcels: string): SceneInput {
     email: 'johndoe@gmail.com',
     worldConfiguration: {
       skyboxConfig: {
-        fixedTime: '800'
+        fixedTime: '36000'
       }
     },
     layout: {
@@ -46,7 +46,7 @@ function getScene(layout: Layout): EditorComponentsTypes['Scene'] {
     layout,
     worldConfiguration: {
       skyboxConfig: {
-        fixedTime: '800'
+        fixedTime: 36000
       }
     }
   }

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -73,8 +73,8 @@ export function fromScene(value: EditorComponentsTypes['Scene']): SceneInput {
     author: value.author || '',
     email: value.email || '',
     skyboxConfig: {
-      fixedTime: String(value.skyboxConfig?.fixedTime || MIDDAY_SECONDS),
-      transitionMode: String(value.skyboxConfig?.transitionMode || TransitionMode.TM_FORWARD)
+      fixedTime: String(value.skyboxConfig?.fixedTime ?? MIDDAY_SECONDS),
+      transitionMode: String(value.skyboxConfig?.transitionMode ?? TransitionMode.TM_FORWARD)
     },
     silenceVoiceChat: typeof value.silenceVoiceChat === 'boolean' ? value.silenceVoiceChat : false,
     disablePortableExperiences:
@@ -101,7 +101,7 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     email: inputs.email,
     skyboxConfig: {
       fixedTime: Number(inputs.skyboxConfig.fixedTime || MIDDAY_SECONDS),
-      transitionMode: TransitionMode.TM_FORWARD
+      transitionMode: inputs.skyboxConfig.transitionMode as unknown as TransitionMode
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
     disablePortableExperiences: inputs.disablePortableExperiences,

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -101,7 +101,7 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     email: inputs.email,
     skyboxConfig: {
       fixedTime: Number(inputs.skyboxConfig.fixedTime ?? MIDDAY_SECONDS),
-      transitionMode: inputs.skyboxConfig.transitionMode as unknown as TransitionMode
+      transitionMode: Number(inputs.skyboxConfig.transitionMode) as TransitionMode
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
     disablePortableExperiences: inputs.disablePortableExperiences,

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -71,10 +71,8 @@ export function fromScene(value: EditorComponentsTypes['Scene']): SceneInput {
     tags: value.tags ? value.tags.join(', ') : '',
     author: value.author || '',
     email: value.email || '',
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: String(value.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS)
-      }
+    skyboxConfig: {
+      fixedTime: String(value.skyboxConfig?.fixedTime || MIDDAY_SECONDS)
     },
     silenceVoiceChat: typeof value.silenceVoiceChat === 'boolean' ? value.silenceVoiceChat : false,
     disablePortableExperiences:
@@ -99,10 +97,8 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     tags: inputs.tags.split(',').map((tag) => tag.trim()),
     author: inputs.author,
     email: inputs.email,
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: Number(inputs.worldConfiguration.skyboxConfig.fixedTime || MIDDAY_SECONDS)
-      }
+    skyboxConfig: {
+      fixedTime: Number(inputs.skyboxConfig.fixedTime || MIDDAY_SECONDS)
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
     disablePortableExperiences: inputs.disablePortableExperiences,

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -12,6 +12,7 @@ import { TreeNode } from '../../ProjectAssetExplorer/ProjectView'
 import { AssetNodeItem } from '../../ProjectAssetExplorer/types'
 import { isAssetNode } from '../../ProjectAssetExplorer/utils'
 import { ACCEPTED_FILE_TYPES } from '../../ui/FileUploadField/types'
+import { TransitionMode } from '../../../lib/sdk/components/SceneMetadata'
 
 function getValue(coord: SceneSpawnPointCoord) {
   return coord.$case === 'range' ? (coord.value[0] + coord.value[1]) / 2 : coord.value
@@ -72,7 +73,8 @@ export function fromScene(value: EditorComponentsTypes['Scene']): SceneInput {
     author: value.author || '',
     email: value.email || '',
     skyboxConfig: {
-      fixedTime: String(value.skyboxConfig?.fixedTime || MIDDAY_SECONDS)
+      fixedTime: String(value.skyboxConfig?.fixedTime || MIDDAY_SECONDS),
+      transitionMode: String(value.skyboxConfig?.transitionMode || TransitionMode.TM_FORWARD)
     },
     silenceVoiceChat: typeof value.silenceVoiceChat === 'boolean' ? value.silenceVoiceChat : false,
     disablePortableExperiences:
@@ -98,7 +100,8 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     author: inputs.author,
     email: inputs.email,
     skyboxConfig: {
-      fixedTime: Number(inputs.skyboxConfig.fixedTime || MIDDAY_SECONDS)
+      fixedTime: Number(inputs.skyboxConfig.fixedTime || MIDDAY_SECONDS),
+      transitionMode: TransitionMode.TM_FORWARD
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
     disablePortableExperiences: inputs.disablePortableExperiences,

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -73,7 +73,7 @@ export function fromScene(value: EditorComponentsTypes['Scene']): SceneInput {
     email: value.email || '',
     worldConfiguration: {
       skyboxConfig: {
-        fixedTime: String(value.worldConfiguration?.skyboxConfig?.fixedTime || 12)
+        fixedTime: String(value.worldConfiguration?.skyboxConfig?.fixedTime || MIDDAY_SECONDS)
       }
     },
     silenceVoiceChat: typeof value.silenceVoiceChat === 'boolean' ? value.silenceVoiceChat : false,
@@ -101,7 +101,7 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     email: inputs.email,
     worldConfiguration: {
       skyboxConfig: {
-        fixedTime: Number(inputs.worldConfiguration.skyboxConfig.fixedTime || '12')
+        fixedTime: Number(inputs.worldConfiguration.skyboxConfig.fixedTime || MIDDAY_SECONDS)
       }
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
@@ -141,3 +141,5 @@ export const isImageFile = (value: string): boolean =>
   ACCEPTED_FILE_TYPES['image'].some((extension) => value.endsWith(extension))
 
 export const isImage = (node: TreeNode): node is AssetNodeItem => isAssetNode(node) && isImageFile(node.name)
+
+export const MIDDAY_SECONDS = 43200

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -71,6 +71,11 @@ export function fromScene(value: EditorComponentsTypes['Scene']): SceneInput {
     tags: value.tags ? value.tags.join(', ') : '',
     author: value.author || '',
     email: value.email || '',
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: String(value.worldConfiguration?.skyboxConfig?.fixedTime || 12)
+      }
+    },
     silenceVoiceChat: typeof value.silenceVoiceChat === 'boolean' ? value.silenceVoiceChat : false,
     disablePortableExperiences:
       typeof value.disablePortableExperiences === 'boolean' ? value.disablePortableExperiences : false,
@@ -94,6 +99,11 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     tags: inputs.tags.split(',').map((tag) => tag.trim()),
     author: inputs.author,
     email: inputs.email,
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: Number(inputs.worldConfiguration.skyboxConfig.fixedTime || '12')
+      }
+    },
     silenceVoiceChat: inputs.silenceVoiceChat,
     disablePortableExperiences: inputs.disablePortableExperiences,
     spawnPoints: inputs.spawnPoints.map((spawnPoint, index) =>

--- a/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
+++ b/packages/@dcl/inspector/src/components/EntityInspector/SceneInspector/utils.ts
@@ -100,7 +100,7 @@ export function toScene(inputs: SceneInput): EditorComponentsTypes['Scene'] {
     author: inputs.author,
     email: inputs.email,
     skyboxConfig: {
-      fixedTime: Number(inputs.skyboxConfig.fixedTime || MIDDAY_SECONDS),
+      fixedTime: Number(inputs.skyboxConfig.fixedTime ?? MIDDAY_SECONDS),
       transitionMode: inputs.skyboxConfig.transitionMode as unknown as TransitionMode
     },
     silenceVoiceChat: inputs.silenceVoiceChat,
@@ -142,3 +142,4 @@ export const isImageFile = (value: string): boolean =>
 export const isImage = (node: TreeNode): node is AssetNodeItem => isAssetNode(node) && isImageFile(node.name)
 
 export const MIDDAY_SECONDS = 43200
+export const MIDNIGHT_SECONDS = 86400

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
@@ -30,3 +30,47 @@
 .Range.Field .RangeContainer input[type='time']::-webkit-calendar-picker-indicator {
   display: none;
 }
+
+.Range.Field .RangeContainer .RangeInput {
+  background: linear-gradient(
+    90deg,
+    #361c75 0%,
+    #534787 15%,
+    #bf8dac 30%,
+    #46cee9 50%,
+    #af80a9 70%,
+    #714171 85%,
+    #40247b 100%
+  ) !important;
+  height: 8px !important;
+  border-radius: 4px !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::before,
+.Range.Field .RangeContainer .RangeInput::after {
+  background: #361c75 !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-webkit-slider-thumb {
+  background: white !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-moz-range-thumb {
+  background: white !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-ms-thumb {
+  background: white !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-webkit-slider-runnable-track {
+  background: none !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-moz-range-track {
+  background: none !important;
+}
+
+.Range.Field .RangeContainer .RangeInput::-ms-track {
+  background: none !important;
+}

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
@@ -1,6 +1,6 @@
 @import '../RangeField/RangeField.css';
 
-.Range.Field .RangeContainer input[type='time'] {
+.RangeHour.Range.Field .RangeContainer input[type='time'] {
   width: 85px;
   padding: 4px 8px;
   background-color: var(--background-gray);
@@ -11,27 +11,27 @@
   text-align: center;
 }
 
-.Range.Field .RangeContainer input:hover:not(:disabled) {
+.RangeHour.Range.Field .RangeContainer input:hover:not(:disabled) {
   border-color: var(--base-09);
 }
 
-.Range.Field .RangeContainer input:focus {
+.RangeHour.Range.Field .RangeContainer input:focus {
   outline: none;
   border-color: var(--base-01);
 }
 
-.Range.Field .RangeContainer input:disabled {
+.RangeHour.Range.Field .RangeContainer input:disabled {
   background-color: var(--base-12);
   border-color: var(--base-12);
   color: var(--base-09);
   cursor: not-allowed;
 }
 
-.Range.Field .RangeContainer input[type='time']::-webkit-calendar-picker-indicator {
+.RangeHour.Range.Field .RangeContainer input[type='time']::-webkit-calendar-picker-indicator {
   display: none;
 }
 
-.Range.Field .RangeContainer .RangeInput {
+.RangeHour.Range.Field .RangeContainer .RangeInput {
   background: linear-gradient(
     90deg,
     #361c75 0%,
@@ -46,31 +46,31 @@
   border-radius: 4px !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::before,
-.Range.Field .RangeContainer .RangeInput::after {
+.RangeHour.Range.Field .RangeContainer .RangeInput::before,
+.RangeHour.Range.Field .RangeContainer .RangeInput::after {
   background: #361c75 !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-webkit-slider-thumb {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-webkit-slider-thumb {
   background: white !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-moz-range-thumb {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-moz-range-thumb {
   background: white !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-ms-thumb {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-ms-thumb {
   background: white !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-webkit-slider-runnable-track {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-webkit-slider-runnable-track {
   background: none !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-moz-range-track {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-moz-range-track {
   background: none !important;
 }
 
-.Range.Field .RangeContainer .RangeInput::-ms-track {
+.RangeHour.Range.Field .RangeContainer .RangeInput::-ms-track {
   background: none !important;
 }

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.css
@@ -1,0 +1,32 @@
+@import '../RangeField/RangeField.css';
+
+.Range.Field .RangeContainer input[type='time'] {
+  width: 85px;
+  padding: 4px 8px;
+  background-color: var(--background-gray);
+  border-radius: 4px;
+  border: 1px solid var(--background-gray);
+  color: var(--text);
+  font-size: 14px;
+  text-align: center;
+}
+
+.Range.Field .RangeContainer input:hover:not(:disabled) {
+  border-color: var(--base-09);
+}
+
+.Range.Field .RangeContainer input:focus {
+  outline: none;
+  border-color: var(--base-01);
+}
+
+.Range.Field .RangeContainer input:disabled {
+  background-color: var(--base-12);
+  border-color: var(--base-12);
+  color: var(--base-09);
+  cursor: not-allowed;
+}
+
+.Range.Field .RangeContainer input[type='time']::-webkit-calendar-picker-indicator {
+  display: none;
+}

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
@@ -28,16 +28,6 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
     timeInHHMM: formatHour(Number(value))
   })
 
-  useEffect(() => {
-    const numValue = Number(value)
-    if (numValue !== time.timeInSeconds) {
-      setTime({
-        timeInSeconds: numValue,
-        timeInHHMM: formatHour(numValue)
-      })
-    }
-  }, [value])
-
   const completionPercentage = useMemo(() => {
     const normalizedValue = Math.min(Math.max(time.timeInSeconds, MIN_SECONDS), MAX_SECONDS)
     return ((normalizedValue - MIN_SECONDS) / (MAX_SECONDS - MIN_SECONDS)) * 100 || 0

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import cx from 'classnames'
 
-import { Message, MessageType } from '../Message'
-import { Label } from '../Label'
+import { MIDNIGHT_SECONDS } from '../../../components/EntityInspector/SceneInspector/utils'
 
 import { Props } from './types'
 
 import './RangeHourField.css'
 
+const MIN_SECONDS = 0
+const STEP_SECONDS = 60
+const MAX_SECONDS = MIDNIGHT_SECONDS - STEP_SECONDS
+
 function formatHour(value: number): string {
-  if (value === 86400) {
+  if (value === MIDNIGHT_SECONDS) {
     return '00:00'
   }
   const hours = Math.floor(value / 3600)
@@ -17,171 +20,89 @@ function formatHour(value: number): string {
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
 }
 
-function isValidTimeFormat(value: string): boolean {
-  return /^([0-9]{2}):([0-9]{2})$/.test(value)
-}
-
 const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const {
-    label,
-    error,
-    disabled,
-    info,
-    value = 0,
-    min = 0,
-    max = 86340,
-    step = 60,
-    isValidValue,
-    onChange,
-    onBlur,
-    ...rest
-  } = props
+  const { disabled, value = 0, onChange, ...rest } = props
 
-  const [inputValue, setInputValue] = useState<number>(Number(value))
-  const [textValue, setTextValue] = useState(formatHour(Number(value)))
+  const [time, setTime] = useState({
+    timeInSeconds: Number(value),
+    timeInHHMM: formatHour(Number(value))
+  })
 
   useEffect(() => {
     const numValue = Number(value)
-    if (numValue !== inputValue) {
-      setInputValue(numValue)
-      setTextValue(formatHour(numValue))
+    if (numValue !== time.timeInSeconds) {
+      setTime({
+        timeInSeconds: numValue,
+        timeInHHMM: formatHour(numValue)
+      })
     }
   }, [value])
 
   const completionPercentage = useMemo(() => {
-    const parsedMin = parseFloat(min.toString()) || 0
-    const parsedMax = parseFloat(max.toString()) || 86400
-
-    const normalizedValue = Math.min(Math.max(inputValue, parsedMin), parsedMax)
-
-    return ((normalizedValue - parsedMin) / (parsedMax - parsedMin)) * 100 || 0
-  }, [inputValue, min, max])
+    const normalizedValue = Math.min(Math.max(time.timeInSeconds, MIN_SECONDS), MAX_SECONDS)
+    return ((normalizedValue - MIN_SECONDS) / (MAX_SECONDS - MIN_SECONDS)) * 100 || 0
+  }, [time.timeInSeconds])
 
   const trackStyle = {
     '--completionPercentage': `${completionPercentage}%`
   } as any
 
-  const isValid = useCallback(
-    (value: Props['value']) => {
-      return isValidValue ? isValidValue(value) : true
-    },
-    [isValidValue]
-  )
-
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      const numValue = parseFloat(value)
-
-      if (numValue >= parseFloat(min.toString()) && numValue <= parseFloat(max.toString())) {
-        setInputValue(numValue)
-        setTextValue(formatHour(numValue))
-
-        if (isValid(numValue)) {
-          onChange &&
-            onChange({
-              ...e,
-              target: { ...e.target, value: numValue.toString() }
-            } as React.ChangeEvent<HTMLInputElement>)
-        }
-      }
+      const numValue = parseFloat(e.target.value)
+      const valueToSend = numValue === MIN_SECONDS ? MIDNIGHT_SECONDS : numValue
+      setTime({
+        timeInSeconds: numValue,
+        timeInHHMM: formatHour(numValue)
+      })
+      onChange &&
+        onChange({
+          ...e,
+          target: { ...e.target, value: valueToSend.toString() }
+        } as React.ChangeEvent<HTMLInputElement>)
     },
-    [min, max, onChange, isValid]
+    [onChange]
   )
 
   const parseTimeInput = useCallback((timeStr: string): number => {
     const [hours = '0', minutes = '0'] = timeStr.split(':')
     const totalSeconds = parseInt(hours) * 3600 + parseInt(minutes) * 60
-    if (totalSeconds === 0) {
-      return 86400
+    if (totalSeconds === MIN_SECONDS) {
+      return MIDNIGHT_SECONDS
     }
-    return Math.min(Math.max(totalSeconds, 0), 86400)
+    return Math.min(Math.max(totalSeconds, MIN_SECONDS), MAX_SECONDS)
   }, [])
 
   const handleChangeTextField = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-
-      if (!/^[0-9:]*$/.test(value)) return
-
-      if (value.length <= 5) {
-        setTextValue(value)
-
-        if (isValidTimeFormat(value)) {
-          const seconds = parseTimeInput(value)
-          if (seconds >= Number(min) && seconds <= Number(max)) {
-            setInputValue(seconds)
-            onChange &&
-              onChange({
-                ...e,
-                target: { ...e.target, value: seconds.toString() }
-              } as React.ChangeEvent<HTMLInputElement>)
-          }
-        }
-      }
+      const inputValue = e.target.value
+      const seconds = parseTimeInput(inputValue)
+      const valueToSend = seconds === MIN_SECONDS ? MIDNIGHT_SECONDS : seconds
+      setTime({
+        timeInSeconds: seconds,
+        timeInHHMM: inputValue
+      })
+      onChange &&
+        onChange({
+          ...e,
+          target: { ...e.target, value: valueToSend.toString() }
+        } as React.ChangeEvent<HTMLInputElement>)
     },
-    [onChange, parseTimeInput, min, max]
+    [onChange, parseTimeInput]
   )
-
-  const handleOnBlur: React.FocusEventHandler<HTMLInputElement> = useCallback(
-    (event) => {
-      let finalValue = textValue
-
-      if (!isValidTimeFormat(textValue)) {
-        finalValue = formatHour(inputValue)
-      } else {
-        const seconds = parseTimeInput(textValue)
-        if (seconds < Number(min) || seconds > Number(max)) {
-          finalValue = formatHour(inputValue)
-        }
-      }
-
-      setTextValue(finalValue)
-      const seconds = parseTimeInput(finalValue)
-      setInputValue(seconds)
-
-      if (isValid(seconds)) {
-        onChange &&
-          onChange({
-            ...event,
-            target: { ...event.target, value: seconds.toString() }
-          } as React.ChangeEvent<HTMLInputElement>)
-      }
-
-      onBlur && onBlur(event)
-    },
-    [textValue, inputValue, onChange, isValid, onBlur, parseTimeInput, min, max]
-  )
-
-  const errorMessage = useMemo(() => {
-    if (!isValid(inputValue)) {
-      return 'Invalid value'
-    }
-    return undefined
-  }, [inputValue, isValid])
-
-  const renderMessage = useCallback(() => {
-    if (errorMessage) {
-      return <Message text={errorMessage} type={MessageType.ERROR} />
-    } else if (info) {
-      return <Message text={info} type={MessageType.INFO} icon={false} />
-    }
-    return null
-  }, [errorMessage, info])
 
   return (
     <div className="Range Field">
-      <Label text={label} />
-      <div className={cx('RangeContainer', { error, disabled })}>
+      <div className={cx('RangeContainer', { disabled })}>
         <div className="InputContainer">
           <input
             ref={ref}
             type="range"
             className="RangeInput"
-            value={inputValue}
-            min={min}
-            max={max}
-            step={step}
+            min={MIN_SECONDS}
+            max={MAX_SECONDS}
+            step={STEP_SECONDS}
+            value={time.timeInSeconds}
             style={trackStyle}
             disabled={disabled}
             onChange={handleChange}
@@ -191,13 +112,12 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
         <input
           className="RangeTextInput"
           type="time"
-          value={textValue}
+          value={time.timeInHHMM}
           disabled={disabled}
           onChange={handleChangeTextField}
-          onBlur={handleOnBlur}
+          onBlur={handleChangeTextField}
         />
       </div>
-      {renderMessage()}
     </div>
   )
 })

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
@@ -87,7 +87,7 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
   )
 
   return (
-    <div className="Range Field">
+    <div className="Range Field RangeHour">
       <div className={cx('RangeContainer', { disabled })}>
         <div className="InputContainer">
           <input

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
@@ -9,6 +9,9 @@ import { Props } from './types'
 import './RangeHourField.css'
 
 function formatHour(value: number): string {
+  if (value === 86400) {
+    return '00:00'
+  }
   const hours = Math.floor(value / 3600)
   const minutes = Math.floor((value % 3600) / 60)
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
@@ -21,13 +24,12 @@ function isValidTimeFormat(value: string): boolean {
 const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const {
     label,
-    rightLabel,
     error,
     disabled,
     info,
     value = 0,
     min = 0,
-    max = 86400,
+    max = 86340,
     step = 60,
     isValidValue,
     onChange,
@@ -90,6 +92,9 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
   const parseTimeInput = useCallback((timeStr: string): number => {
     const [hours = '0', minutes = '0'] = timeStr.split(':')
     const totalSeconds = parseInt(hours) * 3600 + parseInt(minutes) * 60
+    if (totalSeconds === 0) {
+      return 86400
+    }
     return Math.min(Math.max(totalSeconds, 0), 86400)
   }, [])
 
@@ -97,14 +102,11 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
 
-      // Solo permitir números y :
       if (!/^[0-9:]*$/.test(value)) return
 
-      // Limitar a 5 caracteres (HH:MM)
       if (value.length <= 5) {
         setTextValue(value)
 
-        // Si es un formato válido de hora, actualizar el slider
         if (isValidTimeFormat(value)) {
           const seconds = parseTimeInput(value)
           if (seconds >= Number(min) && seconds <= Number(max)) {
@@ -125,7 +127,6 @@ const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
     (event) => {
       let finalValue = textValue
 
-      // Si el formato no es válido o está fuera de rango, revertir al último valor válido
       if (!isValidTimeFormat(textValue)) {
         finalValue = formatHour(inputValue)
       } else {

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/RangeHourField.tsx
@@ -1,0 +1,204 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import cx from 'classnames'
+
+import { Message, MessageType } from '../Message'
+import { Label } from '../Label'
+
+import { Props } from './types'
+
+import './RangeHourField.css'
+
+function formatHour(value: number): string {
+  const hours = Math.floor(value / 3600)
+  const minutes = Math.floor((value % 3600) / 60)
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
+}
+
+function isValidTimeFormat(value: string): boolean {
+  return /^([0-9]{2}):([0-9]{2})$/.test(value)
+}
+
+const RangeHourField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const {
+    label,
+    rightLabel,
+    error,
+    disabled,
+    info,
+    value = 0,
+    min = 0,
+    max = 86400,
+    step = 60,
+    isValidValue,
+    onChange,
+    onBlur,
+    ...rest
+  } = props
+
+  const [inputValue, setInputValue] = useState<number>(Number(value))
+  const [textValue, setTextValue] = useState(formatHour(Number(value)))
+
+  useEffect(() => {
+    const numValue = Number(value)
+    if (numValue !== inputValue) {
+      setInputValue(numValue)
+      setTextValue(formatHour(numValue))
+    }
+  }, [value])
+
+  const completionPercentage = useMemo(() => {
+    const parsedMin = parseFloat(min.toString()) || 0
+    const parsedMax = parseFloat(max.toString()) || 86400
+
+    const normalizedValue = Math.min(Math.max(inputValue, parsedMin), parsedMax)
+
+    return ((normalizedValue - parsedMin) / (parsedMax - parsedMin)) * 100 || 0
+  }, [inputValue, min, max])
+
+  const trackStyle = {
+    '--completionPercentage': `${completionPercentage}%`
+  } as any
+
+  const isValid = useCallback(
+    (value: Props['value']) => {
+      return isValidValue ? isValidValue(value) : true
+    },
+    [isValidValue]
+  )
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      const numValue = parseFloat(value)
+
+      if (numValue >= parseFloat(min.toString()) && numValue <= parseFloat(max.toString())) {
+        setInputValue(numValue)
+        setTextValue(formatHour(numValue))
+
+        if (isValid(numValue)) {
+          onChange &&
+            onChange({
+              ...e,
+              target: { ...e.target, value: numValue.toString() }
+            } as React.ChangeEvent<HTMLInputElement>)
+        }
+      }
+    },
+    [min, max, onChange, isValid]
+  )
+
+  const parseTimeInput = useCallback((timeStr: string): number => {
+    const [hours = '0', minutes = '0'] = timeStr.split(':')
+    const totalSeconds = parseInt(hours) * 3600 + parseInt(minutes) * 60
+    return Math.min(Math.max(totalSeconds, 0), 86400)
+  }, [])
+
+  const handleChangeTextField = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+
+      // Solo permitir números y :
+      if (!/^[0-9:]*$/.test(value)) return
+
+      // Limitar a 5 caracteres (HH:MM)
+      if (value.length <= 5) {
+        setTextValue(value)
+
+        // Si es un formato válido de hora, actualizar el slider
+        if (isValidTimeFormat(value)) {
+          const seconds = parseTimeInput(value)
+          if (seconds >= Number(min) && seconds <= Number(max)) {
+            setInputValue(seconds)
+            onChange &&
+              onChange({
+                ...e,
+                target: { ...e.target, value: seconds.toString() }
+              } as React.ChangeEvent<HTMLInputElement>)
+          }
+        }
+      }
+    },
+    [onChange, parseTimeInput, min, max]
+  )
+
+  const handleOnBlur: React.FocusEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      let finalValue = textValue
+
+      // Si el formato no es válido o está fuera de rango, revertir al último valor válido
+      if (!isValidTimeFormat(textValue)) {
+        finalValue = formatHour(inputValue)
+      } else {
+        const seconds = parseTimeInput(textValue)
+        if (seconds < Number(min) || seconds > Number(max)) {
+          finalValue = formatHour(inputValue)
+        }
+      }
+
+      setTextValue(finalValue)
+      const seconds = parseTimeInput(finalValue)
+      setInputValue(seconds)
+
+      if (isValid(seconds)) {
+        onChange &&
+          onChange({
+            ...event,
+            target: { ...event.target, value: seconds.toString() }
+          } as React.ChangeEvent<HTMLInputElement>)
+      }
+
+      onBlur && onBlur(event)
+    },
+    [textValue, inputValue, onChange, isValid, onBlur, parseTimeInput, min, max]
+  )
+
+  const errorMessage = useMemo(() => {
+    if (!isValid(inputValue)) {
+      return 'Invalid value'
+    }
+    return undefined
+  }, [inputValue, isValid])
+
+  const renderMessage = useCallback(() => {
+    if (errorMessage) {
+      return <Message text={errorMessage} type={MessageType.ERROR} />
+    } else if (info) {
+      return <Message text={info} type={MessageType.INFO} icon={false} />
+    }
+    return null
+  }, [errorMessage, info])
+
+  return (
+    <div className="Range Field">
+      <Label text={label} />
+      <div className={cx('RangeContainer', { error, disabled })}>
+        <div className="InputContainer">
+          <input
+            ref={ref}
+            type="range"
+            className="RangeInput"
+            value={inputValue}
+            min={min}
+            max={max}
+            step={step}
+            style={trackStyle}
+            disabled={disabled}
+            onChange={handleChange}
+            {...rest}
+          />
+        </div>
+        <input
+          className="RangeTextInput"
+          type="time"
+          value={textValue}
+          disabled={disabled}
+          onChange={handleChangeTextField}
+          onBlur={handleOnBlur}
+        />
+      </div>
+      {renderMessage()}
+    </div>
+  )
+})
+
+export default React.memo(RangeHourField)

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/types.ts
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/types.ts
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export type Props = React.InputHTMLAttributes<Omit<HTMLElement, 'type'>> & {
+  label?: React.ReactNode
+  rightLabel?: string
+  error?: string | boolean
+  info?: React.ReactNode
+  isValidValue?: (value: any) => boolean
+}

--- a/packages/@dcl/inspector/src/components/ui/RangeHourField/types.ts
+++ b/packages/@dcl/inspector/src/components/ui/RangeHourField/types.ts
@@ -1,9 +1,7 @@
-import React from 'react'
+import { InputHTMLAttributes } from 'react'
 
-export type Props = React.InputHTMLAttributes<Omit<HTMLElement, 'type'>> & {
-  label?: React.ReactNode
-  rightLabel?: string
-  error?: string | boolean
-  info?: React.ReactNode
-  isValidValue?: (value: any) => boolean
+export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
+  value?: number
+  disabled?: boolean
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 }

--- a/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
+++ b/packages/@dcl/inspector/src/lib/babylon/decentraland/editorComponents/selection.ts
@@ -12,12 +12,19 @@ export const putEntitySelectedComponent: ComponentOperation = (entity, component
 
     const componentValue = component.get(entity.entityId) as unknown as EditorComponentsTypes['Selection']
     setGizmoManager(entity, componentValue)
+    if (entity.boundingInfoMesh) {
+      entity.boundingInfoMesh.onAfterWorldMatrixUpdateObservable.notifyObservers(entity.boundingInfoMesh)
+    }
   }
 }
 
 export const deleteEntitySelectedComponent: ComponentOperation = (entity, component) => {
   if (component.componentType === ComponentType.LastWriteWinElementSet) {
     unsetGizmoManager(entity)
+
+    if (entity.boundingInfoMesh) {
+      entity.boundingInfoMesh.onAfterWorldMatrixUpdateObservable.notifyObservers(entity.boundingInfoMesh)
+    }
   }
 }
 

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -42,6 +42,11 @@ export function generateMinimalComposite({ engine, components }: TempEngine) {
     description: 'This is a test scene',
     thumbnail: 'assets/scene/thumbnail.png',
     ageRating: SceneAgeRating.Teen,
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: 36000
+      }
+    },
     categories: [],
     author: '',
     email: '',

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -42,10 +42,8 @@ export function generateMinimalComposite({ engine, components }: TempEngine) {
     description: 'This is a test scene',
     thumbnail: 'assets/scene/thumbnail.png',
     ageRating: SceneAgeRating.Teen,
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: 36000
-      }
+    skyboxConfig: {
+      fixedTime: 36000
     },
     categories: [],
     author: '',

--- a/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/client/feeded-local-fs.ts
@@ -11,6 +11,7 @@ import { createInMemoryStorage } from '../../logic/storage/in-memory'
 import { downloadAssets } from './builder-utils'
 import { SceneAgeRating } from '../../sdk/components'
 import { THUMBNAIL } from './constants'
+import { TransitionMode } from '../../sdk/components/SceneMetadata'
 
 export function createTempEngineContext() {
   const { engine, components } = createEngineContext()
@@ -43,7 +44,8 @@ export function generateMinimalComposite({ engine, components }: TempEngine) {
     thumbnail: 'assets/scene/thumbnail.png',
     ageRating: SceneAgeRating.Teen,
     skyboxConfig: {
-      fixedTime: 36000
+      fixedTime: 36000,
+      transitionMode: TransitionMode.TM_FORWARD
     },
     categories: [],
     author: '',

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -77,7 +77,7 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
     rating: value.ageRating,
     worldConfiguration: {
       skyboxConfig: {
-        fixedTime: 900
+        fixedTime: value.worldConfiguration?.skyboxConfig?.fixedTime
       }
     }
   }

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -32,6 +32,7 @@ const parseCoords = (coords: string) => {
 
 type SceneWithRating = Scene & { rating: SceneAgeRating }
 
+//TODO check scene init
 export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTypes['Scene']>): Partial<Scene> {
   const tags: string[] = []
   for (const category of value.categories || []) {
@@ -73,7 +74,12 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
       voiceChat: value.silenceVoiceChat ? 'disabled' : 'enabled',
       portableExperiences: value.disablePortableExperiences ? 'disabled' : 'enabled'
     },
-    rating: value.ageRating
+    rating: value.ageRating,
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: 900
+      }
+    }
   }
 
   if (config.segmentAppId && config.projectId) {
@@ -114,6 +120,11 @@ export function toSceneComponent(value: Scene): EditorComponentsTypes['Scene'] {
     silenceVoiceChat: value.featureToggles?.voiceChat === 'disabled',
     disablePortableExperiences: value.featureToggles?.portableExperiences === 'disabled',
     ageRating: (value as SceneWithRating).rating,
+    worldConfiguration: {
+      skyboxConfig: {
+        fixedTime: value.worldConfiguration?.skyboxConfig?.fixedTime
+      }
+    },
     spawnPoints: value.spawnPoints?.map((spawnPoint, index) => ({
       name: spawnPoint.name || `Spawn Point ${index + 1}`,
       default: spawnPoint.default,

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -74,10 +74,8 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
       portableExperiences: value.disablePortableExperiences ? 'disabled' : 'enabled'
     },
     rating: value.ageRating,
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: value.worldConfiguration?.skyboxConfig?.fixedTime
-      }
+    skyboxConfig: {
+      fixedTime: value.skyboxConfig?.fixedTime
     }
   }
 
@@ -119,10 +117,8 @@ export function toSceneComponent(value: Scene): EditorComponentsTypes['Scene'] {
     silenceVoiceChat: value.featureToggles?.voiceChat === 'disabled',
     disablePortableExperiences: value.featureToggles?.portableExperiences === 'disabled',
     ageRating: (value as SceneWithRating).rating,
-    worldConfiguration: {
-      skyboxConfig: {
-        fixedTime: value.worldConfiguration?.skyboxConfig?.fixedTime
-      }
+    skyboxConfig: {
+      fixedTime: value.skyboxConfig?.fixedTime
     },
     spawnPoints: value.spawnPoints?.map((spawnPoint, index) => ({
       name: spawnPoint.name || `Spawn Point ${index + 1}`,

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -5,6 +5,7 @@ import { Scene } from '@dcl/schemas'
 
 import { EditorComponentsTypes, SceneAgeRating, SceneCategory, SceneComponent } from '../../../sdk/components'
 import { getConfig } from '../../../logic/config'
+import { TransitionMode } from '../../../sdk/components/SceneMetadata'
 
 export function isEqual(component: ComponentDefinition<unknown>, prevValue: unknown, newValue: unknown) {
   if (prevValue === newValue || (!prevValue && !newValue)) return true
@@ -30,7 +31,10 @@ const parseCoords = (coords: string) => {
   return { x: parseInt(x), y: parseInt(y) }
 }
 
-type SceneWithRating = Scene & { rating: SceneAgeRating }
+type SceneWithRating = Scene & {
+  rating: SceneAgeRating
+  skyboxConfig?: { fixedTime?: number; transitionMode?: TransitionMode }
+}
 
 export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTypes['Scene']>): Partial<Scene> {
   const tags: string[] = []
@@ -75,7 +79,8 @@ export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTyp
     },
     rating: value.ageRating,
     skyboxConfig: {
-      fixedTime: value.skyboxConfig?.fixedTime
+      fixedTime: value.skyboxConfig?.fixedTime,
+      transitionMode: value.skyboxConfig?.transitionMode
     }
   }
 
@@ -118,7 +123,8 @@ export function toSceneComponent(value: Scene): EditorComponentsTypes['Scene'] {
     disablePortableExperiences: value.featureToggles?.portableExperiences === 'disabled',
     ageRating: (value as SceneWithRating).rating,
     skyboxConfig: {
-      fixedTime: value.skyboxConfig?.fixedTime
+      fixedTime: (value as SceneWithRating).skyboxConfig?.fixedTime,
+      transitionMode: (value as SceneWithRating).skyboxConfig?.transitionMode
     },
     spawnPoints: value.spawnPoints?.map((spawnPoint, index) => ({
       name: spawnPoint.name || `Spawn Point ${index + 1}`,

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/component.ts
@@ -32,7 +32,6 @@ const parseCoords = (coords: string) => {
 
 type SceneWithRating = Scene & { rating: SceneAgeRating }
 
-//TODO check scene init
 export function fromSceneComponent(value: DeepReadonlyObject<EditorComponentsTypes['Scene']>): Partial<Scene> {
   const tags: string[] = []
   for (const category of value.categories || []) {

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/migrate-scene-metadata.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/migrate-scene-metadata.ts
@@ -1,7 +1,11 @@
 import { IEngine } from '@dcl/ecs'
 
 import { EditorComponents } from '../../../../sdk/components'
-import { VERSIONS, getLatestSceneComponentVersion } from '../../../../sdk/components/SceneMetadata'
+import {
+  removeOldSceneVersions,
+  VERSIONS,
+  getLatestSceneComponentVersion
+} from '../../../../sdk/components/SceneMetadata'
 
 /**
  * Retrieves the latest version of the Scene component from the engine.
@@ -46,10 +50,10 @@ export function migrateSceneMetadata(engine: IEngine) {
   const isRunningLatestVersion = component.componentName === latestComponentVersion.key
 
   if (isRunningLatestVersion) return
-
   const oldComponent = component
+
   oldComponent.deleteFrom(engine.RootEntity)
-  engine.removeComponentDefinition(oldComponent.componentName)
+  removeOldSceneVersions(engine, oldComponent.componentName)
 
   const SceneMetadata = engine.getComponent(latestComponentVersion.key) as EditorComponents['Scene']
   SceneMetadata.createOrReplace(engine.RootEntity, value)

--- a/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/migrate-scene-metadata.ts
+++ b/packages/@dcl/inspector/src/lib/data-layer/host/utils/migrations/migrate-scene-metadata.ts
@@ -53,7 +53,7 @@ export function migrateSceneMetadata(engine: IEngine) {
   const oldComponent = component
 
   oldComponent.deleteFrom(engine.RootEntity)
-  removeOldSceneVersions(engine, oldComponent.componentName)
+  removeOldSceneVersions(engine, latestComponentVersion.key)
 
   const SceneMetadata = engine.getComponent(latestComponentVersion.key) as EditorComponents['Scene']
   SceneMetadata.createOrReplace(engine.RootEntity, value)

--- a/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
@@ -25,6 +25,11 @@ export const Coords = Schemas.Map({
   y: Schemas.Int
 })
 
+export enum TransitionMode {
+  TM_FORWARD = 1,
+  TM_BACKWARD = 0
+}
+
 //SceneMetadata component is now versioned, to add new versions you must need to keep the previous properties and add the new ones
 export const SceneMetadataV0 = {
   name: Schemas.Optional(Schemas.String),
@@ -88,7 +93,12 @@ export const SceneMetadataV1 = {
   }),
   silenceVoiceChat: Schemas.Optional(Schemas.Boolean),
   disablePortableExperiences: Schemas.Optional(Schemas.Boolean),
-  skyboxConfig: Schemas.Optional(Schemas.Map({ fixedTime: Schemas.Optional(Schemas.Int) })),
+  skyboxConfig: Schemas.Optional(
+    Schemas.Map({
+      fixedTime: Schemas.Optional(Schemas.Int),
+      transitionMode: Schemas.Optional(Schemas.EnumNumber(TransitionMode, TransitionMode.TM_FORWARD))
+    })
+  ),
   spawnPoints: Schemas.Optional(
     Schemas.Array(
       Schemas.Map({

--- a/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
@@ -26,8 +26,8 @@ export const Coords = Schemas.Map({
 })
 
 export enum TransitionMode {
-  TM_FORWARD = 1,
-  TM_BACKWARD = 0
+  TM_FORWARD = 0,
+  TM_BACKWARD = 1
 }
 
 //SceneMetadata component is now versioned, to add new versions you must need to keep the previous properties and add the new ones

--- a/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
@@ -148,3 +148,11 @@ export function defineSceneComponents(engine: IEngine) {
 
   return components
 }
+
+export function removeOldSceneVersions(engine: IEngine, currentSceneVersion: string) {
+  VERSIONS.forEach(({ key }) => {
+    if (key !== currentSceneVersion) {
+      engine.removeComponentDefinition(key)
+    }
+  })
+}

--- a/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
@@ -88,15 +88,7 @@ export const SceneMetadataV1 = {
   }),
   silenceVoiceChat: Schemas.Optional(Schemas.Boolean),
   disablePortableExperiences: Schemas.Optional(Schemas.Boolean),
-  worldConfiguration: Schemas.Optional(
-    Schemas.Map({
-      skyboxConfig: Schemas.Optional(
-        Schemas.Map({
-          fixedTime: Schemas.Optional(Schemas.Int)
-        })
-      )
-    })
-  ),
+  skyboxConfig: Schemas.Optional(Schemas.Map({ fixedTime: Schemas.Optional(Schemas.Int) })),
   spawnPoints: Schemas.Optional(
     Schemas.Array(
       Schemas.Map({

--- a/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/SceneMetadata.ts
@@ -90,7 +90,7 @@ export const SceneMetadataV1 = {
   disablePortableExperiences: Schemas.Optional(Schemas.Boolean),
   worldConfiguration: Schemas.Optional(
     Schemas.Map({
-      skybox: Schemas.Optional(
+      skyboxConfig: Schemas.Optional(
         Schemas.Map({
           fixedTime: Schemas.Optional(Schemas.Int)
         })

--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -41,9 +41,10 @@ export enum CoreComponents {
   VISIBILITY_COMPONENT = 'core::VisibilityComponent'
 }
 
+//TODO check if this is the correct name for the type
 export enum EditorComponentNames {
   Selection = 'inspector::Selection',
-  Scene = 'inspector::SceneMetadata',
+  Scene = 'inspector::SceneMetadata-v2',
   Nodes = 'inspector::Nodes',
   ActionTypes = ComponentName.ACTION_TYPES,
   Actions = ComponentName.ACTIONS,
@@ -88,6 +89,11 @@ export type SceneSpawnPoint = {
 export type SceneComponent = {
   name?: string
   description?: string
+  worldConfiguration?: {
+    skyboxConfig?: {
+      fixedTime?: number
+    }
+  }
   thumbnail?: string
   ageRating?: SceneAgeRating
   main?: string
@@ -276,6 +282,53 @@ export function createEditorComponents(engine: IEngine): EditorComponents {
     })
   })
 
+  engine.defineComponent('inspector::SceneMetadata', {
+    // everything but layout is set as optional for retrocompat purposes
+    name: Schemas.Optional(Schemas.String),
+    description: Schemas.Optional(Schemas.String),
+    thumbnail: Schemas.Optional(Schemas.String),
+    ageRating: Schemas.Optional(Schemas.EnumString(SceneAgeRating, SceneAgeRating.Teen)),
+    categories: Schemas.Optional(Schemas.Array(Schemas.EnumString(SceneCategory, SceneCategory.GAME))),
+    author: Schemas.Optional(Schemas.String),
+    email: Schemas.Optional(Schemas.String),
+    tags: Schemas.Optional(Schemas.Array(Schemas.String)),
+    layout: Schemas.Map({
+      base: Coords,
+      parcels: Schemas.Array(Coords)
+    }),
+    silenceVoiceChat: Schemas.Optional(Schemas.Boolean),
+    disablePortableExperiences: Schemas.Optional(Schemas.Boolean),
+    spawnPoints: Schemas.Optional(
+      Schemas.Array(
+        Schemas.Map({
+          name: Schemas.String,
+          default: Schemas.Optional(Schemas.Boolean),
+          position: Schemas.Map({
+            x: Schemas.OneOf({
+              single: Schemas.Int,
+              range: Schemas.Array(Schemas.Int)
+            }),
+            y: Schemas.OneOf({
+              single: Schemas.Int,
+              range: Schemas.Array(Schemas.Int)
+            }),
+            z: Schemas.OneOf({
+              single: Schemas.Int,
+              range: Schemas.Array(Schemas.Int)
+            })
+          }),
+          cameraTarget: Schemas.Optional(
+            Schemas.Map({
+              x: Schemas.Int,
+              y: Schemas.Int,
+              z: Schemas.Int
+            })
+          )
+        })
+      )
+    )
+  })
+
   const Scene = engine.defineComponent(EditorComponentNames.Scene, {
     // everything but layout is set as optional for retrocompat purposes
     name: Schemas.Optional(Schemas.String),
@@ -286,6 +339,15 @@ export function createEditorComponents(engine: IEngine): EditorComponents {
     author: Schemas.Optional(Schemas.String),
     email: Schemas.Optional(Schemas.String),
     tags: Schemas.Optional(Schemas.Array(Schemas.String)),
+    worldConfiguration: Schemas.Optional(
+      Schemas.Map({
+        skyboxConfig: Schemas.Optional(
+          Schemas.Map({
+            fixedTime: Schemas.Optional(Schemas.Int)
+          })
+        )
+      })
+    ),
     layout: Schemas.Map({
       base: Coords,
       parcels: Schemas.Array(Coords)

--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -21,7 +21,8 @@ import {
   defineSceneComponents,
   getLatestSceneComponentVersion,
   SceneAgeRating,
-  SceneCategory
+  SceneCategory,
+  TransitionMode
 } from './SceneMetadata'
 
 export { SceneAgeRating, SceneCategory }
@@ -94,6 +95,7 @@ export type SceneComponent = {
   description?: string
   skyboxConfig?: {
     fixedTime?: number
+    transitionMode?: TransitionMode
   }
   thumbnail?: string
   ageRating?: SceneAgeRating

--- a/packages/@dcl/inspector/src/lib/sdk/components/index.ts
+++ b/packages/@dcl/inspector/src/lib/sdk/components/index.ts
@@ -92,10 +92,8 @@ export type SceneSpawnPoint = {
 export type SceneComponent = {
   name?: string
   description?: string
-  worldConfiguration?: {
-    skyboxConfig?: {
-      fixedTime?: number
-    }
+  skyboxConfig?: {
+    fixedTime?: number
   }
   thumbnail?: string
   ageRating?: SceneAgeRating

--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -55,7 +55,6 @@ async function runApp(
     params.set('dclenv', dclenv)
 
     params.set('local-scene', 'true')
-    params.set('debug', 'true')
 
     if (isHub) {
       params.set('hub', 'true')

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -149,7 +149,6 @@ describe('explorer-alpha', () => {
         '--position': '10,20',
         '--realm': 'custom-realm',
         '--local-scene': true,
-        '--debug': false,
         '--dclenv': 'zone',
         '--skip-auth-screen': true,
         '--landscape-terrain-enabled': false,
@@ -177,7 +176,6 @@ describe('explorer-alpha', () => {
       expect(callArgs).toContain('position=10%2C20')
       expect(callArgs).toContain('dclenv=zone')
       expect(callArgs).toContain('local-scene=true')
-      expect(callArgs).toContain('debug=true')
       expect(callArgs).toContain('hub=true')
       expect(callArgs).toContain('skip-auth-screen=true')
       expect(callArgs).toContain('open-deeplink-in-new-instance=true')
@@ -201,9 +199,7 @@ describe('explorer-alpha', () => {
         '/test',
         'open',
         expect.arrayContaining([
-          expect.stringMatching(
-            /decentraland:\/\/.*realm=default-realm.*position=5%2C10.*dclenv=org.*local-scene=true.*debug=true/
-          )
+          expect.stringMatching(/decentraland:\/\/.*realm=default-realm.*position=5%2C10.*dclenv=org.*local-scene=true/)
         ]),
         { silent: true }
       )


### PR DESCRIPTION
- Add skybox config on scene settings (skybox time and trasition)
- The skybox sets the time of the scene while the transition sets how the skybox moves from the current time to the scene time
-  When the skybox value is setted, it cannot be changed from the scene itself
- Run migration to move data from SceneMetadata componente to SceneMetadata-v1 component
- Support easy versioning for future changes of properties


To test:
As it includes a migration of the scene metada componente, please test this feature in new scenes and old scenes.

https://github.com/user-attachments/assets/89400a19-5e64-47d1-bebe-f493868716ad

https://github.com/user-attachments/assets/30369b3a-67a8-4632-a0a3-020eddcb2e17

