### PR TITLE
fix(sdk): respect async observable cancellation

### DIFF
--- a/packages/@dcl/sdk/src/internal/Observable.ts
+++ b/packages/@dcl/sdk/src/internal/Observable.ts
@@ -281,27 +281,21 @@ export class Observable<T> {
 
     // execute one callback after another (not using Promise.all, the order is important)
     this._observers.forEach((obs) => {
-      if (state.skipNextObservers) {
-        return
-      }
-      if (obs._willBeUnregistered) {
-        return
-      }
       if (obs.mask & mask) {
-        if (obs.scope) {
-          p = p.then((lastReturnedValue) => {
-            state.lastReturnValue = lastReturnedValue
-            return obs.callback.apply(obs.scope, [eventData, state])
-          })
-        } else {
-          p = p.then((lastReturnedValue) => {
-            state.lastReturnValue = lastReturnedValue
-            return obs.callback(eventData, state)
-          })
-        }
-        if (obs.unregisterOnNextCall) {
-          this._deferUnregister(obs)
-        }
+        p = p.then((lastReturnedValue) => {
+          if (state.skipNextObservers || obs._willBeUnregistered) {
+            return lastReturnedValue
+          }
+
+          state.lastReturnValue = lastReturnedValue
+          const result = obs.scope ? obs.callback.apply(obs.scope, [eventData, state]) : obs.callback(eventData, state)
+
+          if (obs.unregisterOnNextCall) {
+            this._deferUnregister(obs)
+          }
+
+          return result
+        })
       }
     })
 

--- a/test/sdk/observable.spec.ts
+++ b/test/sdk/observable.spec.ts
@@ -1,0 +1,34 @@
+import { Observable, ObserverEventState } from '../../packages/@dcl/sdk/src/internal/Observable'
+
+describe('Observable.notifyObserversWithPromise', () => {
+  describe('when an asynchronous observer skips the remaining observers', () => {
+    let observable: Observable<number>
+    let calls: string[]
+    let firstCallback: jest.Mock<Promise<void>, [number, ObserverEventState]>
+    let secondCallback: jest.Mock<Promise<void>, [number, ObserverEventState]>
+
+    beforeEach(() => {
+      observable = new Observable<number>()
+      calls = []
+      firstCallback = jest.fn(async (_value: number, state: ObserverEventState) => {
+        calls.push('first')
+        state.skipNextObservers = true
+      })
+      secondCallback = jest.fn(async (_value: number, _state: ObserverEventState) => {
+        calls.push('second')
+      })
+      observable.add(firstCallback)
+      observable.add(secondCallback)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should stop before invoking the next observer', async () => {
+      await observable.notifyObserversWithPromise(1)
+
+      expect(calls).toEqual(['first'])
+    })
+  })
+})


### PR DESCRIPTION
## Why

notifyObserversWithPromise builds its observer chain before any asynchronous callback runs. The previous implementation checked skipNextObservers while constructing that chain, so a callback that set the flag asynchronously could not prevent already-scheduled observers from running. One-shot observers could also be marked for removal even when an earlier observer meant they should be skipped.

## What changed

- Move the skipNextObservers and pending-unregistration checks into each promise-chain step, immediately before that observer is invoked.
- Preserve lastReturnValue as the chain advances.
- Defer one-shot observer removal only after the observer actually runs.
- Added a regression test where the first asynchronous observer sets skipNextObservers and confirms that the second observer is never called.

## Verification

- The focused Observable Jest suite passes.
- The sdk TypeScript check passes.
- make lint passes.