### PR TITLE
feat: add AMT_HIDE_NAMETAGS modifier to AvatarModifierArea 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-25337665839.commit-834aaf3",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -33,6 +33,9 @@
         "@types/node": "^18.11.18",
         "syncpack": "^9.8.4",
         "typedoc": "^0.23.28"
+      },
+      "engines": {
+        "node": "20"
       }
     },
     "node_modules/@actions/core": {
@@ -81,7 +84,6 @@
     "node_modules/@babel/core": {
       "version": "7.18.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -578,9 +580,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-25337665839.commit-834aaf3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-25337665839.commit-834aaf3.tgz",
-      "integrity": "sha512-J9gX2qnLMNw8QS0njTy/XAx6p/9B9jpbft7llUOBTSwZWXSSHV7omu8+IdmzoW9Q1BT3ZKhKekdWE/78g+oogw==",
+      "version": "1.0.0-25678907683.commit-94ee065",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
+      "integrity": "sha512-9CmbKBy7rQ6qPRcncUdFuNwTHao5qzaYnmMWbIK+seyNJlS+QXSIq8UC36kUquZqyveeL46iBg+nurwnOhAGSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -1938,7 +1940,6 @@
       "version": "5.6.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.6.0",
         "@typescript-eslint/types": "5.6.0",
@@ -2050,7 +2051,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2278,6 +2278,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
       "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "find-babel-config": "^2.0.0",
         "glob": "^8.0.3",
@@ -2294,6 +2295,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2303,6 +2305,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2322,6 +2325,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2420,7 +2424,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001370",
         "electron-to-chromium": "^1.4.202",
@@ -3052,7 +3055,6 @@
       "version": "8.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -3282,7 +3284,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -3744,6 +3745,7 @@
       "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
       "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "json5": "^2.1.1",
         "path-exists": "^4.0.0"
@@ -4632,7 +4634,6 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
       "integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.5.0",
         "@jest/types": "^29.5.0",
@@ -6615,7 +6616,6 @@
       "version": "2.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -6819,7 +6819,8 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
       "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -7663,7 +7664,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8042,7 +8042,6 @@
     },
     "@babel/core": {
       "version": "7.18.13",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -8382,9 +8381,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-25337665839.commit-834aaf3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-25337665839.commit-834aaf3.tgz",
-      "integrity": "sha512-J9gX2qnLMNw8QS0njTy/XAx6p/9B9jpbft7llUOBTSwZWXSSHV7omu8+IdmzoW9Q1BT3ZKhKekdWE/78g+oogw==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
+      "integrity": "sha512-9CmbKBy7rQ6qPRcncUdFuNwTHao5qzaYnmMWbIK+seyNJlS+QXSIq8UC36kUquZqyveeL46iBg+nurwnOhAGSg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"
@@ -9447,7 +9445,6 @@
     "@typescript-eslint/parser": {
       "version": "5.6.0",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.6.0",
         "@typescript-eslint/types": "5.6.0",
@@ -9501,8 +9498,7 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9652,6 +9648,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
       "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "find-babel-config": "^2.0.0",
         "glob": "^8.0.3",
@@ -9665,6 +9662,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -9674,6 +9672,7 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
           "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -9687,6 +9686,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
           "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -9744,7 +9744,6 @@
     },
     "browserslist": {
       "version": "4.21.3",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001370",
         "electron-to-chromium": "^1.4.202",
@@ -10169,7 +10168,6 @@
     "eslint": {
       "version": "8.4.1",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -10417,7 +10415,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
       "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -10643,6 +10640,7 @@
       "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
       "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "json5": "^2.1.1",
         "path-exists": "^4.0.0"
@@ -11211,7 +11209,6 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
       "integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
-      "peer": true,
       "requires": {
         "@jest/core": "^29.5.0",
         "@jest/types": "^29.5.0",
@@ -12658,8 +12655,7 @@
     },
     "prettier": {
       "version": "2.5.1",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -12782,7 +12778,8 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
       "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "resolve": {
       "version": "1.22.1",
@@ -13352,8 +13349,7 @@
     "typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "peer": true
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-25337665839.commit-834aaf3",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -196,7 +196,8 @@ export const AvatarModifierArea: LastWriteWinElementSetComponentDefinition<PBAva
 // @public (undocumented)
 export const enum AvatarModifierType {
     AMT_DISABLE_PASSPORTS = 1,
-    AMT_HIDE_AVATARS = 0
+    AMT_HIDE_AVATARS = 0,
+    AMT_HIDE_NAMETAGS = 2
 }
 
 // @public (undocumented)

--- a/packages/@dcl/react-ecs/package-lock.json
+++ b/packages/@dcl/react-ecs/package-lock.json
@@ -76,7 +76,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -149,7 +148,6 @@
     },
     "react": {
       "version": "18.2.0",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.25.0",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-25337665839.commit-834aaf3",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-25337665839.commit-834aaf3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-25337665839.commit-834aaf3.tgz",
-      "integrity": "sha512-J9gX2qnLMNw8QS0njTy/XAx6p/9B9jpbft7llUOBTSwZWXSSHV7omu8+IdmzoW9Q1BT3ZKhKekdWE/78g+oogw==",
+      "version": "1.0.0-25678907683.commit-94ee065",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
+      "integrity": "sha512-9CmbKBy7rQ6qPRcncUdFuNwTHao5qzaYnmMWbIK+seyNJlS+QXSIq8UC36kUquZqyveeL46iBg+nurwnOhAGSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -1460,7 +1460,6 @@
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
       "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -1514,7 +1513,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3701,7 +3699,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.25.0",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-25337665839.commit-834aaf3",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/ecs/components/AvatarModifierArea.spec.ts
+++ b/test/ecs/components/AvatarModifierArea.spec.ts
@@ -17,5 +17,11 @@ describe('Generated Avatar ModifierArea ProtoBuf', () => {
       modifiers: [],
       excludeIds: ['exclude_this', 'testId', '12837127371']
     })
+
+    testComponentSerialization(AvatarModifierArea, {
+      area: { x: 6, y: 7, z: 8 },
+      modifiers: [AvatarModifierType.AMT_HIDE_NAMETAGS],
+      excludeIds: []
+    })
   })
 })


### PR DESCRIPTION
Add AMT_HIDE_NAMETAGS modifier support to AvatarModifierArea

Updates `@dcl/protocol` to include the new `AMT_HIDE_NAMETAGS` modifier type, 
which allows scenes to hide player name tags within a defined area using the 
existing `AvatarModifierArea` component (ID: 1070).

## Changes
- Updated `@dcl/protocol` dependency to include `AMT_HIDE_NAMETAGS = 2` enum value
- Added serialization/deserialization test for the new modifier

## Usage
Once the client implements the behavior, scene creators will be able to use it like this:

AvatarModifierArea.create(entity, {
  area: Vector3.create(5, 3, 5),
  modifiers: [AvatarModifierType.AMT_HIDE_NAMETAGS]
})