### PR TITLE
feat: ui renderer default virtual screen

### DIFF
--- a/packages/@dcl/react-ecs/src/platform.ts
+++ b/packages/@dcl/react-ecs/src/platform.ts
@@ -12,6 +12,7 @@ let isMobileProvider: () => boolean = () => false
 /**
  * Injects the function used to detect whether the scene runs on a mobile
  * platform. Called by `@dcl/sdk` with its `isMobile()` platform helper.
+ * @internal
  */
 export function setIsMobileProvider(provider: () => boolean): void {
   isMobileProvider = provider

--- a/packages/@dcl/react-ecs/src/platform.ts
+++ b/packages/@dcl/react-ecs/src/platform.ts
@@ -1,0 +1,28 @@
+/**
+ * Platform detection hook for the UI scale system.
+ *
+ * react-ecs stays independent of the scene runtime (`~system/*` modules), so
+ * it cannot ask the explorer which platform it runs on. Instead, the host SDK
+ * injects the check at module-load time (see `@dcl/sdk/react-ecs`). Until a
+ * provider is injected — or when none ever is — the platform is assumed to be
+ * non-mobile.
+ */
+let isMobileProvider: () => boolean = () => false
+
+/**
+ * Injects the function used to detect whether the scene runs on a mobile
+ * platform. Called by `@dcl/sdk` with its `isMobile()` platform helper.
+ */
+export function setIsMobileProvider(provider: () => boolean): void {
+  isMobileProvider = provider
+}
+
+/**
+ * Whether the scene is running on a mobile platform, according to the
+ * injected provider. Platform detection is asynchronous on the SDK side, so
+ * this may return false during the first ticks and flip to true once the
+ * explorer information arrives.
+ */
+export function isMobile(): boolean {
+  return isMobileProvider()
+}

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -12,6 +12,11 @@ import {
   setScreenInsetArea,
   setUiScaleFactor
 } from './components/utils'
+import { isMobile } from './platform'
+
+// react-ecs compiles with `types: []` (no runtime typings), so the console
+// global provided by the scene runtime is declared here.
+declare const console: { log(message: string): void }
 
 /**
  * @public
@@ -27,6 +32,26 @@ export type UiRendererOptions = {
 }
 
 /**
+ * Default virtual screen size used on mobile platforms, and the size 16:9
+ * virtual screens are overridden to on mobile (phone screens are much wider
+ * than 16:9, so a 16:9 virtual canvas would letterbox the UI).
+ */
+const MOBILE_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1600, virtualHeight: 720 }
+
+/**
+ * Default virtual screen size used on non-mobile platforms.
+ */
+const DEFAULT_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1920, virtualHeight: 1080 }
+
+function isValidVirtualSize(options: UiRendererOptions | undefined): options is UiRendererOptions {
+  return !!options && options.virtualWidth > 0 && options.virtualHeight > 0
+}
+
+function is16by9(options: UiRendererOptions): boolean {
+  return options.virtualWidth * 9 === options.virtualHeight * 16
+}
+
+/**
  * @public
  */
 export interface ReactBasedUiSystem {
@@ -36,6 +61,11 @@ export interface ReactBasedUiSystem {
   destroy(): void
   /**
    * Set the main UI renderer. Optional virtual size defines the global UI scale factor.
+   *
+   * When no virtual size is provided, a platform default is used: 1600x720 on
+   * mobile, 1920x1080 otherwise. Providing an invalid size (values \<= 0)
+   * disables the virtual screen (no UI scaling). On mobile, a provided 16:9
+   * virtual size is overridden to 1600x720 to fit phone screens.
    */
   setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -50,7 +80,8 @@ export interface ReactBasedUiSystem {
    * @param entity - The entity to associate with this UI renderer. When the entity is removed,
    *                 the UI renderer is automatically cleaned up.
    * @param ui - The UI component to render
-   * @param options - Optional virtual size used for UI scale factor when main UI has none
+   * @param options - Optional virtual size used for UI scale factor when main UI has none.
+   *                  Defaults and the mobile 16:9 override behave as in {@link ReactBasedUiSystem.setUiRenderer}.
    */
   addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -78,6 +109,10 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
   // Unique owner for the interactable area module variable.
   const interactableAreaOwner = Symbol('react-ecs-interactable-area')
 
+  // Last 16:9 size we already logged the mobile override for, so the log
+  // fires once per provided size instead of every tick.
+  let loggedMobileOverrideSize: string | null = null
+
   function getActiveVirtualSize(): UiRendererOptions | undefined {
     // Main renderer options win; otherwise use the first additional renderer option.
     if (virtualSize) return virtualSize
@@ -85,6 +120,40 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       if (entry.options) return entry.options
     }
     return undefined
+  }
+
+  /**
+   * Resolves the virtual screen to scale the UI against, or `undefined` when
+   * the virtual screen is disabled.
+   */
+  function resolveVirtualSize(): UiRendererOptions | undefined {
+    const provided = getActiveVirtualSize()
+    const mobile = isMobile()
+
+    // No creator-provided size: fall back to the platform default.
+    if (!provided) {
+      return mobile ? MOBILE_VIRTUAL_SIZE : DEFAULT_VIRTUAL_SIZE
+    }
+
+    // An explicitly provided but invalid size (values <= 0) disables the
+    // virtual screen — no UI scaling at all.
+    if (!isValidVirtualSize(provided)) {
+      return undefined
+    }
+
+    // On mobile, 16:9 virtual screens don't fit phone aspect ratios — override them.
+    if (mobile && is16by9(provided)) {
+      const providedSize = `${provided.virtualWidth}x${provided.virtualHeight}`
+      if (loggedMobileOverrideSize !== providedSize) {
+        loggedMobileOverrideSize = providedSize
+        console.log(
+          `Mobile platform detected: overriding 16:9 virtual screen size ${providedSize} with ${MOBILE_VIRTUAL_SIZE.virtualWidth}x${MOBILE_VIRTUAL_SIZE.virtualHeight}`
+        )
+      }
+      return MOBILE_VIRTUAL_SIZE
+    }
+
+    return provided
   }
 
   function ReactBasedUiSystem() {
@@ -133,9 +202,17 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       setInteractableArea(canvasInfo.interactableArea, interactableAreaOwner)
     }
 
-    const activeVirtualSize = getActiveVirtualSize()
-    if (!activeVirtualSize) {
+    // The virtual screen (provided or defaulted) only applies while some
+    // renderer is registered; with no UI at all the scale factor is released.
+    if (uiComponent === undefined && additionalRenderers.size === 0) {
       // Reset only if this system owns the scale factor.
+      resetUiScaleFactor(uiScaleFactorOwner)
+      return
+    }
+
+    const activeVirtualSize = resolveVirtualSize()
+    if (!activeVirtualSize) {
+      // Virtual screen explicitly disabled by an invalid provided size.
       resetUiScaleFactor(uiScaleFactorOwner)
       return
     }
@@ -144,7 +221,6 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     const { width, height, devicePixelRatio } = canvasInfo
     const { virtualWidth, virtualHeight } = activeVirtualSize
-    if (!virtualWidth || !virtualHeight) return
 
     // Normalize by devicePixelRatio so virtual px map to logical px (matching the
     // vw/vh path); without it the scale was inflated on high-dpr mobile screens.

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -36,7 +36,7 @@ export type UiRendererOptions = {
  * virtual screens are overridden to on mobile (phone screens are much wider
  * than 16:9, so a 16:9 virtual canvas would letterbox the UI).
  */
-const MOBILE_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1600, virtualHeight: 720 }
+const DEFAULT_MOBILE_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1600, virtualHeight: 720 }
 
 /**
  * Default virtual screen size used on non-mobile platforms.
@@ -110,8 +110,10 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
   const interactableAreaOwner = Symbol('react-ecs-interactable-area')
 
   // Last 16:9 size we already logged the mobile override for, so the log
-  // fires once per provided size instead of every tick.
-  let loggedMobileOverrideSize: string | null = null
+  // fires once per provided size instead of every tick. Tracked as raw numbers
+  // to avoid allocating a comparison string every tick.
+  let loggedMobileOverrideW = 0
+  let loggedMobileOverrideH = 0
 
   function getActiveVirtualSize(): UiRendererOptions | undefined {
     // Main renderer options win; otherwise use the first additional renderer option.
@@ -132,7 +134,7 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     // No creator-provided size: fall back to the platform default.
     if (!provided) {
-      return mobile ? MOBILE_VIRTUAL_SIZE : DEFAULT_VIRTUAL_SIZE
+      return mobile ? DEFAULT_MOBILE_VIRTUAL_SIZE : DEFAULT_VIRTUAL_SIZE
     }
 
     // An explicitly provided but invalid size (values <= 0) disables the
@@ -143,14 +145,14 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     // On mobile, 16:9 virtual screens don't fit phone aspect ratios — override them.
     if (mobile && is16by9(provided)) {
-      const providedSize = `${provided.virtualWidth}x${provided.virtualHeight}`
-      if (loggedMobileOverrideSize !== providedSize) {
-        loggedMobileOverrideSize = providedSize
+      if (loggedMobileOverrideW !== provided.virtualWidth || loggedMobileOverrideH !== provided.virtualHeight) {
+        loggedMobileOverrideW = provided.virtualWidth
+        loggedMobileOverrideH = provided.virtualHeight
         console.log(
-          `Mobile platform detected: overriding 16:9 virtual screen size ${providedSize} with ${MOBILE_VIRTUAL_SIZE.virtualWidth}x${MOBILE_VIRTUAL_SIZE.virtualHeight}`
+          `Mobile platform detected: overriding 16:9 virtual screen size ${provided.virtualWidth}x${provided.virtualHeight} with ${DEFAULT_MOBILE_VIRTUAL_SIZE.virtualWidth}x${DEFAULT_MOBILE_VIRTUAL_SIZE.virtualHeight}`
         )
       }
-      return MOBILE_VIRTUAL_SIZE
+      return DEFAULT_MOBILE_VIRTUAL_SIZE
     }
 
     return provided

--- a/packages/@dcl/sdk/src/react-ecs.ts
+++ b/packages/@dcl/sdk/src/react-ecs.ts
@@ -18,5 +18,12 @@
  */
 
 import ReactEcs from '@dcl/react-ecs'
+import { setIsMobileProvider } from '@dcl/react-ecs/dist/platform'
+import { isMobile } from './platform'
+
+// react-ecs cannot reach ~system/Runtime itself, so the platform check used
+// for virtual screen size defaults is injected here.
+setIsMobileProvider(isMobile)
+
 export * from '@dcl/react-ecs'
 export default ReactEcs

--- a/test/react-ecs/virtual-size-defaults.spec.tsx
+++ b/test/react-ecs/virtual-size-defaults.spec.tsx
@@ -83,6 +83,21 @@ describe('Virtual screen size defaults', () => {
     uiRenderer.destroy()
   })
 
+  it('should apply the default virtual size for an addUiRenderer with no options and no main renderer', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+    const ownerEntity = engine.addEntity()
+
+    // No setUiRenderer at all; only an additional renderer with no options
+    uiRenderer.addUiRenderer(ownerEntity, ui)
+    await engine.update(1)
+
+    // Default 1920x1080 applies → Math.min(3840/1920, 2160/1080) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
   it('should disable the virtual screen when the provided size is NaN', async () => {
     const { engine, uiRenderer } = setupEngine()
     createCanvasInfo(engine, 3840, 2160)

--- a/test/react-ecs/virtual-size-defaults.spec.tsx
+++ b/test/react-ecs/virtual-size-defaults.spec.tsx
@@ -83,6 +83,34 @@ describe('Virtual screen size defaults', () => {
     uiRenderer.destroy()
   })
 
+  it('should disable the virtual screen when the provided size is NaN', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    // NaN fails the `> 0` guard, so it disables UI scaling like any other invalid size
+    uiRenderer.setUiRenderer(ui, { virtualWidth: NaN, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should use the main renderer size when both main and an additional renderer are valid', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+    const ownerEntity = engine.addEntity()
+
+    // Main renderer options win over any additional renderer's options
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale comes from main: Math.min(3840/1920, 2160/1080) = 2 (not 800x600's 4.8)
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
   it('should disable the virtual screen when the main size is invalid, even if an additional renderer has a valid one', async () => {
     const { engine, uiRenderer } = setupEngine()
     createCanvasInfo(engine, 1600, 900)

--- a/test/react-ecs/virtual-size-defaults.spec.tsx
+++ b/test/react-ecs/virtual-size-defaults.spec.tsx
@@ -1,0 +1,221 @@
+import { components } from '../../packages/@dcl/ecs/src'
+import { ReactEcs, UiEntity } from '../../packages/@dcl/react-ecs/src'
+import { getUiScaleFactor, resetUiScaleFactor } from '../../packages/@dcl/react-ecs/src/components/utils'
+import { setIsMobileProvider } from '../../packages/@dcl/react-ecs/src/platform'
+import { setupEngine } from './utils'
+
+const ui = () => <UiEntity uiTransform={{ width: 100 }} />
+
+function createCanvasInfo(engine: any, width: number, height: number) {
+  const UiCanvasInformation = components.UiCanvasInformation(engine)
+  UiCanvasInformation.create(engine.RootEntity, {
+    devicePixelRatio: 1,
+    width,
+    height,
+    interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
+  })
+}
+
+function mobileOverrideLogs(logSpy: jest.SpyInstance) {
+  return logSpy.mock.calls.filter((args) => String(args[0]).includes('Mobile platform detected'))
+}
+
+describe('Virtual screen size defaults', () => {
+  afterEach(() => {
+    setIsMobileProvider(() => false)
+    resetUiScaleFactor()
+  })
+
+  it('should default to 1920x1080 on non-mobile when no virtual size is provided', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+
+    // scale = Math.min(3840/1920, 2160/1080) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should default to 1600x720 on mobile when no virtual size is provided', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+
+    // scale = Math.min(3200/1600, 1440/720) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen when the provided virtualWidth is invalid', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(2)
+
+    // An explicitly invalid size disables UI scaling entirely (no default fallback)
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 0, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen on mobile when the provided virtualHeight is invalid', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: -1 })
+    await engine.update(1)
+
+    // No mobile default applied — scaling stays off
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen when the main size is invalid, even if an additional renderer has a valid one', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const ownerEntity = engine.addEntity()
+
+    // Main renderer options win, and being invalid they disable UI scaling
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 0, virtualHeight: 0 })
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should use the first additional renderer size when neither main nor earlier renderers have one', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const entity1 = engine.addEntity()
+    const entity2 = engine.addEntity()
+
+    uiRenderer.setUiRenderer(ui)
+    uiRenderer.addUiRenderer(entity1, ui)
+    uiRenderer.addUiRenderer(entity2, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale = Math.min(1600/800, 900/600) = 1.5
+    expect(getUiScaleFactor()).toBeCloseTo(1.5)
+
+    uiRenderer.destroy()
+  })
+
+  it('should release the scale factor when the last renderer is removed', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const ownerEntity = engine.addEntity()
+
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBeCloseTo(1.5)
+
+    uiRenderer.removeUiRenderer(ownerEntity)
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+})
+
+describe('Mobile 16:9 virtual screen override', () => {
+  afterEach(() => {
+    setIsMobileProvider(() => false)
+    resetUiScaleFactor()
+  })
+
+  it('should override a 16:9 virtual size to 1600x720 on mobile and log it once', async () => {
+    setIsMobileProvider(() => true)
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    await engine.update(1)
+
+    // Overridden to 1600x720 → scale = Math.min(3200/1600, 1440/720) = 2
+    expect(getUiScaleFactor()).toBe(2)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(1)
+    expect(mobileOverrideLogs(logSpy)[0][0]).toContain('1920x1080')
+    expect(mobileOverrideLogs(logSpy)[0][0]).toContain('1600x720')
+
+    // Subsequent ticks must not repeat the log
+    await engine.update(1)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(1)
+
+    // A different 16:9 size logs again
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1280, virtualHeight: 720 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(2)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(2)
+
+    logSpy.mockRestore()
+    uiRenderer.destroy()
+  })
+
+  it('should respect a non-16:9 virtual size on mobile', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale = Math.min(3200/800, 1440/600) = 2.4
+    expect(getUiScaleFactor()).toBeCloseTo(2.4)
+
+    uiRenderer.destroy()
+  })
+
+  it('should respect a 16:9 virtual size on non-mobile platforms', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1280, virtualHeight: 720 })
+    await engine.update(1)
+
+    // scale = Math.min(3840/1280, 2160/720) = 3
+    expect(getUiScaleFactor()).toBe(3)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(0)
+
+    logSpy.mockRestore()
+    uiRenderer.destroy()
+  })
+
+  it('should apply the override when platform detection resolves to mobile after startup', async () => {
+    // Platform detection is async: the first ticks run as non-mobile.
+    let mobile = false
+    setIsMobileProvider(() => mobile)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1600, virtualHeight: 900 })
+    await engine.update(1)
+
+    // Non-mobile: provided 16:9 size respected → Math.min(3200/1600, 1440/900) = 1.6
+    expect(getUiScaleFactor()).toBeCloseTo(1.6)
+
+    mobile = true
+    await engine.update(1)
+
+    // Mobile: 16:9 overridden to 1600x720 → scale 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+})

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=406.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -6,16 +6,17 @@ SCENE_COMPILED_JS_SIZE_PROD=406.6k bytes
 EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: buffer
   REQUIRE: long
+  REQUIRE: ~system/Runtime
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22271
-  ALIVE_OBJS_DELTA ~= 4.49k
+  MALLOC_COUNT = 22393
+  ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
-  MALLOC_COUNT = 6
-  ALIVE_OBJS_DELTA ~= 0.00k
+  MALLOC_COUNT = -39
+  ALIVE_OBJS_DELTA ~= -0.01k
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x200 c=1062 t=1 data={"pointerEvents":[{"eventType":1,"eventInfo":{"button":1,"hoverText":"Press E to spawn","maxDistance":100,"showFeedback":true}}]}
@@ -66,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1891.24k bytes
+  MEMORY_USAGE_COUNT ~= 1894.90k bytes


### PR DESCRIPTION
Bound to the "Creators Success" `UI must be rebuilt/tested separately for desktop and mobile` Signal.

## What

Changes how `setUiRenderer` / `addUiRenderer` resolve the virtual screen used for UI scaling:

- **No virtual size provided** → a platform default is applied: **1600x720 on mobile**, **1920x1080 otherwise**. Previously no scaling was applied at all.
- **Invalid size provided (values ≤ 0)** → the virtual screen is disabled: no UI scaling, and any previously applied scale factor is released. This matches the old no-options behavior.
- **Valid 16:9 size provided on mobile** (e.g. 1920x1080, 1280x720) → overridden to **1600x720**, since phone screens are much wider than 16:9 and a 16:9 virtual canvas would letterbox the UI. A `console.log` informs the creator, once per provided size (not every tick).
- Non-16:9 sizes on mobile and any valid size on desktop/web are respected as-is.

Resolution happens every tick in `UiScaleSystem`, so it reacts correctly when async platform detection resolves to mobile a few frames after scene start.

## How

- `@dcl/react-ecs` cannot depend on `~system/Runtime` (and depending on `@dcl/sdk` would be circular), so a new `src/platform.ts` exposes an injectable `isMobile` provider that defaults to non-mobile.
- `@dcl/sdk/react-ecs` wires that provider to the existing `isMobile()` helper from `@dcl/sdk`'s platform module at module load.
- `system.ts` resolves the active virtual size (main renderer options win; otherwise the first additional renderer that passed options) and applies the default / disable / mobile-override rules above.

## Changes

- `packages/@dcl/react-ecs/src/system.ts` — virtual size resolution (defaults, invalid-disables, mobile 16:9 override) + updated JSDoc.
- `packages/@dcl/react-ecs/src/platform.ts` — new injectable platform detection hook.
- `packages/@dcl/sdk/src/react-ecs.ts` — injects `isMobile` into react-ecs.
- `test/react-ecs/virtual-size-defaults.spec.tsx` — new spec (11 tests) covering defaults, invalid-size disabling, the 16:9 override and its log-once behavior, and the async mobile-detection flip.
- `test/snapshots/production-bundles/ui.ts.crdt` — regenerated: the UI scene now loads `~system/Runtime` at module load (platform detection), shifting bundle size/memory counters. CRDT component messages are unchanged; verified no `ERR!` lines.

## Notes for reviewers

- **Behavioral change for existing scenes**: scenes calling `setUiRenderer(ui)` with no options previously got no UI scaling; they now always get a virtual screen (platform default), so UI on non-1080p canvases will scale where it previously didn't.
- No public API surface changes (`etc/playground-assets.api.md` is untouched); the provider is wired via a deep `dist` import, following the existing `@dcl/ecs/dist/components` pattern.