### PR TITLE
fix: propagate GitHub template download failures

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/init/download-github-folder.ts
+++ b/packages/@dcl/sdk-commands/src/commands/init/download-github-folder.ts
@@ -2,12 +2,13 @@ import path from 'path'
 
 import { CliComponents } from '../../components'
 
-async function downloadFile(
-  components: Pick<CliComponents, 'fs' | 'logger' | 'fetch'>,
-  fileUrl: string,
-  outputPath: string
-) {
-  const response = await (await components.fetch.fetch(fileUrl)).arrayBuffer()
+async function downloadFile(components: Pick<CliComponents, 'fs' | 'fetch'>, fileUrl: string, outputPath: string) {
+  const fetchResponse = await components.fetch.fetch(fileUrl)
+  if (!fetchResponse.ok) {
+    throw new Error(`Failed to download ${fileUrl}: ${fetchResponse.status} ${fetchResponse.statusText}`)
+  }
+
+  const response = await fetchResponse.arrayBuffer()
   const buffer = Buffer.from(response)
   await components.fs.writeFile(outputPath, buffer)
 }
@@ -39,37 +40,38 @@ function parseGitHubUrl(githubUrl: string) {
 }
 
 export async function downloadGithubFolder(
-  components: Pick<CliComponents, 'fs' | 'logger' | 'fetch'>,
+  components: Pick<CliComponents, 'fs' | 'fetch'>,
   githubUrl: string,
   destination: string
 ) {
   const { owner, repo, branch, path: subfolderPath } = parseGitHubUrl(githubUrl)
   const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${subfolderPath}?ref=${branch}`
 
-  try {
-    const data: any = await (await components.fetch.fetch(apiUrl)).json()
+  const fetchResponse = await components.fetch.fetch(apiUrl)
+  if (!fetchResponse.ok) {
+    throw new Error(`Failed to download ${apiUrl}: ${fetchResponse.status} ${fetchResponse.statusText}`)
+  }
 
-    if (Array.isArray(data)) {
-      for await (const file of data) {
-        const filePath = path.join(destination, file.name)
+  const data: any = await fetchResponse.json()
 
-        if (file.type === 'file') {
-          await downloadFile(components, file.download_url, filePath)
-        } else if (file.type === 'dir') {
-          if (!(await components.fs.directoryExists(filePath))) {
-            await components.fs.mkdir(filePath, { recursive: true })
-          }
-          const nextUrl = `https://github.com/${owner}/${repo}/tree/${branch}/${file.path}`
+  if (Array.isArray(data)) {
+    for await (const file of data) {
+      const filePath = path.join(destination, file.name)
 
-          await downloadGithubFolder(components, nextUrl, filePath)
+      if (file.type === 'file') {
+        await downloadFile(components, file.download_url, filePath)
+      } else if (file.type === 'dir') {
+        if (!(await components.fs.directoryExists(filePath))) {
+          await components.fs.mkdir(filePath, { recursive: true })
         }
+        const nextUrl = `https://github.com/${owner}/${repo}/tree/${branch}/${file.path}`
+
+        await downloadGithubFolder(components, nextUrl, filePath)
       }
-    } else {
-      // Handle single file or root without subfolders
-      const filePath = path.join(destination, data.name)
-      await downloadFile(components, data.download_url, filePath)
     }
-  } catch (error: any) {
-    components.logger.error(`Error downloading folder: ${apiUrl} \n ${error.message}`)
+  } else {
+    // Handle single file or root without subfolders
+    const filePath = path.join(destination, data.name)
+    await downloadFile(components, data.download_url, filePath)
   }
 }

--- a/test/sdk-commands/commands/init/download-github-folder.spec.ts
+++ b/test/sdk-commands/commands/init/download-github-folder.spec.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { downloadGithubFolder } from '../../../../packages/@dcl/sdk-commands/src/commands/init/download-github-folder'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+import { IFetchComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fetch'
+
+function createResponse(status: number, statusText: string, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: jest.fn().mockResolvedValue(body),
+    arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0))
+  } as unknown as Awaited<ReturnType<IFetchComponent['fetch']>>
+}
+
+describe('downloadGithubFolder', () => {
+  let components: Parameters<typeof downloadGithubFolder>[0]
+  let destination: string
+  let fetch: jest.MockedFunction<IFetchComponent['fetch']>
+  let githubUrl: string
+
+  beforeEach(async () => {
+    destination = await mkdtemp(path.join(tmpdir(), 'dcl-github-template-'))
+    fetch = jest.fn()
+    githubUrl = 'https://github.com/decentraland/example'
+    components = { fs: createFsComponent(), fetch: { fetch } }
+  })
+
+  afterEach(async () => {
+    fetch.mockReset()
+    await rm(destination, { recursive: true, force: true })
+  })
+
+  describe('when the GitHub contents request fails', () => {
+    beforeEach(() => {
+      fetch.mockResolvedValueOnce(createResponse(403, 'Forbidden'))
+    })
+
+    it('should reject with the failed response status', async () => {
+      await expect(downloadGithubFolder(components, githubUrl, destination)).rejects.toThrow('403 Forbidden')
+    })
+  })
+
+  describe('when a template file request fails', () => {
+    beforeEach(() => {
+      fetch
+        .mockResolvedValueOnce(
+          createResponse(200, 'OK', [
+            { name: 'package.json', type: 'file', download_url: 'https://example.com/package.json' }
+          ])
+        )
+        .mockResolvedValueOnce(createResponse(404, 'Not Found'))
+    })
+
+    it('should reject with the failed file response status', async () => {
+      await expect(downloadGithubFolder(components, githubUrl, destination)).rejects.toThrow('404 Not Found')
+    })
+  })
+})


### PR DESCRIPTION
## Why

GitHub-backed scene initialization caught metadata and file-download errors, logged them, and then returned normally. The CLI could therefore report success and continue to dependency installation even though the template directory was incomplete or empty. This produced misleading downstream errors such as a missing `package.json` instead of reporting the actual network or GitHub API failure.

## What changed

- Check `response.ok` for both GitHub contents requests and template file downloads.
- Include the failed URL and HTTP status in the thrown error.
- Remove the catch-and-swallow behavior so `init` exits unsuccessfully at the real failure point.
- Add regression tests for GitHub API failures and individual template file failures.

## Verification

- `node_modules/.bin/jest --colors --forceExit --runInBand --testPathPattern=download-github-folder`
- Existing init command suite passed during validation.
- `npx tsc --noEmit -p tsconfig.json` in `packages/@dcl/sdk-commands`