### PR TITLE
chore: export unique avatar mask enum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,15 @@ export DEVELOPER_MODE=true
 install:
 	npm i --silent
 	make install-protobuf
+	make link-ecs-into-js-runtime
+
+# The generated packages/@dcl/js-runtime/apis.d.ts references `import('@dcl/ecs').AvatarMask`
+# (see scripts/rpc-api-generation). This repo has no root-hoisted node_modules, so make
+# @dcl/ecs resolvable from the js-runtime package dir for every build/test tsconfig.
+# @dcl/ecs has no dependencies, so a plain symlink is enough.
+link-ecs-into-js-runtime:
+	mkdir -p packages/@dcl/js-runtime/node_modules/@dcl
+	ln -sf ../../../ecs packages/@dcl/js-runtime/node_modules/@dcl/ecs
 
 update-protocol:
 	npm i --save-exact @dcl/protocol@next

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -191,6 +191,12 @@ export const AvatarEquippedData: LastWriteWinElementSetComponentDefinition<PBAva
 export const AvatarLocomotionSettings: LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>;
 
 // @public (undocumented)
+export const enum AvatarMask {
+    // (undocumented)
+    AM_UPPER_BODY = 0
+}
+
+// @public (undocumented)
 export const AvatarModifierArea: LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>;
 
 // @public (undocumented)

--- a/packages/@dcl/sdk/tsconfig.json
+++ b/packages/@dcl/sdk/tsconfig.json
@@ -4,7 +4,15 @@
     "declaration": true,
     "stripInternal": true,
     "outDir": ".",
-    "removeComments": false
+    "removeComments": false,
+    // `@dcl/js-runtime`'s apis.d.ts references `import('@dcl/ecs').AvatarMask`.
+    // js-runtime is a symlinked (file:) dep, so tsc resolves that import from its
+    // realpath (packages/@dcl/js-runtime), where @dcl/ecs isn't reachable. Pin the
+    // specifier to this package's installed copy for the build. Scenes are unaffected
+    // (they resolve @dcl/ecs from their own node_modules).
+    "paths": {
+      "@dcl/ecs": ["./node_modules/@dcl/ecs"]
+    }
   },
   "include": ["src"],
   "exclude": ["dist"],

--- a/packages/@dcl/sdk/tsconfig.json
+++ b/packages/@dcl/sdk/tsconfig.json
@@ -4,15 +4,7 @@
     "declaration": true,
     "stripInternal": true,
     "outDir": ".",
-    "removeComments": false,
-    // `@dcl/js-runtime`'s apis.d.ts references `import('@dcl/ecs').AvatarMask`.
-    // js-runtime is a symlinked (file:) dep, so tsc resolves that import from its
-    // realpath (packages/@dcl/js-runtime), where @dcl/ecs isn't reachable. Pin the
-    // specifier to this package's installed copy for the build. Scenes are unaffected
-    // (they resolve @dcl/ecs from their own node_modules).
-    "paths": {
-      "@dcl/ecs": ["./node_modules/@dcl/ecs"]
-    }
+    "removeComments": false
   },
   "include": ["src"],
   "exclude": ["dist"],

