### PR TITLE
fix: chunk serialized CRDT network messages

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -258,6 +258,7 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
       // Reset Buffer for each Transport
       transportBuffer.resetBuffer()
       const buffer = new ReadWriteByteBuffer()
+      const serializedMessageBuffer = new ReadWriteByteBuffer()
 
       // Then we send all the new crdtMessages that the transport needs to process
       for (const message of crdtMessages) {
@@ -267,24 +268,6 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
         // Redundant message for the transport
         if (!transport.filter(message)) continue
 
-        // Check if adding this message would exceed the size limit
-        const currentBufferSize = transportBuffer.toBinary().byteLength
-        const messageSize = message.messageBuffer.byteLength
-
-        if (isNetworkTransport && (currentBufferSize + messageSize) / 1024 > LIVEKIT_MAX_SIZE) {
-          // If the current buffer has content, save it as a chunk
-          if (currentBufferSize > 0) {
-            __NetworkMessagesBuffer.push(transportBuffer.toCopiedBinary())
-            transportBuffer.resetBuffer()
-          }
-
-          // If the message itself is larger than the limit, we need to handle it specially
-          // For now, we'll skip it to prevent infinite loops
-          if (messageSize / 1024 > LIVEKIT_MAX_SIZE) {
-            console.error(`Message too large (${messageSize} bytes), skipping message for entity ${message.entityId}`)
-            continue
-          }
-        }
         const { entityId } = findNetworkId(message)
 
         const transformNeedsFix =
@@ -294,17 +277,17 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           NetworkParent.has(entityId) &&
           NetworkEntity.has(entityId)
 
+        buffer.resetBuffer()
+        serializedMessageBuffer.resetBuffer()
+
         // If there was a LOCAL change in the transform. Add the parent to that transform
         if (isRendererTransport && message.type === CrdtMessageType.PUT_COMPONENT && transformNeedsFix) {
           const parent = findNetworkId(NetworkParent.get(entityId))
           const transformData = networkUtils.fixTransformParent(message, Transform.get(entityId), parent.entityId)
           const offset = buffer.currentWriteOffset()
           PutComponentOperation.write(entityId, message.timestamp, message.componentId, transformData, buffer)
-          transportBuffer.writeBuffer(buffer.buffer().subarray(offset, buffer.currentWriteOffset()), false)
-          continue
-        }
-
-        if (isRendererTransport && networkUtils.isNetworkMessage(message)) {
+          serializedMessageBuffer.writeBuffer(buffer.buffer().subarray(offset, buffer.currentWriteOffset()), false)
+        } else if (isRendererTransport && networkUtils.isNetworkMessage(message)) {
           // If it's the renderer transport and its a NetworkMessage, we need to fix the entityId field and convert it to a known Message.
           // PUT_NETWORK_COMPONENT -> PUT_COMPONENT
           let transformData: Uint8Array = 'data' in message ? message.data : new Uint8Array()
@@ -316,25 +299,39 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
             { ...message, data: transformData } as any,
             entityId,
             buffer,
-            transportBuffer
+            serializedMessageBuffer
           )
-          // Iterate the next message
-          continue
-        }
-
-        // If its a network transport and its a PUT_COMPONENT that has a NetworkEntity component, we need to send this message
-        // through comms with the EntityID and NetworkID from ther NetworkEntity so everyone can recieve this message and map to their custom entityID.
-        if (isNetworkTransport && !networkUtils.isNetworkMessage(message)) {
+        } else if (isNetworkTransport && !networkUtils.isNetworkMessage(message)) {
+          // If its a network transport and its a PUT_COMPONENT that has a NetworkEntity component, we need to send this message
+          // through comms with the EntityID and NetworkID from ther NetworkEntity so everyone can recieve this message and map to their custom entityID.
           const networkData = NetworkEntity.getOrNull(message.entityId)
           // If it has networkData convert the message to PUT_NETWORK_COMPONENT.
           if (networkData) {
-            networkUtils.localMessageToNetwork(message, networkData, buffer, transportBuffer)
-            // Iterate the next message
+            networkUtils.localMessageToNetwork(message, networkData, buffer, serializedMessageBuffer)
+          } else {
+            serializedMessageBuffer.writeBuffer(message.messageBuffer, false)
+          }
+        } else {
+          // Common message
+          serializedMessageBuffer.writeBuffer(message.messageBuffer, false)
+        }
+
+        const currentBufferSize = transportBuffer.currentWriteOffset()
+        const messageSize = serializedMessageBuffer.currentWriteOffset()
+
+        if (isNetworkTransport && (currentBufferSize + messageSize) / 1024 > LIVEKIT_MAX_SIZE) {
+          if (currentBufferSize > 0) {
+            __NetworkMessagesBuffer.push(transportBuffer.toCopiedBinary())
+            transportBuffer.resetBuffer()
+          }
+
+          if (messageSize / 1024 > LIVEKIT_MAX_SIZE) {
+            console.error(`Message too large (${messageSize} bytes), skipping message for entity ${message.entityId}`)
             continue
           }
         }
