### PR TITLE
Add @dcl/sdk/platform and @dcl/sdk/text-codec entrypoints

### DIFF
--- a/packages/@dcl/sdk/src/platform/index.ts
+++ b/packages/@dcl/sdk/src/platform/index.ts
@@ -1,0 +1,35 @@
+import { getExplorerInformation } from '~system/Runtime'
+
+export type Platform = 'mobile' | 'desktop' | 'web'
+
+const VALID_PLATFORMS: Set<string> = new Set<string>(['mobile', 'desktop', 'web'])
+
+let platform: Platform | null = null
+void getExplorerInformation({})
+  .then((response) => {
+    const normalized = response.platform.toLowerCase()
+    if (VALID_PLATFORMS.has(normalized)) {
+      platform = normalized as Platform
+    } else {
+      console.error(`Unknown platform value: "${response.platform}"`)
+    }
+  })
+  .catch((error) => {
+    console.error('Failed to get explorer information:', error)
+  })
+
+export function getPlatform(): Platform | null {
+  return platform
+}
+
+export function isMobile(): boolean {
+  return getPlatform() === 'mobile'
+}
+
+export function isDesktop(): boolean {
+  return getPlatform() === 'desktop'
+}
+
+export function isWeb(): boolean {
+  return getPlatform() === 'web'
+}

--- a/packages/@dcl/sdk/src/text-codec.ts
+++ b/packages/@dcl/sdk/src/text-codec.ts
@@ -1,0 +1,23 @@
+import TextEncodingPolyfill from 'text-encoding'
+import { setGlobalPolyfill } from '@dcl/ecs'
+
+/**
+ * Install the `TextEncoder` / `TextDecoder` polyfill on `globalThis`.
+ *
+ * The QuickJS scene runtime ships no native `TextEncoder` / `TextDecoder`, yet
+ * `compositeProvider.loadComposite` decodes `.composite` JSON file bytes via
+ * `TextDecoder`. Callers that load composites at runtime (e.g. `@dcl/asset-packs`'
+ * `SPAWN_ENTITY`) must install this first.
+ *
+ * Exposed from the lean `@dcl/sdk/text-codec` subpath so consumers can install
+ * the polyfill without pulling in the ethereum provider, and without bundling
+ * `text-encoding` into scenes that never reach this module.
+ */
+// NOTE: this function mutates globalThis — it is NOT pure. Do not annotate
+// with /* @__PURE__ */; minifiers would treat the call as dead code and drop
+// the polyfill installation, breaking runtime callers like
+// compositeProvider.loadComposite that rely on globalThis.TextDecoder.
+export function polyfillTextEncoder() {
+  setGlobalPolyfill('TextEncoder', TextEncodingPolyfill.TextEncoder)
+  setGlobalPolyfill('TextDecoder', TextEncodingPolyfill.TextDecoder)
+}


### PR DESCRIPTION
protocol-squad's `@dcl/sdk` is missing the `platform` and `text-codec` subpath entrypoints that exist on `main`. `@dcl/asset-packs`' `scene-entrypoint` (bundled by Creator Hub's publish flow) imports `@dcl/sdk/platform` and `@dcl/sdk/text-codec`, so publishing a scene built against the protocol-squad SDK fails with `Could not resolve "@dcl/sdk/text-codec"`.

Ports the two files verbatim from `main`. Both compile against protocol-squad unchanged:
- `text-codec` → `setGlobalPolyfill` (already in `@dcl/ecs`) + `text-encoding` (already a dep)
- `platform` → `getExplorerInformation().platform` (already in the runtime API)

No package.json/exports changes needed — pure subpaths.