--- a/scripts/protocol-buffer-generation/generateProtocolBuffer.ts
+++ b/scripts/protocol-buffer-generation/generateProtocolBuffer.ts
@@ -19,7 +19,20 @@ export async function generateProtocolBuffer(params: {
   fs.removeSync(pbGeneratedPath)
   fs.mkdirSync(pbGeneratedPath, { recursive: true })
 
-  const protoFiles = components.map((item) => path.resolve(definitionsPath, `${item.componentFile}.proto`)).join(' ')
+  const componentProtoFiles = components.map((item) => path.resolve(definitionsPath, `${item.componentFile}.proto`))
+
+  /**
+   * Common protos that are NOT referenced by any ECS component (so protoc would not
+   * generate them transitively) but whose types must still be exposed to scenes.
+   * e.g. `AvatarMask` is only used as an argument of the `~system/RestrictedActions`
+   * `triggerSceneEmote` RPC, so without this it never reaches `@dcl/sdk/ecs` and is
+   * `undefined` at runtime. Paths are relative to `definitionsPath` (sdk/components).
+   */
+  const additionalCommonProtos = ['common/avatar_mask.proto']
+    .map((relPath) => path.resolve(definitionsPath, relPath))
+    .filter((absPath) => fs.existsSync(absPath))
+
+  const protoFiles = [...componentProtoFiles, ...additionalCommonProtos].join(' ')
 
   const protoCommandArgs: string[] = [
     `--plugin=${TS_PROTO_PLUGIN_PATH}`,

--- a/scripts/rpc-api-generation/index.ts
+++ b/scripts/rpc-api-generation/index.ts
@@ -106,7 +106,39 @@ async function internalCompile() {
     rmSync(apiModuleDirPath, { recursive: true, force: true })
   }
 
+  apisDTsContent = unifyEcsSharedTypes(apisDTsContent)
+
   writeFileSync(path.resolve(outModulesPath, 'index.d.ts'), apisDTsContent)
+}
+
+/**
+ * Some enums used by `~system/*` APIs are shared SDK component types that are also
+ * exported (with a runtime value) by `@dcl/ecs`. The proto-to-dts pipeline inlines a
+ * fresh `export enum` copy into the ambient module, which is nominally distinct from
+ * the `@dcl/ecs` one — so a scene cannot pass a value imported from `@dcl/sdk/ecs` to
+ * the API (e.g. `AvatarMask` on `triggerSceneEmote`). To keep a single type, we drop
+ * the inlined copy and point the remaining references at `@dcl/ecs`.
+ *
+ * We use an inline `import('@dcl/ecs').Type` rather than a top-level import so that
+ * `apis.d.ts` stays a script (not a module) — otherwise its `declare module "~system/*"`
+ * blocks would stop being ambient/global and scenes couldn't resolve `~system/*`.
+ */
+const ECS_SHARED_TYPES = ['AvatarMask']
+
+function unifyEcsSharedTypes(content: string): string {
+  for (const typeName of ECS_SHARED_TYPES) {
+    const enumBlock = new RegExp(`[ \\t]*export enum ${typeName} \\{[\\s\\S]*?\\n[ \\t]*\\}\\n?`, 'g')
+    if (!enumBlock.test(content)) continue
+
+    // Drop an optional one-line JSDoc that immediately precedes the inlined enum
+    content = content.replace(new RegExp(`[ \\t]*/\\*\\*[^\\n]*\\*/\\n(?=[ \\t]*export enum ${typeName}\\b)`, 'g'), '')
+    content = content.replace(enumBlock, '')
+
+    // Point remaining type references at the single `@dcl/ecs` declaration
+    content = content.replace(new RegExp(`\\b${typeName}\\b`, 'g'), `import('@dcl/ecs').${typeName}`)
+  }
+
+  return content
 }
 
 async function preprocessProtoGeneration(protoPath: string) {

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 16310
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1428.51k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=566.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16862
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1434.27k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=566.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16862
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1434.28k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15170
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1070.45k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17688
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1256.51k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14290
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1032.71k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14263
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1022.47k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21025
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1480.98k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 14556
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1042.17k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14395
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1024.92k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=406.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=406.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22272
+  MALLOC_COUNT = 22277
   ALIVE_OBJS_DELTA ~= 4.49k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1891.55k bytes
+  MEMORY_USAGE_COUNT ~= 1891.74k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=608.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=608.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 222k
-  MALLOC_COUNT = 43890
-  ALIVE_OBJS_DELTA ~= 9.89k
+  MALLOC_COUNT = 43928
+  ALIVE_OBJS_DELTA ~= 9.90k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2968.93k bytes
+  MEMORY_USAGE_COUNT ~= 2970.33k bytes


### PR DESCRIPTION
## Problem
`triggerSceneEmote({ mask })` (`~system/RestrictedActions`) takes an `AvatarMask`, but there was **no single `AvatarMask` a scene could use**:

- `@dcl/ecs` / `@dcl/sdk/ecs` did **not** export `AvatarMask` at all — `avatar_mask.proto` is an API-only common type, so the ecs codegen (which only runs protoc over *component* protos) never generated it.
- The js-runtime generator inlined its **own** `export enum AvatarMask` into `apis.d.ts`, nominally distinct from any other.

Result: importing `AvatarMask` from `~system/RestrictedActions` type-checked but was `undefined` at runtime (`TypeError: Cannot read properties of undefined (reading 'AM_UPPER_BODY')`).

## Fix
Make `@dcl/ecs` the single source of `AvatarMask` and have the API reference it.

- **`scripts/protocol-buffer-generation/generateProtocolBuffer.ts`** — add `common/avatar_mask.proto` to the ecs protoc compile list, so `AvatarMask` is generated into `@dcl/ecs` and re-exported (as a `const enum`) through `@dcl/sdk/ecs`.
- **`scripts/rpc-api-generation/index.ts`** — drop the inlined `AvatarMask` enum from `apis.d.ts` and rewrite the `mask` field to `import('@dcl/ecs').AvatarMask`. An *inline* import type is used deliberately: a top-level import would turn `apis.d.ts` into a module and break the ambient `declare module "~system/*"` declarations.

## Result
One `AvatarMask`, imported from `@dcl/sdk/ecs`, usable directly with `triggerSceneEmote` — no cast, real runtime value:

```ts
import { AvatarMask } from '@dcl/sdk/ecs'
import { triggerSceneEmote } from '~system/RestrictedActions'

triggerSceneEmote({ src, loop: true, mask: AvatarMask.AM_UPPER_BODY })