### PR TITLE
fix(sdk-commands): make asset-packs bundling conditional on composite content

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -165,10 +165,6 @@ type SingleProjectOptions = CompileOptions & {
 
 export async function bundleSingleProject(components: BundleComponents, options: SingleProjectOptions) {
   printProgressStep(components.logger, `Bundling file ${colors.bold(options.entrypoint)}`, 1, MAX_STEP)
-  // NOTE: editorScene is evaluated once and baked into stdin at esbuild context-creation
-  // time. In watch mode it is NOT re-evaluated on context.rebuild(). If a scene's
-  // editor status changes (e.g. first smart item added to an empty composite) the
-  // watch process must be restarted for initAssetPacks to be injected correctly.
   const editorScene = await isEditorScene(components, options.workingDirectory)
 
   // Pre-compute composite data so we can inject maxCompositeEntity via esbuild define.

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -83,12 +83,8 @@ ${
   `
 import { syncEntity } from '@dcl/sdk/network'
 import players from '@dcl/sdk/players'
-import { initAssetPacks, setSyncEntity } from '@dcl/asset-packs/dist/scene-entrypoint'
+import { initAssetPacks } from '@dcl/asset-packs/dist/scene-entrypoint'
 initAssetPacks(engine, { syncEntity }, players)
-
-// TODO: do we need to do this on runtime ?
-// I think we have that information at build-time and we avoid to do evaluate this on the worker.
-// Read composite.json or main.crdt => If that file has a NetworkEntity import '@dcl/@sdk/network'
 `
 }
 
@@ -169,6 +165,10 @@ type SingleProjectOptions = CompileOptions & {
 
 export async function bundleSingleProject(components: BundleComponents, options: SingleProjectOptions) {
   printProgressStep(components.logger, `Bundling file ${colors.bold(options.entrypoint)}`, 1, MAX_STEP)
+  // NOTE: editorScene is evaluated once and baked into stdin at esbuild context-creation
+  // time. In watch mode it is NOT re-evaluated on context.rebuild(). If a scene's
+  // editor status changes (e.g. first smart item added to an empty composite) the
+  // watch process must be restarted for initAssetPacks to be injected correctly.
   const editorScene = await isEditorScene(components, options.workingDirectory)
 
   // Pre-compute composite data so we can inject maxCompositeEntity via esbuild define.

--- a/packages/@dcl/sdk-commands/src/logic/project-validations.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-validations.ts
@@ -149,8 +149,43 @@ export async function startValidations(components: Pick<CliComponents, 'spawner'
   }
 }
 
-// If there is a main.composite file, its an editor scene. We need asset-packs package.
-export async function isEditorScene(components: Pick<CliComponents, 'fs'>, workingDirectory: string) {
+/**
+ * Returns true if the scene is an "editor scene" that requires the asset-packs runtime.
+ *
+ * A scene is an editor scene when its main.composite file contains at least one
+ * asset-packs component other than `asset-packs::Script`. The Script component is
+ * a build-time-only construct (it defines JavaScript scripts bundled separately via
+ * `generateInitializeScriptsModule`) and does not require the `initAssetPacks` runtime.
+ * Only Action/Trigger/State and similar runtime components need `initAssetPacks`.
+ *
+ * NOTE: This value is baked into the esbuild stdin at context-creation time and is
+ * NOT re-evaluated during watch-mode rebuilds. If a scene's editor status changes
+ * (e.g. a smart item is added for the first time), the watch process must be restarted.
+ */
+export async function isEditorScene(
+  components: Pick<CliComponents, 'fs'>,
+  workingDirectory: string
+): Promise<boolean> {
   const mainCompositePath = path.resolve(workingDirectory, 'assets', 'scene', 'main.composite')
-  return components.fs.fileExists(mainCompositePath)
+  if (!(await components.fs.fileExists(mainCompositePath))) return false
+
+  try {
+    const fileBuffer = await components.fs.readFile(mainCompositePath)
+    const json = JSON.parse(new TextDecoder().decode(fileBuffer))
+    // asset-packs::Script is a build-time component — its presence alone does not
+    // require the initAssetPacks runtime entrypoint.
+    const SCRIPT_COMPONENT = 'asset-packs::Script'
+    return (
+      Array.isArray(json.components) &&
+      json.components.some(
+        (c: unknown) =>
+          typeof (c as Record<string, unknown>).name === 'string' &&
+          ((c as Record<string, unknown>).name as string).startsWith('asset-packs::') &&
+          (c as Record<string, unknown>).name !== SCRIPT_COMPONENT
+      )
+    )
+  } catch {
+    // Malformed composite — treat as non-editor scene to avoid bundling unnecessary code
+    return false
+  }
 }

--- a/packages/@dcl/sdk-commands/src/logic/project-validations.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-validations.ts
@@ -162,18 +162,14 @@ export async function startValidations(components: Pick<CliComponents, 'spawner'
  * NOT re-evaluated during watch-mode rebuilds. If a scene's editor status changes
  * (e.g. a smart item is added for the first time), the watch process must be restarted.
  */
-export async function isEditorScene(
-  components: Pick<CliComponents, 'fs'>,
-  workingDirectory: string
-): Promise<boolean> {
+export async function isEditorScene(components: Pick<CliComponents, 'fs'>, workingDirectory: string): Promise<boolean> {
   const mainCompositePath = path.resolve(workingDirectory, 'assets', 'scene', 'main.composite')
   if (!(await components.fs.fileExists(mainCompositePath))) return false
 
   try {
     const fileBuffer = await components.fs.readFile(mainCompositePath)
     const json = JSON.parse(new TextDecoder().decode(fileBuffer))
-    // asset-packs::Script is a build-time component — its presence alone does not
-    // require the initAssetPacks runtime entrypoint.
+    // asset-packs::Script is a build-time component — it doesn't require the initAssetPacks runtime entrypoint.
     const SCRIPT_COMPONENT = 'asset-packs::Script'
     return (
       Array.isArray(json.components) &&

--- a/test/sdk-commands/logic/project-validations.spec.ts
+++ b/test/sdk-commands/logic/project-validations.spec.ts
@@ -4,11 +4,6 @@ import { isEditorScene } from '../../../packages/@dcl/sdk-commands/src/logic/pro
 const WORKING_DIR = '/test/project'
 const COMPOSITE_PATH = path.resolve(WORKING_DIR, 'assets', 'scene', 'main.composite')
 
-/**
- * Build a minimal mock fs component for isEditorScene tests.
- * @param fileExists Whether the main.composite file "exists"
- * @param compositeContent The JSON content to return when the file is read (undefined = not called)
- */
 function makeMockFs(fileExists: boolean, compositeContent?: object | string) {
   return {
     fileExists: jest.fn().mockImplementation((p: string) => {
@@ -27,7 +22,6 @@ describe('isEditorScene', () => {
     jest.clearAllMocks()
   })
 
-  // T1 — file absent
   it('returns false when main.composite does not exist', async () => {
     const fs = makeMockFs(false)
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
@@ -35,21 +29,18 @@ describe('isEditorScene', () => {
     expect(fs.readFile).not.toHaveBeenCalled()
   })
 
-  // T2 — file exists, no `components` key
   it('returns false when composite JSON has no components field', async () => {
     const fs = makeMockFs(true, { version: 1 })
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
     expect(result).toBe(false)
   })
 
-  // T3 — file exists, empty components array
   it('returns false when composite has an empty components array', async () => {
     const fs = makeMockFs(true, { version: 1, components: [] })
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
     expect(result).toBe(false)
   })
 
-  // T4 — file exists, only core:: components
   it('returns false when composite contains only core:: components', async () => {
     const fs = makeMockFs(true, {
       version: 1,
@@ -59,7 +50,6 @@ describe('isEditorScene', () => {
     expect(result).toBe(false)
   })
 
-  // T5 — file exists, only asset-packs::Script (excluded from check)
   it('returns false when composite contains only asset-packs::Script', async () => {
     const fs = makeMockFs(true, {
       version: 1,
@@ -69,7 +59,6 @@ describe('isEditorScene', () => {
     expect(result).toBe(false)
   })
 
-  // T6 — file exists, one non-Script asset-packs:: component
   it('returns true when composite contains a non-Script asset-packs:: component', async () => {
     const fs = makeMockFs(true, {
       version: 1,
@@ -79,7 +68,6 @@ describe('isEditorScene', () => {
     expect(result).toBe(true)
   })
 
-  // T7 — file exists, asset-packs::Script + asset-packs::Trigger
   it('returns true when composite contains asset-packs::Script and a non-Script asset-packs:: component', async () => {
     const fs = makeMockFs(true, {
       version: 1,
@@ -89,21 +77,18 @@ describe('isEditorScene', () => {
     expect(result).toBe(true)
   })
 
-  // T8 — file exists, invalid JSON
   it('returns false when composite file contains invalid JSON', async () => {
     const fs = makeMockFs(true, 'this is not valid json {{{')
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
     expect(result).toBe(false)
   })
 
-  // T9 — file exists, components is not an array
   it('returns false when components is not an array', async () => {
     const fs = makeMockFs(true, { version: 1, components: { name: 'asset-packs::Trigger' } })
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
     expect(result).toBe(false)
   })
 
-  // T10 — file exists, component items lack a name field
   it('returns false when component items do not have a name field', async () => {
     const fs = makeMockFs(true, {
       version: 1,
@@ -113,15 +98,10 @@ describe('isEditorScene', () => {
     expect(result).toBe(false)
   })
 
-  // Extra: multiple asset-packs:: components, none being Script
   it('returns true when composite contains multiple non-Script asset-packs:: components', async () => {
     const fs = makeMockFs(true, {
       version: 1,
-      components: [
-        { name: 'core::Transform' },
-        { name: 'asset-packs::Action' },
-        { name: 'asset-packs::State' }
-      ]
+      components: [{ name: 'core::Transform' }, { name: 'asset-packs::Action' }, { name: 'asset-packs::State' }]
     })
     const result = await isEditorScene({ fs } as any, WORKING_DIR)
     expect(result).toBe(true)

--- a/test/sdk-commands/logic/project-validations.spec.ts
+++ b/test/sdk-commands/logic/project-validations.spec.ts
@@ -1,0 +1,129 @@
+import path from 'path'
+import { isEditorScene } from '../../../packages/@dcl/sdk-commands/src/logic/project-validations'
+
+const WORKING_DIR = '/test/project'
+const COMPOSITE_PATH = path.resolve(WORKING_DIR, 'assets', 'scene', 'main.composite')
+
+/**
+ * Build a minimal mock fs component for isEditorScene tests.
+ * @param fileExists Whether the main.composite file "exists"
+ * @param compositeContent The JSON content to return when the file is read (undefined = not called)
+ */
+function makeMockFs(fileExists: boolean, compositeContent?: object | string) {
+  return {
+    fileExists: jest.fn().mockImplementation((p: string) => {
+      if (p === COMPOSITE_PATH) return Promise.resolve(fileExists)
+      return Promise.resolve(false)
+    }),
+    readFile: jest.fn().mockImplementation(() => {
+      const content = typeof compositeContent === 'string' ? compositeContent : JSON.stringify(compositeContent)
+      return Promise.resolve(Buffer.from(content, 'utf-8'))
+    })
+  }
+}
+
+describe('isEditorScene', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // T1 — file absent
+  it('returns false when main.composite does not exist', async () => {
+    const fs = makeMockFs(false)
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+    expect(fs.readFile).not.toHaveBeenCalled()
+  })
+
+  // T2 — file exists, no `components` key
+  it('returns false when composite JSON has no components field', async () => {
+    const fs = makeMockFs(true, { version: 1 })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T3 — file exists, empty components array
+  it('returns false when composite has an empty components array', async () => {
+    const fs = makeMockFs(true, { version: 1, components: [] })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T4 — file exists, only core:: components
+  it('returns false when composite contains only core:: components', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [{ name: 'core::Transform' }, { name: 'core::GltfContainer' }]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T5 — file exists, only asset-packs::Script (excluded from check)
+  it('returns false when composite contains only asset-packs::Script', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [{ name: 'asset-packs::Script' }]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T6 — file exists, one non-Script asset-packs:: component
+  it('returns true when composite contains a non-Script asset-packs:: component', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [{ name: 'asset-packs::Trigger' }]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(true)
+  })
+
+  // T7 — file exists, asset-packs::Script + asset-packs::Trigger
+  it('returns true when composite contains asset-packs::Script and a non-Script asset-packs:: component', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [{ name: 'asset-packs::Script' }, { name: 'asset-packs::Trigger' }]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(true)
+  })
+
+  // T8 — file exists, invalid JSON
+  it('returns false when composite file contains invalid JSON', async () => {
+    const fs = makeMockFs(true, 'this is not valid json {{{')
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T9 — file exists, components is not an array
+  it('returns false when components is not an array', async () => {
+    const fs = makeMockFs(true, { version: 1, components: { name: 'asset-packs::Trigger' } })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // T10 — file exists, component items lack a name field
+  it('returns false when component items do not have a name field', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [{ data: {} }, { jsonSchema: {} }]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(false)
+  })
+
+  // Extra: multiple asset-packs:: components, none being Script
+  it('returns true when composite contains multiple non-Script asset-packs:: components', async () => {
+    const fs = makeMockFs(true, {
+      version: 1,
+      components: [
+        { name: 'core::Transform' },
+        { name: 'asset-packs::Action' },
+        { name: 'asset-packs::State' }
+      ]
+    })
+    const result = await isEditorScene({ fs } as any, WORKING_DIR)
+    expect(result).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- `isEditorScene` previously returned `true` whenever `main.composite` existed, unconditionally injecting `initAssetPacks` even for pure-static scenes with no smart items
- Now reads and parses the composite JSON, injecting `initAssetPacks` only when the composite contains `asset-packs::*` components other than `asset-packs::Script` (which is build-time only)
- Also removes the pre-existing dead `setSyncEntity` import and documents the watch-mode caveat

## Plan

### Root Cause

`isEditorScene` in `project-validations.ts` performed only a file-existence check. The asset-packs runtime (`initAssetPacks`) is only needed when the composite contains runtime `asset-packs::*` components (Actions/Triggers/States). It is **not** needed for:
- Pure static scenes (`core::Transform`, `core::GltfContainer`, etc.)
- Scenes with only `asset-packs::Script` components (handled by `generateInitializeScriptsModule` separately)

### Behavior Change

| Flow | Composite content | Before | After |
|---|---|---|---|
| No composite | File absent | `false` | `false` (unchanged) |
| Pure static | Only `core::*` | `true` ❌ | `false` ✅ |
| Smart items | `asset-packs::Trigger`, etc. | `true` | `true` (unchanged) |
| Script only | Only `asset-packs::Script` | `true` ❌ | `false` ✅ |
| Script + smart items | `asset-packs::Script` + `asset-packs::Trigger` | `true` | `true` (unchanged) |
| Malformed JSON | Invalid JSON | `true` ❌ | `false` ✅ |

### Key implementation notes
- `Composite.fromJson` does not throw on malformed input — try/catch around `JSON.parse` is essential
- `getAllComposites` is called after `isEditorScene` in `bundleSingleProject`, so composite data can't be reused — the function reads `main.composite` independently (one extra file read, minimal overhead)
- `editorScene` is baked into esbuild's `stdin` at context-creation time and is NOT re-evaluated during watch-mode rebuilds — this is a pre-existing limitation, now documented with a `// NOTE:` comment

## Changes

```
packages/@dcl/sdk-commands/src/logic/project-validations.ts  — isEditorScene: content-based detection
packages/@dcl/sdk-commands/src/logic/bundle.ts               — remove dead setSyncEntity import, add watch-mode note
test/sdk-commands/logic/project-validations.spec.ts          — 11 unit tests for all edge cases (new file)
```

## Testing

New test file `test/sdk-commands/logic/project-validations.spec.ts` covers all 10 cases:
- File absent → `false`
- File exists, no `components` key → `false`
- Empty `components: []` → `false`
- Only `core::*` components → `false`
- Only `asset-packs::Script` → `false`
- One non-Script `asset-packs::` component → `true`
- `asset-packs::Script` + `asset-packs::Trigger` → `true`
- Invalid JSON → `false`
- `components` is not an array → `false`
- Component items without `name` field → `false`

## Closes

https://github.com/decentraland/creator-hub/issues/1304

---
🤖 Created via Slack with Claude
Requested by Nico Earnshaw via Slack