-        // Common message
-        transportBuffer.writeBuffer(message.messageBuffer, false)
+
+        transportBuffer.writeBuffer(serializedMessageBuffer.toBinary(), false)
       }
 
       if (isNetworkTransport && transportBuffer.currentWriteOffset()) {

--- a/test/ecs/network/crdt-network-chunk-boundary.spec.ts
+++ b/test/ecs/network/crdt-network-chunk-boundary.spec.ts
@@ -1,0 +1,49 @@
+import { Engine, Entity, IEngine, MapComponentDefinition, Schemas } from '../../../packages/@dcl/ecs/src'
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Transport } from '../../../packages/@dcl/ecs/src/systems/crdt/types'
+
+describe('CRDT network chunk boundaries', () => {
+  let component: MapComponentDefinition<{ value: string }>
+  let engine: IEngine
+  let firstEntity: Entity
+  let networkTransport: Transport
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let secondEntity: Entity
+  let send: jest.MockedFunction<Transport['send']>
+  let sentChunks: Uint8Array[]
+
+  beforeEach(async () => {
+    engine = Engine()
+    component = engine.defineComponent('boundary-component', { value: Schemas.String })
+    sentChunks = []
+    send = jest.fn(async (message: Uint8Array | Uint8Array[]) => {
+      sentChunks = Array.isArray(message) ? message : [message]
+    })
+    networkTransport = {
+      type: 'network',
+      filter: (message) => 'componentId' in message && message.componentId === component.componentId,
+      send
+    }
+    engine.addTransport(networkTransport)
+
+    NetworkEntity = components.NetworkEntity(engine)
+    firstEntity = engine.addEntity()
+    secondEntity = engine.addEntity()
+    NetworkEntity.create(firstEntity, { networkId: 1, entityId: firstEntity })
+    NetworkEntity.create(secondEntity, { networkId: 1, entityId: secondEntity })
+    component.create(firstEntity, { value: 'a'.repeat(6115) })
+    component.create(secondEntity, { value: 'b'.repeat(6115) })
+
+    await engine.update(1)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when network headers push a local batch over the LiveKit limit', () => {
+    it('should split the serialized network messages into valid chunks', () => {
+      expect(sentChunks.map((chunk) => chunk.byteLength)).toEqual([6147, 6147])
+    })
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
+  MALLOC_COUNT = 16302
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1427.41k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16854
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -35,7 +35,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -51,7 +51,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 9k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1433.18k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16854
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -35,7 +35,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -51,7 +51,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 9k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1433.18k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15161
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1069.43k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17678
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -51,7 +51,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x203 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x204 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x205 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
-  OPCODES ~= 114k
+  OPCODES ~= 118k
   MALLOC_COUNT = 361
   ALIVE_OBJS_DELTA ~= 0.10k
 CALL onUpdate(0.1)
@@ -59,7 +59,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=2 data={"position":{"x":12,"y":3.0420734882354736,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=2 data={"position":{"x":12,"y":3.0420734882354736,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=2 data={"position":{"x":8,"y":3.0420734882354736,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -67,7 +67,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=3 data={"position":{"x":8,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -75,7 +75,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=4 data={"position":{"x":12,"y":3.0945944786071777,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=4 data={"position":{"x":12,"y":3.0945944786071777,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=4 data={"position":{"x":8,"y":3.0945944786071777,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1255.40k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14281
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -19,28 +19,28 @@ CALL onStart()
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
-  OPCODES ~= 5k
+  OPCODES ~= 6k
   MALLOC_COUNT = 68
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x201 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x202 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x201
-  OPCODES ~= 6k
+  OPCODES ~= 7k
   MALLOC_COUNT = 4
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x202 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x10201 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x202
-  OPCODES ~= 6k
+  OPCODES ~= 7k
   MALLOC_COUNT = 2
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x10201 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x10202 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   Scene: DELETE_ENTITY e=0x10201
-  OPCODES ~= 6k
+  OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1031.68k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14254
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1021.44k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21015
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -564,7 +564,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1001k
+  OPCODES ~= 1067k
   MALLOC_COUNT = 6214
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
@@ -926,7 +926,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 768k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1288,7 +1288,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 768k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1650,7 +1650,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 768k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1479.88k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
+  MALLOC_COUNT = 14547
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   OPCODES ~= 0k
@@ -29,7 +29,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x201 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x202 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 24k
+  OPCODES ~= 26k
   MALLOC_COUNT = 133
   ALIVE_OBJS_DELTA ~= 0.04k
 CALL onUpdate(0.1)
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1041.14k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14386
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1023.89k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -11,7 +11,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22395
+  MALLOC_COUNT = 22391
   ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
@@ -49,7 +49,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 145k
+  OPCODES ~= 149k
   MALLOC_COUNT = 967
   ALIVE_OBJS_DELTA ~= 0.31k
 CALL onUpdate(0.1)
@@ -67,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1895.34k bytes
+  MEMORY_USAGE_COUNT ~= 1894.50k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21120
+  MALLOC_COUNT = 21116
   ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1300.70k bytes
+  MEMORY_USAGE_COUNT ~= 1299.90k bytes


### PR DESCRIPTION
## Why

Network chunking measured each message before transport-specific serialization. Converting a local CRDT PUT, DELETE, or entity deletion to its network form adds the network identifier and expands the header. A batch that fit under 12 KiB in local form could therefore exceed LiveKit limits after conversion, even though the pre-conversion size check accepted it.

## What changed

- Serialize each message into its exact renderer or network representation before calculating its size.
- Apply the 12 KiB boundary to the actual bytes that will be sent.
- Preserve renderer transformations, network/local entity mapping, oversized-message handling, and copied intermediate chunks.
- Reuse scratch buffers between messages to avoid per-message buffer allocation.
- Add a boundary regression where two local messages total 12,286 bytes but become 12,294 bytes after network headers; they are now emitted as two valid 6,147-byte chunks.

## Verification

- Boundary regression test passed.
- Existing CRDT chunking and transport suites passed (8 tests).
- `npx tsc --noEmit -p tsconfig.json` in `packages/@dcl/ecs`