### PR TITLE
test: suppress local crdt state until statesynch

### DIFF
--- a/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
+++ b/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
@@ -22,6 +22,19 @@ export function incrementTimestamp(entity: Entity, timestamps: Map<Entity, numbe
   return newTimestamp
 }
 
+/**
+ * While `shouldSuppress` returns true for a dirty (entity, component) pair,
+ * `getCrdtUpdates` produces no CRDT message for it: the Lamport timestamp does
+ * not advance and the entity remains dirty, so it is re-evaluated on the next
+ * tick. With the timestamp unset/stale, a concurrently received remote state
+ * (e.g. a RES_CRDT_STATE snapshot) wins the LWW conflict resolution.
+ */
+export const localWriteSuppressor: {
+  shouldSuppress: ((entity: Entity, componentId: number) => boolean) | null
+} = {
+  shouldSuppress: null
+}
+
 export function createDumpLwwFunctionFromCrdt(
   componentId: number,
   timestamps: Map<Entity, number>,
@@ -187,7 +200,13 @@ export function createGetCrdtMessagesForLww(
 ) {
   return function* () {
     const writeBuffer = new ReadWriteByteBuffer()
+    let suppressedEntities: Entity[] | null = null
     for (const entity of dirtyIterator) {
+      if (localWriteSuppressor.shouldSuppress && localWriteSuppressor.shouldSuppress(entity, componentId)) {
+        suppressedEntities = suppressedEntities ?? []
+        suppressedEntities.push(entity)
+        continue
+      }
       if (data.has(entity)) {
         writeBuffer.resetBuffer()
         schema.serialize(data.get(entity)!, writeBuffer)
@@ -227,6 +246,11 @@ export function createGetCrdtMessagesForLww(
       }
     }
     dirtyIterator.clear()
+    if (suppressedEntities) {
+      for (const entity of suppressedEntities) {
+        dirtyIterator.add(entity)
+      }
+    }
   }
 }
 

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -1,4 +1,5 @@
-import { IEngine, Transport, RealmInfo, PlayerIdentityData } from '@dcl/ecs'
+import { IEngine, Transport, RealmInfo, PlayerIdentityData, SyncComponents as _SyncComponents } from '@dcl/ecs'
+import { localWriteSuppressor } from '@dcl/ecs/dist/engine/lww-element-set-component-definition'
 import { type SendBinaryRequest, type SendBinaryResponse } from '~system/CommunicationsController'
 
 import { syncFilter } from './filter'
@@ -11,6 +12,11 @@ import { definePlayerHelper } from '../players'
 import { serializeCrdtMessages } from '../internal/transports/logger'
 
 export type IProfile = { networkId: number; userId: string }
+
+// How long local writes to synced components stay suppressed when comms never connect
+// (offline realms / preview), and the hard cap when the handshake never resolves.
+const SUPPRESSED_WRITES_GRACE_PERIOD_MS = 10_000
+const SUPPRESSED_WRITES_FAILSAFE_PERIOD_MS = 30_000
 // user that we asked for the inital crdt state
 export function addSyncTransport(
   engine: IEngine,
@@ -41,6 +47,36 @@ export function addSyncTransport(
 
   let stateIsSyncronized = false
   let transportInitialzed = false
+
+  // Until the initial state handshake resolves, local writes to synced components are
+  // withheld at the CRDT layer: no message is generated and the Lamport timestamp does
+  // not advance, so a received RES_CRDT_STATE always wins the LWW conflict resolution.
+  // Suppressed writes stay dirty and flush (or are overwritten by the snapshot) on release.
+  const SyncComponents = engine.getComponent(_SyncComponents.componentId) as typeof _SyncComponents
+  let suppressLocalWrites = true
+
+  localWriteSuppressor.shouldSuppress = (entity, componentId) => {
+    if (!suppressLocalWrites) return false
+    const sync = SyncComponents.getOrNull(entity)
+    return !!sync && sync.componentIds.includes(componentId)
+  }
+
+  function releaseLocalWrites(reason: string) {
+    if (!suppressLocalWrites) return
+    suppressLocalWrites = false
+    DEBUG_NETWORK_MESSAGES() && console.log(`[SyncTransport] releasing suppressed local writes: ${reason}`)
+  }
+
+  // Failsafe release for scenes where the handshake can never resolve.
+  void (async () => {
+    await sleep(SUPPRESSED_WRITES_GRACE_PERIOD_MS)
+    if (!RealmInfo.getOrNull(engine.RootEntity)?.isConnectedSceneRoom) {
+      releaseLocalWrites('comms not connected after grace period')
+      return
+    }
+    await sleep(SUPPRESSED_WRITES_FAILSAFE_PERIOD_MS - SUPPRESSED_WRITES_GRACE_PERIOD_MS)
+    releaseLocalWrites('handshake did not resolve within failsafe period')
+  })()
 
   // Add Sync Transport
   const transport: Transport = {
@@ -79,6 +115,9 @@ export function addSyncTransport(
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
     transport.onmessage!(data)
     stateIsSyncronized = true
+    // The snapshot chunk is queued ahead of any local flush: it is applied on the next
+    // tick's receiveMessages, before getCrdtUpdates can emit the released writes.
+    releaseLocalWrites('CRDT state received')
   })
 
   // Answer to REQ_CRDT_STATE
@@ -121,6 +160,7 @@ export function addSyncTransport(
       } else {
         DEBUG_NETWORK_MESSAGES() && console.log('No active players. State syncronized')
         stateIsSyncronized = true
+        releaseLocalWrites('no active players to sync with')
       }
     }
   }


### PR DESCRIPTION
# fix: suppress local writes to synced components until initial CRDT state is synchronized

## Problem

When a peer joins a scene that already has live CRDT state, the scene code starts running (and writing to synced components) before the `REQ_CRDT_STATE` / `RES_CRDT_STATE` handshake completes. Those local writes advance the components' Lamport timestamps, so when the authoritative snapshot (`RES_CRDT_STATE`) finally arrives, the LWW conflict resolution can reject it — the late joiner keeps its own default state (e.g. a video screen playing the default video instead of the one set by the peers already in the scene) and even re-broadcasts it as a "correction".

## Solution

Withhold local writes to synced components at the CRDT layer until the state handshake resolves:

- **`@dcl/ecs`**: `getCrdtUpdates` (LWW) now consults a `localWriteSuppressor` gate. Suppressed dirty entities produce no CRDT message and their Lamport timestamp does not advance; they stay dirty and are re-evaluated on the next tick.
- **`@dcl/sdk`**: the sync transport suppresses `(entity, component)` pairs listed in `SyncComponents` while the handshake is pending, and releases when:
  - a `RES_CRDT_STATE` is received, or
  - `requestState` gives up (no players to sync with), or
  - failsafe: comms never connect within 10s, or the handshake doesn't resolve within 30s.

With timestamps left unset on the late joiner, the received snapshot always wins the LWW merge. Pre-sync local writes are cleanly discarded when the snapshot overwrites them; if no snapshot arrives (peer is alone), the withheld writes flush normally and the peer becomes the state donor.

## Notes

- Suppressed writes are also withheld from the renderer until release, so a late joiner shows the synced state directly instead of flashing the local default first.
- Suppression is one-way per session: once released it does not re-arm on reconnects.