### PR TITLE
fix(sdk-commands): prevent preview path traversal

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { PreviewComponents } from '../types'
 import { fetchEntityByPointer } from '../../../logic/catalyst-requests'
 import { CliComponents } from '../../../components'
+import { resolvePathInside } from './path'
 import {
   b64HashingFunction,
   getProjectPublishableFilesWithHashes,
@@ -194,7 +195,9 @@ async function serveFolders(
 
       // find a project that we are talking about. NOTE: this filter is not exhaustive
       //   relative paths should be used instead
-      const baseProject = workspace.projects.find((project) => fullPath.startsWith(project.workingDirectory))
+      const baseProject = workspace.projects.find(
+        (project) => resolvePathInside(project.workingDirectory, fullPath) !== undefined
+      )
 
       // only return files IF the file is within a baseFolder
       if (!baseProject) {
@@ -473,7 +476,11 @@ function serveStatic(
   ) {
     router.get(route, async (ctx, next) => {
       const file = ctx.params.path
-      const fullPath = path.resolve(folder, transform(file))
+      const fullPath = resolvePathInside(folder, transform(file))
+
+      if (!fullPath) {
+        return next()
+      }
 
       // only return files IF the file is within a baseFolder
       if (!(await components.fs.fileExists(fullPath))) {

--- a/packages/@dcl/sdk-commands/src/commands/start/server/path.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/path.ts
@@ -1,0 +1,21 @@
+import path from 'path'
+
+/**
+ * Resolves a requested path and returns it only when it is contained by the given root.
+ *
+ * @param root - Directory that must contain the resolved path.
+ * @param requestedPath - Relative or absolute path to validate.
+ * @returns The absolute resolved path, or `undefined` when it escapes the root.
+ */
+export function resolvePathInside(root: string, requestedPath: string): string | undefined {
+  const resolvedRoot = path.resolve(root)
+  const resolvedPath = path.resolve(resolvedRoot, requestedPath)
+  const relativePath = path.relative(resolvedRoot, resolvedPath)
+
+  if (relativePath === '') return resolvedPath
+  if (path.isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${path.sep}`)) {
+    return undefined
+  }
+
+  return resolvedPath
+}

--- a/test/sdk-commands/utils/path-containment.spec.ts
+++ b/test/sdk-commands/utils/path-containment.spec.ts
@@ -1,0 +1,58 @@
+import path from 'path'
+import { resolvePathInside } from '../../../packages/@dcl/sdk-commands/src/commands/start/server/path'
+
+describe('resolvePathInside', () => {
+  describe('when the requested path is inside the root', () => {
+    let root: string
+    let requestedPath: string
+
+    beforeEach(() => {
+      root = path.resolve('tmp', 'scene')
+      requestedPath = 'assets/model.glb'
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should return the absolute contained path', () => {
+      expect(resolvePathInside(root, requestedPath)).toBe(path.join(root, requestedPath))
+    })
+  })
+
+  describe('when the requested path traverses above the root', () => {
+    let root: string
+    let requestedPath: string
+
+    beforeEach(() => {
+      root = path.resolve('tmp', 'scene')
+      requestedPath = '../private.txt'
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should reject the escaped path', () => {
+      expect(resolvePathInside(root, requestedPath)).toBeUndefined()
+    })
+  })
+
+  describe('when an absolute path only shares the root prefix', () => {
+    let root: string
+    let requestedPath: string
+
+    beforeEach(() => {
+      root = path.resolve('tmp', 'scene')
+      requestedPath = path.resolve('tmp', 'scene-secret', 'private.txt')
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should reject the sibling path', () => {
+      expect(resolvePathInside(root, requestedPath)).toBeUndefined()
+    })
+  })
+})

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "pretty": true,
-    "types": ["jest", "@dcl/js-runtime"],
+    "types": ["jest", "node", "@dcl/js-runtime"],
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Why

The preview server accepted request-derived paths and used string-prefix checks to decide whether they belonged to a project directory. String prefixes do not represent filesystem boundaries: a sibling such as scene-secret matches scene, and resolved traversal segments can point outside the directory being served. This could allow preview HTTP routes to read files beyond their intended project or static-content roots.

## What changed

- Added a shared resolvePathInside helper based on path.resolve and path.relative.
- The helper only returns paths whose relative form remains within the configured root.
- Applied the containment check to generated b64 content paths and static preview routes before any filesystem lookup or stream is created.
- Added coverage for valid nested paths, parent-directory traversal, and absolute sibling paths that merely share the same prefix.
- Added Node types to the test TypeScript configuration because the regression suite uses the Node path API.

## Verification

- Focused path-containment Jest suite passes.
- The sdk-commands TypeScript check passes.
- make lint passes.