### PR TITLE
chore: single exposure types between kernel API and ECS components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
+        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29274665765.commit-1e0422c",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
-      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
+      "version": "1.0.0-29286492043.commit-0010e70",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
+      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -8385,9 +8385,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-29274665765.commit-1e0422c",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
-      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
+      "version": "1.0.0-29286492043.commit-0010e70",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
+      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29266273106.commit-fb37de5",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
-      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
+      "version": "1.0.0-29274665765.commit-1e0422c",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
+      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -8385,8 +8385,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
-      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
+      "version": "1.0.0-29274665765.commit-1e0422c",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
+      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-28974105118.commit-a598406",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-28974105118.commit-a598406",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-28974105118.commit-a598406.tgz",
-      "integrity": "sha512-wUPTxo6Efk/pFenm7rKGiSIlia+m/FeTlICUT2CmJxZwD5XDpsYl8q9szWWccltqeKFP8zrJsOWu2C2gFfCw2Q==",
+      "version": "1.0.0-29266273106.commit-fb37de5",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -593,6 +593,7 @@
       "version": "1.154.0",
       "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.154.0.tgz",
       "integrity": "sha512-2S5AKMMPVZrVfa/1WRy4/h0niikcbu3Yf6dCoudh7ScG7BsyKAPC3CMg6IJKHzrmWS593UZClq7YJof6Vt4O+w==",
+      "license": "ISC",
       "dependencies": {
         "@types/object-hash": "^3.0.2",
         "case-anything": "^2.1.10",
@@ -607,9 +608,10 @@
       }
     },
     "node_modules/@dcl/protocol/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/protocol/node_modules/protobufjs": {
       "version": "7.2.4",
@@ -639,6 +641,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
       "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
+      "license": "ISC",
       "dependencies": {
         "long": "^5.2.3",
         "protobufjs": "^7.2.4"
@@ -8382,9 +8385,8 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-28974105118.commit-a598406",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-28974105118.commit-a598406.tgz",
-      "integrity": "sha512-wUPTxo6Efk/pFenm7rKGiSIlia+m/FeTlICUT2CmJxZwD5XDpsYl8q9szWWccltqeKFP8zrJsOWu2C2gFfCw2Q==",
+      "version": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"
@@ -8405,9 +8407,9 @@
           }
         },
         "long": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+          "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
         },
         "protobufjs": {
           "version": "7.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-28974105118.commit-a598406",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
+    "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+    "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -191,6 +191,12 @@ export const AvatarEquippedData: LastWriteWinElementSetComponentDefinition<PBAva
 export const AvatarLocomotionSettings: LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>;
 
 // @public (undocumented)
+export const enum AvatarMask {
+    // (undocumented)
+    AM_UPPER_BODY = 0
+}
+
+// @public (undocumented)
 export const AvatarModifierArea: LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>;
 
 // @public (undocumented)
@@ -2529,6 +2535,8 @@ export interface PBAvatarEmoteCommand {
     emoteUrn: string;
     // (undocumented)
     loop: boolean;
+    // (undocumented)
+    mask?: AvatarMask | undefined;
     timestamp: number;
 }
 

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
+        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29274665765.commit-1e0422c",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
-      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
+      "version": "1.0.0-29286492043.commit-0010e70",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
+      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29266273106.commit-fb37de5",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
-      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
+      "version": "1.0.0-29274665765.commit-1e0422c",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29274665765.commit-1e0422c.tgz",
+      "integrity": "sha512-lFlFyz67HYG7y66BEwMp4O22tfrAEY7Yg/6TsLOaX4sP6ygFGVmwV7R6E9wf17Ki7j6MO65oWpicE+KGPiZ2lA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-28974105118.commit-a598406",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-28974105118.commit-a598406",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-28974105118.commit-a598406.tgz",
-      "integrity": "sha512-wUPTxo6Efk/pFenm7rKGiSIlia+m/FeTlICUT2CmJxZwD5XDpsYl8q9szWWccltqeKFP8zrJsOWu2C2gFfCw2Q==",
+      "version": "1.0.0-29266273106.commit-fb37de5",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+      "integrity": "sha512-ccEZyy6Fk3WhluYbwu5hCMc1wFb/rRsOw8iZKWADBaiAwM5Oh27pRnypJhJEjOf1wlGXJyDMQ3BDG6v6woaJ0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.34.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-28974105118.commit-a598406",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.34.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-29266273106.commit-fb37de5.tgz",
+    "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.34.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
+    "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/scripts/rpc-api-generation/index.ts
+++ b/scripts/rpc-api-generation/index.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, readFileSync, removeSync, rmSync, writeFileSync } from 'fs-extra'
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, removeSync, rmSync, writeFileSync } from 'fs-extra'
 import * as path from 'path'
 import { TSC } from '../common'
 import { runCommand } from '../helpers'
