### PR TITLE
fix: init-test-scene with asset-packs usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,4 +171,13 @@ clean:
 
 init-test-scene:
 	git clone https://github.com/decentraland/sdk7-scene-template test-scene
-	cd test-scene && npm i ./../packages/@dcl/sdk  && npm i ./../packages/@dcl/sdk-commands  && npm i ./../packages/@dcl/js-runtime
+	make prepare-link-packages
+	cd test-scene && npm install
+	cd test-scene && npm link @dcl/sdk @dcl/react-ecs @dcl/sdk-commands @dcl/js-runtime @dcl/ecs @dcl/ecs-math @dcl/asset-packs
+
+prepare-link-packages:
+	cd packages/@dcl/sdk && npm link
+	cd packages/@dcl/react-ecs && npm link
+	cd packages/@dcl/sdk-commands && npm link
+	cd packages/@dcl/js-runtime && npm link
+	cd packages/@dcl/ecs && npm link


### PR DESCRIPTION
### WHY

Currently if a local test scene is initialized with `make init-test-scene`, it works OK for scenes that don't use asset-packs (or don't have a `main.crdt` file). Otherwise the running of the scene (`npm run start -- --explorer-alpha`) fails due to some missing packages (`asset-packs` and others...)

### WHAT

Refactored pertinent make commands to use npm link instead