### PR TITLE
fix(sdk-commands): avoid mutating immutable fetch response headers in auth proxy

### DIFF
--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -72,8 +72,14 @@ export function setRoutes<T extends { [key: string]: any }>(
 
       // undici decompresses the body but leaves content-encoding / content-length in
       // place; forwarding them would make the client re-decode or truncate the body.
-      resp.headers.delete('content-encoding')
-      resp.headers.delete('content-length')
+      // The headers on a fetch() Response are immutable (mutating them throws
+      // `TypeError: immutable`), so build a filtered copy instead of deleting in place.
+      const headers: Record<string, string> = {}
+      for (const [key, value] of resp.headers) {
+        const name = key.toLowerCase()
+        if (name === 'content-encoding' || name === 'content-length') continue
+        headers[key] = value
+      }
 
       // Return the proxied response, including body, status, and headers.
       // `resp.body` is a web ReadableStream; convert it to a Node stream so the
@@ -81,7 +87,7 @@ export function setRoutes<T extends { [key: string]: any }>(
       return {
         body: resp.body ? Readable.fromWeb(resp.body as any) : undefined,
         status: resp.status,
-        headers: Object.fromEntries(resp.headers)
+        headers
       }
     } catch (error) {
       return {


### PR DESCRIPTION
## Problem

Logging in through the linker dApp's `/auth` proxy fails with:

```
Proxy error: immutable
```

and the request returns a 500.

## Root cause

The `/auth/(.*)` proxy in `packages/@dcl/sdk-commands/src/linker-dapp/routes.ts` mutated the response headers of a native-`fetch` (undici) `Response`:

```ts
resp.headers.delete('content-encoding')
resp.headers.delete('content-length')
```

undici guards fetch-response headers as **immutable** (`undici/lib/fetch/index.js` sets `kGuard = 'immutable'`), so `.delete()` throws `TypeError('immutable')`. That error is caught in the route's `catch` and surfaced as `Proxy error: immutable`, breaking the login flow.

This is a regression from the node-fetch → native fetch migration in #1428 — `node-fetch`'s response headers were mutable, undici's are not.

## Fix

Build a filtered copy of the headers (skipping `content-encoding` / `content-length`) instead of deleting them in place. That object is what the response return value needs anyway, so it also replaces the previous `Object.fromEntries(resp.headers)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)