@@ -162,17 +162,47 @@ async function preprocessProtoGeneration(protoPath: string) {
   return apis
 }
 
+const COMPONENTS_PROTO_PATH = path.resolve(
+  __dirname,
+  '../../node_modules/@dcl/protocol/proto/decentraland/sdk/components'
+)
+
+// The ecs codegen only compiles (and @dcl/ecs only exports) the common protos that some
+// component proto imports. A common proto used exclusively by kernel APIs has no @dcl/ecs
+// counterpart, so its declarations must stay embedded in apis.d.ts.
+function isExportedByEcs(commonModuleName: string): boolean {
+  const protoImport = `import "decentraland/sdk/components/${commonModuleName
+    .replace(/^.*decentraland\/sdk\/components\//, '')
+    .replace(/\.gen$/, '.proto')}"`
+  return readdirSync(COMPONENTS_PROTO_PATH)
+    .filter((file) => file.endsWith('.proto'))
+    .some((file) => readFileSync(path.resolve(COMPONENTS_PROTO_PATH, file)).toString().includes(protoImport))
+}
+
 function processDeclarations(apiName: string, filePath: string) {
   const decFile = readFileSync(filePath).toString()
 
   const blocks: string[] = []
+  const typesFromEcs: Set<string> = new Set()
   let where = 0
   do {
     where = decFile.indexOf('declare module', where)
     if (where !== -1) {
+      const moduleName = decFile.slice(where).match(/^declare module "([^"]+)"/)?.[1] ?? ''
       const block = getBlock(decFile, where).replace(/export const protobufPackage (.*)\n/, '')
       if (block.length > 0) {
-        blocks.push(block)
+        if (moduleName.includes('decentraland/sdk/components/common/') && isExportedByEcs(moduleName)) {
+          // Nominal types (enums) shared with sdk components are already exported by
+          // @dcl/sdk/ecs. Import them instead of re-declaring, so a value typed with the
+          // @dcl/sdk/ecs declaration is assignable to the RPC request fields.
+          for (const [, typeName] of block.matchAll(
+            /export\s+(?:declare\s+)?(?:const\s+)?(?:enum|interface|type|class)\s+(\w+)/g
+          )) {
+            typesFromEcs.add(typeName)
+          }
+        } else {
+          blocks.push(block)
+        }
       } else {
         throw new Error('bad block')
       }
@@ -182,6 +212,12 @@ function processDeclarations(apiName: string, filePath: string) {
     where += 'declare module'.length
   } while (where)
 
-  const content = blocks.join('\n\t// Function declaration section').replace(/import(.*)\n/g, '')
+  let content = blocks.join('\n\t// Function declaration section').replace(/import(.*)\n/g, '')
+  for (const typeName of typesFromEcs) {
+    // '../ecs' is @dcl/ecs, always a sibling of @dcl/js-runtime (both under @dcl/) and the
+    // same nominal types that @dcl/sdk/ecs re-exports. Inlined at each reference (instead of
+    // a local alias) because everything declared in an ambient module is importable from it.
+    content = content.replace(new RegExp(`\\b${typeName}\\b`, 'g'), `import('../ecs').${typeName}`)
+  }
   writeFileSync(filePath, `declare module "~system/${apiName}" {\n${content}\n}`)
 }

--- a/scripts/rpc-api-generation/index.ts
+++ b/scripts/rpc-api-generation/index.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, readdirSync, readFileSync, removeSync, rmSync, writeFileSync } from 'fs-extra'
+import { copyFileSync, mkdirSync, readFileSync, removeSync, rmSync, writeFileSync } from 'fs-extra'
 import * as path from 'path'
 import { TSC } from '../common'
 import { runCommand } from '../helpers'
