### PR TITLE
feat: serve asset bundles in preview through an abgen sidecar

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/abgen-binary.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/abgen-binary.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'crypto'
+import { homedir } from 'os'
+import * as path from 'path'
+
+import { CliComponents } from '../../components'
+
+/**
+ * The pinned abgen release the sidecar runs. Each release archive is
+ * self-contained: the `abgen` binary plus the `template/` and `shader/`
+ * assets it resolves from its own directory, so the whole archive is
+ * extracted and the binary runs from inside it.
+ */
+export const ABGEN_VERSION = 'v0.11.3'
+
+const ABGEN_RELEASE_BASE_URL = `https://github.com/decentraland/abgen/releases/download/${ABGEN_VERSION}`
+
+// sha256 of each release archive, straight from the release's SHA256SUMS.txt.
+// The builds are reproducible (built twice in CI, required bit-identical), so
+// these are stable for the pinned tag.
+const ABGEN_SHA256: Record<string, string> = {
+  'x86_64-unknown-linux-gnu': 'e0ca4e8088de2f161519c82a66ff8787f5324523e3787dc08f68a60d619d98bc',
+  'aarch64-unknown-linux-gnu': 'b8a91cfb40bb2d585dba48886d573381c67334b83ce70ff3618411c4fe20b60c',
+  'x86_64-apple-darwin': '00564f0a1794fc2b11a86ecb60106d7ec31b9dceada2432c14c52a03d4ebc1cd',
+  'aarch64-apple-darwin': 'a5e815ab34e21b7d293d617f16116a899dc1b066e8333123e4345465128aae69',
+  'x86_64-pc-windows-gnu': '9dbe053160f51966ef4e2e0c2424356db4aebb5e2921e90ecb0f44ab246aaaf3',
+  'aarch64-pc-windows-gnullvm': 'cedd380d7002b8ae64d7ecde28833a10ba98425c749e8a23b072ed0d6b1de89d'
+}
+
+const TARGET_BY_PLATFORM: Record<string, string> = {
+  'linux-x64': 'x86_64-unknown-linux-gnu',
+  'linux-arm64': 'aarch64-unknown-linux-gnu',
+  'darwin-x64': 'x86_64-apple-darwin',
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'win32-x64': 'x86_64-pc-windows-gnu',
+  'win32-arm64': 'aarch64-pc-windows-gnullvm'
+}
+
+/**
+ * Cache-class storage (the archive is re-downloadable): XDG_CACHE_HOME when
+ * set, otherwise the platform's native cache dir. Deliberately not
+ * ~/.decentraland — that is the Creator Hub's *legacy* home it is migrating
+ * away from.
+ */
+export function getAbgenStorageRoot(): string {
+  if (process.env.XDG_CACHE_HOME) return path.join(process.env.XDG_CACHE_HOME, 'decentraland', 'abgen')
+  if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
+    return path.join(process.env.LOCALAPPDATA, 'decentraland', 'abgen')
+  }
+  if (process.platform === 'darwin') return path.join(homedir(), 'Library', 'Caches', 'decentraland', 'abgen')
+  return path.join(homedir(), '.cache', 'decentraland', 'abgen')
+}
+
+/**
+ * Resolves the abgen binary to run: $ABGEN_BIN if set, then a previously
+ * downloaded copy of the pinned release, then a fresh download (sha256-verified
+ * against the values above), and finally `abgen` on the PATH when the platform
+ * has no prebuilt archive or the download fails.
+ */
+export async function resolveAbgenBin(
+  components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'fs'>
+): Promise<string> {
+  if (process.env.ABGEN_BIN) return process.env.ABGEN_BIN
+
+  const target = TARGET_BY_PLATFORM[`${process.platform}-${process.arch}`]
+  if (!target) {
+    components.logger.warn(
+      `asset-bundles: no prebuilt abgen ${ABGEN_VERSION} for ${process.platform}-${process.arch}; falling back to "abgen" on the PATH`
+    )
+    return 'abgen'
+  }
+
+  const dist = `abgen-${ABGEN_VERSION}-${target}`
+  const binName = process.platform === 'win32' ? 'abgen.exe' : 'abgen'
+  const binPath = path.join(getAbgenStorageRoot(), dist, binName)
+  if (await components.fs.fileExists(binPath)) return binPath
+
+  try {
+    await downloadRelease(components, dist, target)
+    if (!(await components.fs.fileExists(binPath))) {
+      throw new Error(`${dist}.tar.gz did not contain ${dist}/${binName}`)
+    }
+    return binPath
+  } catch (error: any) {
+    components.logger.warn(
+      `asset-bundles: could not download abgen ${ABGEN_VERSION} (${error.message}); falling back to "abgen" on the PATH`
+    )
+    return 'abgen'
+  }
+}
+
+async function downloadRelease(
+  components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'fs'>,
+  dist: string,
+  target: string
+): Promise<void> {
+  const url = `${ABGEN_RELEASE_BASE_URL}/${dist}.tar.gz`
+  components.logger.info(`asset-bundles: downloading ${url}`)
+
+  const response = await components.fetch.fetch(url)
+  if (!response.ok) throw new Error(`GET ${url} responded ${response.status}`)
+  const archive = Buffer.from(await response.arrayBuffer())
+
+  const sha256 = createHash('sha256').update(archive).digest('hex')
+  if (sha256 !== ABGEN_SHA256[target]) {
+    throw new Error(`sha256 mismatch for ${dist}.tar.gz: expected ${ABGEN_SHA256[target]}, got ${sha256}`)
+  }
+
+  const root = getAbgenStorageRoot()
+  await components.fs.mkdir(root, { recursive: true })
+  const tarball = path.join(root, `${dist}.tar.gz`)
+  await components.fs.writeFile(tarball, archive)
+  try {
+    // tar ships with Linux, macOS and Windows 10+; the archive extracts to <dist>/
+    await components.spawner.exec(root, 'tar', ['-xzf', tarball], { silent: true, shell: false })
+  } finally {
+    await components.fs.unlink(tarball).catch(() => {})
+  }
+}

