### PR TITLE
fix: sandbox data layer filesystem access

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/data-layer/fs.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/data-layer/fs.ts
@@ -14,6 +14,42 @@ export function createFileSystemInterfaceFromFsComponent(
   { fs }: Pick<CliComponents, 'fs'>,
   projectWorkingDirectory: string = process.cwd()
 ): FileSystemInterface {
+  const projectRoot = path.resolve(projectWorkingDirectory)
+  const canonicalProjectRoot = fs.realpath(projectRoot)
+
+  function assertContainedPath(rootPath: string, requestedPath: string, resolvedPath: string): void {
+    const relativePath = path.relative(rootPath, resolvedPath)
+
+    if (relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+      throw new Error(`Path is outside the project directory: ${requestedPath}`)
+    }
+  }
+
+  async function resolveProjectPath(requestedPath: string): Promise<string> {
+    const normalizedPath = requestedPath.replace(/[\\/]/g, path.sep)
+    const resolvedPath = path.resolve(projectRoot, normalizedPath)
+    assertContainedPath(projectRoot, requestedPath, resolvedPath)
+
+    const missingSegments: string[] = []
+    let existingPath = resolvedPath
+
+    while (true) {
+      try {
+        const canonicalExistingPath = await fs.realpath(existingPath)
+        const canonicalResolvedPath = path.join(canonicalExistingPath, ...missingSegments)
+        assertContainedPath(await canonicalProjectRoot, requestedPath, canonicalResolvedPath)
+        return canonicalResolvedPath
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT' || existingPath === path.dirname(existingPath)) {
+          throw error
+        }
+
+        missingSegments.unshift(path.basename(existingPath))
+        existingPath = path.dirname(existingPath)
+      }
+    }
+  }
+
   return {
     dirname(value: string): string {
       return pathToPosix(path.dirname(value))
@@ -25,15 +61,13 @@ export function createFileSystemInterfaceFromFsComponent(
       return path.join(...paths)
     },
     async existFile(filePath: string): Promise<boolean> {
-      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
-      return fs.fileExists(resolvedPath)
+      return fs.fileExists(await resolveProjectPath(filePath))
     },
     async readFile(filePath: string): Promise<Buffer> {
-      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
-      return fs.readFile(resolvedPath)
+      return fs.readFile(await resolveProjectPath(filePath))
     },
     async writeFile(filePath: string, content: Buffer): Promise<void> {
-      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
+      const resolvedPath = await resolveProjectPath(filePath)
       const folder = path.dirname(resolvedPath)
       if (!(await fs.directoryExists(folder))) {
         await fs.mkdir(folder, { recursive: true })
@@ -41,26 +75,19 @@ export function createFileSystemInterfaceFromFsComponent(
       await fs.writeFile(resolvedPath, content as Uint8Array)
     },
     async rm(filePath: string) {
-      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
-      await fs.rm(resolvedPath)
+      await fs.rm(await resolveProjectPath(filePath))
     },
     async rmdir(dirPath: string) {
-      const resolvedPath = path.isAbsolute(dirPath) ? dirPath : path.resolve(projectWorkingDirectory, dirPath)
-      await fs.rm(resolvedPath, { recursive: true })
+      await fs.rm(await resolveProjectPath(dirPath), { recursive: true })
     },
     async readdir(dirPath: string): Promise<{ name: string; isDirectory: boolean }[]> {
-      if (dirPath.indexOf('/../') !== -1) {
-        throw new Error('The usage of /../ is not allowed')
-      }
-
-      const root = dirPath === '.' || dirPath === './' || dirPath === ''
-      const resolvedPath = root ? projectWorkingDirectory : dirPath
+      const resolvedPath = await resolveProjectPath(dirPath)
 
       const result = await fs.readdir(resolvedPath)
       return Promise.all(
         result.map(async (name) => ({
           name: pathToPosix(name),
-          isDirectory: await fs.directoryExists(path.resolve(dirPath, name))
+          isDirectory: await fs.directoryExists(path.resolve(resolvedPath, name))
         }))
       )
     },
@@ -68,8 +95,7 @@ export function createFileSystemInterfaceFromFsComponent(
       return pathToPosix(projectWorkingDirectory)
     },
     async stat(filePath: string): Promise<{ size: number }> {
-      const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
-      const stats = await fs.stat(resolvedPath)
+      const stats = await fs.stat(await resolveProjectPath(filePath))
       return { size: Number(stats.size) }
     }
   }

--- a/packages/@dcl/sdk-commands/src/components/fs.ts
+++ b/packages/@dcl/sdk-commands/src/components/fs.ts
@@ -24,6 +24,7 @@ export type IFileSystemComponent = Pick<typeof fs, 'createReadStream'> &
     | 'appendFile'
     | 'rm'
     | 'copyFile'
+    | 'realpath'
   > & {
     constants: Pick<typeof fs.constants, 'F_OK' | 'R_OK'>
   } & {
@@ -67,6 +68,7 @@ export function createFsComponent(): IFileSystemComponent {
     readdir: fsPromises.readdir,
     readFile: fsPromises.readFile,
     copyFile: fsPromises.copyFile,
+    realpath: fsPromises.realpath,
     constants: {
       F_OK: fs.constants.F_OK,
       R_OK: fs.constants.R_OK

--- a/test/sdk-commands/utils/data-layer-fs-security.spec.ts
+++ b/test/sdk-commands/utils/data-layer-fs-security.spec.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm, symlink } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { createFileSystemInterfaceFromFsComponent } from '../../../packages/@dcl/sdk-commands/src/commands/start/data-layer/fs'
+import { createFsComponent, IFileSystemComponent } from '../../../packages/@dcl/sdk-commands/src/components/fs'
+
+describe('createFileSystemInterfaceFromFsComponent', () => {
+  let fs: IFileSystemComponent
+  let fsInterface: ReturnType<typeof createFileSystemInterfaceFromFsComponent>
+  let projectDirectory: string
+  let outsideFile: string
+
+  beforeEach(async () => {
+    projectDirectory = await mkdtemp(path.join(tmpdir(), 'dcl-data-layer-'))
+    outsideFile = path.resolve(projectDirectory, '..', 'outside.txt')
+    fs = createFsComponent()
+    fsInterface = createFileSystemInterfaceFromFsComponent({ fs }, projectDirectory)
+  })
+
+  afterEach(async () => {
+    await rm(projectDirectory, { recursive: true, force: true })
+  })
+
+  describe('when a relative path escapes the project directory', () => {
+    it('should reject file reads outside the project directory', async () => {
+      await expect(fsInterface.readFile('../outside.txt')).rejects.toThrow('Path is outside the project directory')
+    })
+  })
+
+  describe('when an absolute path is outside the project directory', () => {
+    it('should reject file writes outside the project directory', async () => {
+      await expect(fsInterface.writeFile(outsideFile, Buffer.from('unsafe'))).rejects.toThrow(
+        'Path is outside the project directory'
+      )
+    })
+  })
+
+  describe('when a path uses Windows separators to escape the project directory', () => {
+    it('should reject directory removal outside the project directory', async () => {
+      await expect(fsInterface.rmdir('..\\outside')).rejects.toThrow('Path is outside the project directory')
+    })
+  })
+
+  describe('when a project symlink points outside the project directory', () => {
+    beforeEach(async () => {
+      await symlink(path.dirname(outsideFile), path.join(projectDirectory, 'outside-link'))
+    })
+
+    it('should reject file reads through the symlink', async () => {
+      await expect(fsInterface.readFile('outside-link/outside.txt')).rejects.toThrow(
+        'Path is outside the project directory'
+      )
+    })
+  })
+
+  describe('when a relative directory is inside a non-default project directory', () => {
+    let canonicalProjectDirectory: string
+    let readdir: jest.SpyInstance
+
+    beforeEach(async () => {
+      canonicalProjectDirectory = await fs.realpath(projectDirectory)
+      readdir = jest.spyOn(fs, 'readdir').mockResolvedValueOnce([])
+    })
+
+    afterEach(() => {
+      readdir.mockRestore()
+    })
+
+    it('should resolve directory reads from the configured project directory', async () => {
+      await fsInterface.readdir('assets')
+
+      expect(readdir).toHaveBeenCalledWith(path.join(canonicalProjectDirectory, 'assets'))
+    })
+  })
+})

--- a/test/sdk-commands/utils/data-layer-fs.spec.ts
+++ b/test/sdk-commands/utils/data-layer-fs.spec.ts
@@ -92,9 +92,9 @@ describe('FsInterface', () => {
       expect(result).toEqual(expectedOutput)
     })
 
-    test('should throw an error when the path contains "/../"', async () => {
-      const input = 'scene/assets/../'
-      await expect(fsInterface.readdir(input)).rejects.toThrow('The usage of /../ is not allowed')
+    test('should throw an error when the path escapes the project directory', async () => {
+      const input = 'scene/assets/../../../outside'
+      await expect(fsInterface.readdir(input)).rejects.toThrow('Path is outside the project directory')
     })
   })
 })


### PR DESCRIPTION
## Why

The preview data-layer RPC accepts paths supplied by connected clients. Those paths were previously resolved without enforcing the project boundary, allowing absolute paths, traversal segments, and project symlinks to reach files elsewhere on the host. Relative directory reads were also resolved inconsistently when the configured project directory differed from the process working directory.

## What changed

- Resolve every data-layer filesystem operation against the configured project root.
- Reject lexical traversal and absolute paths outside that root.
- Canonicalize the nearest existing ancestor so symlinks cannot escape the sandbox, including for files that do not exist yet.
- Resolve directory entries from the canonical requested directory.
- Add `realpath` to the filesystem component and regression coverage for relative, absolute, Windows-style, symlink, and non-default-root paths.

## Verification

- `node_modules/.bin/jest --colors --forceExit --runInBand --testPathPattern=data-layer-fs`
- `npx tsc --noEmit -p tsconfig.json` in `packages/@dcl/sdk-commands`