### PR TITLE
feat: Upgrade @dcl/asset-packs package

### DIFF
--- a/packages/@dcl/inspector/package-lock.json
+++ b/packages/@dcl/inspector/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@dcl/inspector",
       "version": "0.1.0",
       "dependencies": {
-        "@dcl/asset-packs": "2.5.4",
+        "@dcl/asset-packs": "2.5.6",
         "ts-deepmerge": "^7.0.0"
       },
       "devDependencies": {
@@ -296,9 +296,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.5.4.tgz",
-      "integrity": "sha512-iX88UjeclnZsMadaxfUHHDoxDrLnxWUjKttHFJrNNnQv3dT/0EJdRieQ/mEVDTCxXoiB8SkCuKyDVOhAOtiz/g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.5.6.tgz",
+      "integrity": "sha512-RpCCMdq56GmVZAddZsQZ8qQF1uIYN2dpxR4efzmGwJRqtmUyWqdW2sUyj3vLrCMaV22fSdd4OFMN7vyk0IAFfA==",
       "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",

--- a/packages/@dcl/inspector/package.json
+++ b/packages/@dcl/inspector/package.json
@@ -2,7 +2,7 @@
   "name": "@dcl/inspector",
   "version": "0.1.0",
   "dependencies": {
-    "@dcl/asset-packs": "2.5.4",
+    "@dcl/asset-packs": "2.5.6",
     "ts-deepmerge": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades the package @dcl/asset-packs to version 2.5.6