### PR TITLE
feat: add --split-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ test/ecs/snippets/**/*.js
 test/sdk/simple-scene
 **/bin/game.js
 **/bin/game.js.map
+**/bin/scene.js
+**/bin/sdk-runtime.js
 **/*.js.map
 
 test/build-ecs/fixtures/*/package-lock.json

--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
@@ -416,7 +416,8 @@ async function bundle(components: Pick<CliComponents, 'fs' | 'logger'>, project:
         production: false, // keep source maps for better error messages
         emitDeclaration: false,
         ignoreComposite: true, // don't load existing composite files
-        customEntryPoint: false
+        customEntryPoint: false,
+        splitBuild: false // run the scene in-process (Node require): a single bundle, not chunks
       },
       project.scene
     )

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -163,19 +163,7 @@ type SingleProjectOptions = CompileOptions & {
   outputFile: string
 }
 
-export async function bundleSingleProject(components: BundleComponents, options: SingleProjectOptions) {
-  printProgressStep(components.logger, `Bundling file ${colors.bold(options.entrypoint)}`, 1, MAX_STEP)
-  const editorScene = await isEditorScene(components, options.workingDirectory)
-
-  // Pre-compute composite data so we can inject maxCompositeEntity via esbuild define.
-  // This must happen before the esbuild context is created because the define values
-  // are baked into the engine at compile time (the entity counter initializer reads it)
-  let maxCompositeEntity = 0
-  if (!options.ignoreComposite) {
-    const composites = await getAllComposites(components, options.workingDirectory)
-    maxCompositeEntity = composites.maxCompositeEntity
-  }
-
+function resolveSdkAliases(options: SingleProjectOptions): Record<string, string> {
   const sdkPackagePath = (() => {
     try {
       // First try to resolve from project's node_modules
@@ -185,12 +173,78 @@ export async function bundleSingleProject(components: BundleComponents, options:
       return path.dirname(require.resolve('@dcl/sdk/package.json', { paths: [__dirname] }))
     }
   })()
-  const context = await esbuild.context({
+  return {
+    // Ensure React is always resolved to the same module to prevent duplication
+    react: (() => {
+      try {
+        // First try to resolve from project's node_modules
+        return require.resolve('react', { paths: [options.workingDirectory] })
+      } catch {
+        try {
+          // Fallback to SDK's React dependency
+          return require.resolve('react', { paths: [path.join(__dirname, '../../../@dcl/sdk')] })
+        } catch {
+          // Final fallback to bundled React
+          return require.resolve('react')
+        }
+      }
+    })(),
+    // Ensure @dcl/sdk is always resolved to workspace version to prevent version conflicts
+    '@dcl/sdk': sdkPackagePath,
+    // Resolve ecs from sdk dependencies (nested in @dcl/sdk)
+    '@dcl/ecs': (() => {
+      try {
+        // First try to resolve from project's @dcl/sdk node_modules
+        return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [sdkPackagePath] }))
+      } catch {
+        try {
+          // Fallback: try to resolve from project's node_modules
+          return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [options.workingDirectory] }))
+        } catch {
+          // Last resort: try resolving from current directory
+          return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [__dirname] }))
+        }
+      }
+    })(),
+    // Resolve asset-packs from the scene's own node_modules (if the user explicitly installed it),
+    // otherwise fall back to the version bundled inside @dcl/inspector.
+    // NOTE: We use a direct path check (fs.existsSync) instead of require.resolve here because
+    // require.resolve walks UP the directory tree from workingDirectory, which would incorrectly
+    // pick up @dcl/asset-packs installed next to the scene (e.g. at a monorepo root) rather
+    // than the one the user intentionally installed inside the scene.
+    '@dcl/asset-packs': (() => {
+      const sceneOwnAssetPacks = path.join(
+        options.workingDirectory,
+        'node_modules',
+        '@dcl',
+        'asset-packs',
+        'package.json'
+      )
+      if (fs.existsSync(sceneOwnAssetPacks)) {
+        return path.dirname(sceneOwnAssetPacks)
+      }
+      try {
+        // Fallback: resolve from @dcl/inspector's node_modules
+        const inspectorPath = require.resolve('@dcl/inspector/package.json', { paths: [__dirname] })
+        return path.dirname(require.resolve('@dcl/asset-packs/package.json', { paths: [path.dirname(inspectorPath)] }))
+      } catch {
+        // Last resort: try resolving from current directory
+        return path.dirname(require.resolve('@dcl/asset-packs/package.json', { paths: [__dirname] }))
+      }
+    })()
+  }
+}
+
+function sharedEsbuildOptions(
+  options: SingleProjectOptions,
+  maxCompositeEntity: number,
+  outputFile: string
+): esbuild.BuildOptions {
+  return {
     bundle: true,
     platform: 'browser',
     format: 'cjs',
     preserveSymlinks: false,
-    outfile: options.outputFile,
     allowOverwrite: false,
     sourcemap: options.production ? false : 'inline',
     minify: options.production,
@@ -201,71 +255,8 @@ export async function bundleSingleProject(components: BundleComponents, options:
     metafile: true,
     absWorkingDir: options.workingDirectory,
     target: 'es2020',
-    external: ['~system/*', '@dcl/inspector', '@dcl/inspector/*' /* ban importing the inspector from the SDK */],
-    alias: {
-      // Ensure React is always resolved to the same module to prevent duplication
-      react: (() => {
-        try {
-          // First try to resolve from project's node_modules
-          return require.resolve('react', { paths: [options.workingDirectory] })
-        } catch {
-          try {
-            // Fallback to SDK's React dependency
-            return require.resolve('react', { paths: [path.join(__dirname, '../../../@dcl/sdk')] })
-          } catch {
-            // Final fallback to bundled React
-            return require.resolve('react')
-          }
-        }
-      })(),
-      // Ensure @dcl/sdk is always resolved to workspace version to prevent version conflicts
-      '@dcl/sdk': sdkPackagePath,
-      // Resolve ecs from sdk dependencies (nested in @dcl/sdk)
-      '@dcl/ecs': (() => {
-        try {
-          // First try to resolve from project's @dcl/sdk node_modules
-          return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [sdkPackagePath] }))
-        } catch {
-          try {
-            // Fallback: try to resolve from project's node_modules
-            return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [options.workingDirectory] }))
-          } catch {
-            // Last resort: try resolving from current directory
-            return path.dirname(require.resolve('@dcl/ecs/package.json', { paths: [__dirname] }))
-          }
-        }
-      })(),
-      // Resolve asset-packs from the scene's own node_modules (if the user explicitly installed it),
-      // otherwise fall back to the version bundled inside @dcl/inspector.
-      // NOTE: We use a direct path check (fs.existsSync) instead of require.resolve here because
-      // require.resolve walks UP the directory tree from workingDirectory, which would incorrectly
-      // pick up @dcl/asset-packs installed next to the scene (e.g. at a monorepo root) rather
-      // than the one the user intentionally installed inside the scene.
-      '@dcl/asset-packs': (() => {
-        const sceneOwnAssetPacks = path.join(
-          options.workingDirectory,
-          'node_modules',
-          '@dcl',
-          'asset-packs',
-          'package.json'
-        )
-        if (fs.existsSync(sceneOwnAssetPacks)) {
-          return path.dirname(sceneOwnAssetPacks)
-        }
-        try {
-          // Fallback: resolve from @dcl/inspector's node_modules
-          const inspectorPath = require.resolve('@dcl/inspector/package.json', { paths: [__dirname] })
-          return path.dirname(
-            require.resolve('@dcl/asset-packs/package.json', { paths: [path.dirname(inspectorPath)] })
-          )
-        } catch {
-          // Last resort: try resolving from current directory
-          return path.dirname(require.resolve('@dcl/asset-packs/package.json', { paths: [__dirname] }))
-        }
-      })()
-    },
     // convert filesystem paths into file:// to enable VSCode debugger
