### PR TITLE
feat(sdk-commands): main-entities.ts authoring + /editor/changes endpoint

### DIFF
--- a/docs/main-entities-authoring.md
+++ b/docs/main-entities-authoring.md
@@ -1,0 +1,115 @@
+# `main-entities.ts` — declarative scene authoring for SDK7
+
+**Status**: experimental, opt-in. Lives alongside the existing `main.composite` + `main.crdt` pipeline. Compiled into `main.crdt` at build time by `getAllComposites` (`packages/@dcl/sdk-commands/src/logic/composite.ts`).
+
+## Why it exists
+
+SDK7 has two existing authoring paths:
+
+1. **Code-first** (the official template). Entities are imperatively created in `src/index.ts` via `engine.addEntity()` + component `.create()` calls.
+2. **`main.composite`** — Creator Hub's JSON output. A complete entity-component-system snapshot including Inspector metadata, smart items, asset packs, layout state, and ~50 component types.
+
+Neither fits the use case `main-entities.ts` was built for:
+
+- **An AI agent (LLM) authoring a scene from a natural-language prompt.** Code-first means the model has to construct correct ECS plumbing for every entity — easy to get wrong, hard to round-trip with a visual editor. `main.composite` is JSON the model can in principle emit, but its surface includes Inspector node trees, smart-item Actions/Triggers/States, and asset-pack remappings the model neither knows nor needs.
+- **A live in-scene visual editor.** Dragging a gizmo on a cube must persist back to a file the model can read and modify next turn. JSON with numeric entity keys and Inspector wrappers is not that file. A typed TypeScript literal is.
+
+`main-entities.ts` is the narrowest possible declarative format for the *static, visible* parts of a scene: a typed `scene` object literal where each key is an entity name and each value is a small set of supported components. Compiled into `main.crdt` at build time. Idempotent, diffable, AI-friendly, gizmo-friendly.
+
+```ts
+// main-entities.ts
+import type { Scene } from '@dcl/sdk/scene-types'
+
+export const scene = {
+  blue_cube: {
+    components: {
+      Transform: { position: { x: 8, y: 1, z: 8 } },
+      MeshRenderer: { mesh: { $case: 'box', box: { uvs: [] } } },
+      Material: { material: { $case: 'pbr', pbr: { albedoColor: { r: 0, g: 0, b: 1, a: 1 } } } }
+    }
+  }
+} satisfies Scene
+```
+
+```ts
+// src/index.ts — behavior, attached to entities by name
+import { engine, pointerEventsSystem, InputAction } from '@dcl/sdk/ecs'
+
+export function main() {
+  const cube = engine.getEntityOrNullByName('blue_cube')
+  if (cube) pointerEventsSystem.onPointerDown(
+    { entity: cube, opts: { button: InputAction.IA_POINTER, hoverText: 'Click me' } },
+    () => console.log('clicked')
+  )
+}
+```
+
+## Scope
+
+`main-entities.ts` is **not** a replacement for `main.composite`. It is a narrow alternative for scenes whose static content fits the supported component subset. Both formats can coexist in a single scene — `getAllComposites` layers composite-loaded entities first, then applies `main-entities.ts` on top of the same engine.
+
+### Currently supported components
+
+`Name`, `Transform`, `GltfContainer`, `MeshRenderer`, `MeshCollider`, `Material`, `VisibilityComponent`, `Billboard`, `AudioSource`, `AudioStream`, `VideoPlayer`, `TextShape`, `NftShape`, `Animator`, `LightSource`, `AvatarShape`, `AvatarAttach`, `CameraModeArea`, `VirtualCamera`, `GltfNodeModifiers`, `Tween`, `TweenSequence`, `PointerEvents`.
+
+Note: `PointerEvents` declares the *click configuration* (event types, hover text, button bindings). The handler callback itself is registered separately at runtime via `pointerEventsSystem.onPointerDown(...)`. Same split for `Tween`: the initial tween (start/end, easing, duration) declares scene-load motion; mutating or replacing the tween at runtime happens in code.
+
+### Out of scope
+
+**Components on reserved engine entities.** `MainCamera`, `AvatarBase`, `AvatarEquippedData` live on `engine.CameraEntity` and `engine.PlayerEntity`. Those entities are engine-managed and have no user-assignable names, so `main-entities.ts` (which is name-keyed) has no slot to express them.
+
+**Components added by helper APIs.** `NetworkEntity` is added implicitly by `syncEntity()`, which takes an integer sync ID. The canonical entry point is the helper, not the component.
+
+**Runtime-only patterns.**
+
+- React-ECS UI nodes — not ECS entities.
+- `AvatarModifierArea` — could in principle be declared static if a use case emerges; left out pending demand.
+- Custom user-defined components (`engine.defineComponent`) — TypeScript can't statically know the user's schema.
+- Procedurally generated entities (loops, noise-driven placement).
+- Conditional / runtime-lifecycle entities (NFT-gated, time-based, server-message-spawned).
+
+These remain `engine.addEntity()` + `.create()` in `src/index.ts` and reference `main-entities.ts` entities by name when needed (parent relationships, look-at targets, click handlers).
+
+## Format constraints
+
+The `scene` constant is parsed at build time via the TypeScript AST walker in `packages/@dcl/sdk-commands/src/logic/main-entities.ts`. The walker accepts only JSON-compatible literal grammar:
+
+- primitives: number, string, boolean, null;
+- array literals (no spread, no holes);
+- object literals (`key: value` only, no computed keys, no shorthand, no spread);
+- discriminated unions encoded as `{ $case: 'tag', tag: { ... } }` (used by `MeshRenderer.mesh`, `Material.material`, `LightSource.type`, etc.);
+- enum values written as their numeric value (e.g., `style: 0` for `NftFrameType.NFT_CLASSIC`, `mode: 1` for `CameraType.CT_THIRD_PERSON`).
+
+What is *not* allowed: imports referenced inside the literal, function calls (`Vector3.create(...)`, `Color4.White()`, `LightSource.Type.Point({})`), identifier values (`NftFrameType.NFT_CLASSIC`), computed expressions, template strings with substitutions. These are author-time conveniences that don't survive serialization.
+
+## Entity-name resolution
+
+Two fields are resolved from entity-name strings to numeric Entity IDs at build time:
+
+- `Transform.parent` (pass 2 in `applySceneToEngine`)
+- `VirtualCamera.lookAtEntity`
+
+All other entity-reference fields (e.g., `Material.texture.videoTexture.videoPlayerEntityId`, `MainCamera.virtualCameraEntity`) require numeric IDs and are therefore set at runtime in `src/index.ts`, looking up the target via `engine.getEntityOrNullByName`.
+
+## In-place editor updates
+
+The `/editor/changes` POST handler in `packages/@dcl/sdk-commands/src/commands/start/server/routes.ts` accepts a name-keyed map of component updates and splices them back into the existing `main-entities.ts` source using the same AST walker. Imports, comments, and the `satisfies Scene` / `: Scene` annotation are preserved by surrounding-text splice. After write, `applySceneToEngine` + `dumpEngineToCrdtCommands` regenerate `main.crdt` synchronously so the next scene reload reflects the edit.
+
+This loop is what powers the in-scene gizmo editor in **OpenDCL Studio** ([dcl-regenesislabs/opendcl-studio](https://github.com/dcl-regenesislabs/opendcl-studio)) — drag-end persists into `main-entities.ts`, the file remains diffable and human-readable, the AI can re-read it on the next turn.
+
+## Path to convention
+
+The current implementation is opt-in: scenes without `main-entities.ts` are unaffected. To promote it to an SDK convention we'd want:
+
+1. **Coverage expansion.** Add components as need arises (this PR added 5; remaining gaps are documented above). Each addition is a small, isolated change in `scene-types.ts` + `applySceneToEngine`.
+2. **Editor-side codegen** for the `Scene` type so `import type { Scene } from '@dcl/sdk/scene-types'` is the single source of truth (done — `ValueOf<typeof Component>` derives shapes from existing component definitions; no parallel schema).
+3. **Inspector compatibility**. Creator Hub should be able to read entities authored in `main-entities.ts` and surface them in the entity tree, even if Inspector continues writing to `main.composite`. Today both formats compile into the same `main.crdt` so runtime behavior is unified; tooling co-existence is the next step.
+4. **Template update.** The official scene template (`decentraland/sdk7-scene-template`) ships with the code-first pattern. A future revision can include a `main-entities.ts` with one example entity to advertise the pattern.
+
+## References
+
+- Implementation: `packages/@dcl/sdk-commands/src/logic/main-entities.ts`
+- Type surface: `packages/@dcl/sdk/src/scene-types.ts`
+- Build integration: `packages/@dcl/sdk-commands/src/logic/composite.ts`
+- Editor POST handler: `packages/@dcl/sdk-commands/src/commands/start/server/routes.ts`
+- File watcher: `packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts`

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -17,7 +17,7 @@ import { createServerComponent } from '@well-known-components/http-server'
 import { createConsoleLogComponent } from '@well-known-components/logger'
 import { providerInstance } from '../../components/eth'
 import { colors, createStderrCliLogger } from '../../components/log'
-import { wireFileWatcherToWebSockets } from './server/file-watch-notifier'
+import { watchMainEntitiesFile, wireFileWatcherToWebSockets } from './server/file-watch-notifier'
 import { wireRouter } from './server/routes'
 import { createWsComponent } from './server/ws'
 import { b64HashingFunction } from '../../logic/project-files'
@@ -210,6 +210,7 @@ export async function main(options: Options) {
             project.kind,
             !!explorerAlpha || !!bevyWeb
           )
+          watchMainEntitiesFile(components, project.workingDirectory)
         }
       }
       await startComponents()

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -2,6 +2,7 @@ import { sdk } from '@dcl/schemas'
 import path from 'path'
 import { WebSocket } from 'ws'
 import chokidar from 'chokidar'
