### PR TITLE
chore: explorer start multi-instance by default

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -46,7 +46,6 @@ async function runApp(
   const skipAuthScreen = !!args['--skip-auth-screen']
   const landscapeTerrainEnabled = !!args['--landscape-terrain-enabled']
   const openDeeplinkInNewInstance = !!args['-n']
-  const multiInstance = !!args['--multi-instance']
 
   try {
     if (isWindows) {
@@ -62,6 +61,7 @@ async function runApp(
     params.set('dclenv', dclenv)
 
     params.set('local-scene', 'true')
+    params.set('multi-instance', 'true')
 
     if (isHub) {
       params.set('hub', 'true')
@@ -74,9 +74,6 @@ async function runApp(
     }
     if (openDeeplinkInNewInstance) {
       params.set('open-deeplink-in-new-instance', 'true')
-    }
-    if (multiInstance) {
-      params.set('multi-instance', 'true')
     }
 
     const queryParams = params.toString()

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -143,48 +143,6 @@ describe('explorer-alpha', () => {
     })
   })
 
-  describe('multiInstance parameter', () => {
-    it('should include multi-instance parameter when --multi-instance flag is provided', async () => {
-      const args: any = {
-        '--multi-instance': true
-      }
-
-      await runExplorerAlpha(mockComponents, {
-        cwd: '/test',
-        realm: 'test-realm',
-        baseCoords: { x: 0, y: 0 },
-        isHub: false,
-        args
-      })
-
-      expect(mockExec).toHaveBeenCalledWith(
-        '/test',
-        'open',
-        expect.arrayContaining([expect.stringContaining('multi-instance=true')]),
-        { silent: true }
-      )
-    })
-
-    it('should not include multi-instance parameter when --multi-instance flag is not provided', async () => {
-      const args: any = {}
-
-      await runExplorerAlpha(mockComponents, {
-        cwd: '/test',
-        realm: 'test-realm',
-        baseCoords: { x: 0, y: 0 },
-        isHub: false,
-        args
-      })
-
-      expect(mockExec).toHaveBeenCalledWith(
-        '/test',
-        'open',
-        expect.arrayContaining([expect.not.stringContaining('multi-instance')]),
-        { silent: true }
-      )
-    })
-  })
-
   describe('URL parameter construction', () => {
     it('should construct URL with all parameters correctly', async () => {
       const args: any = {


### PR DESCRIPTION
### WHY

When working on a local scene creators either:
- Don't care about multi-instance
- WANT multi-instance (to be able to test multiplayer functionalities)

It makes absolutely no sense to make a creator go out of their way to toggle it ON, losing time with that.

### WHAT

Made multi-instance param for the explorer deep link TRUE by default.