### PR TITLE
chore: reduce per-tick allocations in CRDT messaging

### DIFF
--- a/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
+++ b/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
@@ -185,8 +185,17 @@ export function createGetCrdtMessagesForLww(
   data: Map<Entity, unknown>,
   lastSentData: Map<Entity, Uint8Array>
 ) {
+  // Reused across ticks: the generator runs for every registered component on every engine tick,
+  // so allocating the buffer inside it produced a 10KB allocation per component per tick even when
+  // nothing was dirty. The yielded data is always a copy (toCopiedBinary) so reuse is safe.
+  let reusableWriteBuffer: ReadWriteByteBuffer | null = null
+
   return function* () {
-    const writeBuffer = new ReadWriteByteBuffer()
+    // Skip the buffer allocation entirely for clean components (the common case)
+    if (dirtyIterator.size === 0) return
+
+    const writeBuffer = (reusableWriteBuffer = reusableWriteBuffer ?? new ReadWriteByteBuffer())
+
     for (const entity of dirtyIterator) {
       if (data.has(entity)) {
         writeBuffer.resetBuffer()

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,10 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  // Scratch buffers reused across ticks to avoid a 10KB ReadWriteByteBuffer allocation per frame each.
+  // Safe to reuse: their contents never escape sendMessages (views are copied into the per-call transport buffer).
+  const outgoingMessagesBuffer = new ReadWriteByteBuffer()
+  const conversionBuffer = new ReadWriteByteBuffer()
 
   /**
    *
@@ -201,13 +205,20 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   async function sendMessages(entitiesDeletedThisTick: Entity[]) {
     // CRDT Messages will be the merge between the recieved transport messages and the new crdt messages
     const crdtMessages = getMessages(broadcastMessages)
-    const buffer = new ReadWriteByteBuffer()
+    const buffer = outgoingMessagesBuffer
+    buffer.resetBuffer()
 
     for (const component of engine.componentsIter()) {
       for (const message of component.getCrdtUpdates()) {
         const offset = buffer.currentWriteOffset()
-        // Avoid creating messages if there is no transport that will handle it
-        if (transports.some((t) => t.filter(message))) {
+
+        // Avoid creating messages if there is no transport that will handle it.
+        // Plain loop instead of transports.some(...) to avoid a closure allocation per message
+        let anyTransportAcceptsIt = false
+        for (let t = 0; t < transports.length && !anyTransportAcceptsIt; t++)
+          anyTransportAcceptsIt = transports[t].filter(message)
+
+        if (anyTransportAcceptsIt) {
           if (message.type === CrdtMessageType.PUT_COMPONENT) {
             PutComponentOperation.write(message.entityId, message.timestamp, message.componentId, message.data, buffer)
           } else if (message.type === CrdtMessageType.DELETE_COMPONENT) {
@@ -245,19 +256,22 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
       onProcessEntityComponentChange && onProcessEntityComponentChange(entityId, CrdtMessageType.DELETE_ENTITY)
     }
 
-    // Send CRDT messages to transports
+    // Send CRDT messages to transports.
+    // The transport buffer is deliberately allocated per call: its final toBinary() view is handed
+    // to transport.send and reusing it across ticks would alias memory a transport may still hold
     const transportBuffer = new ReadWriteByteBuffer()
-    for (const index in transports) {
+
+    for (let transportIndex = 0; transportIndex < transports.length; transportIndex++) {
       const __NetworkMessagesBuffer: Uint8Array[] = []
 
-      const transportIndex = Number(index)
       const transport = transports[transportIndex]
       const isRendererTransport = transport.type === 'renderer'
       const isNetworkTransport = transport.type === 'network'
 
-      // Reset Buffer for each Transport
+      // Reset Buffers for each Transport
       transportBuffer.resetBuffer()
-      const buffer = new ReadWriteByteBuffer()
+      const buffer = conversionBuffer
+      buffer.resetBuffer()
 
       // Then we send all the new crdtMessages that the transport needs to process
       for (const message of crdtMessages) {
@@ -268,7 +282,8 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
         if (!transport.filter(message)) continue
 
         // Check if adding this message would exceed the size limit
-        const currentBufferSize = transportBuffer.toBinary().byteLength
+        // (currentWriteOffset is the written length; toBinary() would allocate a subarray view per message)
+        const currentBufferSize = transportBuffer.currentWriteOffset()
         const messageSize = message.messageBuffer.byteLength
 
         if (isNetworkTransport && (currentBufferSize + messageSize) / 1024 > LIVEKIT_MAX_SIZE) {

--- a/packages/@dcl/sdk/src/internal/transports/rendererTransport.ts
+++ b/packages/@dcl/sdk/src/internal/transports/rendererTransport.ts
@@ -8,8 +8,11 @@ export type EngineApiForTransport = {
 
 export function createRendererTransport(engineApi: EngineApiForTransport): Transport {
   async function sendToRenderer(message: Uint8Array) {
+    // The batch is passed as-is (it may be a view over the CRDT system's transport buffer):
+    // the engine api consumes the bytes within this call and the buffer is not rewritten
+    // until the next frame's send, after this await resolves
     const response = await engineApi.crdtSendToRenderer({
-      data: new Uint8Array(message)
+      data: message
     })
     if (response && response.data && response.data.length) {
       if (rendererTransport.onmessage) {
@@ -28,7 +31,6 @@ export function createRendererTransport(engineApi: EngineApiForTransport): Trans
         // this is the console.error of the scene
         // eslint-disable-next-line no-console
         console.error(error)
-        debugger
       }
     },
     filter(message: TransportMessage) {

--- a/scripts/protocol-buffer-generation/componentSchemaTemplate.ts
+++ b/scripts/protocol-buffer-generation/componentSchemaTemplate.ts
@@ -9,7 +9,7 @@ export const $\{ComponentName\}Schema: ISchema<PB$\{ComponentName\}> & { COMPONE
   COMPONENT_ID: $\{ComponentId\},
   serialize(value: PB$\{ComponentName\}, builder: ByteBuffer): void {
     const writer = PB$\{ComponentName\}.encode(value)
-    const buffer = new Uint8Array(writer.finish(), 0, writer.len)
+    const buffer = writer.finish()
     builder.writeBuffer(buffer, false)
   },
   deserialize(reader: ByteBuffer): PB$\{ComponentName\} {

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564k bytes
+SCENE_COMPILED_JS_SIZE_PROD=562.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,9 +11,9 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 73k
-  MALLOC_COUNT = 16289
-  ALIVE_OBJS_DELTA ~= 3.24k
+  OPCODES ~= 74k
+  MALLOC_COUNT = 16337
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -47,14 +47,14 @@ CALL onStart()
   ALIVE_OBJS_DELTA ~= 0.09k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"ensure that cubes are in the scene on the first frame"}]}
-  OPCODES ~= 19k
-  MALLOC_COUNT = 67
+  OPCODES ~= 18k
+  MALLOC_COUNT = 64
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
   LOG: ["🧪 Running test ensure that cubes are in the scene on the first frame"]
   LOG: ["🟢 Test passed ensure that cubes are in the scene on the first frame"]
   ~system/Testing: logTestResult {"name":"ensure that cubes are in the scene on the first frame","ok":true,"totalFrames":0,"totalTime":0}
-  OPCODES ~= 5k
+  OPCODES ~= 3k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1425.94k bytes
+  MEMORY_USAGE_COUNT ~= 1444.91k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=563.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,18 +12,18 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16841
-  ALIVE_OBJS_DELTA ~= 3.40k
+  MALLOC_COUNT = 16919
+  ALIVE_OBJS_DELTA ~= 3.42k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   OPCODES ~= 3k
-  MALLOC_COUNT = 56
-  ALIVE_OBJS_DELTA ~= 0.02k
+  MALLOC_COUNT = 69
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"two way communication"}]}
   LOG: ["Adding one to position.y=0"]
-  OPCODES ~= 6k
+  OPCODES ~= 4k
   MALLOC_COUNT = 12
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -35,15 +35,15 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
-  MALLOC_COUNT = 80
-  ALIVE_OBJS_DELTA ~= 0.02k
+  OPCODES ~= 10k
+  MALLOC_COUNT = 93
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   LOG: ["⏱️ yield"]
   Scene: DELETE_COMPONENT e=0x200 c=1 t=2 data=null
   Scene: DELETE_COMPONENT e=0x0 c=1 t=4 data=null
   Scene: DELETE_ENTITY e=0x200
-  OPCODES ~= 10k
+  OPCODES ~= 8k
   MALLOC_COUNT = -78
   ALIVE_OBJS_DELTA ~= -0.03k
 CALL onUpdate(0.1)
@@ -51,7 +51,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 7k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -60,7 +60,7 @@ CALL onUpdate(0.1)
   LOG: ["🟢 Test passed two way communication"]
   ~system/Testing: logTestResult {"name":"two way communication","ok":true,"totalFrames":3,"totalTime":0.30000000000000004}
   LOG: ["Adding one to position.y=0"]
-  OPCODES ~= 6k
+  OPCODES ~= 4k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1431.70k bytes
+  MEMORY_USAGE_COUNT ~= 1492.98k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=563.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,18 +12,18 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16841
-  ALIVE_OBJS_DELTA ~= 3.40k
+  MALLOC_COUNT = 16919
+  ALIVE_OBJS_DELTA ~= 3.42k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   OPCODES ~= 3k
-  MALLOC_COUNT = 56
-  ALIVE_OBJS_DELTA ~= 0.02k
+  MALLOC_COUNT = 69
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"two way communication"}]}
   LOG: ["Adding one to position.y=0"]
-  OPCODES ~= 6k
+  OPCODES ~= 4k
   MALLOC_COUNT = 12
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -35,15 +35,15 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
-  MALLOC_COUNT = 80
-  ALIVE_OBJS_DELTA ~= 0.02k
+  OPCODES ~= 10k
+  MALLOC_COUNT = 93
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   LOG: ["⏱️ yield"]
   Scene: DELETE_COMPONENT e=0x200 c=1 t=2 data=null
   Scene: DELETE_COMPONENT e=0x0 c=1 t=4 data=null
   Scene: DELETE_ENTITY e=0x200
-  OPCODES ~= 10k
+  OPCODES ~= 8k
   MALLOC_COUNT = -78
   ALIVE_OBJS_DELTA ~= -0.03k
 CALL onUpdate(0.1)
@@ -51,7 +51,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 7k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -60,7 +60,7 @@ CALL onUpdate(0.1)
   LOG: ["🟢 Test passed two way communication"]
   ~system/Testing: logTestResult {"name":"two way communication","ok":true,"totalFrames":3,"totalTime":0.30000000000000004}
   LOG: ["Adding one to position.y=0"]
-  OPCODES ~= 6k
+  OPCODES ~= 4k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1431.70k bytes
+  MEMORY_USAGE_COUNT ~= 1492.99k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248k bytes
+SCENE_COMPILED_JS_SIZE_PROD=246.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,13 +9,13 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 85k
-  MALLOC_COUNT = 15153
-  ALIVE_OBJS_DELTA ~= 3.40k
+  OPCODES ~= 86k
+  MALLOC_COUNT = 15227
+  ALIVE_OBJS_DELTA ~= 3.41k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
-  MALLOC_COUNT = 90
+  MALLOC_COUNT = 85
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0)
   LOG: ["PointerEventsResult",[{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}]]
@@ -24,9 +24,9 @@ CALL onUpdate(0)
   LOG: ["✅ Has DOWN command"]
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5,"tickNumber":0}
-  OPCODES ~= 18k
-  MALLOC_COUNT = 91
-  ALIVE_OBJS_DELTA ~= 0.03k
+  OPCODES ~= 16k
+  MALLOC_COUNT = 107
+  ALIVE_OBJS_DELTA ~= 0.04k
 CALL onUpdate(0.1)
   LOG: ["PointerEventsResult",[{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0},{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5,"tickNumber":0}]]
   LOG: ["✅ Second state is not pressed"]
@@ -34,7 +34,7 @@ CALL onUpdate(0.1)
   LOG: ["✅ UP Was triggered"]
   LOG: ["✅ Doesn't have DOWN command"]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":3,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 14k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -43,7 +43,7 @@ CALL onUpdate(0.1)
   LOG: ["✅ Was triggered"]
   LOG: ["✅ Has DOWN command"]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":4,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 13k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -53,7 +53,7 @@ CALL onUpdate(0.1)
   LOG: ["isTriggered(RootEntity)=",false]
   LOG: ["getCommand(RootEntity)=",null]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":5,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 13k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1068.72k bytes
+  MEMORY_USAGE_COUNT ~= 1117.57k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=288.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=287.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17670
-  ALIVE_OBJS_DELTA ~= 3.87k
+  MALLOC_COUNT = 17718
+  ALIVE_OBJS_DELTA ~= 3.88k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -51,15 +51,15 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x203 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x204 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x205 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
-  OPCODES ~= 114k
-  MALLOC_COUNT = 361
-  ALIVE_OBJS_DELTA ~= 0.10k
+  OPCODES ~= 113k
+  MALLOC_COUNT = 437
+  ALIVE_OBJS_DELTA ~= 0.12k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":3.0420734882354736,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1 t=2 data={"position":{"x":12,"y":3.0420734882354736,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=2 data={"position":{"x":12,"y":3.0420734882354736,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=2 data={"position":{"x":8,"y":3.0420734882354736,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 11k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -67,7 +67,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=3 data={"position":{"x":8,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 11k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -75,7 +75,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=4 data={"position":{"x":12,"y":3.0945944786071777,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=4 data={"position":{"x":12,"y":3.0945944786071777,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=4 data={"position":{"x":8,"y":3.0945944786071777,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 11k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1254.70k bytes
+  MEMORY_USAGE_COUNT ~= 1335.14k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=242.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14273
+  MALLOC_COUNT = 14316
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -19,28 +19,28 @@ CALL onStart()
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
-  OPCODES ~= 5k
-  MALLOC_COUNT = 68
-  ALIVE_OBJS_DELTA ~= 0.02k
+  OPCODES ~= 4k
+  MALLOC_COUNT = 92
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x201 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x202 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x201
-  OPCODES ~= 6k
+  OPCODES ~= 5k
   MALLOC_COUNT = 4
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x202 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x10201 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x202
-  OPCODES ~= 6k
+  OPCODES ~= 5k
   MALLOC_COUNT = 2
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x10201 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x10202 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x10201
-  OPCODES ~= 6k
+  OPCODES ~= 5k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1031.00k bytes
+  MEMORY_USAGE_COUNT ~= 1069.30k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=242.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,28 +9,28 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 75k
-  MALLOC_COUNT = 14246
-  ALIVE_OBJS_DELTA ~= 3.16k
+  OPCODES ~= 76k
+  MALLOC_COUNT = 14289
+  ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 4k
-  MALLOC_COUNT = 35
-  ALIVE_OBJS_DELTA ~= 0.01k
-CALL onUpdate(0.1)
   OPCODES ~= 3k
+  MALLOC_COUNT = 46
+  ALIVE_OBJS_DELTA ~= 0.02k
+CALL onUpdate(0.1)
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1020.75k bytes
+  MEMORY_USAGE_COUNT ~= 1048.52k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=287.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21007
+  MALLOC_COUNT = 21054
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -564,9 +564,9 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1001k
-  MALLOC_COUNT = 6214
-  ALIVE_OBJS_DELTA ~= 1.83k
+  OPCODES ~= 1009k
+  MALLOC_COUNT = 6290
+  ALIVE_OBJS_DELTA ~= 1.85k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":-3,"y":2.7722561359405518,"z":-3},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":0.5,"y":0.5,"z":0.5},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1 t=2 data={"position":{"x":-4,"y":3.498049020767212,"z":-4},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":0.5,"y":0.5,"z":0.5},"parent":0}
@@ -926,7 +926,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1288,7 +1288,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1650,7 +1650,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1479.18k bytes
+  MEMORY_USAGE_COUNT ~= 1576.00k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245k bytes
+SCENE_COMPILED_JS_SIZE_PROD=243.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14539
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 14583
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -30,18 +30,18 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x201 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x202 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   OPCODES ~= 24k
-  MALLOC_COUNT = 133
-  ALIVE_OBJS_DELTA ~= 0.04k
+  MALLOC_COUNT = 183
+  ALIVE_OBJS_DELTA ~= 0.05k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1040.45k bytes
+  MEMORY_USAGE_COUNT ~= 1099.84k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=242.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,26 +10,26 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14378
-  ALIVE_OBJS_DELTA ~= 3.19k
+  MALLOC_COUNT = 14422
+  ALIVE_OBJS_DELTA ~= 3.20k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0)
-  OPCODES ~= 3k
-  MALLOC_COUNT = 31
+  OPCODES ~= 2k
+  MALLOC_COUNT = 42
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
-  OPCODES ~= 3k
+  OPCODES ~= 1k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1023.20k bytes
+  MEMORY_USAGE_COUNT ~= 1050.97k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=405.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=404.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22243
-  ALIVE_OBJS_DELTA ~= 4.49k
+  MALLOC_COUNT = 22294
+  ALIVE_OBJS_DELTA ~= 4.50k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -48,22 +48,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 145k
-  MALLOC_COUNT = 967
-  ALIVE_OBJS_DELTA ~= 0.31k
+  OPCODES ~= 144k
+  MALLOC_COUNT = 1082
+  ALIVE_OBJS_DELTA ~= 0.35k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 70k
+  OPCODES ~= 68k
   MALLOC_COUNT = 259
   ALIVE_OBJS_DELTA ~= 0.13k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=3 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.017452405765652657,"z":0,"w":0.9998477101325989},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 69k
+  OPCODES ~= 67k
   MALLOC_COUNT = 35
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=4 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.026176948100328445,"z":0,"w":0.9996573328971863},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 69k
+  OPCODES ~= 67k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1888.63k bytes
+  MEMORY_USAGE_COUNT ~= 2000.74k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=607.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=604.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 222k
-  MALLOC_COUNT = 43870
-  ALIVE_OBJS_DELTA ~= 9.88k
+  MALLOC_COUNT = 43998
+  ALIVE_OBJS_DELTA ~= 9.90k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -20,22 +20,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1041 t=1 data={"src":"test.glb"}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 8k
-  MALLOC_COUNT = 96
-  ALIVE_OBJS_DELTA ~= 0.03k
+  OPCODES ~= 7k
+  MALLOC_COUNT = 133
+  ALIVE_OBJS_DELTA ~= 0.04k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x202 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 3k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x203 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 3k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x204 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 3k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2964.74k bytes
+  MEMORY_USAGE_COUNT ~= 3029.32k bytes


### PR DESCRIPTION
## What

Allocation pass over the per-tick CRDT messaging path (part of a scene↔renderer CRDT pipeline audit; companion Unity-side PRs: decentraland/unity-explorer#8967, decentraland/unity-explorer#8968):

- **LWW outgoing generator** (`lww-element-set-component-definition.ts`): the 10KB `ReadWriteByteBuffer` was allocated inside the generator, i.e. once **per registered component per tick, even with nothing dirty** (`sendMessages` drains every component's generator every frame). It is now lazily created once per component definition and the generator returns immediately when the dirty set is empty.
- **`sendMessages` scratch buffers** (`systems/crdt/index.ts`): the outgoing-messages buffer and the network-conversion buffer are hoisted to the system closure and reset per use — their contents never escape the call (views are always copied into the transport buffer). The transport buffer itself is deliberately still per-call: its final `toBinary()` view is handed to `transport.send`, and reusing it would alias memory a transport may still hold.
- **Generated protobuf schemas** (`componentSchemaTemplate.ts`): `new Uint8Array(writer.finish(), 0, writer.len)` copies a second time — the TypedArray-from-TypedArray constructor copies and silently ignores the offset/length arguments, and `writer.finish()` already returns an exact-sized array. One-line template fix; the `*.gen.ts` files are gitignored and regenerate on build.
- **Hot-loop micro-fixes** in `sendMessages`: per-message `transports.some((t) => ...)` closure → plain loop; `toBinary().byteLength` (allocates a subarray per message) → `currentWriteOffset()`; `for..in` over the transports array → indexed loop.
- **Renderer transport** (`rendererTransport.ts`): the outgoing batch is no longer copied before `crdtSendToRenderer` — the engine api consumes the bytes within the awaited call and the underlying buffer is not rewritten until the next frame. ⚠️ Reviewers: please double-check this assumption holds for all `~system/EngineApi` implementations (Unity reads synchronously; RPC-based explorers encode the request at call time). Also removes a stray `debugger` statement from the catch block.

## Why

For a scene at 30 ticks/s with ~60 registered components this removes hundreds of KB of garbage per second inside the scene VM before any real work happens. The regenerated bundle snapshots quantify it: compiled scene size −1.6KB, and steady-state `onUpdate` drops from ~3k to ~1k opcodes with `MALLOC_COUNT = 0` (previously 35+ mallocs per idle tick).
