### PR TITLE
fix: light source helper

### DIFF
--- a/packages/@dcl/ecs/src/components/types.ts
+++ b/packages/@dcl/ecs/src/components/types.ts
@@ -12,3 +12,4 @@ export type { ISyncComponents, ISyncComponentsType } from './manual/SyncComponen
 export type { INetowrkEntity, INetowrkEntityType } from './manual/NetworkEntity'
 export type { INetowrkParent, INetowrkParentType } from './manual/NetworkParent'
 export type { InputModifierHelper, InputModifierComponentDefinitionExtended } from './extended/InputModifier'
+export type { LightSourceHelper, LightSourceComponentDefinitionExtended } from './extended/LightSource'


### PR DESCRIPTION
Fixes an issue with `LightSourceHelper` not being exported correctly and thus not being usable in scene code.