### PR TITLE
fix(sdk): await network profile initialization

### DIFF
--- a/packages/@dcl/sdk/src/network/index.ts
+++ b/packages/@dcl/sdk/src/network/index.ts
@@ -4,7 +4,26 @@ import { addSyncTransport } from './message-bus-sync'
 import { getUserData } from '~system/UserIdentity'
 
 // initialize sync transport for sdk engine
-const { getChildren, syncEntity, parentEntity, getParent, myProfile, removeParent, getFirstChild, isStateSyncronized } =
-  addSyncTransport(engine, sendBinary, getUserData)
+const {
+  getChildren,
+  syncEntity,
+  parentEntity,
+  getParent,
+  myProfile,
+  removeParent,
+  getFirstChild,
+  isStateSyncronized,
+  ready: networkReady
+} = addSyncTransport(engine, sendBinary, getUserData)
 
-export { getFirstChild, getChildren, syncEntity, parentEntity, getParent, myProfile, removeParent, isStateSyncronized }
+export {
+  getFirstChild,
+  getChildren,
+  syncEntity,
+  parentEntity,
+  getParent,
+  myProfile,
+  removeParent,
+  isStateSyncronized,
+  networkReady
+}

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -24,27 +24,36 @@ export function addSyncTransport(
   // Entity utils
   const entityDefinitions = entityUtils(engine, myProfile)
   const pendingProfileOperations: (() => void)[] = []
-  let profileInitialized = false
+  let profileInitializationState: 'pending' | 'ready' | 'failed' = 'pending'
 
   const ready = fetchProfile(myProfile, getUserData).then(() => {
-    profileInitialized = true
+    profileInitializationState = 'ready'
     for (const operation of pendingProfileOperations.splice(0)) {
-      operation()
+      try {
+        operation()
+      } catch (error) {
+        console.error('Queued network operation failed', error)
+      }
     }
   })
 
   // Keep module-level initialization failures handled even when callers do not
   // explicitly await readiness. The returned `ready` promise still rejects for
   // callers that do await it.
-  void ready.catch((error) => {
-    pendingProfileOperations.length = 0
-    console.error(error)
-  })
+  const profileInitializedSuccessfully = ready.then(
+    () => true,
+    (error) => {
+      profileInitializationState = 'failed'
+      pendingProfileOperations.length = 0
+      console.error(error)
+      return false
+    }
+  )
 
   function runWhenProfileIsReady(operation: () => void): void {
-    if (profileInitialized) {
+    if (profileInitializationState === 'ready') {
       operation()
-    } else {
+    } else if (profileInitializationState === 'pending') {
       pendingProfileOperations.push(operation)
     }
   }
@@ -70,7 +79,8 @@ export function addSyncTransport(
   const transport: Transport = {
     filter: syncFilter(engine),
     send: async (messages) => {
-      await ready
+      if (!(await profileInitializedSuccessfully)) return
+
       for (const message of [messages].flat()) {
         if (message.byteLength && transportInitialzed) {
           DEBUG_NETWORK_MESSAGES() &&

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -20,10 +20,34 @@ export function addSyncTransport(
   const DEBUG_NETWORK_MESSAGES = () => (globalThis as any).DEBUG_NETWORK_MESSAGES ?? false
   // Profile Info
   const myProfile: IProfile = {} as IProfile
-  fetchProfile(myProfile!, getUserData)
 
   // Entity utils
   const entityDefinitions = entityUtils(engine, myProfile)
+  const pendingProfileOperations: (() => void)[] = []
+  let profileInitialized = false
+
+  const ready = fetchProfile(myProfile, getUserData).then(() => {
+    profileInitialized = true
+    for (const operation of pendingProfileOperations.splice(0)) {
+      operation()
+    }
+  })
+
+  // Keep module-level initialization failures handled even when callers do not
+  // explicitly await readiness. The returned `ready` promise still rejects for
+  // callers that do await it.
+  void ready.catch((error) => {
+    pendingProfileOperations.length = 0
+    console.error(error)
+  })
+
+  function runWhenProfileIsReady(operation: () => void): void {
+    if (profileInitialized) {
+      operation()
+    } else {
+      pendingProfileOperations.push(operation)
+    }
+  }
 
   // List of MessageBuss messsages to be sent on every frame to comms
   const pendingMessageBusMessagesToSend: { data: Uint8Array[]; address: string[] }[] = []
@@ -46,6 +70,7 @@ export function addSyncTransport(
   const transport: Transport = {
     filter: syncFilter(engine),
     send: async (messages) => {
+      await ready
       for (const message of [messages].flat()) {
         if (message.byteLength && transportInitialzed) {
           DEBUG_NETWORK_MESSAGES() &&
@@ -169,7 +194,17 @@ export function addSyncTransport(
 
   return {
     ...entityDefinitions,
+    syncEntity(...args: Parameters<typeof entityDefinitions.syncEntity>) {
+      runWhenProfileIsReady(() => entityDefinitions.syncEntity(...args))
+    },
+    parentEntity(...args: Parameters<typeof entityDefinitions.parentEntity>) {
+      runWhenProfileIsReady(() => entityDefinitions.parentEntity(...args))
+    },
+    removeParent(...args: Parameters<typeof entityDefinitions.removeParent>) {
+      runWhenProfileIsReady(() => entityDefinitions.removeParent(...args))
+    },
     myProfile,
+    ready,
     isStateSyncronized
   }
 }

--- a/packages/@dcl/sdk/src/network/utils.ts
+++ b/packages/@dcl/sdk/src/network/utils.ts
@@ -5,18 +5,17 @@ import type { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdenti
 import { IProfile } from './message-bus-sync'
 
 // Retrieve userId to start sending this info as the networkId
-export function fetchProfile(
+export async function fetchProfile(
   myProfile: IProfile,
   getUserData: (value: GetUserDataRequest) => Promise<GetUserDataResponse>
-) {
-  void getUserData({}).then(({ data }) => {
-    if (data?.userId) {
-      const userId = data.userId
-      const networkId = componentNumberFromName(data.userId)
-      myProfile.networkId = networkId
-      myProfile.userId = userId
-    } else {
-      throw new Error(`Couldn't fetch profile data`)
-    }
-  })
+): Promise<void> {
+  const { data } = await getUserData({})
+  if (!data?.userId) {
+    throw new Error(`Couldn't fetch profile data`)
+  }
+
+  const userId = data.userId
+  const networkId = componentNumberFromName(userId)
+  myProfile.networkId = networkId
+  myProfile.userId = userId
 }

--- a/test/sdk/network/profile-initialization.spec.ts
+++ b/test/sdk/network/profile-initialization.spec.ts
@@ -70,4 +70,87 @@ describe('network profile initialization', () => {
       await expect(fetchProfile(profile, getUserData)).rejects.toThrow("Couldn't fetch profile data")
     })
   })
+
+  describe('when a queued network operation fails', () => {
+    let engine: IEngine
+    let firstEntity: Entity
+    let duplicateEntity: Entity
+    let entityAfterFailure: Entity
+    let NetworkEntityComponent: ReturnType<typeof components.NetworkEntity>
+    let resolveProfile: (response: GetUserDataResponse) => void
+    let getUserData: jest.Mock<Promise<GetUserDataResponse>, [GetUserDataRequest]>
+    let sendBinary: jest.Mock
+    let network: ReturnType<typeof addSyncTransport>
+    let consoleErrorMock: jest.SpyInstance
+
+    beforeEach(() => {
+      engine = Engine()
+      NetworkEntityComponent = defineNetworkComponents(engine)
+      firstEntity = engine.addEntity()
+      duplicateEntity = engine.addEntity()
+      entityAfterFailure = engine.addEntity()
+      resolveProfile = () => undefined
+      getUserData = jest.fn(
+        (_request: GetUserDataRequest) =>
+          new Promise<GetUserDataResponse>((resolve) => {
+            resolveProfile = resolve
+          })
+      )
+      sendBinary = jest.fn().mockResolvedValue({ data: [] })
+      consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      network = addSyncTransport(engine, sendBinary, getUserData)
+      network.syncEntity(firstEntity, [Transform.componentId], 1)
+      network.syncEntity(duplicateEntity, [Transform.componentId], 1)
+      network.syncEntity(entityAfterFailure, [Transform.componentId])
+      resolveProfile({
+        data: { userId: 'user-id', version: 1, displayName: 'User', hasConnectedWeb3: false, avatar: undefined }
+      })
+    })
+
+    afterEach(() => {
+      consoleErrorMock.mockRestore()
+      jest.restoreAllMocks()
+    })
+
+    it('should continue applying the remaining operations', async () => {
+      await network.ready
+
+      expect(NetworkEntityComponent.has(entityAfterFailure)).toBe(true)
+    })
+  })
+
+  describe('when profile initialization fails before a transport tick', () => {
+    let engine: IEngine
+    let getUserData: jest.Mock<Promise<GetUserDataResponse>, [GetUserDataRequest]>
+    let sendBinary: jest.Mock
+    let network: ReturnType<typeof addSyncTransport>
+    let consoleErrorMock: jest.SpyInstance
+
+    beforeEach(() => {
+      engine = Engine()
+      defineNetworkComponents(engine)
+      getUserData = jest.fn().mockRejectedValue(new Error('identity unavailable'))
+      sendBinary = jest.fn().mockResolvedValue({ data: [] })
+      consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      network = addSyncTransport(engine, sendBinary, getUserData)
+    })
+
+    afterEach(() => {
+      consoleErrorMock.mockRestore()
+      jest.restoreAllMocks()
+    })
+
+    it('should let the engine update complete', async () => {
+      await network.ready.catch(() => undefined)
+
+      await expect(engine.update(1)).resolves.toBeUndefined()
+    })
+
+    it('should not send network messages', async () => {
+      await network.ready.catch(() => undefined)
+      await engine.update(1)
+
+      expect(sendBinary).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/test/sdk/network/profile-initialization.spec.ts
+++ b/test/sdk/network/profile-initialization.spec.ts
@@ -1,0 +1,73 @@
+import { Engine, Entity, IEngine, Transform } from '../../../packages/@dcl/ecs'
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { addSyncTransport } from '../../../packages/@dcl/sdk/src/network/message-bus-sync'
+import { fetchProfile } from '../../../packages/@dcl/sdk/src/network/utils'
+import { IProfile } from '../../../packages/@dcl/sdk/src/network/message-bus-sync'
+import { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdentity'
+
+function defineNetworkComponents(engine: IEngine): ReturnType<typeof components.NetworkEntity> {
+  components.Transform(engine as any)
+  const NetworkEntityComponent = components.NetworkEntity(engine as any)
+  components.NetworkParent(engine as any)
+  components.SyncComponents(engine as any)
+  return NetworkEntityComponent
+}
+
+describe('network profile initialization', () => {
+  describe('when syncEntity is called before the profile loads', () => {
+    let engine: IEngine
+    let entity: Entity
+    let NetworkEntityComponent: ReturnType<typeof components.NetworkEntity>
+    let resolveProfile: (response: GetUserDataResponse) => void
+    let getUserData: jest.Mock<Promise<GetUserDataResponse>, [GetUserDataRequest]>
+    let sendBinary: jest.Mock
+
+    beforeEach(() => {
+      engine = Engine()
+      NetworkEntityComponent = defineNetworkComponents(engine)
+      entity = engine.addEntity()
+      components.Transform(engine as any).create(entity)
+      resolveProfile = () => undefined
+      getUserData = jest.fn(
+        (_request: GetUserDataRequest) =>
+          new Promise<GetUserDataResponse>((resolve) => {
+            resolveProfile = resolve
+          })
+      )
+      sendBinary = jest.fn().mockResolvedValue({ data: [] })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should apply the queued operation after initialization', async () => {
+      const network = addSyncTransport(engine, sendBinary, getUserData)
+      network.syncEntity(entity, [Transform.componentId])
+      resolveProfile({
+        data: { userId: 'user-id', version: 1, displayName: 'User', hasConnectedWeb3: false, avatar: undefined }
+      })
+      await network.ready
+
+      expect(NetworkEntityComponent.has(entity)).toBe(true)
+    })
+  })
+
+  describe('when the identity response has no user id', () => {
+    let profile: IProfile
+    let getUserData: jest.Mock<Promise<GetUserDataResponse>, [GetUserDataRequest]>
+
+    beforeEach(() => {
+      profile = {} as IProfile
+      getUserData = jest.fn((_request: GetUserDataRequest) => Promise.resolve({ data: undefined }))
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should reject initialization with a descriptive error', async () => {
+      await expect(fetchProfile(profile, getUserData)).rejects.toThrow("Couldn't fetch profile data")
+    })
+  })
+})


### PR DESCRIPTION
## Why

Network setup loaded the local profile as an unawaited side effect. Entity synchronization and transport ticks could run before userId and networkId were populated, causing profile-not-initialized errors or filtering messages with undefined identity data. Failures from getUserData were also thrown inside an unobserved promise chain, producing unhandled rejections without a readiness signal for callers.

## What changed

- Make fetchProfile await getUserData and return a Promise that rejects with a descriptive error when no user ID is available.
- Add a ready promise to the network transport initialization result and export it as networkReady from the public network module.
- Queue syncEntity, parentEntity, and removeParent operations until profile initialization completes.
- Await readiness before the transport sends or processes network responses.
- Attach handling for module-level initialization failures while preserving rejection on ready for callers that explicitly await it.
- Added regression coverage for an early syncEntity call and for an identity response without a user ID.

## Verification

- The profile-initialization regression suite passes.
- Existing network transport, engine synchronization, and CRDT state suites pass.
- The sdk TypeScript check passes.
- make lint passes.