### PR TITLE
fix(sdk-commands): stop bundling a second copy of @dcl/ecs into every scene

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
+++ b/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { IEngine, Entity, EntityState } from '@dcl/ecs/dist-cjs'
+import { IEngine, Entity, EntityState } from '@dcl/ecs'
 import { type ActionRef, getActionEvents } from '@dcl/inspector/node_modules/@dcl/asset-packs'
 
 declare global {

--- a/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
+++ b/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import { IEngine, Entity, EntityState } from '@dcl/ecs'
+import type { IEngine, Entity } from '@dcl/ecs'
+import { EntityState } from '@dcl/ecs/dist-cjs/engine/entity'
 import { type ActionRef, getActionEvents } from '@dcl/inspector/node_modules/@dcl/asset-packs'
 
 declare global {

--- a/test/sdk-commands/logic/runtime-script.spec.ts
+++ b/test/sdk-commands/logic/runtime-script.spec.ts
@@ -9,7 +9,7 @@ jest.mock(
 )
 
 import { runScripts } from '../../../packages/@dcl/sdk-commands/src/logic/runtime-script'
-import { IEngine, Entity, EntityState } from '../../../packages/@dcl/ecs/dist-cjs'
+import { IEngine, Entity, EntityState } from '../../../packages/@dcl/ecs/dist'
 
 describe('runtime-script', () => {
   let mockEngine: IEngine

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=318.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 145k
-  MALLOC_COUNT = 30543
-  ALIVE_OBJS_DELTA ~= 7.25k
+  OPCODES ~= 102k
+  MALLOC_COUNT = 21120
+  ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -20,22 +20,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1041 t=1 data={"src":"test.glb"}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 13k
-  MALLOC_COUNT = 98
+  OPCODES ~= 8k
+  MALLOC_COUNT = 96
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x202 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 9k
+  OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x203 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 9k
+  OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x204 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 9k
+  OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1606.23k bytes
+  MEMORY_USAGE_COUNT ~= 1300.70k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=608.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=318.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 222k
-  MALLOC_COUNT = 43890
-  ALIVE_OBJS_DELTA ~= 9.89k
+  OPCODES ~= 145k
+  MALLOC_COUNT = 30543
+  ALIVE_OBJS_DELTA ~= 7.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -20,22 +20,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1041 t=1 data={"src":"test.glb"}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 8k
-  MALLOC_COUNT = 96
+  OPCODES ~= 13k
+  MALLOC_COUNT = 98
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x202 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 9k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x203 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 9k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x204 c=1041 t=1 data={"src":"test.glb"}
-  OPCODES ~= 5k
+  OPCODES ~= 9k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2968.93k bytes
+  MEMORY_USAGE_COUNT ~= 1606.23k bytes


### PR DESCRIPTION
## What

Two commits, one line of imports each:

1. The runtime script embedded into every scene bundle as `~sdk/script-utils` imported `@dcl/ecs/dist-cjs`. `EntityState` is a runtime enum, so the import survives into the emitted bundle and pulls the entire CommonJS build of `@dcl/ecs` (~319 KB minified, unshakeable) in **next to** the ESM build the rest of the scene already uses.
2. Importing the `@dcl/ecs` barrel instead deduplicates, but creates a subtler cost: a CJS `require()` of the ESM barrel forces esbuild to materialize its full namespace, defeating tree-shaking — every `/* @__PURE__ */` core-component initializer stays alive, so the engine registers **65** component definitions instead of the **20** the scene actually uses, and `engine.update()`'s per-frame dirty sweep doubles. The final shape imports the types as type-only and the single runtime value, `EntityState`, from the `dist-cjs` leaf (`engine/entity.js` + its one dependency, ~2 KB minified) — the barrel stays import-only and shakeable, and the file stays loadable under Node's `require()` like every other CLI-side file.

## Impact

Measured on standard (non-custom-entrypoint) production builds:

| scene | before | after |
|---|---|---|
| workspace fixture (`ecs7-scene`) | 650,248 B (318,932 B dist-cjs + 229,660 B ESM) | 333,579 B (**−49%**; 354,800 B with the barrel import alone) |
| `with-main-function` snapshot | 608.6k | 292.2k (**−52%**) |

Every standard scene built with `sdk-commands build` since #1245 ships the duplicate.

Runtime, from the `with-main-function` snapshot VM (QuickJS, opcode-counted; identical CRDT output in all three states):

| | main | barrel import only | this PR |
|---|---|---|---|
| eval opcodes | 222k | 145k | **102k** |
| eval mallocs | 43,890 | 30,543 | **21,120** |
| `onUpdate` opcodes (steady state) | 5k | 9k | **5k** |
| VM memory after run | 2,968.9k | 1,606.2k | **1,300.7k** |
| component definitions registered | 20 | 65 | **20** |

## Why it was never caught

The size-tracked bundle snapshots build with `--customEntryPoint --ignoreComposite`, which skips `~sdk/script-utils` entirely — so the duplication was invisible to CI. `with-main-function` is the one snapshot that exercises the real path; its expectation (608.6k → 292.2k, onUpdate steady at 5k) is regenerated in this PR and now guards against regressing either axis.

## Why dist-cjs was there

`dist-cjs` exists so the CLI itself (a CommonJS Node program) can `require('@dcl/ecs')` at CLI runtime (#584) — `dist/` is `module: esnext` output that Node's `require()` can't load, and the package has no `exports` map. That convention is correct for CLI-side files (`composite.ts`, `coordinates.ts`, `scene-validations.ts`, unchanged here) but `runtime-script.ts` crosses the boundary into scene bundles. The leaf import keeps both properties at once: scene bundles get a shakeable ESM barrel plus a ~2 KB CJS leaf, and the compiled file remains Node-requirable.

## Verification

- `runtime-script.spec.ts`: 16/16
- all 17 bundle snapshots green after regeneration; full test suite green
- built scenes execute correctly (CRDT output verified equal against a pre-change control through a scene-runtime harness, all three variants)
- compiled `dist/logic/runtime-script.js` contains a single `require("@dcl/ecs/dist-cjs/engine/entity")` and no barrel require; the emitted scene bundle contains no `__toCommonJS` materialization of the ecs namespace
