### PR TITLE
fix(react-ecs): don't drop an optional prop set for the first time

### DIFF
--- a/packages/@dcl/react-ecs/src/reconciler/utils.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/utils.ts
@@ -38,9 +38,22 @@ export function propsChanged<K extends keyof EntityComponents>(
   }
 
   const changes: Partial<EntityComponents[K]> = {}
+  // Iterate prevProps (this also catches removed keys, where nextProps[k] is undefined)...
   for (const k in prevProps) {
     const propKey = k as keyof typeof prevProps
     if (!isEqual(prevProps[propKey], nextProps[propKey])) {
+      changes[propKey] = nextProps[propKey]
+    }
+  }
+  // ...then catch keys present only in nextProps (an optional prop set for the first time,
+  // e.g. `scrollPosition` going from undefined to a value). Iterating prevProps alone would
+  // drop these. Two allocation-free loops are used instead of a Set union to keep this hot
+  // path cheap. These keys aren't in prevProps, so emitting them whenever they're defined is
+  // both cheaper than (and avoids the falsy-value trap of) an isEqual(undefined, ...) compare.
+  for (const k in nextProps) {
+    if (k in prevProps) continue
+    const propKey = k as keyof typeof nextProps
+    if (nextProps[propKey] !== undefined) {
       changes[propKey] = nextProps[propKey]
     }
   }

--- a/test/react-ecs/transform.spec.tsx
+++ b/test/react-ecs/transform.spec.tsx
@@ -556,6 +556,52 @@ describe('UiTransform React Ecs', () => {
     })
   })
 
+  it('should apply an optional prop set for the first time (undefined -> value)', async () => {
+    // Regression for a reconciler diff bug: `propsChanged` only iterated the keys present
+    // in the previous props, so a field that was absent before (an optional prop rendered
+    // for the first time) was silently dropped on its first appearance. `scrollPosition`
+    // is the canonical case — while undefined it is omitted from the parsed transform, so
+    // the first `undefined -> reference` change produced no CRDT update at all.
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const entityIndex = engine.addEntity() as number
+    const rootDivEntity = (entityIndex + 1) as Entity
+
+    let scrollPosition: { x: number; y: number } | string | undefined = undefined
+
+    const ui = () => <UiEntity uiTransform={{ scrollPosition }} />
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+    // nothing requested yet
+    expect(UiTransform.get(rootDivEntity).scrollPosition).toBeUndefined()
+
+    // first ever scrollPosition: must be transmitted, not dropped
+    scrollPosition = 'row-50'
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+    expect(UiTransform.get(rootDivEntity)).toMatchObject({
+      scrollPosition: {
+        value: {
+          $case: 'reference',
+          reference: 'row-50'
+        }
+      }
+    })
+
+    // and a subsequent change still works
+    scrollPosition = 'row-10'
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+    expect(UiTransform.get(rootDivEntity)).toMatchObject({
+      scrollPosition: {
+        value: {
+          $case: 'reference',
+          reference: 'row-10'
+        }
+      }
+    })
+  })
+
   it('should parse positive zIndex correctly', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=425.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=425.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -52,17 +52,17 @@ CALL onUpdate(0)
   ALIVE_OBJS_DELTA ~= 0.24k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 72k
+  OPCODES ~= 78k
   MALLOC_COUNT = 259
   ALIVE_OBJS_DELTA ~= 0.13k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=3 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.017452405765652657,"z":0,"w":0.9998477101325989},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 71k
+  OPCODES ~= 76k
   MALLOC_COUNT = 35
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=4 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.026176948100328445,"z":0,"w":0.9996573328971863},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 71k
+  OPCODES ~= 76k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1933.93k bytes
+  MEMORY_USAGE_COUNT ~= 1934.09k bytes


### PR DESCRIPTION
## Problem

`propsChanged` (the reconciler diff) only iterated the keys present in `prevProps`:

```ts
for (const k in prevProps) { ... }
```

So a prop that appears for the **first time** — present in `nextProps` but absent from `prevProps` — is never compared, and its change is silently dropped.

`scrollPosition` is the canonical victim: while it's `undefined`, `parseUiTransform`'s `...(scrollPosition && getScrollPosition(...))` omits the key entirely, so the first `undefined → reference` render has no `scrollPosition` key in `prevProps` and produces **no CRDT update at all**. The next change (key now present in `prevProps`) works. This is exactly the reported symptom: the **first** scroll-to-target on a scrollable is lost, every later one works, and seeding a non-null *initial* `scrollPosition` avoids it.

Verified at runtime against a real scene/explorer: the engine received `None → row-10 → row-40 → row-5` (the first request, `row-50`, never arrived); with the fix it receives `None → row-50 → row-10 → row-40 → row-5`.

## Fix

`propsChanged` runs every frame for each changed UI node, so it's a hot path. Add a second loop over `nextProps` for keys **not** already in `prevProps` — the first loop still handles changed/removed keys, the second only catches first-appearance additions. This is **allocation-free** (no `Object.keys`/`Set`/spread), unlike a Set-union, to avoid per-frame GC pressure in QuickJS. It only *adds* previously-missed change detection, so it cannot introduce false negatives, and removal behaviour is unchanged.

## Test

Added a regression test in `test/react-ecs/transform.spec.tsx` that drives `scrollPosition` from `undefined → "row-50" → "row-10"`. It fails on `main`/`protocol-squad` (the first reference is dropped) and passes with the fix. The pre-existing scroll test missed this because it starts with a non-null `{x, y}`. Full `test/react-ecs` suite: 94/94.

Same fix against `main` (where `scrollPosition` doesn't exist, covered by a direct `propsChanged` unit test): decentraland/js-sdk-toolchain#1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)