### PR TITLE
feat(react-ecs): expose createContext and useContext

### DIFF
--- a/packages/@dcl/react-ecs/src/react-ecs.ts
+++ b/packages/@dcl/react-ecs/src/react-ecs.ts
@@ -92,4 +92,57 @@ export namespace ReactEcs {
   type EffectHook = (effect: EffectCallback, deps?: DependencyList) => void
   export const useEffect: EffectHook = (React as any).useEffect
   export const useState: StateHook = (React as any).useState
+
+  // --- Context API ---------------------------------------------------------
+  //
+  // `react-ecs` is built on top of `react-reconciler`, which fully supports
+  // React's Context API at runtime. We just re-expose `createContext` and
+  // `useContext` from React so scenes can use the standard Provider/Consumer
+  // pattern without reaching into the React package directly.
+
+  /**
+   * @public
+   * Provider component returned by `createContext`. Wrap a subtree with it
+   * to make `value` available to any descendant that calls `useContext`.
+   */
+  export interface Provider<T> {
+    (props: { value: T; children?: JSX.ReactNode }): JSX.Element | null
+  }
+
+  /**
+   * @public
+   * Consumer component returned by `createContext`. Renders its child
+   * function with the current context value.
+   */
+  export interface Consumer<T> {
+    (props: { children: (value: T) => JSX.ReactNode }): JSX.Element | null
+  }
+
+  /**
+   * @public
+   * Object returned by `createContext`. Pass to `useContext` to read the
+   * current value, or use `<MyContext.Provider value={...}>` to set one.
+   */
+  export interface Context<T> {
+    Provider: Provider<T>
+    Consumer: Consumer<T>
+    displayName?: string
+  }
+
+  type CreateContext = <T>(defaultValue: T) => Context<T>
+  type ContextHook = <T>(context: Context<T>) => T
+
+  /**
+   * @public
+   * Creates a Context object. The default value is used by descendants that
+   * don't have a matching Provider above them in the tree.
+   */
+  export const createContext: CreateContext = (React as any).createContext
+
+  /**
+   * @public
+   * Reads the value of the nearest matching Provider for the given Context.
+   * If none is found, returns the Context's default value.
+   */
+  export const useContext: ContextHook = (React as any).useContext
 }

--- a/packages/@dcl/react-ecs/src/react-ecs.ts
+++ b/packages/@dcl/react-ecs/src/react-ecs.ts
@@ -93,13 +93,6 @@ export namespace ReactEcs {
   export const useEffect: EffectHook = (React as any).useEffect
   export const useState: StateHook = (React as any).useState
 
-  // --- Context API ---------------------------------------------------------
-  //
-  // `react-ecs` is built on top of `react-reconciler`, which fully supports
-  // React's Context API at runtime. We just re-expose `createContext` and
-  // `useContext` from React so scenes can use the standard Provider/Consumer
-  // pattern without reaching into the React package directly.
-
   /**
    * @public
    * Provider component returned by `createContext`. Wrap a subtree with it


### PR DESCRIPTION
Re-export React's Context API from `@dcl/react-ecs` so scenes can use the standard Provider/Consumer pattern. The underlying `react-reconciler` already supports context at runtime; this PR only adds the public surface plus typings:

- `Provider<T>`, `Consumer<T>`, `Context<T>` interfaces
- `createContext<T>(defaultValue)` factory
- `useContext<T>(context)` hook

Enables ergonomic theming / layout-context flows in scenes (e.g. a single `<LayoutContext.Provider value={CONTEXT.DIALOG}>` wraps a popup subtree without prop-drilling).

Example: https://github.com/dcl-regenesislabs/bevy-ui-scene/commit/0548e9a0284cf3aaa73b9c025678b837430c6170