### PR TITLE
fix: onProximityEnter/Leave without an explicit button

### DIFF
--- a/packages/@dcl/ecs/src/engine/input.ts
+++ b/packages/@dcl/ecs/src/engine/input.ts
@@ -107,7 +107,10 @@ export function createInputSystem(engine: IEngine): IInputSystem {
   ): PBPointerEventsResult | undefined {
     const ascendingTimestampIterator = PointerEventsResult.get(entity)
     for (const command of Array.from(ascendingTimestampIterator).reverse()) {
-      if (command.button === inputAction && command.state === pointerEventType) {
+      if (
+        (command.button === inputAction || command.button === InputAction.IA_ANY) &&
+        command.state === pointerEventType
+      ) {
         return command
       }
     }


### PR DESCRIPTION
## Summary

`pointerEventsSystem.onProximityEnter` (and `onProximityLeave`) silently never fires unless the caller passes `button: InputAction.IA_POINTER` (or another specific button) in `opts`. This makes the documented \"button is optional\" usage actually work:

\`\`\`ts
pointerEventsSystem.onProximityEnter(
  { entity, opts: { maxPlayerDistance: 5 } },
  () => { /* now actually fires */ }
)
\`\`\`

## Why it doesn't fire today

When the user omits `button`, `getDefaultOpts` fills it with `IA_ANY`. The proximity entry on the renderer side ends up with `eventInfo.button = IA_ANY`, the renderer writes the `PointerEventsResult` with `button = IA_ANY`, and the SDK then looks up via `getInputCommand(IA_ANY, PET_PROXIMITY_ENTER, entity)`. That expands to iterating `InputCommands` `[IaPointer, IaPrimary, IaSecondary, IaForward, …]` and, for each, calls `findLastAction(pet, <specific>, entity)` — which does strict `command.button === inputAction`. `IA_ANY` isn't in `InputCommands`, and the result's button **is** `IA_ANY`, so every iteration misses and the callback never runs.

The 2023 fix (`091fce46`) added wildcard handling on the global-state path only. The per-entity path was left as-is.

## The fix

One line in `findLastAction`: also treat `command.button === IA_ANY` as a match. The existing iteration in `getInputCommandFromEntity` is preserved, so InputCommands ordering for specific-button matches is unchanged. Strict matches keep working; only the previously-impossible IA_ANY-command case now resolves.

## Side-effect analysis

- No `IA_ANY` commands written → behavior unchanged everywhere.
- Specific-button lookup, `IA_ANY` command present → now matches. This is the desired wildcard semantics on the command side, mirroring the global-state fix on the lookup side.
- `IA_ANY` lookup → iteration first tries `IaPointer`, which now matches any `IA_ANY` command (returning the most recent). If no `IA_ANY` command exists, falls back to specific buttons in InputCommands order, same as before.

The only theoretical change is \"an entity has both an `IA_ANY` command and a specific-button command of the same event type, and the lookup is for that specific button\" — old returns the specific one, new returns whichever is more recent. Renderers don't mix `IA_ANY` and specific-button results for the same event type on the same entity in practice.

## Notes

- A symmetric workaround in renderer code (write `IA_POINTER` when the entry's button is unset/`IA_ANY`) is what `WriteHover` already does. The SDK fix removes the need for renderers to know about this quirk per event type.