### PR TITLE
chore: export unique avatar mask enum (experimental)

### DIFF
--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -199,6 +199,12 @@ export const AvatarEquippedData: LastWriteWinElementSetComponentDefinition<PBAva
 export const AvatarLocomotionSettings: LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>;
 
 // @public (undocumented)
+export const enum AvatarMask {
+    // (undocumented)
+    AM_UPPER_BODY = 0
+}
+
+// @public (undocumented)
 export const AvatarModifierArea: LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>;
 
 // @public (undocumented)

--- a/packages/@dcl/sdk/tsconfig.json
+++ b/packages/@dcl/sdk/tsconfig.json
@@ -4,7 +4,15 @@
     "declaration": true,
     "stripInternal": true,
     "outDir": ".",
-    "removeComments": false
+    "removeComments": false,
+    // `@dcl/js-runtime`'s apis.d.ts references `import('@dcl/ecs').AvatarMask`.
+    // js-runtime is a symlinked (file:) dep, so tsc resolves that import from its
+    // realpath (packages/@dcl/js-runtime), where @dcl/ecs isn't reachable. Pin the
+    // specifier to this package's installed copy for the build. Scenes are unaffected
+    // (they resolve @dcl/ecs from their own node_modules).
+    "paths": {
+      "@dcl/ecs": ["./node_modules/@dcl/ecs"]
+    }
   },
   "include": ["src"],
   "exclude": ["dist"],

--- a/scripts/protocol-buffer-generation/generateProtocolBuffer.ts
+++ b/scripts/protocol-buffer-generation/generateProtocolBuffer.ts
@@ -19,7 +19,20 @@ export async function generateProtocolBuffer(params: {
   fs.removeSync(pbGeneratedPath)
   fs.mkdirSync(pbGeneratedPath, { recursive: true })
 
-  const protoFiles = components.map((item) => path.resolve(definitionsPath, `${item.componentFile}.proto`)).join(' ')
+  const componentProtoFiles = components.map((item) => path.resolve(definitionsPath, `${item.componentFile}.proto`))
+
+  /**
+   * Common protos that are NOT referenced by any ECS component (so protoc would not
+   * generate them transitively) but whose types must still be exposed to scenes.
+   * e.g. `AvatarMask` is only used as an argument of the `~system/RestrictedActions`
+   * `triggerSceneEmote` RPC, so without this it never reaches `@dcl/sdk/ecs` and is
+   * `undefined` at runtime. Paths are relative to `definitionsPath` (sdk/components).
+   */
+  const additionalCommonProtos = ['common/avatar_mask.proto']
+    .map((relPath) => path.resolve(definitionsPath, relPath))
+    .filter((absPath) => fs.existsSync(absPath))
+
+  const protoFiles = [...componentProtoFiles, ...additionalCommonProtos].join(' ')
 
   const protoCommandArgs: string[] = [
     `--plugin=${TS_PROTO_PLUGIN_PATH}`,

--- a/scripts/rpc-api-generation/index.ts
+++ b/scripts/rpc-api-generation/index.ts
@@ -106,7 +106,39 @@ async function internalCompile() {
     rmSync(apiModuleDirPath, { recursive: true, force: true })
   }
 
+  apisDTsContent = unifyEcsSharedTypes(apisDTsContent)
+
   writeFileSync(path.resolve(outModulesPath, 'index.d.ts'), apisDTsContent)
+}
+
+/**
+ * Some enums used by `~system/*` APIs are shared SDK component types that are also
+ * exported (with a runtime value) by `@dcl/ecs`. The proto-to-dts pipeline inlines a
+ * fresh `export enum` copy into the ambient module, which is nominally distinct from
+ * the `@dcl/ecs` one — so a scene cannot pass a value imported from `@dcl/sdk/ecs` to
+ * the API (e.g. `AvatarMask` on `triggerSceneEmote`). To keep a single type, we drop
+ * the inlined copy and point the remaining references at `@dcl/ecs`.
+ *
+ * We use an inline `import('@dcl/ecs').Type` rather than a top-level import so that
+ * `apis.d.ts` stays a script (not a module) — otherwise its `declare module "~system/*"`
+ * blocks would stop being ambient/global and scenes couldn't resolve `~system/*`.
+ */
+const ECS_SHARED_TYPES = ['AvatarMask']
+
+function unifyEcsSharedTypes(content: string): string {
+  for (const typeName of ECS_SHARED_TYPES) {
+    const enumBlock = new RegExp(`[ \\t]*export enum ${typeName} \\{[\\s\\S]*?\\n[ \\t]*\\}\\n?`, 'g')
+    if (!enumBlock.test(content)) continue
+
+    // Drop an optional one-line JSDoc that immediately precedes the inlined enum
+    content = content.replace(new RegExp(`[ \\t]*/\\*\\*[^\\n]*\\*/\\n(?=[ \\t]*export enum ${typeName}\\b)`, 'g'), '')
+    content = content.replace(enumBlock, '')
+
+    // Point remaining type references at the single `@dcl/ecs` declaration
+    content = content.replace(new RegExp(`\\b${typeName}\\b`, 'g'), `import('@dcl/ecs').${typeName}`)
+  }
+
+  return content
 }
 
 async function preprocessProtoGeneration(protoPath: string) {


### PR DESCRIPTION
## Problem
`triggerSceneEmote({ mask })` (`~system/RestrictedActions`) takes an `AvatarMask`, but there was **no single `AvatarMask` a scene could use**:

- `@dcl/ecs` / `@dcl/sdk/ecs` did **not** export `AvatarMask` at all — `avatar_mask.proto` is an API-only common type, so the ecs codegen (which only runs protoc over *component* protos) never generated it.
- The js-runtime generator inlined its **own** `export enum AvatarMask` into `apis.d.ts`, nominally distinct from any other.

Result: importing `AvatarMask` from `~system/RestrictedActions` type-checked but was `undefined` at runtime (`TypeError: Cannot read properties of undefined (reading 'AM_UPPER_BODY')`).

## Fix
Make `@dcl/ecs` the single source of `AvatarMask` and have the API reference it.

- **`scripts/protocol-buffer-generation/generateProtocolBuffer.ts`** — add `common/avatar_mask.proto` to the ecs protoc compile list, so `AvatarMask` is generated into `@dcl/ecs` and re-exported (as a `const enum`) through `@dcl/sdk/ecs`.
- **`scripts/rpc-api-generation/index.ts`** — drop the inlined `AvatarMask` enum from `apis.d.ts` and rewrite the `mask` field to `import('@dcl/ecs').AvatarMask`. An *inline* import type is used deliberately: a top-level import would turn `apis.d.ts` into a module and break the ambient `declare module "~system/*"` declarations.

## Result
One `AvatarMask`, imported from `@dcl/sdk/ecs`, usable directly with `triggerSceneEmote` — no cast, real runtime value:

```ts
import { AvatarMask } from '@dcl/sdk/ecs'
import { triggerSceneEmote } from '~system/RestrictedActions'

triggerSceneEmote({ src, loop: true, mask: AvatarMask.AM_UPPER_BODY })