### PR TITLE
chore: bump CI Node to 24.16.0 to restore npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
           cache: 'npm'
       - name: install
         run: make install
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
           cache: 'npm'
       - name: docs
         run: make docs
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
           cache: 'npm'
       - name: install
         run: make install
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
           cache: 'npm'
 
       - name: (PR) Check if it's a PR
@@ -401,7 +401,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
       - run: mkdir -p scene
       - name: npx @dcl/sdk-commands init --skip-install
         run: npx ${{ secrets.SDK_TEAM_S3_BASE_URL }}/${{ needs.build.outputs.decentraland_sdk_commands_s3_bucket_key }} init --skip-install
@@ -452,7 +452,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
 
       - name: Download prepared packages
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

Pushes to `protocol-squad` have not published to npm since 2026-04-27 — the `protocol-squad` dist-tag is stuck at `7.22.6-25007982108.commit-83012ab` (#1384), and the runs for #1398 and #1421 both failed in the `build` job with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@dcl%2fjs-runtime
```

npm publishing for the `@dcl/*` packages moved to trusted publishing (OIDC), which requires npm >= 11.5.1. This branch's CI still runs Node 20 (npm 10), so oddish-action falls back to the now-invalid `NPM_TOKEN` and the registry rejects the PUT (npm reports rejected credentials as 404). `main` was fixed by bumping to Node 24 in #1409 / pinned in #1425; its build logs show `using OIDC (npm Trusted Publishing) — skipping _authToken in .npmrc`.

## Fix

Bump `node-version` to `24.16.0` (main's pin) across ci.yml. The `build` job already has `id-token: write`, so with npm 11 the publish takes the OIDC path. Once merged, the push run should publish and move the `protocol-squad` npm tag again.

Note: the `test` job has 16 pre-existing failures on this branch and will show red here — it has never gated publishing (publish lives in the independent `build` job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)