### PR TITLE
fix: verify TLS in linker auth proxy

### DIFF
--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -1,6 +1,5 @@
 import { dirname, resolve } from 'path'
 import { Readable } from 'stream'
-import { Agent } from 'undici'
 import { Router } from '@well-known-components/http-server'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { ChainId } from '@dcl/schemas'
@@ -22,10 +21,6 @@ export function setRoutes<T extends { [key: string]: any }>(
   const { fs } = components
   const router = new Router()
   const linkerDapp = dirname(require.resolve('@dcl/linker-dapp/package.json'))
-
-  // Dispatcher used by the /auth proxy below to skip TLS verification, mirroring the
-  // previous `new https.Agent({ rejectUnauthorized: false })` behavior with native fetch.
-  const insecureDispatcher = new Agent({ connect: { rejectUnauthorized: false } })
 
   router.get(mainRoute, async () => ({
     headers: { 'Content-Type': 'text/html' },
@@ -66,8 +61,7 @@ export function setRoutes<T extends { [key: string]: any }>(
           Origin: url
         }, // Forward headers for proper proxy behavior.
         body: ctx.request.body as any, // Forward request body if necessary.
-        duplex: 'half', // Required by native fetch when streaming a request body.
-        dispatcher: insecureDispatcher // Skip TLS verification.
+        duplex: 'half' // Required by native fetch when streaming a request body.
       })
 
       // undici decompresses the body but leaves content-encoding / content-length in

--- a/test/sdk-commands/linker-dapp/routes.spec.ts
+++ b/test/sdk-commands/linker-dapp/routes.spec.ts
@@ -1,0 +1,45 @@
+import {
+  createTestServerComponent,
+  ITestHttpServerComponent
+} from '../../../packages/@dcl/sdk-commands/node_modules/@well-known-components/http-server'
+import { IFetchComponent } from '../../../packages/@dcl/sdk-commands/src/components/fetch'
+import { createFsComponent } from '../../../packages/@dcl/sdk-commands/src/components/fs'
+import { setRoutes } from '../../../packages/@dcl/sdk-commands/src/linker-dapp/routes'
+
+describe('linker dApp routes', () => {
+  let components: Parameters<typeof setRoutes>[0]
+  let fetch: jest.MockedFunction<IFetchComponent['fetch']>
+  let server: ITestHttpServerComponent<Record<string, never>>
+
+  beforeEach(() => {
+    fetch = jest.fn().mockResolvedValue({
+      body: null,
+      headers: new Map<string, string>(),
+      status: 200
+    })
+    components = {
+      config: {} as Parameters<typeof setRoutes>[0]['config'],
+      fetch: { fetch },
+      fs: createFsComponent(),
+      logger: {} as Parameters<typeof setRoutes>[0]['logger']
+    }
+    server = createTestServerComponent()
+
+    const { router } = setRoutes(components, {})
+    server.use(router.middleware())
+    server.use(router.allowedMethods())
+  })
+
+  afterEach(() => {
+    fetch.mockReset()
+    server.resetMiddlewares()
+  })
+
+  describe('when the auth endpoint proxies a request', () => {
+    it('should use the fetch client default TLS verification', async () => {
+      await server.fetch('/auth/login')
+
+      expect(fetch.mock.calls[0][1]).not.toHaveProperty('dispatcher')
+    })
+  })
+})


### PR DESCRIPTION
## Why

The linker auth proxy supplied a custom Undici dispatcher with `rejectUnauthorized: false` for requests to `https://decentraland.org`. That disabled certificate validation for an authentication flow and allowed a network attacker with a forged certificate to intercept or modify proxied traffic. The destination uses publicly trusted TLS, so bypassing validation is unnecessary.

## What changed

- Remove the insecure Undici agent and its dispatcher override.
- Let the injected fetch component use its normal certificate validation and trust store.
- Keep the existing proxy method, headers, streaming body, decompression-header filtering, and response handling unchanged.
- Add a WKC test-server regression verifying that auth requests do not override the fetch dispatcher.

## Verification

- `node_modules/.bin/jest --colors --forceExit --runInBand --testPathPattern=linker-dapp/routes.spec.ts`
- `npx tsc --noEmit -p tsconfig.json` in `packages/@dcl/sdk-commands`