### PR TITLE
chore: index NetworkEntity lookups in the CRDT system

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,28 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  // Lazy index of NetworkEntity components used by findNetworkId: networkId -> (network entityId -> mapping).
+  // Rebuilt at most once per receive/send pass; without it every network message linearly scanned
+  // all networked entities (O(messages x networked entities) per tick).
+  const networkEntitiesIndex = new Map<number, Map<number, { entityId: Entity; network: INetowrkEntityType }>>()
+  let networkEntitiesIndexDirty = true
+
+  function registerInNetworkEntitiesIndex(entityId: Entity, network: INetowrkEntityType) {
+    let byNetworkEntityId = networkEntitiesIndex.get(network.networkId)
+    if (!byNetworkEntityId) {
+      byNetworkEntityId = new Map()
+      networkEntitiesIndex.set(network.networkId, byNetworkEntityId)
+    }
+    byNetworkEntityId.set(network.entityId as number, { entityId, network })
+  }
+
+  function rebuildNetworkEntitiesIndex() {
+    networkEntitiesIndex.clear()
+    for (const [entityId, network] of engine.getEntitiesWith(NetworkEntity)) {
+      registerInNetworkEntitiesIndex(entityId, network)
+    }
+    networkEntitiesIndexDirty = false
+  }
 
   /**
    *
@@ -120,11 +142,12 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     const hasNetworkId = 'networkId' in msg
 
     if (hasNetworkId) {
-      for (const [entityId, network] of engine.getEntitiesWith(NetworkEntity)) {
-        if (network.networkId === msg.networkId && network.entityId === msg.entityId) {
-          return { entityId, network }
-        }
+      if (networkEntitiesIndexDirty) {
+        rebuildNetworkEntitiesIndex()
       }
+
+      const found = networkEntitiesIndex.get(msg.networkId!)?.get(msg.entityId as number)
+      if (found) return found
     }
 
     return { entityId: msg.entityId }
@@ -138,6 +161,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     const messagesToProcess = getMessages(receivedMessages)
     const entitiesShouldBeCleaned: Entity[] = []
 
+    // NetworkEntity components may have been added/removed since the last pass (e.g. by user systems)
+    networkEntitiesIndexDirty = true
+
     for (const msg of messagesToProcess) {
       let { entityId, network } = findNetworkId(msg)
       // We receive a new Entity. Create the localEntity and map it to the NetworkEntity component
@@ -145,6 +171,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
         entityId = engine.addEntity()
         network = { entityId: msg.entityId, networkId: msg.networkId }
         NetworkEntity.createOrReplace(entityId, network)
+
+        // Keep the already-built index coherent for the rest of this batch
+        if (!networkEntitiesIndexDirty) registerInNetworkEntitiesIndex(entityId, network)
       }
       if (msg.type === CrdtMessageType.DELETE_ENTITY || msg.type === CrdtMessageType.DELETE_ENTITY_NETWORK) {
         entitiesShouldBeCleaned.push(entityId)
@@ -199,6 +228,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
    * Iterates the dirty map and generates crdt messages to be send
    */
   async function sendMessages(entitiesDeletedThisTick: Entity[]) {
+    // NetworkEntity components may have changed while user systems ran this tick
+    networkEntitiesIndexDirty = true
+
     // CRDT Messages will be the merge between the recieved transport messages and the new crdt messages
     const crdtMessages = getMessages(broadcastMessages)
     const buffer = new ReadWriteByteBuffer()

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.8k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16289
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 16315
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1425.94k bytes
+  MEMORY_USAGE_COUNT ~= 1428.65k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16841
-  ALIVE_OBJS_DELTA ~= 3.40k
+  MALLOC_COUNT = 16881
+  ALIVE_OBJS_DELTA ~= 3.41k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1431.70k bytes
+  MEMORY_USAGE_COUNT ~= 1434.62k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16841
-  ALIVE_OBJS_DELTA ~= 3.40k
+  MALLOC_COUNT = 16881
+  ALIVE_OBJS_DELTA ~= 3.41k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1431.70k bytes
+  MEMORY_USAGE_COUNT ~= 1434.62k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15153
+  MALLOC_COUNT = 15188
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1068.72k bytes
+  MEMORY_USAGE_COUNT ~= 1070.17k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=288.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17670
+  MALLOC_COUNT = 17688
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1254.70k bytes
+  MEMORY_USAGE_COUNT ~= 1255.86k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14273
+  MALLOC_COUNT = 14294
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1031.00k bytes
+  MEMORY_USAGE_COUNT ~= 1032.24k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14246
+  MALLOC_COUNT = 14267
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1020.75k bytes
+  MEMORY_USAGE_COUNT ~= 1021.99k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21007
+  MALLOC_COUNT = 21025
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1479.18k bytes
+  MEMORY_USAGE_COUNT ~= 1480.33k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14539
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 14560
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1040.45k bytes
+  MEMORY_USAGE_COUNT ~= 1041.69k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14378
-  ALIVE_OBJS_DELTA ~= 3.19k
+  MALLOC_COUNT = 14399
+  ALIVE_OBJS_DELTA ~= 3.20k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1023.20k bytes
+  MEMORY_USAGE_COUNT ~= 1024.44k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=405.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=405.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22243
+  MALLOC_COUNT = 22261
   ALIVE_OBJS_DELTA ~= 4.49k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 69k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1888.63k bytes
+  MEMORY_USAGE_COUNT ~= 1889.90k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=607.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=607.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 222k
-  MALLOC_COUNT = 43870
-  ALIVE_OBJS_DELTA ~= 9.88k
+  MALLOC_COUNT = 43909
+  ALIVE_OBJS_DELTA ~= 9.89k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2964.74k bytes
+  MEMORY_USAGE_COUNT ~= 2967.32k bytes


### PR DESCRIPTION
## What

`findNetworkId` resolved every network message by linearly scanning **all** entities with `NetworkEntity` (`engine.getEntitiesWith` per message — which also allocates the tuple array each call). It runs on both the receive path (per received message) and the send path (per message per transport, plus the Transform-parent fix), making multiplayer traffic O(messages × networked entities) per tick.

This PR replaces the scan with a lazy reverse index `networkId -> (network entityId -> local entity)`:

- Rebuilt at most **once per receive/send pass**, and only when a lookup actually happens (scenes without networking never pay for it).
- Marked dirty at the start of each pass, since user systems may add/remove `NetworkEntity` components between passes.
- Kept coherent mid-batch: when `receiveMessages` creates a local entity for a newly seen network entity, it registers it in the already-built index — preserving the exact visibility semantics of the old scan (deletions only take effect at the end of the batch, as before).

Part of a scene↔renderer CRDT pipeline audit (companion PR: #1418 — independent; whichever merges second needs a mechanical snapshot regeneration since both touch `@dcl/ecs` and the committed bundle snapshots).
