### PR TITLE
feat: handle unreachable catalysts during deploy

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -52,13 +52,16 @@ export async function getCatalyst(
     const catalysts = getCatalystServersFromCache('mainnet')
 
     for (const catalyst of catalysts) {
-      const client = createCatalystClient({ url: catalyst.address, fetcher: createFetchComponent() })
-
-      const isHealthy = (await client.fetchAbout()).healthy
-
-      if (isHealthy) {
-        catalystClient = client
-        break
+      try {
+        const client = createCatalystClient({ url: catalyst.address, fetcher: createFetchComponent() })
+        const about = await client.fetchAbout()
+        if (about.healthy) {
+          catalystClient = client
+          break
+        }
+      } catch (_) {
+        // Unreachable or invalid response — skip and try next catalyst
+        continue
       }
     }
   }


### PR DESCRIPTION
## Summary                                                                                          
- Wrap catalyst health check in try/catch during deploy to skip unreachable or invalid catalysts instead of crashing the entire selection loop                                                       
- Previously, if a catalyst returned a non-JSON response (e.g. Cloudflare HTML error page), `fetchAbout()` would throw and abort the deploy without trying other available catalysts            
                                                                                               

<img width="1246" height="410" alt="Screenshot 2026-04-06 at 11 55 23" src="https://github.com/user-attachments/assets/276a5aa7-790e-4355-b27f-fcc62a2ecb5c" />
