### PR TITLE
perf: index CRDT network entities

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,35 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  const networkEntityIndex = new Map<string, { localEntityId: Entity; network: INetowrkEntityType }>()
+  const networkEntityKeyByLocalEntity = new Map<Entity, string>()
+
+  function networkEntityKey(networkId: number, entityId: Entity): string {
+    return `${networkId}:${entityId}`
+  }
+
+  function removeIndexedNetworkEntity(localEntityId: Entity): void {
+    const previousKey = networkEntityKeyByLocalEntity.get(localEntityId)
+    if (!previousKey) return
+
+    if (networkEntityIndex.get(previousKey)?.localEntityId === localEntityId) {
+      networkEntityIndex.delete(previousKey)
+    }
+    networkEntityKeyByLocalEntity.delete(localEntityId)
+  }
+
+  function indexNetworkEntity(localEntityId: Entity, network?: INetowrkEntityType): void {
+    removeIndexedNetworkEntity(localEntityId)
+    if (!network) return
+
+    const key = networkEntityKey(network.networkId, network.entityId)
+    const indexedNetwork = {
+      localEntityId,
+      network: { networkId: network.networkId, entityId: network.entityId }
+    }
+    networkEntityIndex.set(key, indexedNetwork)
+    networkEntityKeyByLocalEntity.set(localEntityId, key)
+  }
 
   /**
    *
@@ -120,10 +149,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     const hasNetworkId = 'networkId' in msg
 
     if (hasNetworkId) {
-      for (const [entityId, network] of engine.getEntitiesWith(NetworkEntity)) {
-        if (network.networkId === msg.networkId && network.entityId === msg.entityId) {
-          return { entityId, network }
-        }
+      const indexedNetwork = networkEntityIndex.get(networkEntityKey(msg.networkId!, msg.entityId))
+      if (indexedNetwork) {
+        return { entityId: indexedNetwork.localEntityId, network: indexedNetwork.network }
       }
     }
 
@@ -145,6 +173,7 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
         entityId = engine.addEntity()
         network = { entityId: msg.entityId, networkId: msg.networkId }
         NetworkEntity.createOrReplace(entityId, network)
+        indexNetworkEntity(entityId, network)
       }
       if (msg.type === CrdtMessageType.DELETE_ENTITY || msg.type === CrdtMessageType.DELETE_ENTITY_NETWORK) {
         entitiesShouldBeCleaned.push(entityId)
@@ -174,6 +203,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           }
           const [conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
           if (!conflictMessage) {
+            if (component.componentId === NetworkEntity.componentId) {
+              indexNetworkEntity(entityId, value as INetowrkEntityType | undefined)
+            }
             // Add message to transport queue to be processed by others transports
             broadcastMessages.push(msg)
             onProcessEntityComponentChange && onProcessEntityComponentChange(entityId, msg.type, component, value)
@@ -186,6 +218,7 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     }
     // the last stage of the syncrhonization is to delete the entities
     for (const entity of entitiesShouldBeCleaned) {
+      removeIndexedNetworkEntity(entity)
       for (const definition of engine.componentsIter()) {
         // TODO: check this with pato/pravus
         definition.entityDeleted(entity, true)
@@ -220,19 +253,24 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
             messageBuffer: buffer.buffer().subarray(offset, buffer.currentWriteOffset())
           })
         }
-        if (onProcessEntityComponentChange) {
+        if (onProcessEntityComponentChange || component.componentId === NetworkEntity.componentId) {
           const rawValue =
             message.type === CrdtMessageType.PUT_COMPONENT || message.type === CrdtMessageType.APPEND_VALUE
               ? component.get(message.entityId)
               : undefined
 
-          onProcessEntityComponentChange(message.entityId, message.type, component, rawValue)
+          if (component.componentId === NetworkEntity.componentId) {
+            indexNetworkEntity(message.entityId, rawValue as INetowrkEntityType | undefined)
+          }
+          onProcessEntityComponentChange &&
+            onProcessEntityComponentChange(message.entityId, message.type, component, rawValue)
         }
       }
     }
 
     // After all updates, I execute the DeletedEntity messages
     for (const entityId of entitiesDeletedThisTick) {
+      removeIndexedNetworkEntity(entityId)
       const offset = buffer.currentWriteOffset()
       DeleteEntity.write(entityId, buffer)
 

--- a/test/ecs/crdt-network-entity-index.spec.ts
+++ b/test/ecs/crdt-network-entity-index.spec.ts
@@ -1,0 +1,159 @@
+import {
+  Engine,
+  Entity,
+  IEngine,
+  MapComponentDefinition,
+  PutNetworkComponentOperation,
+  Schemas
+} from '../../packages/@dcl/ecs/src'
+import * as components from '../../packages/@dcl/ecs/src/components'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
+
+const NETWORK_ID = 7
+const REMOTE_ENTITY = 100 as Entity
+
+type Harness = {
+  component: MapComponentDefinition<{ value: number }>
+  engine: IEngine
+  NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  sendRemoteUpdate: (value: number) => void
+}
+
+function setup(): Harness {
+  const engine = Engine()
+  const component = engine.defineComponent('indexed-component', { value: Schemas.Int })
+  const networkTransport: Transport = {
+    type: 'network',
+    filter: () => false,
+    send: jest.fn().mockResolvedValue(undefined)
+  }
+  engine.addTransport(networkTransport)
+  const NetworkEntity = components.NetworkEntity(engine)
+
+  // A remote peer addressing (NETWORK_ID, REMOTE_ENTITY) with a component update.
+  const sendRemoteUpdate = (value: number) => {
+    const payload = new ReadWriteByteBuffer()
+    component.schema.serialize({ value }, payload)
+    const message = new ReadWriteByteBuffer()
+    PutNetworkComponentOperation.write(
+      REMOTE_ENTITY,
+      value,
+      component.componentId,
+      NETWORK_ID,
+      payload.toBinary(),
+      message
+    )
+    networkTransport.onmessage!(message.toBinary())
+  }
+
+  return { component, engine, NetworkEntity, sendRemoteUpdate }
+}
+
+describe('CRDT network entity index', () => {
+  describe('when a network message targets an existing mapped entity', () => {
+    let component: MapComponentDefinition<{ value: number }>
+    let getEntitiesWith: jest.SpyInstance
+    let localEntity: Entity
+
+    beforeEach(async () => {
+      const h = setup()
+      component = h.component
+      localEntity = h.engine.addEntity()
+      h.NetworkEntity.create(localEntity, { networkId: NETWORK_ID, entityId: REMOTE_ENTITY })
+      await h.engine.update(1)
+
+      getEntitiesWith = jest.spyOn(h.engine, 'getEntitiesWith')
+      h.sendRemoteUpdate(42)
+      await h.engine.update(1)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should apply the component update to the mapped local entity', () => {
+      expect(component.get(localEntity).value).toBe(42)
+    })
+
+    it('should resolve the mapping without scanning engine entities', () => {
+      expect(getEntitiesWith).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the mapped entity is re-pointed at a different remote entity', () => {
+    let component: MapComponentDefinition<{ value: number }>
+    let localEntity: Entity
+
+    beforeEach(async () => {
+      const h = setup()
+      component = h.component
+      localEntity = h.engine.addEntity()
+      h.NetworkEntity.create(localEntity, { networkId: NETWORK_ID, entityId: REMOTE_ENTITY })
+      await h.engine.update(1)
+
+      // The local entity now represents a different remote entity.
+      h.NetworkEntity.createOrReplace(localEntity, { networkId: NETWORK_ID, entityId: 999 as Entity })
+      await h.engine.update(1)
+
+      h.sendRemoteUpdate(42)
+      await h.engine.update(1)
+    })
+
+    it('should not deliver the old mapping to the re-pointed entity', () => {
+      expect(component.getOrNull(localEntity)).toBeNull()
+    })
+  })
+
+  describe('when the NetworkEntity component is deleted from the mapped entity', () => {
+    let component: MapComponentDefinition<{ value: number }>
+    let localEntity: Entity
+
+    beforeEach(async () => {
+      const h = setup()
+      component = h.component
+      localEntity = h.engine.addEntity()
+      h.NetworkEntity.create(localEntity, { networkId: NETWORK_ID, entityId: REMOTE_ENTITY })
+      await h.engine.update(1)
+
+      h.NetworkEntity.deleteFrom(localEntity)
+      await h.engine.update(1)
+
+      h.sendRemoteUpdate(42)
+      await h.engine.update(1)
+    })
+
+    it('should not deliver the update to the unmapped entity', () => {
+      expect(component.getOrNull(localEntity)).toBeNull()
+    })
+  })
+
+  describe('and a second local entity takes over the same remote mapping', () => {
+    let component: MapComponentDefinition<{ value: number }>
+    let firstEntity: Entity
+    let secondEntity: Entity
+
+    beforeEach(async () => {
+      const h = setup()
+      component = h.component
+      firstEntity = h.engine.addEntity()
+      h.NetworkEntity.create(firstEntity, { networkId: NETWORK_ID, entityId: REMOTE_ENTITY })
+      await h.engine.update(1)
+
+      secondEntity = h.engine.addEntity()
+      h.NetworkEntity.create(secondEntity, { networkId: NETWORK_ID, entityId: REMOTE_ENTITY })
+      await h.engine.update(1)
+
+      // Removing the previous owner must not unindex the mapping the new owner holds.
+      h.engine.removeEntity(firstEntity)
+      await h.engine.update(1)
+
+      h.sendRemoteUpdate(42)
+      await h.engine.update(1)
+    })
+
+    it('should deliver the update to the entity that took the mapping over', () => {
+      expect(component.get(secondEntity).value).toBe(42)
+    })
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16880
+  MALLOC_COUNT = 16918
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.59k bytes
+  MEMORY_USAGE_COUNT ~= 1554.05k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,8 +10,8 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
-  ALIVE_OBJS_DELTA ~= 3.47k
+  MALLOC_COUNT = 17494
+  ALIVE_OBJS_DELTA ~= 3.48k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -33,7 +33,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1560.15k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,8 +10,8 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
-  ALIVE_OBJS_DELTA ~= 3.47k
+  MALLOC_COUNT = 17494
+  ALIVE_OBJS_DELTA ~= 3.48k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -33,7 +33,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1560.16k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15760
-  ALIVE_OBJS_DELTA ~= 3.53k
+  MALLOC_COUNT = 15810
+  ALIVE_OBJS_DELTA ~= 3.54k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.45k bytes
+  MEMORY_USAGE_COUNT ~= 1141.96k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18266
-  ALIVE_OBJS_DELTA ~= 4.00k
+  MALLOC_COUNT = 18295
+  ALIVE_OBJS_DELTA ~= 4.01k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -49,7 +49,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x203 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x204 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x205 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
-  OPCODES ~= 114k
+  OPCODES ~= 115k
   MALLOC_COUNT = 361
   ALIVE_OBJS_DELTA ~= 0.10k
 CALL onUpdate(0.1)
@@ -65,7 +65,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=3 data={"position":{"x":8,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.29k bytes
+  MEMORY_USAGE_COUNT ~= 1327.43k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14877
-  ALIVE_OBJS_DELTA ~= 3.30k
+  MALLOC_COUNT = 14906
+  ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.53k bytes
+  MEMORY_USAGE_COUNT ~= 1103.68k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14850
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14879
+  ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.28k bytes
+  MEMORY_USAGE_COUNT ~= 1093.44k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21603
-  ALIVE_OBJS_DELTA ~= 5.29k
+  MALLOC_COUNT = 21632
+  ALIVE_OBJS_DELTA ~= 5.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -562,7 +562,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1002k
+  OPCODES ~= 1010k
   MALLOC_COUNT = 6214
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
@@ -924,7 +924,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 731k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1286,7 +1286,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 731k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1648,7 +1648,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 731k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.76k bytes
+  MEMORY_USAGE_COUNT ~= 1551.91k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15143
+  MALLOC_COUNT = 15172
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.98k bytes
+  MEMORY_USAGE_COUNT ~= 1113.14k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14982
+  OPCODES ~= 82k
+  MALLOC_COUNT = 15011
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1093.73k bytes
+  MEMORY_USAGE_COUNT ~= 1095.89k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23146
+  MALLOC_COUNT = 23174
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -48,7 +48,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 154k
+  OPCODES ~= 155k
   MALLOC_COUNT = 1012
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1978.82k bytes
+  MEMORY_USAGE_COUNT ~= 1981.00k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15086
+  MALLOC_COUNT = 15115
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.76k bytes
+  MEMORY_USAGE_COUNT ~= 1112.92k bytes


### PR DESCRIPTION
## Why

Resolving an inbound network CRDT message to its local entity scanned every `NetworkEntity` component. That lookup runs per received message, so the update path cost `messages x synchronized entities` — quadratic in scene population for a busy multiplayer scene.

## What changed

- Keep a per-engine map keyed by `(networkId, entityId)` and resolve in constant time.
- Track the reverse local-entity key, so a replacement or deletion drops only its own mapping.
- Maintain the index on every path that can change it: locally emitted `NetworkEntity` changes, newly received mappings, accepted remote updates, component deletion, and entity cleanup.

## Measured

Inbound messages targeting the last synced entity — worst case for the scan, and the realistic one when a scene addresses whichever peer just moved:

| synced entities | messages/frame | main | this branch |
| --- | --- | --- | --- |
| 100 | 20 | 1.12 ms/frame | 0.27 ms/frame |
| 500 | 50 | 7.82 ms/frame | 0.34 ms/frame |
| 1 000 | 100 | **31.81 ms/frame** | **0.49 ms/frame** |

The scaling confirms the cost model rather than a tuned constant: quadrupling the work (500→1000 entities, 50→100 messages) takes `main` from 7.8 to 31.8 ms, almost exactly 4x, while this branch goes 0.34 to 0.49 ms. At the top row `main` spends about two 60 fps frames per frame on entity resolution alone.

## Tests

`test/ecs/crdt-network-entity-index.spec.ts` — moved from `test/ecs/network/`, which was a new directory holding one file; `test/ecs` already keeps `crdt-rules-lww`, `crdt-rules-gset`, `crdtMessage` and `ecs.crdt` flat, and `test/sdk/network/` covers the SDK-side transport layer rather than this system.

An index is only as good as its invalidation, so the two original happy-path tests are joined by three that exercise it, each mutation-checked:

- **re-pointing** a mapped entity at a different remote entity — the old key must stop resolving
- **deleting** `NetworkEntity` from a mapped entity — same
- **ownership transfer**: a second local entity claims the same remote mapping, then the first is removed; the mapping must survive, which is what the `localEntityId` guard in `removeIndexedNetworkEntity` exists for

Verified by mutation: dropping the stale-mapping removal fails 2, dropping the ownership guard fails 1, and dropping the local-change indexing fails 2. Only that last one was caught by the original pair.

## Scene-level test

[`crdt-network-entity-index`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/crdt-network-entity-index) — 400 entities registered with `syncEntity`, 40 mutated per frame, measuring the per-frame cost of the SDK's systems while checking peer entities still arrive and track. Resolution only runs for inbound messages, so it needs two clients (`npm start -- --multi-instance`); with one it reports `SOLO` rather than a number that measures nothing.

## Verification

- `jest test/ecs test/sdk test/react-ecs` — 1175 passed
- `jest test/snapshots.spec.ts` — 17 passed after regeneration
- `make build`, `make lint`

`Generated EngineInfo ProtoBuf › should serialize/deserialize EngineInfo` fails here and on a clean `main` checkout, from the protocol bump in ffb26183. Unrelated to this change.