--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -1,0 +1,75 @@
+import * as os from 'os'
+import * as path from 'path'
+
+import { CliComponents } from '../../components'
+import { getCatalystBaseUrl } from '../../logic/config'
+import { drainResponse } from '../../logic/fetch'
+import { getPort } from '../../logic/get-free-port'
+
+const READY_TIMEOUT_MS = 15_000
+const READY_POLL_INTERVAL_MS = 250
+const READY_REQUEST_TIMEOUT_MS = 2_000
+
+/**
+ * Boots an `abgen` sidecar: an ab-cdn-compatible server that JIT-converts the
+ * scene being previewed into asset bundles, reading it through the preview's
+ * own /content endpoints. Returns the sidecar URL once it answers /readyz, or
+ * undefined — with a warning — when the binary is missing or never comes up.
+ */
+export async function runAssetBundlesSidecar(
+  components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'config'>,
+  previewPort: number
+): Promise<string | undefined> {
+  const bin = process.env.ABGEN_BIN || 'abgen'
+  const port = await getPort(0)
+  const url = `http://127.0.0.1:${port}`
+  const catalystUrl = await getCatalystBaseUrl(components)
+  const cacheRoot = path.join(os.tmpdir(), 'dcl-abgen')
+
+  // ABGEN_* variables already present in the environment win over this wiring
+  const env: Record<string, string> = {
+    HTTP_SERVER_HOST: '127.0.0.1',
+    HTTP_SERVER_PORT: port.toString(),
+    ABGEN_CATALYST_URL: process.env.ABGEN_CATALYST_URL || `http://127.0.0.1:${previewPort}/content`,
+    ABGEN_WORLDS_CONTENT_URL: process.env.ABGEN_WORLDS_CONTENT_URL || `${catalystUrl}/content`,
+    ABGEN_OUT_ROOT: process.env.ABGEN_OUT_ROOT || path.join(cacheRoot, 'out'),
+    ABGEN_CACHE_DIR: process.env.ABGEN_CACHE_DIR || path.join(cacheRoot, 'cache'),
+    RUST_LOG: process.env.RUST_LOG || 'abgen=info,tower_http=warn'
+  }
+
+  // shell-less spawn: paths with spaces need no quoting, and kill() reaches abgen itself
+  let exited = false
+  components.spawner
+    .exec(process.cwd(), bin, [], { env, silent: false, shell: false })
+    .catch((error: Error) => components.logger.warn(`asset-bundles: ${bin} exited (${error.message})`))
+    .finally(() => {
+      exited = true
+    })
+
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline && !exited) {
+    if (await isReady(components, url)) return url
+    await sleep(READY_POLL_INTERVAL_MS)
+  }
+
+  components.logger.warn(
+    `asset-bundles: ${bin} did not come up on ${url}. Install the abgen binary (or set ABGEN_BIN to its path) to serve asset bundles in preview, or pass --no-asset-bundles to turn this off.`
+  )
+  return undefined
+}
+
+async function isReady(components: Pick<CliComponents, 'fetch'>, url: string): Promise<boolean> {
+  try {
+    const response = await components.fetch.fetch(`${url}/readyz`, {
+      signal: AbortSignal.timeout(READY_REQUEST_TIMEOUT_MS)
+    })
+    await drainResponse(response)
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -1,10 +1,10 @@
-import * as os from 'os'
 import * as path from 'path'
 
 import { CliComponents } from '../../components'
 import { getCatalystBaseUrl } from '../../logic/config'
 import { drainResponse } from '../../logic/fetch'
 import { getPort } from '../../logic/get-free-port'
+import { ABGEN_VERSION, resolveAbgenBin } from './abgen-binary'
 
 const READY_TIMEOUT_MS = 15_000
 const READY_POLL_INTERVAL_MS = 250
@@ -15,16 +15,22 @@ const READY_REQUEST_TIMEOUT_MS = 2_000
  * scene being previewed into asset bundles, reading it through the preview's
  * own /content endpoints. Returns the sidecar URL once it answers /readyz, or
  * undefined — with a warning — when the binary is missing or never comes up.
+ * The binary resolves from $ABGEN_BIN, then the pinned abgen release
+ * (downloaded and cached on first use), then `abgen` on the PATH.
  */
 export async function runAssetBundlesSidecar(
-  components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'config'>,
-  previewPort: number
+  components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'config' | 'fs'>,
+  previewPort: number,
+  projectRoot: string
 ): Promise<string | undefined> {
-  const bin = process.env.ABGEN_BIN || 'abgen'
+  const bin = await resolveAbgenBin(components)
   const port = await getPort(0)
   const url = `http://127.0.0.1:${port}`
   const catalystUrl = await getCatalystBaseUrl(components)
-  const cacheRoot = path.join(os.tmpdir(), 'dcl-abgen')
+  // next to scene.json: converted bundles survive preview restarts (never
+  // reconverted) and stay per-scene; the leading dot rides the default
+  // dcl-ignore, keeping the dir out of the watcher and deployments
+  const cacheRoot = path.join(projectRoot, '.dcl-optimized-assets')
 
   // ABGEN_* variables already present in the environment win over this wiring
   const env: Record<string, string> = {
@@ -53,7 +59,7 @@ export async function runAssetBundlesSidecar(
   }
 
   components.logger.warn(
-    `asset-bundles: ${bin} did not come up on ${url}. Install the abgen binary (or set ABGEN_BIN to its path) to serve asset bundles in preview, or pass --no-asset-bundles to turn this off.`
+    `asset-bundles: ${bin} did not come up on ${url}. Install abgen ${ABGEN_VERSION} (put abgen on the PATH or set ABGEN_BIN) to serve asset bundles in preview, or pass --no-asset-bundles to turn this off.`
   )
   return undefined
 }

--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -12,11 +12,12 @@ export async function runExplorerAlpha(
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
+    assetBundlesUrl?: string
   }
 ) {
-  const { cwd, realm, baseCoords, isHub } = opts
+  const { cwd, realm, baseCoords, isHub, assetBundlesUrl } = opts
 
-  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args })) {
+  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args, assetBundlesUrl })) {
     return
   }
 
