### PR TITLE
chore: update protocol to include PBUiInput.clear_on_submit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-25001674716.commit-044c893",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
-      "integrity": "sha512-CbOb1SRTxNDa1uvc4lXLpyYXvWAK5/D8yh9Sxy/OMEpYrWaApD4RN4H/rRaRi7l+HI0p/0b1WZ045izBhv/8XQ==",
+      "version": "1.0.0-25726165615.commit-2f417f5",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
+      "integrity": "sha512-DY5KtUGWhevH+lpSir8NIqOYk6CX3R753OzbrZHSgh9ZxjVKuugDVUJDsfxtiymtq5YGLUq+5SXI51ohJfRRdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -1643,9 +1643,10 @@
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -1667,9 +1668,10 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -1682,9 +1684,10 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.28",
@@ -8883,8 +8886,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
-      "integrity": "sha512-CbOb1SRTxNDa1uvc4lXLpyYXvWAK5/D8yh9Sxy/OMEpYrWaApD4RN4H/rRaRi7l+HI0p/0b1WZ045izBhv/8XQ==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
+      "integrity": "sha512-DY5KtUGWhevH+lpSir8NIqOYk6CX3R753OzbrZHSgh9ZxjVKuugDVUJDsfxtiymtq5YGLUq+5SXI51ohJfRRdg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"
@@ -9707,9 +9710,9 @@
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -9731,9 +9734,9 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
@@ -9746,9 +9749,9 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
     },
     "@sinclair/typebox": {
       "version": "0.24.28"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.25.0",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-25001674716.commit-044c893",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
-      "integrity": "sha512-CbOb1SRTxNDa1uvc4lXLpyYXvWAK5/D8yh9Sxy/OMEpYrWaApD4RN4H/rRaRi7l+HI0p/0b1WZ045izBhv/8XQ==",
+      "version": "1.0.0-25726165615.commit-2f417f5",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
+      "integrity": "sha512-DY5KtUGWhevH+lpSir8NIqOYk6CX3R753OzbrZHSgh9ZxjVKuugDVUJDsfxtiymtq5YGLUq+5SXI51ohJfRRdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.25.0",
     "@dcl/linker-dapp": "^0.14.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=601.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=602.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 70k
-  MALLOC_COUNT = 16806
+  MALLOC_COUNT = 16794
   ALIVE_OBJS_DELTA ~= 3.37k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -47,7 +47,7 @@ CALL onStart()
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"ensure that cubes are in the scene on the first frame"}]}
   OPCODES ~= 17k
-  MALLOC_COUNT = -61
+  MALLOC_COUNT = -63
   ALIVE_OBJS_DELTA ~= -0.03k
 CALL onUpdate(0.1)
   LOG: ["🧪 Running test ensure that cubes are in the scene on the first frame"]
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1482.16k bytes
+  MEMORY_USAGE_COUNT ~= 1482.13k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=602.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=602.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 79k
-  MALLOC_COUNT = 17330
+  MALLOC_COUNT = 17318
   ALIVE_OBJS_DELTA ~= 3.52k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1490.33k bytes
+  MEMORY_USAGE_COUNT ~= 1490.36k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=602.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=602.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,7 +11,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 79k
-  MALLOC_COUNT = 17330
+  MALLOC_COUNT = 17318
   ALIVE_OBJS_DELTA ~= 3.52k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -40
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1490.33k bytes
+  MEMORY_USAGE_COUNT ~= 1490.36k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -170,7 +170,7 @@
         "@dcl/inspector": "7.25.0",
         "@dcl/linker-dapp": "^0.14.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25001674716.commit-044c893.tgz",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25726165615.commit-2f417f5.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=265.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=265.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,8 +9,8 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 82k
-  MALLOC_COUNT = 15636
-  ALIVE_OBJS_DELTA ~= 3.52k
+  MALLOC_COUNT = 15627
+  ALIVE_OBJS_DELTA ~= 3.51k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -24,7 +24,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5,"tickNumber":0}
   OPCODES ~= 16k
-  MALLOC_COUNT = 79
+  MALLOC_COUNT = 75
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   LOG: ["PointerEventsResult",[{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0},{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5,"tickNumber":0}]]
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 14k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1113.90k bytes
+  MEMORY_USAGE_COUNT ~= 1113.54k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=306.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=306.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: long
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
-  OPCODES ~= 84k
-  MALLOC_COUNT = 18142
+  OPCODES ~= 83k
+  MALLOC_COUNT = 18133
   ALIVE_OBJS_DELTA ~= 3.99k
 CALL onStart()
   OPCODES ~= 0k
@@ -77,4 +77,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 10k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1291.85k bytes
+  MEMORY_USAGE_COUNT ~= 1291.61k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=261.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=262k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 72k
-  MALLOC_COUNT = 14778
+  MALLOC_COUNT = 14769
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1075.92k bytes
+  MEMORY_USAGE_COUNT ~= 1075.69k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=261.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=261.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,8 +9,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 72k
-  MALLOC_COUNT = 14748
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14739
+  ALIVE_OBJS_DELTA ~= 3.28k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1065.77k bytes
+  MEMORY_USAGE_COUNT ~= 1065.54k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=307.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=307.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: long
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
-  OPCODES ~= 123k
-  MALLOC_COUNT = 21484
+  OPCODES ~= 122k
+  MALLOC_COUNT = 21475
   ALIVE_OBJS_DELTA ~= 5.28k
 CALL onStart()
   OPCODES ~= 0k
@@ -1652,4 +1652,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 701k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1427.78k bytes
+  MEMORY_USAGE_COUNT ~= 1427.54k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=262.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=263k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 73k
-  MALLOC_COUNT = 15042
+  MALLOC_COUNT = 15033
   ALIVE_OBJS_DELTA ~= 3.37k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1084.01k bytes
+  MEMORY_USAGE_COUNT ~= 1083.78k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=261.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=262k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,8 +9,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 76k
-  MALLOC_COUNT = 14875
-  ALIVE_OBJS_DELTA ~= 3.32k
+  MALLOC_COUNT = 14866
+  ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1068.19k bytes
+  MEMORY_USAGE_COUNT ~= 1067.96k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=425.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=425.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 85k
-  MALLOC_COUNT = 22808
+  MALLOC_COUNT = 22799
   ALIVE_OBJS_DELTA ~= 4.64k
 CALL onStart()
   OPCODES ~= 0k
@@ -65,4 +65,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 71k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1934.07k bytes
+  MEMORY_USAGE_COUNT ~= 1933.93k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=636.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=637k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   OPCODES ~= 220k
-  MALLOC_COUNT = 44497
+  MALLOC_COUNT = 44488
   ALIVE_OBJS_DELTA ~= 9.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -37,4 +37,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 3061.06k bytes
+  MEMORY_USAGE_COUNT ~= 3061.32k bytes


### PR DESCRIPTION
## Summary

Bumps `@dcl/protocol` to the branch artifact from decentraland/protocol#404, which adds `clear_on_submit` (optional bool, default `true`) to `PBUiInput`.

Refs: decentraland/bevy-explorer#773, decentraland/protocol#404