@@ -170,13 +170,22 @@ const COMPONENTS_PROTO_PATH = path.resolve(
 // The ecs codegen only compiles (and @dcl/ecs only exports) the common protos that some
 // component proto imports. A common proto used exclusively by kernel APIs has no @dcl/ecs
 // counterpart, so its declarations must stay embedded in apis.d.ts.
+let componentProtoImports: Set<string> | undefined
 function isExportedByEcs(commonModuleName: string): boolean {
-  const protoImport = `import "decentraland/sdk/components/${commonModuleName
-    .replace(/^.*decentraland\/sdk\/components\//, '')
-    .replace(/\.gen$/, '.proto')}"`
-  return readdirSync(COMPONENTS_PROTO_PATH)
-    .filter((file) => file.endsWith('.proto'))
-    .some((file) => readFileSync(path.resolve(COMPONENTS_PROTO_PATH, file)).toString().includes(protoImport))
+  componentProtoImports ??= new Set(
+    getFilePathsSync(COMPONENTS_PROTO_PATH)
+      .filter((file) => file.endsWith('.proto'))
+      .flatMap((file) =>
+        Array.from(
+          readFileSync(path.resolve(COMPONENTS_PROTO_PATH, file))
+            .toString()
+            .matchAll(/^\s*import\s+"decentraland\/sdk\/components\/([^"]+)"/gm),
+          (match) => match[1]
+        )
+      )
+  )
+  const protoFile = commonModuleName.replace(/^.*decentraland\/sdk\/components\//, '').replace(/\.gen$/, '.proto')
+  return componentProtoImports.has(protoFile)
 }
 
 function processDeclarations(apiName: string, filePath: string) {
@@ -212,7 +221,7 @@ function processDeclarations(apiName: string, filePath: string) {
     where += 'declare module'.length
   } while (where)
 
-  let content = blocks.join('\n\t// Function declaration section').replace(/import(.*)\n/g, '')
+  let content = blocks.join('\n\t// Function declaration section').replace(/^[ \t]*import\b(.*)\n/gm, '')
   for (const typeName of typesFromEcs) {
     // '../ecs' is @dcl/ecs, always a sibling of @dcl/js-runtime (both under @dcl/) and the
     // same nominal types that @dcl/sdk/ecs re-exports. Inlined at each reference (instead of

--- a/test/ecs/components/AvatarEmoteCommand.spec.ts
+++ b/test/ecs/components/AvatarEmoteCommand.spec.ts
@@ -1,8 +1,8 @@
 ﻿import { AvatarMask, Engine, components } from '../../../packages/@dcl/ecs/src'
 import { testSchemaSerializationIdentity } from './assertion'
 
-describe('Generated PointerEventsResult ProtoBuf', () => {
-  it('should serialize/deserialize PointerEventsResult', () => {
+describe('Generated AvatarEmoteCommand ProtoBuf', () => {
+  it('should serialize/deserialize AvatarEmoteCommand', () => {
     const newEngine = Engine()
     const AvatarEmoteCommand = components.AvatarEmoteCommand(newEngine)
     // AvatarEmoteCommand.addValue()

--- a/test/ecs/components/AvatarEmoteCommand.spec.ts
+++ b/test/ecs/components/AvatarEmoteCommand.spec.ts
@@ -1,4 +1,4 @@
-﻿import { Engine, components } from '../../../packages/@dcl/ecs/src'
+﻿import { AvatarMask, Engine, components } from '../../../packages/@dcl/ecs/src'
 import { testSchemaSerializationIdentity } from './assertion'
 
 describe('Generated PointerEventsResult ProtoBuf', () => {
@@ -6,6 +6,17 @@ describe('Generated PointerEventsResult ProtoBuf', () => {
     const newEngine = Engine()
     const AvatarEmoteCommand = components.AvatarEmoteCommand(newEngine)
     // AvatarEmoteCommand.addValue()
-    testSchemaSerializationIdentity(AvatarEmoteCommand.schema, { emoteUrn: 'boedo', loop: false, timestamp: 1 })
+    testSchemaSerializationIdentity(AvatarEmoteCommand.schema, {
+      emoteUrn: 'boedo',
+      loop: false,
+      timestamp: 1,
+      mask: undefined
+    })
+    testSchemaSerializationIdentity(AvatarEmoteCommand.schema, {
+      emoteUrn: 'boedo',
+      loop: false,
+      timestamp: 1,
+      mask: AvatarMask.AM_UPPER_BODY
+    })
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.8k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 16310
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1428.83k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=566.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16862
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1434.60k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=566.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16862
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1434.60k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -170,7 +170,7 @@
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
+        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -170,7 +170,7 @@
         "@dcl/inspector": "7.34.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-28974105118.commit-a598406",
+        "@dcl/protocol": "1.0.0-29274665765.commit-1e0422c",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15170
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1070.63k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17688
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1256.70k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14290
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1032.90k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14263
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1022.66k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21025
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1481.17k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 14556
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1042.36k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14395
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1025.11k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -11,7 +11,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22395
+  MALLOC_COUNT = 22400
   ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
@@ -67,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1895.34k bytes
+  MEMORY_USAGE_COUNT ~= 1895.72k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21120
+  MALLOC_COUNT = 21131
   ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1300.70k bytes
+  MEMORY_USAGE_COUNT ~= 1301.17k bytes


### PR DESCRIPTION
Two codegen pipelines consume the protocol's `decentraland/sdk/components/common/*` protos: the ECS components codegen (exported through `@dcl/sdk/ecs`) and the RPC API codegen (embedded into the `~system/*` ambient modules of `apis.d.ts`). When the same common type was referenced by both a component and a kernel API, each pipeline emitted its own declaration. TypeScript enums are nominal, so the two identical-looking declarations were incompatible: a value typed with the `@dcl/sdk/ecs` enum could not be passed to the RPC functions, and the type was importable from two unrelated places.

**Example**: the protocol change adding `common.AvatarMask mask = 4` to `PBAvatarEmoteCommand` made `AvatarMask` (already used by the `TriggerEmote`/`TriggerSceneEmote` RPCs) the first type in this situation — exposed from both `~system/RestrictedActions` and `@dcl/sdk/ecs`, with the two incompatible with each other.

## Change

`scripts/rpc-api-generation/index.ts` no longer embeds declarations coming from `decentraland/sdk/components/common/*` protos into the `~system/*` modules when the ECS side also generates them. Instead, each reference is inlined as an `import()` type pointing at `@dcl/ecs`:

```ts
mask?: import('../ecs').AvatarMask | undefined;
```

- Single source of truth: the common type is importable only from `@dcl/sdk/ecs` (or `@dcl/ecs`) and the same import works in both the RPC requests and the component.
- The relative `'../ecs'` specifier is used because ambient module declarations reject relative `import` statements (TS2439) and bare `@dcl/...` specifiers don't resolve from `@dcl/js-runtime`'s location; both packages are always siblings under `node_modules/@dcl` in scene projects.
- Inlined at each reference (rather than a local type alias) because everything declared inside an ambient module is importable from it — an alias would still leak the name.

## The two scenarios

- **Common type used by a component** (and possibly by kernel APIs — the `AvatarMask` case): the RPC generator drops the embedded copy and inlines `import('../ecs').<Type>`. One nominal type, exposed only by `@dcl/sdk/ecs`, usable everywhere.
- **Common type used only by kernel APIs** (what `AvatarMask` was before the protocol change): `@dcl/ecs` doesn't compile or export it, so the generator keeps it embedded in `apis.d.ts` as before. The distinction is made by checking whether any component proto in `@dcl/protocol` imports the common proto — the exact condition under which the ECS pipeline generates it. When a component later adopts such a type, the next build flips it to the unified form automatically, with no generator changes.

## Breaking change

Whenever a common type flips to the unified form, importing it from the `~system/*` module no longer compiles (the module no longer declares the name); it must be imported from `@dcl/sdk/ecs` instead. With this PR that applies to `AvatarMask` in `~system/RestrictedActions`. Note the old value-level import was already broken at runtime — the ambient enum had no runtime backing in the kernel module.

## Result
One `AvatarMask`, imported from `@dcl/sdk/ecs`, usable directly with `triggerSceneEmote` — no cast, real runtime value:

```ts
import { AvatarMask } from '@dcl/sdk/ecs'
import { triggerSceneEmote } from '~system/RestrictedActions'

triggerSceneEmote({ src, loop: true, mask: AvatarMask.AM_UPPER_BODY })