@@ -30,13 +31,15 @@ async function runApp(
     realm: realmValue,
     baseCoords,
     isHub,
-    args
+    args,
+    assetBundlesUrl
   }: {
     cwd: string
     realm: string
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
+    assetBundlesUrl?: string
   }
 ) {
   const cmd = isWindows ? 'start' : 'open'
@@ -62,6 +65,10 @@ async function runApp(
     params.set('dclenv', dclenv)
 
     params.set('local-scene', 'true')
+
+    if (assetBundlesUrl) {
+      params.set('optimized-assets-url', assetBundlesUrl)
+    }
 
     if (isHub) {
       params.set('hub', 'true')

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -28,6 +28,7 @@ import { printCurrentProjectStarting, printProgressInfo, printWarning } from '..
 import { Result } from 'arg'
 import { startValidations } from '../../logic/project-validations'
 import { runExplorerAlpha } from './explorer-alpha'
+import { runAssetBundlesSidecar } from './asset-bundles'
 import { getLanUrl } from './utils'
 
 interface Options {
@@ -68,7 +69,8 @@ export const args = declareArgs({
   '-n': Boolean,
   '--bevy-web': Boolean,
   '--multi-instance': Boolean,
-  '--no-client': Boolean
+  '--no-client': Boolean,
+  '--no-asset-bundles': Boolean
 })
 
 export async function help(options: Options) {
@@ -98,6 +100,7 @@ export async function help(options: Options) {
       --mobile                          Show QR code for mobile preview on the same network.
       --multi-instance                  Allow running multiple Explorer instances simultaneously.
       --no-client                       Suppress every auto-launch (desktop Explorer deeplink, browser open, mobile QR). The file watcher still notifies a desktop Explorer if it connects on its own — useful when an external tool owns the Explorer process.
+      --no-asset-bundles                Do not run the abgen asset-bundle sidecar (default; the abgen binary on the PATH or ABGEN_BIN, skipped with a warning when missing).
 
 
     Examples:
@@ -130,6 +133,7 @@ export async function main(options: Options) {
 
   let hasSmartWearable = false
   const workspace = await getValidWorkspace(options.components, workingDirectory)
+  const withAssetBundles = !options.args['--no-asset-bundles']
 
   /* istanbul ignore if */
   if (workspace.projects.length > 1)
@@ -217,6 +221,14 @@ export async function main(options: Options) {
       }
       await startComponents()
 
+      let assetBundlesUrl: string | undefined
+      if (withAssetBundles) {
+        assetBundlesUrl = await runAssetBundlesSidecar(components, port)
+        if (assetBundlesUrl) {
+          printProgressInfo(options.components.logger, `Serving asset bundles (abgen JIT): ${assetBundlesUrl}`)
+        }
+      }
+
       const networkInterfaces = os.networkInterfaces()
       const availableURLs: string[] = []
 
@@ -265,7 +277,14 @@ export async function main(options: Options) {
 
       if (explorerAlpha && !isMobile && !skipClient) {
         const realm = new URL(sortedURLs[0]).origin
-        await runExplorerAlpha(components, { cwd: workingDirectory, realm, baseCoords, isHub, args: options.args })
+        await runExplorerAlpha(components, {
+          cwd: workingDirectory,
+          realm,
+          baseCoords,
+          isHub,
+          args: options.args,
+          assetBundlesUrl
+        })
       }
 
       if (isMobile && !skipClient && lanUrl) {

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -100,7 +100,7 @@ export async function help(options: Options) {
       --mobile                          Show QR code for mobile preview on the same network.
       --multi-instance                  Allow running multiple Explorer instances simultaneously.
       --no-client                       Suppress every auto-launch (desktop Explorer deeplink, browser open, mobile QR). The file watcher still notifies a desktop Explorer if it connects on its own — useful when an external tool owns the Explorer process.
-      --no-asset-bundles                Do not run the abgen asset-bundle sidecar (default; the abgen binary on the PATH or ABGEN_BIN, skipped with a warning when missing).
+      --no-asset-bundles                Do not run the abgen asset-bundle sidecar (the binary resolves from ABGEN_BIN, a cached download of the pinned abgen release, or the PATH; skipped with a warning when none is found).
 
 
     Examples:
@@ -223,7 +223,11 @@ export async function main(options: Options) {
 
       let assetBundlesUrl: string | undefined
       if (withAssetBundles) {
-        assetBundlesUrl = await runAssetBundlesSidecar(components, port)
+        assetBundlesUrl = await runAssetBundlesSidecar(
+          components,
+          port,
+          workspace.projects[0]?.workingDirectory || workingDirectory
+        )
         if (assetBundlesUrl) {
           printProgressInfo(options.components.logger, `Serving asset bundles (abgen JIT): ${assetBundlesUrl}`)
         }

--- a/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
@@ -9,7 +9,7 @@ import { PreviewComponents } from '../types'
 import { fetchEntityByPointer } from '../../../logic/catalyst-requests'
 import { CliComponents } from '../../../components'
 import {
-  b64HashingFunction,
+  b64UrlHashingFunction,
   getProjectPublishableFilesWithHashes,
   machineId,
   projectFilesToContentMappings
@@ -188,7 +188,7 @@ async function serveFolders(
 
   router.get('/content/contents/:hash', async (ctx, next) => {
     if (ctx.params.hash && ctx.params.hash.startsWith('b64-')) {
-      const decoded = Buffer.from(ctx.params.hash.replace(/^b64-/, ''), 'base64').toString('utf8')
+      const decoded = Buffer.from(ctx.params.hash.replace(/^b64-/, ''), 'base64url').toString('utf8')
       // Strip the machineId suffix that was added during encoding
       const fullPath = path.resolve(decoded.slice(0, -(machineId.length + 1)))
 
@@ -203,7 +203,7 @@ async function serveFolders(
 
       if (path.resolve(fullPath) === path.resolve(baseProject.workingDirectory)) {
         // if we are talking about the root directory, then we must return the json of the entity
-        const entity = await fakeEntityV3FromProject(components, baseProject, async ($) => b64HashingFunction($))
+        const entity = await fakeEntityV3FromProject(components, baseProject, async ($) => b64UrlHashingFunction($))
 
         if (!entity) return { status: 404 }
 
@@ -344,7 +344,7 @@ async function serveWearable(
   }
 
   const projectFiles = await getProjectPublishableFilesWithHashes(components, project.workingDirectory, async ($) =>
-    b64HashingFunction($)
+    b64UrlHashingFunction($)
   )
   const contentFiles = projectFilesToContentMappings(project.workingDirectory, projectFiles)
 
@@ -353,7 +353,7 @@ async function serveWearable(
     thumbnailFiltered.length > 0 && thumbnailFiltered[0]!.hash && `${baseUrl}/${thumbnailFiltered[0].hash}`
 
   // Set wearable ID.
-  const sceneHash = b64HashingFunction(project.workingDirectory)
+  const sceneHash = b64UrlHashingFunction(project.workingDirectory)
   const wearableId = wearableCache.get(sceneHash) ?? `urn:${uuidv4()}`
   wearableCache.set(sceneHash, wearableId)
 
@@ -398,7 +398,7 @@ async function getSceneJson(
 
   const allDeployments = await Promise.all(
     workspace.projects.map((project) =>
-      fakeEntityV3FromProject(components, project, async ($) => b64HashingFunction($))
+      fakeEntityV3FromProject(components, project, async ($) => b64UrlHashingFunction($))
     )
   )
 

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -6,7 +6,7 @@ import { getDCLIgnorePatterns } from '../../../logic/dcl-ignore'
 import { PreviewComponents } from '../types'
 import { sceneUpdateClients } from './routes'
 import { ProjectUnion } from '../../../logic/project-validations'
-import { b64HashingFunction } from '../../../logic/project-files'
+import { b64UrlHashingFunction } from '../../../logic/project-files'
 import {
   WsSceneMessage,
   UpdateModelType
@@ -26,7 +26,7 @@ export async function wireFileWatcherToWebSockets(
   desktopClient: boolean
 ) {
   const ignored = await getDCLIgnorePatterns(components, projectRoot)
-  const sceneId = b64HashingFunction(projectRoot)
+  const sceneId = b64UrlHashingFunction(projectRoot)
 
   chokidar
     .watch(path.resolve(projectRoot), {
@@ -61,7 +61,7 @@ function updateScene(sceneId: string, file: string) {
   if (isGLTFModel(file)) {
     message = {
       $case: 'updateModel',
-      updateModel: { hash: b64HashingFunction(file), sceneId, src: file, type: UpdateModelType.UMT_CHANGE }
+      updateModel: { hash: b64UrlHashingFunction(file), sceneId, src: file, type: UpdateModelType.UMT_CHANGE }
     }
   } else {
     message = {
@@ -77,7 +77,7 @@ function removeModel(sceneId: string, file: string) {
     const sceneMessage: WsSceneMessage = {
       message: {
         $case: 'updateModel',
-        updateModel: { sceneId, src: file, hash: b64HashingFunction(file), type: UpdateModelType.UMT_REMOVE }
+        updateModel: { sceneId, src: file, hash: b64UrlHashingFunction(file), type: UpdateModelType.UMT_REMOVE }
       }
     }
 
@@ -102,7 +102,7 @@ export function __LEGACY__updateScene(dir: string, clients: Set<WebSocket>, proj
     if (client.readyState === WebSocket.OPEN) {
       const message: sdk.SceneUpdate = {
         type: sdk.SCENE_UPDATE,
-        payload: { sceneId: b64HashingFunction(dir), sceneType: projectKind }
+        payload: { sceneId: b64UrlHashingFunction(dir), sceneType: projectKind }
       }
 
       // Old explorer

--- a/packages/@dcl/sdk-commands/src/logic/exec.ts
+++ b/packages/@dcl/sdk-commands/src/logic/exec.ts
@@ -3,6 +3,9 @@ import type { spawn } from 'child_process'
 interface Options {
   env: { [key: string]: string }
   silent: boolean
+  // default true; false spawns the binary directly (no shell quoting, and kill() reaches
+  // the binary itself - on Windows killing the wrapping shell leaves grandchildren alive)
+  shell: boolean
 }
 
 export type IProcessSpawnerComponent = {
@@ -11,10 +14,10 @@ export type IProcessSpawnerComponent = {
 
 export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSpawnerComponent {
   return {
-    exec(cwd: string, command: string, args: string[], { env, silent }: Partial<Options> = {}): Promise<void> {
+    exec(cwd: string, command: string, args: string[], { env, silent, shell }: Partial<Options> = {}): Promise<void> {
       return new Promise((resolve, reject) => {
         const child = spawnFn(command, args, {
-          shell: true,
+          shell: shell ?? true,
           cwd,
           env: { ...process.env, NODE_ENV: '', ...env }
         })
@@ -32,10 +35,20 @@ export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSp
         process.on('SIGINT', cleanup)
         process.on('exit', cleanup)
 
-        child.on('close', (code: number) => {
+        const offCleanup = () => {
           process.off('SIGTERM', cleanup)
           process.off('SIGINT', cleanup)
           process.off('exit', cleanup)
+        }
+
+        // without a shell, a missing binary emits 'error' (ENOENT) and never 'close'
+        child.on('error', (error: Error) => {
+          offCleanup()
+          reject(new Error(`Command "${command}" failed: ${error.message}`))
+        })
+
+        child.on('close', (code: number) => {
+          offCleanup()
 
           // Don't reject if we killed the child during shutdown
           if (code !== 0 && !child.killed) {

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -107,6 +107,13 @@ export const b64HashingFunction = (str: string) => {
   const unique = `${str}-${machineId}`
   return 'b64-' + Buffer.from(unique).toString('base64')
 }
+
+// The preview content server hands these ids out in URL path segments, and the asset-bundle
+// tooling turns them into directory names. base64url keeps them free of '/', '+' and '='.
+export const b64UrlHashingFunction = (str: string) => {
+  const unique = `${str}-${machineId}`
+  return 'b64-' + Buffer.from(unique).toString('base64url')
+}
 // export const ipfsHashingFunction = async (str: string) => hashV1(Buffer.from(str, 'utf8'))
 
 interface PackageJson {

--- a/test/sdk-commands/commands/start/abgen-binary.spec.ts
+++ b/test/sdk-commands/commands/start/abgen-binary.spec.ts
@@ -1,0 +1,99 @@
+import {
+  ABGEN_VERSION,
+  getAbgenStorageRoot,
+  resolveAbgenBin
+} from '../../../../packages/@dcl/sdk-commands/src/commands/start/abgen-binary'
+
+function makeComponents({
+  cached,
+  response
+}: {
+  cached: boolean
+  response?: { ok: boolean; status?: number; body?: Buffer }
+}) {
+  const body = response?.body ?? Buffer.alloc(0)
+  const fetch = jest.fn(async () => ({
+    ok: response?.ok ?? false,
+    status: response?.status ?? 500,
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)
+  }))
+  const logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+  const exec = jest.fn(async () => {})
+  const fs = {
+    fileExists: jest.fn(async () => cached),
+    mkdir: jest.fn(async () => {}),
+    writeFile: jest.fn(async () => {}),
+    unlink: jest.fn(async () => {})
+  }
+  return { components: { fetch: { fetch }, logger, spawner: { exec }, fs } as any, fetch, logger, exec, fs }
+}
+
+describe('start/abgen-binary', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    delete process.env.ABGEN_BIN
+  })
+
+  it('honors XDG_CACHE_HOME for the storage root', async () => {
+    process.env.XDG_CACHE_HOME = '/custom/cache'
+    try {
+      expect(getAbgenStorageRoot().startsWith('/custom/cache')).toBe(true)
+      expect(getAbgenStorageRoot()).toContain('decentraland')
+    } finally {
+      delete process.env.XDG_CACHE_HOME
+    }
+    expect(getAbgenStorageRoot().startsWith('/custom/cache')).toBe(false)
+  })
+
+  it('honors ABGEN_BIN over everything else', async () => {
+    const { components, fetch, fs } = makeComponents({ cached: true })
+    process.env.ABGEN_BIN = '/opt/abgen/bin/abgen'
+
+    expect(await resolveAbgenBin(components)).toBe('/opt/abgen/bin/abgen')
+    expect(fs.fileExists).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns the cached pinned-release binary without touching the network', async () => {
+    const { components, fetch } = makeComponents({ cached: true })
+
+    const bin = await resolveAbgenBin(components)
+
+    expect(bin.startsWith(getAbgenStorageRoot())).toBe(true)
+    expect(bin).toContain(`abgen-${ABGEN_VERSION}-`)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the PATH with a warning when the download fails', async () => {
+    const { components, logger } = makeComponents({ cached: false, response: { ok: false, status: 404 } })
+
+    expect(await resolveAbgenBin(components)).toBe('abgen')
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('404'))
+  })
+
+  it('rejects a download whose sha256 does not match the pinned release', async () => {
+    const { components, logger, exec, fs } = makeComponents({
+      cached: false,
+      response: { ok: true, body: Buffer.from('not the real archive') }
+    })
+
+    expect(await resolveAbgenBin(components)).toBe('abgen')
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('sha256 mismatch'))
+    // nothing was written or extracted from the tampered archive
+    expect(fs.writeFile).not.toHaveBeenCalled()
+    expect(exec).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the PATH on platforms without a prebuilt archive', async () => {
+    const { components, fetch, logger } = makeComponents({ cached: false })
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'freebsd' })
+    try {
+      expect(await resolveAbgenBin(components)).toBe('abgen')
+    } finally {
+      Object.defineProperty(process, 'platform', platform)
+    }
+    expect(fetch).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('no prebuilt abgen'))
+  })
+})

--- a/test/sdk-commands/commands/start/asset-bundles.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles.spec.ts
@@ -7,8 +7,10 @@ function makeComponents({ ready, execRejects }: { ready: boolean; execRejects?: 
   const fetch = jest.fn(async () => ({ ok: ready }))
   const logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
   const config = { getString: jest.fn(async () => undefined), requireString: jest.fn(), getNumber: jest.fn() }
+  // the pinned release is "already downloaded", keeping these tests off the network
+  const fs = { fileExists: jest.fn(async () => true), mkdir: jest.fn(), writeFile: jest.fn(), unlink: jest.fn() }
   return {
-    components: { spawner: { exec }, fetch: { fetch }, logger, config } as any,
+    components: { spawner: { exec }, fetch: { fetch }, logger, config, fs } as any,
     exec,
     fetch,
     logger
@@ -23,12 +25,13 @@ describe('start/asset-bundles', () => {
   it('spawns the sidecar wired to the preview content endpoints and returns its url when ready', async () => {
     const { components, exec, fetch } = makeComponents({ ready: true })
 
-    const url = await runAssetBundlesSidecar(components, 8000)
+    const url = await runAssetBundlesSidecar(components, 8000, '/tmp/e2e-scene')
 
     expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
     expect(exec).toHaveBeenCalledTimes(1)
     const [, bin, execArgs, options] = exec.mock.calls[0] as any
-    expect(bin).toBe('abgen')
+    // the cached pinned-release binary (fs.fileExists mocked true)
+    expect(bin).toMatch(/abgen-v\d+\.\d+\.\d+-[a-z0-9_]+-[a-z-]+[/\\]abgen(\.exe)?$/)
     expect(execArgs).toEqual([])
     expect(options.env.ABGEN_CATALYST_URL).toBe('http://127.0.0.1:8000/content')
     expect(options.env.ABGEN_WORLDS_CONTENT_URL).toBe('https://peer.decentraland.org/content')
@@ -41,7 +44,7 @@ describe('start/asset-bundles', () => {
     const { components, exec } = makeComponents({ ready: true })
     process.env.ABGEN_BIN = '/opt/abgen/bin/abgen'
     try {
-      await runAssetBundlesSidecar(components, 8000)
+      await runAssetBundlesSidecar(components, 8000, '/tmp/e2e-scene')
     } finally {
       delete process.env.ABGEN_BIN
     }
@@ -51,7 +54,7 @@ describe('start/asset-bundles', () => {
   it('returns undefined and warns when the sidecar exits before becoming ready', async () => {
     const { components, logger } = makeComponents({ ready: false, execRejects: true })
 
-    const url = await runAssetBundlesSidecar(components, 8000)
+    const url = await runAssetBundlesSidecar(components, 8000, '/tmp/e2e-scene')
 
     expect(url).toBeUndefined()
     expect(logger.warn).toHaveBeenCalled()

--- a/test/sdk-commands/commands/start/asset-bundles.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles.spec.ts
@@ -1,0 +1,70 @@
+import { runAssetBundlesSidecar } from '../../../../packages/@dcl/sdk-commands/src/commands/start/asset-bundles'
+import { b64UrlHashingFunction } from '../../../../packages/@dcl/sdk-commands/src/logic/project-files'
+
+function makeComponents({ ready, execRejects }: { ready: boolean; execRejects?: boolean }) {
+  const sidecarKeepsRunning = new Promise<void>(() => {})
+  const exec = jest.fn(() => (execRejects ? Promise.reject(new Error('spawn abgen ENOENT')) : sidecarKeepsRunning))
+  const fetch = jest.fn(async () => ({ ok: ready }))
+  const logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+  const config = { getString: jest.fn(async () => undefined), requireString: jest.fn(), getNumber: jest.fn() }
+  return {
+    components: { spawner: { exec }, fetch: { fetch }, logger, config } as any,
+    exec,
+    fetch,
+    logger
+  }
+}
+
+describe('start/asset-bundles', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('spawns the sidecar wired to the preview content endpoints and returns its url when ready', async () => {
+    const { components, exec, fetch } = makeComponents({ ready: true })
+
+    const url = await runAssetBundlesSidecar(components, 8000)
+
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+    expect(exec).toHaveBeenCalledTimes(1)
+    const [, bin, execArgs, options] = exec.mock.calls[0] as any
+    expect(bin).toBe('abgen')
+    expect(execArgs).toEqual([])
+    expect(options.env.ABGEN_CATALYST_URL).toBe('http://127.0.0.1:8000/content')
+    expect(options.env.ABGEN_WORLDS_CONTENT_URL).toBe('https://peer.decentraland.org/content')
+    expect(options.env.HTTP_SERVER_HOST).toBe('127.0.0.1')
+    expect(url).toContain(options.env.HTTP_SERVER_PORT)
+    expect(fetch).toHaveBeenCalledWith(`${url}/readyz`, expect.objectContaining({ signal: expect.anything() }))
+  })
+
+  it('resolves the binary from ABGEN_BIN when set', async () => {
+    const { components, exec } = makeComponents({ ready: true })
+    process.env.ABGEN_BIN = '/opt/abgen/bin/abgen'
+    try {
+      await runAssetBundlesSidecar(components, 8000)
+    } finally {
+      delete process.env.ABGEN_BIN
+    }
+    expect((exec.mock.calls[0] as any)[1]).toBe('/opt/abgen/bin/abgen')
+  })
+
+  it('returns undefined and warns when the sidecar exits before becoming ready', async () => {
+    const { components, logger } = makeComponents({ ready: false, execRejects: true })
+
+    const url = await runAssetBundlesSidecar(components, 8000)
+
+    expect(url).toBeUndefined()
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})
+
+describe('b64UrlHashingFunction', () => {
+  it('produces URL- and path-safe identifiers', () => {
+    const hash = b64UrlHashingFunction('/home/someone/my scene/with+special_chars')
+    expect(hash.startsWith('b64-')).toBe(true)
+    expect(hash).toMatch(/^b64-[A-Za-z0-9_-]+$/)
+    expect(hash).not.toContain('/')
+    expect(hash).not.toContain('+')
+    expect(hash).not.toContain('=')
+  })
+})

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -57,6 +57,45 @@ describe('explorer-alpha', () => {
       )
     })
 
+    it('should include optimized-assets-url only when an asset bundles url is provided', async () => {
+      const args: any = {}
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args,
+        assetBundlesUrl: 'http://127.0.0.1:5147'
+      })
+
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.arrayContaining([
+          expect.stringContaining(`optimized-assets-url=${encodeURIComponent('http://127.0.0.1:5147')}`)
+        ]),
+        { silent: true }
+      )
+
+      mockExec.mockClear()
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args
+      })
+
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.arrayContaining([expect.not.stringContaining('optimized-assets-url')]),
+        { silent: true }
+      )
+    })
+
     it('should always include local-scene and debug even when they are false', async () => {
       const args: any = {
         '--local-scene': false,

--- a/test/sdk-commands/utils/exec.spec.ts
+++ b/test/sdk-commands/utils/exec.spec.ts
@@ -22,8 +22,8 @@ describe('utils/exec', () => {
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'])
@@ -35,6 +35,42 @@ describe('utils/exec', () => {
     })
     expect(pipeSpy).toBeCalled()
     expect(res).toBe(undefined)
+  })
+
+  it('spawns without a shell when shell:false is passed', async () => {
+    const spawnMock = {
+      stdout: { on: jest.fn(), pipe: jest.fn() },
+      stderr: { pipe: jest.fn() },
+      on: jest.fn()
+    }
+    const spawnSpy = jest.fn(() => spawnMock as any)
+    const component = execUtils.createProcessSpawnerComponent(spawnSpy)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
+    })
+
+    await component.exec(process.cwd(), '/path with spaces/abgen', [], { shell: false })
+
+    expect(spawnSpy).toBeCalledWith('/path with spaces/abgen', [], {
+      shell: false,
+      cwd: process.cwd(),
+      env: { ...process.env, NODE_ENV: '' }
+    })
+  })
+
+  it('rejects when the child emits a spawn error', async () => {
+    const spawnMock = {
+      stdout: { on: jest.fn(), pipe: jest.fn() },
+      stderr: { pipe: jest.fn() },
+      on: jest.fn()
+    }
+    const spawnSpy = jest.fn(() => spawnMock as any)
+    const component = execUtils.createProcessSpawnerComponent(spawnSpy)
+    spawnMock.on.mockImplementation((event: string, cb: (arg: any) => void) => {
+      if (event === 'error') cb(new Error('spawn abgen ENOENT'))
+    })
+
+    await expect(component.exec(process.cwd(), 'abgen', [], { shell: false })).rejects.toThrow('spawn abgen ENOENT')
   })
 
   it('it should be called with proper params #2', async () => {
@@ -51,8 +87,8 @@ describe('utils/exec', () => {
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'], {
@@ -82,8 +118,8 @@ describe('utils/exec', () => {
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'], {
@@ -113,8 +149,8 @@ describe('utils/exec', () => {
     }
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(1)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(1)
     })
 
     let error


### PR DESCRIPTION
`sdk-commands start` now runs an abgen sidecar by default: an ab-cdn-compatible server that JIT-converts the scene being previewed into Unity asset bundles, reading it through the preview's own /content endpoints and falling back to the configured catalyst for anything else. The CLI prints the sidecar URL and passes it to the Desktop Explorer deep link as `optimized-assets-url` (verified against the shipped 0.159 `DecentralandUrlsSource` — the single arg activates the override); `--no-asset-bundles` turns it off.

The sidecar binary resolves from $ABGEN_BIN, then a cached download of the pinned [abgen v0.11.3 release](https://github.com/decentraland/abgen/releases/tag/v0.11.3) (per-platform self-contained archives, sha256-verified against hashes committed in-tree; the linux archive is a loader bundle that runs on any distro), then `abgen` on the PATH. When no binary is available or it is not ready in 15s, the preview continues with a warning. Binaries live in cache-class storage: `$XDG_CACHE_HOME` when set, else the platform's native cache dir (`%LOCALAPPDATA%` / `~/Library/Caches` / `~/.cache`) under `decentraland/abgen/`.

Converted bundles land in **`.dcl-optimized-assets/` next to `scene.json`** — durable across preview restarts and inside the default dcl-ignore, so the watcher and deployments never see it. Texture encoding is GPU-accelerated where hardware allows (CUDA on NVIDIA, Metal via wgpu on Apple Silicon), with an automatic CPU fallback.

Verified end-to-end on Linux, Windows, and macOS: resolver download + sha256 + extraction with the system tar, sidecar boot, preview /content wiring, and a real multi-asset scene conversion on each — cold converts in seconds, repeat requests serve from the durable cache in milliseconds (no reconversion, including across preview restarts), and GPU encoding qualified on all three platforms.

The preview's b64 pseudo-hashes switch to base64url so they are safe inside URL paths and asset-bundle directory names. exec() gains a shell:false option to spawn binaries directly, and an error handler so a missing binary rejects instead of hanging.