-    sourceRoot: options.production ? 'dcl:///' : pathToFileURL(path.dirname(options.outputFile)).toString(),
+    sourceRoot: options.production ? 'dcl:///' : pathToFileURL(path.dirname(outputFile)).toString(),
     define: {
       document: 'undefined',
       window: 'undefined',
@@ -283,7 +274,28 @@ export async function bundleSingleProject(components: BundleComponents, options:
     },
     logOverride: {
       'import-is-undefined': 'silent'
-    },
+    }
+  }
+}
+
+export async function bundleSingleProject(components: BundleComponents, options: SingleProjectOptions) {
+  printProgressStep(components.logger, `Bundling file ${colors.bold(options.entrypoint)}`, 1, MAX_STEP)
+  const editorScene = await isEditorScene(components, options.workingDirectory)
+
+  // Pre-compute composite data so we can inject maxCompositeEntity via esbuild define.
+  // This must happen before the esbuild context is created because the define values
+  // are baked into the engine at compile time (the entity counter initializer reads it)
+  let maxCompositeEntity = 0
+  if (!options.ignoreComposite) {
+    const composites = await getAllComposites(components, options.workingDirectory)
+    maxCompositeEntity = composites.maxCompositeEntity
+  }
+
+  const context = await esbuild.context({
+    ...sharedEsbuildOptions(options, maxCompositeEntity, options.outputFile),
+    outfile: options.outputFile,
+    external: ['~system/*', '@dcl/inspector', '@dcl/inspector/*' /* ban importing the inspector from the SDK */],
+    alias: resolveSdkAliases(options),
     plugins: [compositeLoader(components, options)],
     stdin: {
       contents: getEntrypointCode(options.entrypoint, options.customEntryPoint, editorScene),

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -19,6 +19,7 @@ import { getAllComposites, type Script } from './composite'
 import { isEditorScene } from './project-validations'
 import { watch } from 'chokidar'
 import { debounce } from './debounce'
+import { chunkPaths, isRegistryModule, loaderStub, registryKeys, sceneExternals, sdkRuntimeEntry } from './split'
 
 export type BundleComponents = Pick<CliComponents, 'logger' | 'fs'>
 
@@ -42,9 +43,19 @@ export type CompileOptions = {
 
   ignoreComposite: boolean
   customEntryPoint: boolean
+
+  // Internal: set false to force a single-file bundle. code-to-composite runs the scene
+  // in-process (Node require), where a loader stub can't readFile its chunks. Not a CLI flag —
+  // scenes always split; `--single` builds also stay single-file regardless of this.
+  splitBuild?: boolean
 }
 
 const MAX_STEP = 2
+const SPLIT_MAX_STEP = 3
+
+// Host modules plus the inspector, kept out of every bundle (the inspector must never
+// leak into the scene runtime). Shared by the normal, scene-chunk and SDK-chunk builds.
+const HOST_AND_INSPECTOR_EXTERNALS = ['~system/*', '@dcl/inspector', '@dcl/inspector/*']
 
 // Keep only the last 10KB of output to prevent memory leaks in watch mode
 const MAX_OUTPUT_SIZE = 10 * 1024
@@ -279,6 +290,12 @@ function sharedEsbuildOptions(
 }
 
 export async function bundleSingleProject(components: BundleComponents, options: SingleProjectOptions) {
+  // A scene always builds as a split bundle: an SDK-runtime chunk, a scene chunk and a loader
+  // stub written to the scene's main. `--single` emits a standalone file (a lib entry or a test
+  // bundle), not a scene main, so it can't carry the loader stub; code-to-composite opts out via
+  // splitBuild:false because it runs the scene in-process. Both build single-file.
+  if (!options.single && options.splitBuild !== false) return bundleSplitProject(components, options)
+
   printProgressStep(components.logger, `Bundling file ${colors.bold(options.entrypoint)}`, 1, MAX_STEP)
   const editorScene = await isEditorScene(components, options.workingDirectory)
 
@@ -294,7 +311,7 @@ export async function bundleSingleProject(components: BundleComponents, options:
   const context = await esbuild.context({
     ...sharedEsbuildOptions(options, maxCompositeEntity, options.outputFile),
     outfile: options.outputFile,
-    external: ['~system/*', '@dcl/inspector', '@dcl/inspector/*' /* ban importing the inspector from the SDK */],
+    external: HOST_AND_INSPECTOR_EXTERNALS,
     alias: resolveSdkAliases(options),
     plugins: [compositeLoader(components, options)],
     stdin: {
@@ -352,7 +369,112 @@ export async function bundleSingleProject(components: BundleComponents, options:
   await runTypeChecker(components, options)
 }
 
-function runTypeChecker(components: BundleComponents, options: CompileOptions) {
+async function bundleSplitProject(components: BundleComponents, options: SingleProjectOptions) {
+  const chunks = chunkPaths(options.outputFile)
+  const sceneOut = path.join(options.workingDirectory, chunks.scene)
+  const sdkOut = path.join(options.workingDirectory, chunks.sdk)
+  const mainOut = path.join(options.workingDirectory, options.outputFile)
+  const editorScene = await isEditorScene(components, options.workingDirectory)
+
+  let maxCompositeEntity = 0
+  if (!options.ignoreComposite) {
+    maxCompositeEntity = (await getAllComposites(components, options.workingDirectory)).maxCompositeEntity
+  }
+
+  // Emit all three files. Watch mode just re-runs this on change; esbuild is deterministic, so a
+  // scene-only edit re-emits an identical SDK chunk and a preview client 304s it (content-addressed).
+  const buildChunks = async () => {
+    // The scene chunk: just the scene code; the SDK, composites and scripts stay external.
+    const sceneResult = await buildSplitChunk({
+      ...sharedEsbuildOptions(options, maxCompositeEntity, chunks.scene),
+      outfile: sceneOut,
+      external: [...HOST_AND_INSPECTOR_EXTERNALS, ...sceneExternals],
+      plugins: [compositeLoader(components, options)],
+      stdin: {
+        contents: getEntrypointCode(options.entrypoint, options.customEntryPoint, editorScene),
+        resolveDir: path.dirname(options.entrypoint),
+        sourcefile: path.basename(options.entrypoint) + '.entry-point.ts',
+        loader: 'ts'
+      }
+    })
+
+    // The registry is the resolvable candidate superset plus whatever the scene chunk imports
+    // (its metafile), so same-SDK scenes emit an identical chunk yet an exotic deep import is
+    // never missing.
+    const keys = registryKeys(options.workingDirectory, collectSdkExternals(sceneResult.metafile))
+    await buildSplitChunk({
+      ...sharedEsbuildOptions(options, maxCompositeEntity, chunks.sdk),
+      outfile: sdkOut,
+      // Keep the full SDK: tree-shaking would prune the chunk to what *this* scene reaches, so
+      // scenes exercising different SDK surfaces would emit different chunks and lose the
+      // cross-scene sharing that is the whole point. The scene chunk above still tree-shakes.
+      treeShaking: false,
+      // a stable sourceRoot keeps the chunk byte-identical across scene directories
+      sourceRoot: 'dcl:///',
+      external: HOST_AND_INSPECTOR_EXTERNALS,
+      alias: resolveSdkAliases(options),
+      plugins: [compositeLoader(components, options)],
+      stdin: {
+        contents: sdkRuntimeEntry(keys),
+        resolveDir: options.workingDirectory,
+        sourcefile: 'sdk-runtime-entry.js',
+        loader: 'js'
+      }
+    })
+
+    // The loader stub only references the chunk paths.
+    await components.fs.writeFile(mainOut, await loaderStub(components, chunks.sdk, chunks.scene))
+  }
+
+  printProgressStep(components.logger, `Bundling scene and SDK runtime`, 1, SPLIT_MAX_STEP)
+  await buildChunks()
+  printProgressStep(components.logger, `Loader stub saved ${colors.bold(options.outputFile)}`, 2, SPLIT_MAX_STEP)
+
+  /* istanbul ignore if */
+  if (options.watch) {
+    const watcher = watch(path.resolve(options.workingDirectory), {
+      ignored: ['**/dist/**', '**/*.crdt', '**/*.d.ts', sceneOut, sdkOut, mainOut],
+      ignoreInitial: true
+    })
+    const debouncedRebuild = debounce(async () => {
+      try {
+        await buildChunks()
+        printProgressInfo(components.logger, `Chunks saved ${colors.bold(chunks.scene)}`)
+      } catch (err: any) {
+        components.logger.error(err.toString())
+      }
+    }, 100)
+    watcher.on('all', (_event, filePath) => {
+      if (/\.(ts|tsx|js|jsx|composite)$/.test(filePath)) {
+        printProgressInfo(components.logger, `File ${filePath} changed, rebuilding...`)
+        debouncedRebuild()
+      }
+    })
+    printProgressInfo(components.logger, `The compiler is watching for changes`)
+  }
+
+  await runTypeChecker(components, options, 3, SPLIT_MAX_STEP)
+}
+
+async function buildSplitChunk(buildOptions: esbuild.BuildOptions) {
+  try {
+    return await esbuild.build(buildOptions)
+  } catch (err: any) {
+    throw new CliError('BUNDLE_REBUILD_FAILED', i18next.t('errors.bundle.rebuild_failed', { error: err.toString() }))
+  }
+}
+
+function collectSdkExternals(metafile: esbuild.Metafile | undefined): string[] {
+  const keys = new Set<string>()
+  for (const output of Object.values(metafile?.outputs ?? {})) {
+    for (const imported of output.imports) {
+      if (imported.external && isRegistryModule(imported.path)) keys.add(imported.path)
+    }
+  }
+  return [...keys].sort()
+}
+
+function runTypeChecker(components: BundleComponents, options: CompileOptions, step = 2, maxStep = MAX_STEP) {
   const tsBin = require.resolve('typescript/lib/tsc')
   const args = [
     '-p',
@@ -364,7 +486,7 @@ function runTypeChecker(components: BundleComponents, options: CompileOptions) {
   /* istanbul ignore if */
   if (options.watch) args.push('--watch')
 
-  printProgressStep(components.logger, `Running type checker`, 2, MAX_STEP)
+  printProgressStep(components.logger, `Running type checker`, step, maxStep)
   const ts = child_process.fork(tsBin, args, {
     stdio: 'pipe',
     env: process.env,

--- a/packages/@dcl/sdk-commands/src/logic/split-loader.template
+++ b/packages/@dcl/sdk-commands/src/logic/split-loader.template
@@ -1,0 +1,72 @@
+// Split-bundle loader stub, written into the scene's `main` file by
+// `sdk-commands build --split-build`. It reads the SDK-runtime and scene chunks
+// at runtime and wires them together. Top-level names and the eval helper's
+// locals are __dclSplit-prefixed: chunk code is direct-eval'd inside that helper,
+// so those names sit on the chunk's scope chain and must not shadow globals.
+'use strict'
+
+var __dclSplitSdkChunkPath = __DCL_SDK_CHUNK__
+var __dclSplitSceneChunkPath = __DCL_SCENE_CHUNK__
+var __dclSplitSceneModule = null
+
+// Chunks are ASCII (esbuild's default charset). TextDecoder is not a sandbox
+// contract on every runtime, so fall back to chunked String.fromCharCode.
+function __dclSplitDecode(bytes) {
+  if (typeof TextDecoder === 'function') {
+    try {
+      return new TextDecoder().decode(bytes)
+    } catch (err) {}
+  }
+  var parts = []
+  for (var i = 0; i < bytes.length; i += 32768) {
+    var slice = bytes.subarray ? bytes.subarray(i, i + 32768) : bytes.slice(i, i + 32768)
+    parts.push(String.fromCharCode.apply(null, slice))
+  }
+  return parts.join('')
+}
+
+// ~system/* passes through to the host require; every other specifier must be a
+// registry key or fail loudly. The scene chunk externalizes the SDK with wildcards
+// that are broader than the registry, so an unregistered SDK deep-import is caught here.
+function __dclSplitMakeRequire(registry, hostRequire) {
+  return function (spec) {
+    if (spec.lastIndexOf('~system/', 0) === 0) return hostRequire(spec)
+    if (spec in registry) return registry[spec]
+    throw new Error('split bundle: "' + spec + '" is not in the sdk runtime registry')
+  }
+}
+
+// Direct eval, never new Function: the web sandbox provides console/fetch/etc. as
+// lexical consts of this stub, and only direct eval keeps them on the chunk's scope
+// chain. The sourceURL suffix names the chunk in stack traces.
+function __dclSplitEvalChunk(__dclSplitCode, __dclSplitPath, __dclSplitRequire) {
+  var __dclSplitModule = { exports: {} }
+  var __dclSplitFactory = eval(
+    '"use strict";(function(globalThis,module,exports,require){' +
+      __dclSplitCode +
+      '\n})\n//# sourceURL=dcl:///' +
+      __dclSplitPath
+  )
+  __dclSplitFactory.call(globalThis, globalThis, __dclSplitModule, __dclSplitModule.exports, __dclSplitRequire)
+  return __dclSplitModule.exports
+}
+
+// Both runtimes fully await onStart before the first onUpdate, so the null guard
+// in onUpdate is enough.
+module.exports.onStart = async function () {
+  var runtime = require('~system/Runtime')
+  var sdkSrc = __dclSplitDecode((await runtime.readFile({ fileName: __dclSplitSdkChunkPath })).content)
+  var sceneSrc = __dclSplitDecode((await runtime.readFile({ fileName: __dclSplitSceneChunkPath })).content)
+
+  var registry = __dclSplitEvalChunk(sdkSrc, __dclSplitSdkChunkPath, __dclSplitMakeRequire({}, require))
+  var scene = __dclSplitEvalChunk(sceneSrc, __dclSplitSceneChunkPath, __dclSplitMakeRequire(registry, require))
+
+  __dclSplitSceneModule = scene
+  if (typeof scene.onStart === 'function') return scene.onStart()
+}
+
+module.exports.onUpdate = function (deltaTime) {
+  if (__dclSplitSceneModule && typeof __dclSplitSceneModule.onUpdate === 'function') {
+    return __dclSplitSceneModule.onUpdate(deltaTime)
+  }
+}

--- a/packages/@dcl/sdk-commands/src/logic/split.ts
+++ b/packages/@dcl/sdk-commands/src/logic/split.ts
@@ -1,0 +1,123 @@
+import * as path from 'path'
+
+import { CliComponents } from '../components'
+
+/**
+ * `sdk-commands build --split-build` emits three files instead of one bundle:
+ *
+ *   - the SDK-runtime chunk (`<main-dir>/sdk-runtime.js`): every stable SDK package,
+ *     bundled once and exported as a require-registry keyed by module specifier.
+ *   - the scene chunk (`<main-dir>/scene.js`): just the scene code, with the SDK
+ *     packages, composites and scripts left as external `require(...)` calls.
+ *   - a loader stub (the scene's `main`): reads both chunks at runtime and resolves
+ *     the scene's SDK requires from the registry.
+ *
+ * The SDK chunk carries the composites and scripts too (see VIRTUAL_MODULES), so it is
+ * identical across code edits; a runtime that caches it only re-fetches the small scene
+ * chunk until a composite changes.
+ */
+
+// The SDK packages that move to the SDK-runtime chunk. Everything under these roots is
+// externalized out of the scene chunk (as require calls) and registered in the SDK chunk.
+const SDK_MODULE_ROOTS = ['@dcl/sdk', '@dcl/ecs', '@dcl/ecs-math', '@dcl/react-ecs', '@dcl/asset-packs', 'react']
+
+// The composite and script virtual modules also go in the SDK chunk: `@dcl/sdk`'s
+// composite-provider imports `~sdk/all-composites`, so the scene's composite data has to
+// live alongside the SDK code that reads it. The SDK-chunk build resolves them via the
+// composite-loader plugin, so they carry the real composites and scripts, not empty stubs.
+const VIRTUAL_MODULES = ['~sdk/all-composites', '~sdk/script-utils']
+
+/** Scene-chunk externals: every SDK root plus its sub-paths, and the virtual modules. */
+export const sceneExternals = [...SDK_MODULE_ROOTS.flatMap((root) => [root, `${root}/*`]), ...VIRTUAL_MODULES]
+
+/** Whether an external import belongs in the SDK-runtime registry (vs ~system/* or the inspector). */
+export function isRegistryModule(specifier: string): boolean {
+  if (VIRTUAL_MODULES.includes(specifier)) return true
+  return SDK_MODULE_ROOTS.some((root) => specifier === root || specifier.startsWith(`${root}/`))
+}
+
+// Every SDK specifier a scene may import. The registry bundles all of these that resolve,
+// not just what one scene uses, so two scenes on the same SDK version emit an identical
+// SDK-runtime chunk and a runtime cache shares it across scenes.
+const REGISTRY_CANDIDATES = [
+  '@dcl/sdk',
+  '@dcl/sdk/ecs',
+  '@dcl/sdk/math',
+  '@dcl/sdk/react-ecs',
+  '@dcl/sdk/composite-provider',
+  '@dcl/sdk/observables',
+  '@dcl/sdk/message-bus',
+  '@dcl/sdk/players',
+  '@dcl/sdk/network',
+  '@dcl/sdk/ethereum-provider',
+  '@dcl/sdk/testing',
+  '@dcl/ecs',
+  '@dcl/ecs-math',
+  '@dcl/react-ecs',
+  'react',
+  'react/jsx-runtime',
+  '@dcl/asset-packs',
+  '@dcl/asset-packs/dist/scene-entrypoint'
+]
+
+/** The candidates that resolve from the scene, unioned with what the scene chunk imports. */
+export function registryKeys(workingDirectory: string, sceneImports: string[]): string[] {
+  const keys = new Set(sceneImports)
+  for (const candidate of REGISTRY_CANDIDATES) {
+    try {
+      require.resolve(candidate, { paths: [workingDirectory] })
+      keys.add(candidate)
+    } catch {}
+  }
+  return [...keys].sort()
+}
+
+/**
+ * Source for the SDK-runtime chunk's entrypoint: a CJS module exporting a lazy
+ * registry of the SDK packages. esbuild bundles the `require(...)` calls, so the
+ * emitted chunk carries the SDK code and exposes it keyed by specifier.
+ */
+export function sdkRuntimeEntry(keys: string[]): string {
+  const defs = keys.map(
+    (key) => `  ${JSON.stringify(key)}: memo(function () { return require(${JSON.stringify(key)}) })`
+  )
+  return `'use strict'
+function memo(load) {
+  var value
+  var done = false
+  return function () {
+    if (!done) {
+      value = load()
+      done = true
+    }
+    return value
+  }
+}
+var defs = {
+${defs.join(',\n')}
+}
+var registry = {}
+Object.keys(defs).forEach(function (key) {
+  Object.defineProperty(registry, key, { enumerable: true, get: defs[key] })
+})
+module.exports = registry
+`
+}
+
+/** Derives the two chunk paths from the scene's `main` (e.g. bin/index.js). */
+export function chunkPaths(main: string): { sdk: string; scene: string } {
+  const slash = main.lastIndexOf('/')
+  const dir = slash === -1 ? '' : main.slice(0, slash + 1)
+  return { sdk: `${dir}sdk-runtime.js`, scene: `${dir}scene.js` }
+}
+
+export async function loaderStub(
+  components: Pick<CliComponents, 'fs'>,
+  sdkChunk: string,
+  sceneChunk: string
+): Promise<string> {
+  const template = await components.fs.readFile(path.join(__dirname, 'split-loader.template'), 'utf-8')
+  return template
+    .replace('__DCL_SDK_CHUNK__', () => JSON.stringify(sdkChunk))
+    .replace('__DCL_SCENE_CHUNK__', () => JSON.stringify(sceneChunk))
+}

--- a/test/build-ecs/compile-ecs7.spec.ts
+++ b/test/build-ecs/compile-ecs7.spec.ts
@@ -11,22 +11,30 @@ describe('build: simple scene compilation', () => {
   itExecutes('npm i --silent --no-progress', cwd)
   itExecutes('npm run build --silent', cwd)
 
-  it('ensure files exist', () => {
-    const binPath = ensureFileExists('bin/game.js', cwd)
-    const fileText = readFileSync(binPath, 'utf8')
-    const ecs7Included = fileText.includes(`require("~system/EngineApi")`)
-    if (!ecs7Included) {
-      throw new Error('scene doesn\'t include require("~system/EngineApi")')
-    }
+  it('emits the SDK-runtime chunk, the scene chunk and a loader stub', () => {
+    // a scene builds as three files: the scene's main is a loader stub that wires the other two
+    const stub = readFileSync(ensureFileExists('bin/game.js', cwd), 'utf8')
+    const sceneText = readFileSync(ensureFileExists('bin/scene.js', cwd), 'utf8')
+    const sdkText = readFileSync(ensureFileExists('bin/sdk-runtime.js', cwd), 'utf8')
 
-    const transformComponentIncluded = fileText.includes(`Transform(engine)`)
-    if (!transformComponentIncluded) {
-      throw new Error("scene doesn't include Transform(engine)")
-    }
-    const textEncodingLibraryIncluded = fileText.includes('text-encoding')
-    if (textEncodingLibraryIncluded) {
-      throw new Error('textEncoding is being bundled in the scene.')
-    }
+    // the loader stub reads both chunks from the scene runtime
+    expect(stub).toContain('bin/sdk-runtime.js')
+    expect(stub).toContain('bin/scene.js')
+    expect(stub).toContain('~system/Runtime')
+
+    // the scene chunk stays lean: it requires the SDK as an external and never inlines it
+    expect(sceneText).toContain('require("@dcl/ecs")')
+    expect(sceneText).not.toContain('~system/EngineApi')
+    // ...nor pulls in SDK-only dependencies (they belong to the SDK-runtime chunk)
+    expect(sceneText).not.toContain('text-encoding')
+
+    // the SDK-runtime chunk carries the engine and components and exposes the require registry
+    expect(sdkText).toContain('require("~system/EngineApi")')
+    expect(sdkText).toContain('Transform(engine)')
+    expect(sdkText).toContain('module.exports = registry')
+    // the registry is the probed candidate superset, not just this scene's imports:
+    // ecs7-scene never touches ethereum, yet same-SDK scenes share one chunk
+    expect(sdkText).toContain('"@dcl/sdk/ethereum-provider"')
   })
 })
 describe('build: scene with etherum', () => {
@@ -39,12 +47,23 @@ describe('build: scene with etherum', () => {
   itExecutes('npm run build --silent', cwd)
 
   it('ensure files exist', () => {
-    const binPath = ensureFileExists('bin/game.js', cwd)
-    const fileText = readFileSync(binPath, 'utf8')
+    ensureFileExists('bin/game.js', cwd)
+    const sceneText = readFileSync(ensureFileExists('bin/scene.js', cwd), 'utf8')
+    const sdkText = readFileSync(ensureFileExists('bin/sdk-runtime.js', cwd), 'utf8')
 
-    const textEncodingLibraryIncluded = fileText.includes('text-encoding')
-    if (!textEncodingLibraryIncluded) {
-      throw new Error(`scene doesn't include textEncoding`)
-    }
+    // the scene requires the ethereum provider as an external
+    expect(sceneText).toContain('require("@dcl/sdk/ethereum-provider")')
+    // ethereum support (text-encoding) ships in the shared SDK-runtime chunk
+    expect(sdkText).toContain('text-encoding')
+  })
+
+  // a react + ethereum scene also builds in production mode (formerly compile-scene's
+  // 'scene with react'); kept in this file so nothing else mutates the fixture concurrently
+  itExecutes('npm run build-prod --silent', cwd)
+
+  it('builds in production mode', () => {
+    ensureFileExists('bin/game.js', cwd)
+    ensureFileExists('bin/scene.js', cwd)
+    ensureFileExists('bin/sdk-runtime.js', cwd)
   })
 })

--- a/test/build-ecs/compile-scene.spec.ts
+++ b/test/build-ecs/compile-scene.spec.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path'
+import { resolve } from 'path'
 import { createFsComponent } from '../../packages/@dcl/sdk-commands/src/components/fs'
 import { getInstalledPackageVersion } from '../../packages/@dcl/sdk-commands/src/logic/config'
 import { itExecutes, ensureFileExists, itDeletesFolder } from '../../scripts/helpers'
@@ -21,7 +21,8 @@ describe('build-ecs: simple scene compilation', () => {
 
     expect(await getInstalledPackageVersion({ fs: createFsComponent() }, '@dcl/sdk', cwd)).toEqual('7.0.0')
 
-    const { map } = await loadSourceMap(join(cwd, 'bin/game.js'))
+    // the scene main is the loader stub; the scene code and its source map live in the scene chunk
+    const { map } = await loadSourceMap(ensureFileExists('bin/scene.js', cwd))
     assertFilesExist(map)
   })
 })
@@ -40,16 +41,3 @@ describe('build-ecs: simple scene compilation, production mode', () => {
   })
 })
 
-describe('build-ecs: scene with react', () => {
-  const cwd = resolve(__dirname, './fixtures/ecs7-ui-ethereum')
-
-  itDeletesFolder('./bin', cwd)
-  itDeletesFolder('./node_modules', cwd)
-
-  itExecutes('npm install --silent --no-progress', cwd)
-  itExecutes('npm run --silent build-prod', cwd)
-
-  it('ensure files exist', () => {
-    ensureFileExists('bin/game.js', cwd)
-  })
-})

--- a/test/sdk-commands/logic/split.spec.ts
+++ b/test/sdk-commands/logic/split.spec.ts
@@ -1,0 +1,76 @@
+import { readFile } from 'fs/promises'
+import {
+  chunkPaths,
+  isRegistryModule,
+  loaderStub,
+  registryKeys,
+  sceneExternals,
+  sdkRuntimeEntry
+} from '../../../packages/@dcl/sdk-commands/src/logic/split'
+
+describe('split-build logic', () => {
+  it('derives the two chunk paths from the scene main', () => {
+    expect(chunkPaths('bin/index.js')).toEqual({ sdk: 'bin/sdk-runtime.js', scene: 'bin/scene.js' })
+    expect(chunkPaths('game.js')).toEqual({ sdk: 'sdk-runtime.js', scene: 'scene.js' })
+    expect(chunkPaths('dist/nested/main.js')).toEqual({
+      sdk: 'dist/nested/sdk-runtime.js',
+      scene: 'dist/nested/scene.js'
+    })
+  })
+
+  it('externalizes the SDK roots and the composite/script virtual modules', () => {
+    const externals = sceneExternals
+    expect(externals).toContain('@dcl/sdk')
+    expect(externals).toContain('@dcl/sdk/*')
+    expect(externals).toContain('react/*')
+    expect(externals).toContain('~sdk/all-composites')
+    expect(externals).toContain('~sdk/script-utils')
+  })
+
+  it('registers SDK modules and virtual modules, not host or inspector imports', () => {
+    expect(isRegistryModule('@dcl/sdk')).toBe(true)
+    expect(isRegistryModule('@dcl/ecs/dist-cjs')).toBe(true)
+    expect(isRegistryModule('react/jsx-runtime')).toBe(true)
+    expect(isRegistryModule('~sdk/all-composites')).toBe(true)
+    expect(isRegistryModule('~sdk/script-utils')).toBe(true)
+    expect(isRegistryModule('~system/Runtime')).toBe(false)
+    expect(isRegistryModule('@dcl/inspector')).toBe(false)
+    expect(isRegistryModule('@dcl/sdkx')).toBe(false)
+  })
+
+  it('every package aliased by the bundler is externalized into the registry', () => {
+    // resolveSdkAliases (bundle.ts) redirects these packages; each must be a registry
+    // module, or it would be aliased into the SDK chunk yet still bundled into the scene
+    // chunk. This guards against the two lists drifting apart.
+    for (const aliased of ['react', '@dcl/sdk', '@dcl/ecs', '@dcl/asset-packs']) {
+      expect(isRegistryModule(aliased)).toBe(true)
+    }
+  })
+
+  it('registry keys keep the scene imports, deduped and sorted', () => {
+    // candidate probing needs real module resolution; test/build-ecs/split-build.spec.ts
+    // asserts it against a built scene (jest's sandboxed resolver ignores resolve paths)
+    const keys = registryKeys(process.cwd(), ['~sdk/script-utils', '~sdk/all-composites', '~sdk/all-composites'])
+    expect(keys).toContain('~sdk/all-composites')
+    expect(keys).toContain('~sdk/script-utils')
+    expect(keys).toEqual([...keys].sort())
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('builds an SDK-runtime entry that requires and re-exports every key', () => {
+    const entry = sdkRuntimeEntry(['@dcl/sdk', '@dcl/ecs', '~sdk/all-composites'])
+    expect(entry).toContain(`require("@dcl/sdk")`)
+    expect(entry).toContain(`require("@dcl/ecs")`)
+    expect(entry).toContain(`require("~sdk/all-composites")`)
+    expect(entry).toContain('module.exports = registry')
+  })
+
+  it('substitutes both chunk paths into the loader stub', async () => {
+    const components = { fs: { readFile: (p: string, e: BufferEncoding) => readFile(p, e) } } as any
+    const stub = await loaderStub(components, 'bin/sdk-runtime.js', 'bin/scene.js')
+    expect(stub).toContain(`"bin/sdk-runtime.js"`)
+    expect(stub).toContain(`"bin/scene.js"`)
+    expect(stub).not.toContain('__DCL_SDK_CHUNK__')
+    expect(stub).not.toContain('__DCL_SCENE_CHUNK__')
+  })
+})


### PR DESCRIPTION
Emit the scene as three files instead of one bundle: an SDK-runtime chunk (the SDK packages, composites and scripts, exported as a require-registry), a scene chunk (just the scene code, with the SDK left as external requires), and a loader stub written to the scene's main that wires them together at runtime. A runtime that caches the SDK-runtime chunk only re-fetches the small scene chunk on a code edit.

The SDK-runtime registry is derived from the scene chunk's own external imports (via its metafile), so it never references a module path esbuild cannot resolve. The shared esbuild config and SDK alias resolution are factored out so the split and non-split paths stay in sync.