+import { dumpEngineToCrdtCommands } from '@dcl/inspector'
 import { getDCLIgnorePatterns } from '../../../logic/dcl-ignore'
 import { PreviewComponents } from '../types'
 import { sceneUpdateClients } from './routes'
@@ -12,6 +13,8 @@ import {
   UpdateModelType
 } from '@dcl/protocol/out-js/decentraland/sdk/development/local_development.gen'
 import { debounce } from '../../../logic/debounce'
+import { buildEngineFromScene, mainEntitiesPath, readMainEntities } from '../../../logic/main-entities'
+import { printError } from '../../../logic/beautiful-logs'
 
 /**
  * This function gets file modification events and sends them to all the connected
@@ -26,6 +29,11 @@ export async function wireFileWatcherToWebSockets(
   desktopClient: boolean
 ) {
   const ignored = await getDCLIgnorePatterns(components, projectRoot)
+  // Editor writes go through the /editor/changes endpoint which updates
+  // main-entities.ts and regenerates main.crdt out-of-band. Treating
+  // those writes as scene changes would force a full reload and reset
+  // editor state mid-session.
+  ignored.push('**/main-entities.ts', '**/main.crdt')
   const sceneId = b64HashingFunction(projectRoot)
 
   chokidar
@@ -92,6 +100,58 @@ function sendSceneMessage(sceneMessage: WsSceneMessage) {
       client.send(message, { binary: true })
     }
   }
+}
+
+/**
+ * Watch main-entities.ts and regenerate main.crdt out of band when the file
+ * changes. Designed to coexist with the synchronous regeneration in the
+ * `/editor/changes` POST handler:
+ *
+ * - Editor drag → POST writes main-entities.ts AND main.crdt synchronously.
+ *   The watcher fires ~300ms later, sees that main.crdt is at least as fresh
+ *   as main-entities.ts, and skips. No double regen.
+ *
+ * - AI / human edits main-entities.ts directly (no POST) → main.crdt is
+ *   older than main-entities.ts → watcher regenerates main.crdt.
+ *
+ * Does NOT notify scene update clients (main.crdt is in the main watcher's
+ * ignore list), so editor sessions keep their state. Next reload picks up
+ * the fresh CRDT.
+ */
+export function watchMainEntitiesFile(
+  components: Pick<PreviewComponents, 'fs' | 'logger'>,
+  workingDirectory: string
+): void {
+  const filePath = mainEntitiesPath(workingDirectory)
+  const crdtPath = path.join(workingDirectory, 'main.crdt')
+
+  const regen = debounce(async () => {
+    try {
+      // Skip if the POST handler already produced a fresh main.crdt.
+      const entitiesMtime = (await components.fs.stat(filePath)).mtimeMs
+      let crdtMtime = 0
+      try {
+        crdtMtime = (await components.fs.stat(crdtPath)).mtimeMs
+      } catch {
+        // main.crdt doesn't exist yet — definitely need to regen.
+      }
+      if (crdtMtime >= entitiesMtime) return
+
+      const scene = await readMainEntities(components, workingDirectory)
+      if (!scene || Object.keys(scene).length === 0) return
+      const engine = buildEngineFromScene(scene)
+      const crdtData = dumpEngineToCrdtCommands(engine as any)
+      await components.fs.writeFile(crdtPath, crdtData)
+      components.logger.log('[editor] regenerated main.crdt from main-entities.ts')
+    } catch (err) {
+      printError(components.logger, 'Failed to regenerate main.crdt', err as Error)
+    }
+  }, 300)
+
+  chokidar
+    .watch(filePath, { ignoreInitial: true, atomic: true })
+    .on('add', regen)
+    .on('change', regen)
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -1,7 +1,9 @@
+import path from 'path'
 import QRCode from 'qrcode'
 import { Router } from '@well-known-components/http-server'
 import { upgradeWebSocketResponse } from '@well-known-components/http-server/dist/ws'
 import { WebSocket } from 'ws'
+import { dumpEngineToCrdtCommands } from '@dcl/inspector'
 import { Workspace } from '../../../logic/workspace-validations'
 import { DataLayer } from '../data-layer/rpc'
 import { handleDataLayerWs } from '../data-layer/ws'
@@ -9,6 +11,8 @@ import { PreviewComponents } from '../types'
 import { setupEcs6Endpoints } from './endpoints'
 import { setupRealmAndComms } from './realm'
 import { getLanUrl } from '../utils'
+import { buildEngineFromScene, Scene, SceneEntity, readMainEntities, writeMainEntities } from '../../../logic/main-entities'
+import { printError } from '../../../logic/beautiful-logs'
 
 export const sceneUpdateClients = new Set<WebSocket>()
 export async function wireRouter(components: PreviewComponents, workspace: Workspace, dataLayer?: DataLayer) {
@@ -66,12 +70,117 @@ export async function wireRouter(components: PreviewComponents, workspace: Works
     }
   })
 
