### PR TITLE
fix(sdk): serialize MessageBus sends

### DIFF
--- a/packages/@dcl/sdk/src/message-bus.ts
+++ b/packages/@dcl/sdk/src/message-bus.ts
@@ -41,6 +41,7 @@ export class MessageBus {
     if (this.flushing) return
 
     const message = this.messageQueue.shift()!
+    this.flushing = true
     communicationsController.send({ message }).then(
       (_) => {
         this.flushing = false
@@ -48,6 +49,7 @@ export class MessageBus {
       },
       (_) => {
         this.flushing = false
+        this.flush()
       }
     )
   }

--- a/test/sdk/message-bus.spec.ts
+++ b/test/sdk/message-bus.spec.ts
@@ -1,0 +1,92 @@
+import type { MessageBus } from '../../packages/@dcl/sdk/src/message-bus'
+
+type Deferred = {
+  promise: Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (reason: Error) => void
+}
+
+describe('MessageBus', () => {
+  describe('when a message is still being sent', () => {
+    let MessageBusConstructor: typeof MessageBus
+    let sendMock: jest.Mock
+    let deferred: Deferred
+    let messageBus: MessageBus
+
+    beforeEach(() => {
+      let resolvePromise: (value: unknown) => void = () => undefined
+      let rejectPromise: (reason: Error) => void = () => undefined
+      const promise = new Promise<unknown>((resolve, reject) => {
+        resolvePromise = resolve
+        rejectPromise = reject
+      })
+      deferred = { promise, resolve: resolvePromise, reject: rejectPromise }
+      sendMock = jest.fn().mockReturnValueOnce(deferred.promise).mockResolvedValueOnce(undefined)
+      jest.doMock('~system/CommunicationsController', () => ({ send: sendMock }), { virtual: true })
+      jest.doMock('../../packages/@dcl/sdk/src/observables', () => ({
+        onCommsMessage: { add: jest.fn(), notifyObservers: jest.fn() }
+      }))
+      jest.isolateModules(() => {
+        MessageBusConstructor = require('../../packages/@dcl/sdk/src/message-bus').MessageBus
+      })
+      messageBus = new MessageBusConstructor()
+    })
+
+    afterEach(async () => {
+      deferred.resolve(undefined)
+      await deferred.promise
+      await Promise.resolve()
+      jest.resetModules()
+      jest.restoreAllMocks()
+    })
+
+    it('should keep the next message queued', () => {
+      messageBus.sendRaw('first')
+      messageBus.sendRaw('second')
+
+      expect(sendMock.mock.calls.map(([request]) => request.message)).toEqual(['first'])
+    })
+  })
+
+  describe('when sending a message fails', () => {
+    let MessageBusConstructor: typeof MessageBus
+    let sendMock: jest.Mock
+    let deferred: Deferred
+    let messageBus: MessageBus
+
+    beforeEach(() => {
+      let resolvePromise: (value: unknown) => void = () => undefined
+      let rejectPromise: (reason: Error) => void = () => undefined
+      const promise = new Promise<unknown>((resolve, reject) => {
+        resolvePromise = resolve
+        rejectPromise = reject
+      })
+      deferred = { promise, resolve: resolvePromise, reject: rejectPromise }
+      sendMock = jest.fn().mockReturnValueOnce(deferred.promise).mockResolvedValueOnce(undefined)
+      jest.doMock('~system/CommunicationsController', () => ({ send: sendMock }), { virtual: true })
+      jest.doMock('../../packages/@dcl/sdk/src/observables', () => ({
+        onCommsMessage: { add: jest.fn(), notifyObservers: jest.fn() }
+      }))
+      jest.isolateModules(() => {
+        MessageBusConstructor = require('../../packages/@dcl/sdk/src/message-bus').MessageBus
+      })
+      messageBus = new MessageBusConstructor()
+      messageBus.sendRaw('first')
+      messageBus.sendRaw('second')
+    })
+
+    afterEach(async () => {
+      await Promise.resolve()
+      jest.resetModules()
+      jest.restoreAllMocks()
+    })
+
+    it('should continue flushing the remaining messages', async () => {
+      deferred.reject(new Error('send failed'))
+      await deferred.promise.catch(() => undefined)
+      await Promise.resolve()
+
+      expect(sendMock.mock.calls.map(([request]) => request.message)).toEqual(['first', 'second'])
+    })
+  })
+})


### PR DESCRIPTION
## Why

MessageBus.flush checked a flushing guard but never set it before starting an asynchronous communications send. Calling sendRaw again while that promise was pending therefore started another send immediately, breaking message ordering and allowing concurrent writes. A rejected send also stopped queue processing, leaving later messages stranded.

## What changed

- Set the flushing flag before invoking CommunicationsController.send.
- Keep later messages queued until the active send settles.
- Clear the guard and continue flushing on both fulfillment and rejection.
- Added regression coverage for a pending send that must serialize a second message and for a failed send that must not block the remaining queue.

## Verification

- The focused MessageBus Jest suite passes.
- The sdk TypeScript check passes.
- make lint passes.