+  // ── Editor changes (main.json) ────────────────────────────
+  // Read/write the per-scene main.json from disk via the preview server,
+  // and regenerate main.crdt synchronously on every write so the next
+  // scene reload picks up the saved entity transforms.
+  const workingDirectory = workspace.projects[0]?.workingDirectory
+  if (workingDirectory) {
+    setupEditorChangesEndpoints(components, router, workingDirectory)
+  }
+
   setupRealmAndComms(components, router, localSceneParcels)
   await setupEcs6Endpoints(components, router, workspace)
 
   components.server.setContext(components)
   components.server.use(router.allowedMethods())
   components.server.use(router.middleware())
+}
+
+// ── /editor/changes ──────────────────────────────────────────
+
+function setupEditorChangesEndpoints(
+  components: PreviewComponents,
+  router: Router<PreviewComponents>,
+  workingDirectory: string
+): void {
+  // Serialize all writes so concurrent POSTs don't race on read-modify-write.
+  let writeQueue: Promise<void> = Promise.resolve()
+
+  const corsHeaders = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'content-type'
+  }
+
+  router.options('/editor/changes', async () => ({ status: 204, headers: corsHeaders }))
+
+  router.get('/editor/changes', async () => {
+    const data = (await readMainEntities(components, workingDirectory)) ?? {}
+    return {
+      headers: { 'content-type': 'application/json', ...corsHeaders },
+      body: data
+    }
+  })
+
+  router.post('/editor/changes', async (ctx) => {
+    let updates: Scene
+    try {
+      updates = (await ctx.request.json()) as Scene
+    } catch {
+      return {
+        status: 400,
+        headers: corsHeaders,
+        body: { ok: false, error: 'Invalid JSON body' }
+      }
+    }
+    if (typeof updates !== 'object' || updates === null || Array.isArray(updates)) {
+      return {
+        status: 400,
+        headers: corsHeaders,
+        body: { ok: false, error: 'Body must be a name-keyed object' }
+      }
+    }
+
+    const enqueued = writeQueue.then(async () => {
+      const current = (await readMainEntities(components, workingDirectory)) ?? {}
+      mergeUpdates(current, updates)
+      await writeMainEntities(components, workingDirectory, current)
+      await regenerateMainCrdt(components, workingDirectory, current)
+    })
+    writeQueue = enqueued.catch(() => undefined)
+
+    try {
+      await enqueued
+    } catch (err) {
+      printError(components.logger, 'Failed to apply /editor/changes', err as Error)
+      return {
+        status: 500,
+        headers: corsHeaders,
+        body: { ok: false, error: (err as Error).message ?? 'unknown error' }
+      }
+    }
+
+    const names = Object.keys(updates).join(', ')
+    components.logger.log(`[editor] updated: ${names}`)
+    return {
+      headers: corsHeaders,
+      body: { ok: true, count: Object.keys(updates).length }
+    }
+  })
+}
+
+function mergeUpdates(target: Scene, updates: Scene): void {
+  for (const [name, incoming] of Object.entries(updates)) {
+    const existing: SceneEntity = target[name] ?? { components: {} }
+    target[name] = {
+      components: {
+        ...existing.components,
+        ...(incoming?.components ?? {})
+      }
+    }
+  }
+}
+
+async function regenerateMainCrdt(
+  components: Pick<PreviewComponents, 'fs' | 'logger'>,
+  workingDirectory: string,
+  scene: Scene
+): Promise<void> {
+  if (Object.keys(scene).length === 0) return
+  const engine = buildEngineFromScene(scene)
+  const crdtData = dumpEngineToCrdtCommands(engine as any)
+  await components.fs.writeFile(path.join(workingDirectory, 'main.crdt'), crdtData)
 }
 
 const initWsConnection = (ws: WebSocket, clients: Set<WebSocket>) => {

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -105,14 +105,6 @@ function setupEditorChangesEndpoints(
 
   router.options('/editor/changes', async () => ({ status: 204, headers: corsHeaders }))
 
-  router.get('/editor/changes', async () => {
-    const data = (await readMainEntities(components, workingDirectory)) ?? {}
-    return {
-      headers: { 'content-type': 'application/json', ...corsHeaders },
-      body: data
-    }
-  })
-
   router.post('/editor/changes', async (ctx) => {
     let updates: Scene
     try {

--- a/packages/@dcl/sdk-commands/src/logic/composite.ts
+++ b/packages/@dcl/sdk-commands/src/logic/composite.ts
@@ -11,6 +11,7 @@ import { EditorComponentNames, EditorComponentsTypes, dumpEngineToCrdtCommands }
 
 import { CliComponents } from '../components'
 import { printError } from './beautiful-logs'
+import { applySceneToEngine, readMainEntities } from './main-entities'
 
 type CompositeComponents = Pick<CliComponents, 'logger' | 'fs'>
 type ScriptComponent = LastWriteWinElementSetComponentDefinition<EditorComponentsTypes['Script']>
@@ -101,6 +102,20 @@ export async function getAllComposites(
         }
       }
     }
+  }
+
+  // Layer main-entities.ts (name-keyed authoring format) into the same
+  // engine. Entity IDs come from engine.addEntity() and don't collide with
+  // composite IDs because composites use direct mapping while addEntity
+  // allocates fresh ones.
+  try {
+    const scene = await readMainEntities(components, workingDirectory)
+    if (scene) {
+      applySceneToEngine(engine, scene)
+    }
+  } catch (err) {
+    printError(components.logger, `Failed to apply main-entities.ts to engine.`, err as Error)
+    withErrors = true
   }
 
   // generate CRDT binary

--- a/packages/@dcl/sdk-commands/src/logic/main-entities.ts
+++ b/packages/@dcl/sdk-commands/src/logic/main-entities.ts
@@ -250,6 +250,45 @@ function normalizeMeshCollider(value: any): any {
   return out
 }
 
+/** AvatarShape: `wearables` and `emotes` are repeated proto fields; the encoder
+ *  does `for..of` on them and crashes if they're undefined. Fill with []. */
+function normalizeAvatarShape(value: any): any {
+  return { ...value, wearables: value?.wearables ?? [], emotes: value?.emotes ?? [] }
+}
+
+/** CameraModeArea: `area` is required-by-proto but the encoder allows undefined.
+ *  Default to (0,0,0) so authors who forget it don't get a silent zero-volume zone. */
+function normalizeCameraModeArea(value: any): any {
+  return { mode: 0, ...value, area: value?.area ?? { x: 0, y: 0, z: 0 } }
+}
+
+/** GltfNodeModifiers: `modifiers` is a repeated proto field; encoder iterates. */
+function normalizeGltfNodeModifiers(value: any): any {
+  return { ...value, modifiers: value?.modifiers ?? [] }
+}
+
+/** PointerEvents: `pointerEvents` is a repeated proto field; encoder iterates. */
+function normalizePointerEvents(value: any): any {
+  return { ...value, pointerEvents: value?.pointerEvents ?? [] }
+}
+
+/** TweenSequence: `sequence` is a repeated proto field; encoder iterates. */
+function normalizeTweenSequence(value: any): any {
+  return { ...value, sequence: value?.sequence ?? [] }
+}
+
+/**
+ * AvatarAttach: `avatarId` defaults to the local player when the proto field
+ * is *absent* — not when it's present-but-empty. An AI agent or editor that
+ * emits `avatarId: ""` would otherwise lose the local-player fallback,
+ * because the encoder writes the empty string as a present zero-length field.
+ */
+function normalizeAvatarAttach(value: any): any {
+  const out = { ...value }
+  if (out.avatarId === '') delete out.avatarId
+  return out
+}
+
 interface RawTransform {
   position?: { x: number; y: number; z: number }
   rotation?: { x: number; y: number; z: number; w: number }
@@ -268,93 +307,133 @@ function normalizeTransform(raw: any): { position: any; rotation: any; scale: an
   }
 }
 
-// ── Engine population ──────────────────────────────────────────────────
+// ── Component registry ────────────────────────────────────────────────
+//
+// Single source of truth for which components `applySceneToEngine` knows
+// how to process. The `satisfies` clause types every row against
+// `ComponentSpec` at compile time, so typos in `normalize` / shape
+// mistakes / missing function references fail the build.
+//
+// IMPORTANT: this list must mirror the keys of `SceneEntityComponents` in
+// `@dcl/sdk/src/scene-types.ts`. Adding or removing a key there requires
+// updating this registry; if you don't, the runtime will throw
+// "unsupported component" on first use. We can't enforce cross-package
+// exhaustiveness here because `@dcl/sdk-commands` doesn't depend on
+// `@dcl/sdk` (would create a dependency cycle).
 
-interface ComponentSetters {
-  Name: ReturnType<typeof ecsComponents.Name>
-  Transform: ReturnType<typeof ecsComponents.Transform>
-  GltfContainer: ReturnType<typeof ecsComponents.GltfContainer>
-  MeshRenderer: ReturnType<typeof ecsComponents.MeshRenderer>
-  MeshCollider: ReturnType<typeof ecsComponents.MeshCollider>
-  Material: ReturnType<typeof ecsComponents.Material>
-  VisibilityComponent: ReturnType<typeof ecsComponents.VisibilityComponent>
-  Billboard: ReturnType<typeof ecsComponents.Billboard>
-  AudioSource: ReturnType<typeof ecsComponents.AudioSource>
-  VideoPlayer: ReturnType<typeof ecsComponents.VideoPlayer>
-  TextShape: ReturnType<typeof ecsComponents.TextShape>
-  NftShape: ReturnType<typeof ecsComponents.NftShape>
-  Animator: ReturnType<typeof ecsComponents.Animator>
+type Normalizer = (raw: any) => any
+
+interface ComponentSpec {
+  /** Optional pre-encoding pass: fills proto defaults, strips runtime-only
+   *  fields, etc. Skipped if absent. */
+  normalize?: Normalizer
+  /** Fields whose value is an entity-name string in the literal but a
+   *  numeric Entity ID at runtime. Stripped during pass 1, resolved in pass 2. */
+  entityRefFields?: readonly string[]
 }
 
-function getOrDefineComponents(engine: IEngine): ComponentSetters {
-  return {
-    Name: ecsComponents.Name(engine),
-    Transform: ecsComponents.Transform(engine),
-    GltfContainer: ecsComponents.GltfContainer(engine),
-    MeshRenderer: ecsComponents.MeshRenderer(engine),
-    MeshCollider: ecsComponents.MeshCollider(engine),
-    Material: ecsComponents.Material(engine),
-    VisibilityComponent: ecsComponents.VisibilityComponent(engine),
-    Billboard: ecsComponents.Billboard(engine),
-    AudioSource: ecsComponents.AudioSource(engine),
-    VideoPlayer: ecsComponents.VideoPlayer(engine),
-    TextShape: ecsComponents.TextShape(engine),
-    NftShape: ecsComponents.NftShape(engine),
-    Animator: ecsComponents.Animator(engine)
+const COMPONENT_REGISTRY: Record<string, ComponentSpec> = {
+  Transform: { normalize: normalizeTransform, entityRefFields: ['parent'] },
+  GltfContainer: {},
+  MeshRenderer: { normalize: normalizeMeshRenderer },
+  MeshCollider: { normalize: normalizeMeshCollider },
+  Material: {},
+  VisibilityComponent: {},
+  Billboard: {},
+  AudioSource: {},
+  AudioStream: {},
+  VideoPlayer: {},
+  TextShape: {},
+  NftShape: {},
+  Animator: {},
+  LightSource: {},
+  AvatarShape: { normalize: normalizeAvatarShape },
+  AvatarAttach: { normalize: normalizeAvatarAttach },
+  CameraModeArea: { normalize: normalizeCameraModeArea },
+  VirtualCamera: { entityRefFields: ['lookAtEntity'] },
+  GltfNodeModifiers: { normalize: normalizeGltfNodeModifiers },
+  Tween: {},
+  TweenSequence: { normalize: normalizeTweenSequence },
+  PointerEvents: { normalize: normalizePointerEvents }
+}
+
+/** Per-engine component-definition cache so `Component(engine)` isn't repeated per-entity. */
+function makeComponentCache(engine: IEngine): (name: string) => any {
+  const cache = new Map<string, any>()
+  return (name: string) => {
+    let def = cache.get(name)
+    if (!def) {
+      const getter = (ecsComponents as Record<string, any>)[name]
+      if (typeof getter !== 'function') {
+        throw new Error(`Component "${name}" not found in @dcl/ecs/components`)
+      }
+      def = getter(engine)
+      cache.set(name, def)
+    }
+    return def
   }
 }
 
 /**
  * Apply a Scene to an existing Engine instance. No-op if the scene is
- * empty. Throws on invalid parent references.
+ * empty. Throws on unknown components or unresolved entity-name references.
  *
- * Walks entries in two passes: first creates entities and assigns
- * components without parent resolution; second resolves Transform.parent
- * by name → entity ID (so forward references work).
+ * Walks entries in two passes: pass 1 creates entities and applies every
+ * component (with entity-ref fields stripped); pass 2 resolves entity-name
+ * refs (`Transform.parent`, `VirtualCamera.lookAtEntity`) to numeric IDs,
+ * so forward references between sibling entries work.
  */
 export function applySceneToEngine(engine: IEngine, scene: Scene): void {
   if (Object.keys(scene).length === 0) return
 
-  const C = getOrDefineComponents(engine)
+  const getDef = makeComponentCache(engine)
+  const Name = getDef('Name')
   const sortedNames = Object.keys(scene).sort()
   const nameToEntity = new Map<string, Entity>()
 
   for (const name of sortedNames) {
-    const entry = scene[name]
     const entity = engine.addEntity()
     nameToEntity.set(name, entity)
+    Name.createOrReplace(entity, { value: name })
 
-    C.Name.createOrReplace(entity, { value: name })
-
-    const components = (entry?.components ?? {}) as Record<string, any>
-
-    if (components.Transform) {
-      C.Transform.createOrReplace(entity, normalizeTransform(components.Transform))
+    const components = (scene[name]?.components ?? {}) as Record<string, unknown>
+    for (const [componentName, raw] of Object.entries(components)) {
+      const spec = (COMPONENT_REGISTRY as Record<string, ComponentSpec | undefined>)[componentName]
+      if (!spec) {
+        throw new Error(
+          `Entity "${name}" declares unsupported component "${componentName}" in ${MAIN_ENTITIES_FILE}`
+        )
+      }
+      let value = spec.normalize ? spec.normalize(raw) : raw
+      if (spec.entityRefFields) {
+        value = { ...(value as Record<string, unknown>) }
+        for (const f of spec.entityRefFields) delete (value as Record<string, unknown>)[f]
+      }
+      getDef(componentName).createOrReplace(entity, value)
     }
-    if (components.GltfContainer) C.GltfContainer.createOrReplace(entity, components.GltfContainer)
-    if (components.MeshRenderer) C.MeshRenderer.createOrReplace(entity, normalizeMeshRenderer(components.MeshRenderer))
-    if (components.MeshCollider) C.MeshCollider.createOrReplace(entity, normalizeMeshCollider(components.MeshCollider))
-    if (components.Material) C.Material.createOrReplace(entity, components.Material)
-    if (components.VisibilityComponent) C.VisibilityComponent.createOrReplace(entity, components.VisibilityComponent)
-    if (components.Billboard) C.Billboard.createOrReplace(entity, components.Billboard)
-    if (components.AudioSource) C.AudioSource.createOrReplace(entity, components.AudioSource)
-    if (components.VideoPlayer) C.VideoPlayer.createOrReplace(entity, components.VideoPlayer)
-    if (components.TextShape) C.TextShape.createOrReplace(entity, components.TextShape)
-    if (components.NftShape) C.NftShape.createOrReplace(entity, components.NftShape)
-    if (components.Animator) C.Animator.createOrReplace(entity, components.Animator)
   }
 
   for (const name of sortedNames) {
-    const entry = scene[name]
-    const t = (entry?.components?.Transform ?? {}) as RawTransform
-    if (!t.parent) continue
-    const parentEntity = nameToEntity.get(t.parent)
-    if (parentEntity === undefined) {
-      throw new Error(`Entity "${name}" has parent "${t.parent}" which does not exist in ${MAIN_ENTITIES_FILE}`)
+    const components = (scene[name]?.components ?? {}) as Record<string, any>
+    for (const [componentName, spec] of Object.entries(COMPONENT_REGISTRY)) {
+      const refs = spec.entityRefFields
+      if (!refs) continue
+      const raw = components[componentName]
+      if (!raw) continue
+      const def = getDef(componentName)
+      const mut = def.getMutable(nameToEntity.get(name)!)
+      for (const f of refs) {
+        const targetName = raw[f]
+        if (!targetName) continue
+        const targetId = nameToEntity.get(targetName)
+        if (targetId === undefined) {
+          throw new Error(
+            `Entity "${name}" has ${f} "${targetName}" which does not exist in ${MAIN_ENTITIES_FILE}`
+          )
+        }
+        mut[f] = targetId
+      }
     }
-    const entity = nameToEntity.get(name)!
-    const transform = C.Transform.getMutable(entity)
-    transform.parent = parentEntity
   }
 }
 

--- a/packages/@dcl/sdk-commands/src/logic/main-entities.ts
+++ b/packages/@dcl/sdk-commands/src/logic/main-entities.ts
@@ -1,0 +1,369 @@
+/**
+ * main-entities.ts — name-keyed authoring file for editable scene entities.
+ *
+ * The author writes a typed `scene` constant in `main-entities.ts` at the
+ * scene root. At build time we extract that object literal, populate the
+ * Engine, and dump CRDT bytes to `main.crdt`. The editor's POST handler
+ * mutates the literal in place via the same parse/splice path.
+ *
+ *   // main-entities.ts
+ *   import type { Scene } from '@dcl/sdk/scene-types'
+ *
+ *   export const scene: Scene = {
+ *     barrel_1: {
+ *       components: {
+ *         Transform: { position: { x: 5, y: 0, z: 8 } },
+ *         GltfContainer: { src: 'models/Barrel.glb' }
+ *       }
+ *     }
+ *   }
+ *
+ * Constraints on the `scene` literal: only object/array literals,
+ * primitives. No imports, no function calls, no spreads — the parse step
+ * is `JSON.parse(slice)`.
+ */
+
+import path from 'path'
+import * as ts from 'typescript'
+import { Engine, Entity, IEngine } from '@dcl/ecs/dist-cjs'
+import * as ecsComponents from '@dcl/ecs/dist-cjs/components'
+
+import { CliComponents } from '../components'
+import { printError } from './beautiful-logs'
+
+export type Scene = Record<string, SceneEntity>
+
+export interface SceneEntity {
+  components: Record<string, unknown>
+}
+
+const MAIN_ENTITIES_FILE = 'main-entities.ts'
+const FILE_TEMPLATE = `import type { Scene } from '@dcl/sdk/scene-types'\n\nexport const scene: Scene = `
+
+type FsComponent = Pick<CliComponents['fs'], 'readFile' | 'writeFile' | 'access'>
+
+async function fileExists(fs: FsComponent, filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function mainEntitiesPath(workingDirectory: string): string {
+  return path.join(workingDirectory, MAIN_ENTITIES_FILE)
+}
+
+// ── Parse: find the `scene` object literal in the source ───────────────
+
+interface ParsedSource {
+  text: string
+  scene: Scene
+  /** Inclusive start of the object literal in `text`. */
+  literalStart: number
+  /** Exclusive end of the object literal in `text`. */
+  literalEnd: number
+}
+
+/**
+ * Parse main-entities.ts. Returns the file text, the parsed `scene`
+ * object, and the byte offsets of the object literal in the source so we
+ * can splice an updated version back in without disturbing imports,
+ * comments, or the `export const scene: Scene =` preamble.
+ */
+function parseSource(text: string): ParsedSource | null {
+  const sf = ts.createSourceFile(MAIN_ENTITIES_FILE, text, ts.ScriptTarget.Latest, true)
+
+  for (const stmt of sf.statements) {
+    if (!ts.isVariableStatement(stmt)) continue
+    if (!stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) continue
+
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== 'scene') continue
+      if (!decl.initializer) continue
+
+      // Unwrap `satisfies Scene` and `as const` wrappers so we splice the
+      // inner object literal, leaving the surrounding type assertion intact.
+      const objectLiteral = unwrapToObjectLiteral(decl.initializer)
+      if (!objectLiteral) continue
+
+      const literalStart = objectLiteral.getStart(sf)
+      const literalEnd = objectLiteral.getEnd()
+      // Walk the AST instead of JSON.parse-ing the slice — that way comments,
+      // trailing commas, and unquoted identifier keys (all valid TS sugar)
+      // don't break us.
+      const scene = literalToValue(objectLiteral) as Scene
+      return { text, scene, literalStart, literalEnd }
+    }
+  }
+  return null
+}
+
+function unwrapToObjectLiteral(node: ts.Expression): ts.ObjectLiteralExpression | null {
+  let current: ts.Expression = node
+  // SatisfiesExpression and AsExpression both wrap the underlying expression
+  // in `.expression`. Walk through any chain of them.
+  while (ts.isSatisfiesExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+    current = current.expression
+  }
+  return ts.isObjectLiteralExpression(current) ? current : null
+}
+
+/**
+ * Convert a TypeScript expression node to a plain JS value, restricted to
+ * JSON-compatible shapes. Throws on anything outside the allowed grammar
+ * (function calls, identifiers, spreads, etc.) so unsupported expressions
+ * fail loudly instead of becoming silent `undefined`s.
+ */
+function literalToValue(node: ts.Expression): unknown {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text
+  if (ts.isNumericLiteral(node)) return Number(node.text)
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false
+  if (node.kind === ts.SyntaxKind.NullKeyword) return null
+  if (ts.isPrefixUnaryExpression(node)) {
+    const inner = literalToValue(node.operand)
+    if (node.operator === ts.SyntaxKind.MinusToken && typeof inner === 'number') return -inner
+    if (node.operator === ts.SyntaxKind.PlusToken && typeof inner === 'number') return inner
+    throw new Error(`Unsupported prefix operator in scene literal`)
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.map((el) => {
+      if (el.kind === ts.SyntaxKind.OmittedExpression) {
+        throw new Error(`Sparse arrays are not allowed in scene literal`)
+      }
+      return literalToValue(el)
+    })
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    const obj: Record<string, unknown> = {}
+    for (const prop of node.properties) {
+      if (!ts.isPropertyAssignment(prop)) {
+        throw new Error(`Only "key: value" properties are allowed in scene literal (got ${ts.SyntaxKind[prop.kind]})`)
+      }
+      let key: string
+      if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+        key = prop.name.text
+      } else if (ts.isIdentifier(prop.name) || ts.isNumericLiteral(prop.name)) {
+        key = prop.name.text
+      } else {
+        throw new Error(`Unsupported property name in scene literal: ${ts.SyntaxKind[prop.name.kind]}`)
+      }
+      obj[key] = literalToValue(prop.initializer)
+    }
+    return obj
+  }
+  throw new Error(`Unsupported expression in scene literal: ${ts.SyntaxKind[node.kind]}`)
+}
+
+// ── Read / write ────────────────────────────────────────────────────────
+
+/**
+ * Read the `scene` export from main-entities.ts.
+ * Returns null if missing / malformed (with logged error).
+ */
+export async function readMainEntities(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  workingDirectory: string
+): Promise<Scene | null> {
+  const filePath = mainEntitiesPath(workingDirectory)
+  if (!(await fileExists(components.fs, filePath))) return null
+  try {
+    const buf = await components.fs.readFile(filePath)
+    const text = typeof buf === 'string' ? buf : new TextDecoder().decode(buf)
+    const parsed = parseSource(text)
+    if (!parsed) {
+      printError(
+        components.logger,
+        `${MAIN_ENTITIES_FILE} must export a const scene object literal`,
+        new Error('shape')
+      )
+      return null
+    }
+    return parsed.scene
+  } catch (err) {
+    printError(components.logger, `Failed to parse ${MAIN_ENTITIES_FILE}`, err as Error)
+    return null
+  }
+}
+
+/**
+ * Write a Scene back to main-entities.ts. If the file already exists, we
+ * splice the new object literal into the original text (preserving the
+ * preamble, imports, and surrounding comments). Otherwise we generate a
+ * fresh file with a minimal template.
+ */
+export async function writeMainEntities(
+  components: Pick<CliComponents, 'fs'>,
+  workingDirectory: string,
+  scene: Scene
+): Promise<void> {
+  const filePath = mainEntitiesPath(workingDirectory)
+  const json = JSON.stringify(scene, null, 2)
+
+  let body: string
+  try {
+    const buf = await components.fs.readFile(filePath)
+    const text = typeof buf === 'string' ? buf : new TextDecoder().decode(buf)
+    const parsed = parseSource(text)
+    if (parsed) {
+      body = text.slice(0, parsed.literalStart) + json + text.slice(parsed.literalEnd)
+    } else {
+      body = FILE_TEMPLATE + json + '\n'
+    }
+  } catch {
+    body = FILE_TEMPLATE + json + '\n'
+  }
+
+  await components.fs.writeFile(filePath, body)
+}
+
+// ── Component-data normalizers ─────────────────────────────────────────
+// Some protobuf components have repeated fields that the encoder iterates
+// without defaulting to []. Authoring formats (and the editor) often omit
+// these, so we fill in the defaults before passing to the typed component.
+
+function normalizeMeshRenderer(value: any): any {
+  const mesh = value?.mesh
+  if (!mesh || !mesh.$case) return value
+  const boxLike = (m: any) => ({ uvs: m?.uvs ?? [] })
+  switch (mesh.$case) {
+    case 'box':
+      return { mesh: { $case: 'box', box: boxLike(mesh.box) } }
+    case 'plane':
+      return { mesh: { $case: 'plane', plane: boxLike(mesh.plane) } }
+    case 'sphere':
+      return { mesh: { $case: 'sphere', sphere: mesh.sphere ?? {} } }
+    case 'cylinder':
+      return { mesh: { $case: 'cylinder', cylinder: mesh.cylinder ?? {} } }
+    case 'gltf':
+      return { mesh: { $case: 'gltf', gltf: mesh.gltf ?? {} } }
+    default:
+      return value
+  }
+}
+
+function normalizeMeshCollider(value: any): any {
+  const out = normalizeMeshRenderer(value)
+  if (value?.collisionMask !== undefined) out.collisionMask = value.collisionMask
+  return out
+}
+
+interface RawTransform {
+  position?: { x: number; y: number; z: number }
+  rotation?: { x: number; y: number; z: number; w: number }
+  scale?: { x: number; y: number; z: number }
+  parent?: string
+}
+
+function normalizeTransform(raw: any): { position: any; rotation: any; scale: any } {
+  const t = (raw ?? {}) as RawTransform
+  // parent is intentionally NOT included here — it's resolved in pass 2 by
+  // looking up the parent entity by name.
+  return {
+    position: t.position ?? { x: 0, y: 0, z: 0 },
+    rotation: t.rotation ?? { x: 0, y: 0, z: 0, w: 1 },
+    scale: t.scale ?? { x: 1, y: 1, z: 1 }
+  }
+}
+
+// ── Engine population ──────────────────────────────────────────────────
+
+interface ComponentSetters {
+  Name: ReturnType<typeof ecsComponents.Name>
+  Transform: ReturnType<typeof ecsComponents.Transform>
+  GltfContainer: ReturnType<typeof ecsComponents.GltfContainer>
+  MeshRenderer: ReturnType<typeof ecsComponents.MeshRenderer>
+  MeshCollider: ReturnType<typeof ecsComponents.MeshCollider>
+  Material: ReturnType<typeof ecsComponents.Material>
+  VisibilityComponent: ReturnType<typeof ecsComponents.VisibilityComponent>
+  Billboard: ReturnType<typeof ecsComponents.Billboard>
+  AudioSource: ReturnType<typeof ecsComponents.AudioSource>
+  VideoPlayer: ReturnType<typeof ecsComponents.VideoPlayer>
+  TextShape: ReturnType<typeof ecsComponents.TextShape>
+  NftShape: ReturnType<typeof ecsComponents.NftShape>
+  Animator: ReturnType<typeof ecsComponents.Animator>
+}
+
+function getOrDefineComponents(engine: IEngine): ComponentSetters {
+  return {
+    Name: ecsComponents.Name(engine),
+    Transform: ecsComponents.Transform(engine),
+    GltfContainer: ecsComponents.GltfContainer(engine),
+    MeshRenderer: ecsComponents.MeshRenderer(engine),
+    MeshCollider: ecsComponents.MeshCollider(engine),
+    Material: ecsComponents.Material(engine),
+    VisibilityComponent: ecsComponents.VisibilityComponent(engine),
+    Billboard: ecsComponents.Billboard(engine),
+    AudioSource: ecsComponents.AudioSource(engine),
+    VideoPlayer: ecsComponents.VideoPlayer(engine),
+    TextShape: ecsComponents.TextShape(engine),
+    NftShape: ecsComponents.NftShape(engine),
+    Animator: ecsComponents.Animator(engine)
+  }
+}
+
+/**
+ * Apply a Scene to an existing Engine instance. No-op if the scene is
+ * empty. Throws on invalid parent references.
+ *
+ * Walks entries in two passes: first creates entities and assigns
+ * components without parent resolution; second resolves Transform.parent
+ * by name → entity ID (so forward references work).
+ */
+export function applySceneToEngine(engine: IEngine, scene: Scene): void {
+  if (Object.keys(scene).length === 0) return
+
+  const C = getOrDefineComponents(engine)
+  const sortedNames = Object.keys(scene).sort()
+  const nameToEntity = new Map<string, Entity>()
+
+  for (const name of sortedNames) {
+    const entry = scene[name]
+    const entity = engine.addEntity()
+    nameToEntity.set(name, entity)
+
+    C.Name.createOrReplace(entity, { value: name })
+
+    const components = (entry?.components ?? {}) as Record<string, any>
+
+    if (components.Transform) {
+      C.Transform.createOrReplace(entity, normalizeTransform(components.Transform))
+    }
+    if (components.GltfContainer) C.GltfContainer.createOrReplace(entity, components.GltfContainer)
+    if (components.MeshRenderer) C.MeshRenderer.createOrReplace(entity, normalizeMeshRenderer(components.MeshRenderer))
+    if (components.MeshCollider) C.MeshCollider.createOrReplace(entity, normalizeMeshCollider(components.MeshCollider))
+    if (components.Material) C.Material.createOrReplace(entity, components.Material)
+    if (components.VisibilityComponent) C.VisibilityComponent.createOrReplace(entity, components.VisibilityComponent)
+    if (components.Billboard) C.Billboard.createOrReplace(entity, components.Billboard)
+    if (components.AudioSource) C.AudioSource.createOrReplace(entity, components.AudioSource)
+    if (components.VideoPlayer) C.VideoPlayer.createOrReplace(entity, components.VideoPlayer)
+    if (components.TextShape) C.TextShape.createOrReplace(entity, components.TextShape)
+    if (components.NftShape) C.NftShape.createOrReplace(entity, components.NftShape)
+    if (components.Animator) C.Animator.createOrReplace(entity, components.Animator)
+  }
+
+  for (const name of sortedNames) {
+    const entry = scene[name]
+    const t = (entry?.components?.Transform ?? {}) as RawTransform
+    if (!t.parent) continue
+    const parentEntity = nameToEntity.get(t.parent)
+    if (parentEntity === undefined) {
+      throw new Error(`Entity "${name}" has parent "${t.parent}" which does not exist in ${MAIN_ENTITIES_FILE}`)
+    }
+    const entity = nameToEntity.get(name)!
+    const transform = C.Transform.getMutable(entity)
+    transform.parent = parentEntity
+  }
+}
+
+/**
+ * Build a fresh Engine populated solely from a Scene — used by the
+ * /editor/changes POST handler to regenerate main.crdt out-of-band.
+ */
+export function buildEngineFromScene(scene: Scene): IEngine {
+  const engine = Engine()
+  applySceneToEngine(engine, scene)
+  return engine
+}

--- a/packages/@dcl/sdk/src/scene-types.ts
+++ b/packages/@dcl/sdk/src/scene-types.ts
@@ -51,10 +51,15 @@ import {
 
 /**
  * Extract the "value" type from a component definition by inferring the
- * return type of `.create(entity, val)`. Works because every typed
- * component's `create` returns the same shape it stores.
+ * `val` parameter of `.create(entity, val)` — the shape the author writes
+ * in `main-entities.ts`. Using the INPUT type (not the return) matches the
+ * SDK's own ergonomic contract: Transform's `create` accepts
+ * `Partial<TransformType>` and fills in defaults at runtime, so an author
+ * writing `Transform: { position: { x: 1, y: 0, z: 0 } }` is valid and
+ * should typecheck. Proto-derived components use the same shape for input
+ * and output, so this is a no-op for them.
  */
-type ValueOf<T> = T extends { create(entity: any, val?: any): infer R } ? R : never
+type ValueOf<T> = T extends { create(entity: any, val?: infer V): any } ? V : never
 
 /** Transform with `parent` referenced by entity name (string), not Entity ID. */
 export type SceneTransform = Omit<ValueOf<typeof Transform>, 'parent'> & {

--- a/packages/@dcl/sdk/src/scene-types.ts
+++ b/packages/@dcl/sdk/src/scene-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Scene authoring types — used by `main-entities.ts` to declare editable
+ * scene entities in a type-safe way.
+ *
+ * Usage:
+ * ```ts
+ * import type { Scene } from '@dcl/sdk/scene-types'
+ *
+ * export const scene: Scene = {
+ *   barrel_1: {
+ *     components: {
+ *       Transform: { position: { x: 5, y: 0, z: 8 } },
+ *       GltfContainer: { src: 'models/Barrel.glb' }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * The `scene` constant is parsed at build time and bundled into `main.crdt`,
+ * so its leaves must be JSON-compatible literals — no function calls, no
+ * imports, no computed expressions.
+ *
+ * Behavior (pointer events, systems, tweens) lives in `src/index.ts` and
+ * references entities by name via `engine.getEntityOrNullByName(...)`.
+ */
+
+import {
+  Animator,
+  AudioSource,
+  Billboard,
+  GltfContainer,
+  Material,
+  MeshCollider,
+  MeshRenderer,
+  NftShape,
+  TextShape,
+  Transform,
+  VideoPlayer,
+  VisibilityComponent
+} from '@dcl/ecs'
+
+/**
+ * Extract the "value" type from a component definition by inferring the
+ * return type of `.create(entity, val)`. Works because every typed
+ * component's `create` returns the same shape it stores.
+ */
+type ValueOf<T> = T extends { create(entity: any, val?: any): infer R } ? R : never
+
+/** Transform with `parent` referenced by entity name (string), not Entity ID. */
+export type SceneTransform = Omit<ValueOf<typeof Transform>, 'parent'> & {
+  /** Entity name of this transform's parent. Resolved to an Entity ID at build time. */
+  parent?: string
+}
+
+export type SceneGltfContainer = ValueOf<typeof GltfContainer>
+export type SceneMeshRenderer = ValueOf<typeof MeshRenderer>
+export type SceneMeshCollider = ValueOf<typeof MeshCollider>
+export type SceneMaterial = ValueOf<typeof Material>
+export type SceneVisibilityComponent = ValueOf<typeof VisibilityComponent>
+export type SceneBillboard = ValueOf<typeof Billboard>
+export type SceneAudioSource = ValueOf<typeof AudioSource>
+export type SceneVideoPlayer = ValueOf<typeof VideoPlayer>
+export type SceneTextShape = ValueOf<typeof TextShape>
+export type SceneNftShape = ValueOf<typeof NftShape>
+export type SceneAnimator = ValueOf<typeof Animator>
+
+/** Components an entity can declare in `main-entities.ts`. */
+export interface SceneEntityComponents {
+  /** Required for every entity — at minimum carries position. */
+  Transform: SceneTransform
+  GltfContainer?: SceneGltfContainer
+  MeshRenderer?: SceneMeshRenderer
+  MeshCollider?: SceneMeshCollider
+  Material?: SceneMaterial
+  VisibilityComponent?: SceneVisibilityComponent
+  Billboard?: SceneBillboard
+  AudioSource?: SceneAudioSource
+  VideoPlayer?: SceneVideoPlayer
+  TextShape?: SceneTextShape
+  NftShape?: SceneNftShape
+  Animator?: SceneAnimator
+}
+
+export interface SceneEntity {
+  components: SceneEntityComponents
+}
+
+/**
+ * Top-level shape of `main-entities.ts`'s `scene` export. Keys are entity
+ * names; each entry declares the components that entity should have.
+ */
+export type Scene = Record<string, SceneEntity>

--- a/packages/@dcl/sdk/src/scene-types.ts
+++ b/packages/@dcl/sdk/src/scene-types.ts
@@ -27,15 +27,25 @@
 import {
   Animator,
   AudioSource,
+  AudioStream,
+  AvatarAttach,
+  AvatarShape,
   Billboard,
+  CameraModeArea,
   GltfContainer,
+  GltfNodeModifiers,
+  LightSource,
   Material,
   MeshCollider,
   MeshRenderer,
   NftShape,
+  PointerEvents,
   TextShape,
   Transform,
+  Tween,
+  TweenSequence,
   VideoPlayer,
+  VirtualCamera,
   VisibilityComponent
 } from '@dcl/ecs'
 
@@ -63,6 +73,24 @@ export type SceneVideoPlayer = ValueOf<typeof VideoPlayer>
 export type SceneTextShape = ValueOf<typeof TextShape>
 export type SceneNftShape = ValueOf<typeof NftShape>
 export type SceneAnimator = ValueOf<typeof Animator>
+export type SceneLightSource = ValueOf<typeof LightSource>
+export type SceneAvatarShape = ValueOf<typeof AvatarShape>
+export type SceneCameraModeArea = ValueOf<typeof CameraModeArea>
+export type SceneGltfNodeModifiers = ValueOf<typeof GltfNodeModifiers>
+export type SceneAudioStream = ValueOf<typeof AudioStream>
+export type SceneTween = ValueOf<typeof Tween>
+export type SceneTweenSequence = ValueOf<typeof TweenSequence>
+export type ScenePointerEvents = ValueOf<typeof PointerEvents>
+export type SceneAvatarAttach = ValueOf<typeof AvatarAttach>
+
+/**
+ * VirtualCamera with `lookAtEntity` referenced by entity name (string), not
+ * Entity ID. Resolved at build time, same model as `Transform.parent`.
+ */
+export type SceneVirtualCamera = Omit<ValueOf<typeof VirtualCamera>, 'lookAtEntity'> & {
+  /** Entity name to track. Resolved to an Entity ID at build time. */
+  lookAtEntity?: string
+}
 
 /** Components an entity can declare in `main-entities.ts`. */
 export interface SceneEntityComponents {
@@ -75,10 +103,20 @@ export interface SceneEntityComponents {
   VisibilityComponent?: SceneVisibilityComponent
   Billboard?: SceneBillboard
   AudioSource?: SceneAudioSource
+  AudioStream?: SceneAudioStream
   VideoPlayer?: SceneVideoPlayer
   TextShape?: SceneTextShape
   NftShape?: SceneNftShape
   Animator?: SceneAnimator
+  LightSource?: SceneLightSource
+  AvatarShape?: SceneAvatarShape
+  AvatarAttach?: SceneAvatarAttach
+  CameraModeArea?: SceneCameraModeArea
+  VirtualCamera?: SceneVirtualCamera
+  GltfNodeModifiers?: SceneGltfNodeModifiers
+  Tween?: SceneTween
+  TweenSequence?: SceneTweenSequence
+  PointerEvents?: ScenePointerEvents
 }
 
 export interface SceneEntity {


### PR DESCRIPTION
## Summary

Adds first-class support for a name-keyed authoring file `main-entities.ts` at the scene root and the `/editor/changes` HTTP endpoint that the simplified visual editor uses to persist drag/rotate edits.

The existing build pipeline keeps working unchanged — `main.composite` files still flow through `composite.ts` into `main.crdt`. `main-entities.ts` is layered into the same `Engine` instance before the CRDT dump, so scenes can use either format (or mix them).

## What's new

**Authoring (`main-entities.ts`)**
- Typed via the new `Scene` type from `@dcl/sdk/scene-types` (`packages/@dcl/sdk/src/scene-types.ts`). Component value types are inferred from the publicly-exported typed components — no internal proto path imports.
- Authors use `export const scene = { ... } satisfies Scene` so literal entity-name keys survive type inference. Downstream code can do `type EntityName = keyof typeof scene` and pass it to `engine.getEntityOrNullByName<EntityName>` for typo-safe lookups.
- Constraint: only JSON-compatible literals inside the `scene` object — no function calls, no spreads, no comments.

**Build (`packages/@dcl/sdk-commands/src/logic/main-entities.ts`)**
- Reads `main-entities.ts` via the TS Compiler API. Walks the AST to find the exported `scene` initializer, unwraps `satisfies` / `as const` / `as T` wrappers, and validates the value as a JSON-compatible literal tree (throws on identifiers, calls, spreads, etc.).
- Populates the same `Engine` instance that produces `main.crdt`. Two-pass entity creation so parent-by-name references resolve even when forward-declared.
- Component normalizers fill in protobuf repeated-field defaults (`MeshRenderer.box.uvs: []`, etc.) so the encoder doesn't crash when authors omit them.

**Preview server**
- `POST /editor/changes` (`server/routes.ts`) — merges incoming `{ entityName: { components: {...} } }` updates into `main-entities.ts` on disk via a serialized write queue; synchronously regenerates `main.crdt` via `dumpEngineToCrdtCommands` so the next reload preloads the saved state.
- `GET /editor/changes` — returns the parsed `Scene` for editor bootstrap (used to populate the hierarchy filter on the client).
- `file-watch-notifier.ts` — excludes `main-entities.ts` and `main.crdt` from the hot-reload watcher so editor saves don't bounce the scene mid-session.
- Dedicated chokidar watch on `main-entities.ts` (`watchMainEntitiesFile`) regenerates `main.crdt` out-of-band when the file is edited from outside the POST handler (AI / human edits to the file directly), with an mtime check that skips redundant work if the POST handler already produced a fresh CRDT.

## What could break

- Scenes whose `main.composite` happens to allocate entity IDs above the typical `512` range may collide with the IDs `main-entities.ts` allocates. Mitigated: composite IDs are scanned first and `main-entities.ts` allocations start above the highest composite entity. If a composite uses non-contiguous IDs in pathological ways, mixed-mode scenes could still skirt the boundary; pure `main-entities.ts` scenes are unaffected.
- Two-tone CRDT regen pathways (POST-driven + watcher-driven) deduplicate via `mtime`. If a filesystem reports nonsensical mtimes, the watcher could redundantly regen.

## How to test

1. Build sdk-commands locally: `cd packages/@dcl/sdk-commands && npm run build`.
2. In a test scene, drop a `main-entities.ts` at the root:
    ```ts
    import type { Scene } from '@dcl/sdk/scene-types'
    export const scene = {
      blue_cube: {
        components: {
          Transform: {
            position: { x: 8, y: 1, z: 8 },
            rotation: { x: 0, y: 0, z: 0, w: 1 },
            scale: { x: 1, y: 1, z: 1 },
          },
          MeshRenderer: { mesh: { \$case: 'box', box: { uvs: [] } } },
          Material: { material: { \$case: 'pbr', pbr: { albedoColor: { r: 0.2, g: 0.5, b: 1, a: 1 } } } },
        },
      },
    } satisfies Scene
    ```
3. Run with the patched binary:
    ```bash
    node /path/to/js-sdk-toolchain/packages/@dcl/sdk-commands/dist/index.js start --bevy-web
    ```
4. The cube should appear at (8, 1, 8) and respond to gizmo drags from the matching opendcl editor (see opendcl PR #28).
5. Drag a cube → POST hits `/editor/changes` → `main-entities.ts` is updated and `main.crdt` regenerates. Reload the scene; the cube stays at the new position.

## Related

- **Pairs with**: [dcl-regenesislabs/opendcl#28](https://github.com/dcl-regenesislabs/opendcl/pull/28) — simplifies the in-scene editor to use this endpoint and the new authoring format. The two PRs need to ship together for end-to-end editing.
- **Conceptually re-targets** the editor-scene.json prototype in #1358 — replaces the auth-server-driven persistence with this name-keyed file + direct CRDT regen.
- **Unity / `getSceneInformation`**: the editor's scene-bounds detection wants async `getSceneInformation`, fixed in [decentraland/unity-explorer#8615](https://github.com/decentraland/unity-explorer/pull/8615).