### PR TITLE
perf: skip readonly component copies in production

### DIFF
--- a/packages/@dcl/ecs/src/engine/readonly.ts
+++ b/packages/@dcl/ecs/src/engine/readonly.ts
@@ -1,4 +1,5 @@
 import { ComponentDefinition } from './component'
+import { __DEV__ } from '../runtime/invariant'
 
 /**
  * @public
@@ -42,6 +43,6 @@ export type DeepReadonly<T> = T extends ReadonlyPrimitive
 /**
  * @internal
  */
-export function deepReadonly<T extends Record<string, unknown>>(val: T): DeepReadonly<T> {
-  return Object.freeze({ ...val }) as DeepReadonly<T>
+export function deepReadonly<T extends Record<string, unknown>>(val: T, freeze = __DEV__): DeepReadonly<T> {
+  return (freeze ? Object.freeze({ ...val }) : val) as DeepReadonly<T>
 }

--- a/test/ecs/engineUtils.spec.ts
+++ b/test/ecs/engineUtils.spec.ts
@@ -41,4 +41,16 @@ describe('Engine utils', () => {
     const newArray = array.filter(isNotUndefined)
     expect(newArray).toStrictEqual([1, 2, 3])
   })
+
+  describe('when development readonly checks are disabled', () => {
+    let value: { x: number }
+
+    beforeEach(() => {
+      value = { x: 1 }
+    })
+
+    it('should return the original value without allocating a frozen copy', () => {
+      expect(deepReadonly(value, false)).toBe(value)
+    })
+  })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
+  MALLOC_COUNT = 16301
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1426.75k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16853
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1432.52k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16853
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1432.52k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15161
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1069.23k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=288.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17678
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -67,7 +67,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x201 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x204 c=1 t=3 data={"position":{"x":12,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
   Scene: PUT_COMPONENT e=0x203 c=1 t=3 data={"position":{"x":8,"y":3.087538480758667,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
-  OPCODES ~= 12k
+  OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1255.21k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14281
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1031.50k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14254
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1021.25k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21015
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -564,7 +564,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1001k
+  OPCODES ~= 1010k
   MALLOC_COUNT = 6214
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
@@ -926,7 +926,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 733k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1288,7 +1288,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 733k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1650,7 +1650,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 733k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1479.68k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
+  MALLOC_COUNT = 14547
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   OPCODES ~= 0k
@@ -29,7 +29,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x201 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x202 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 24k
+  OPCODES ~= 25k
   MALLOC_COUNT = 133
   ALIVE_OBJS_DELTA ~= 0.04k
 CALL onUpdate(0.1)
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1040.95k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14386
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1023.70k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -11,7 +11,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22395
+  MALLOC_COUNT = 22391
   ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
@@ -67,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1895.34k bytes
+  MEMORY_USAGE_COUNT ~= 1894.32k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21120
+  MALLOC_COUNT = 21116
   ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1300.70k bytes
+  MEMORY_USAGE_COUNT ~= 1299.68k bytes


### PR DESCRIPTION
## Why
Every LWW component `get()` and `getOrNull()` call passed through `deepReadonly`, which cloned and froze the component object. These reads are among the hottest operations in scene systems, so production scenes paid an allocation and shallow-copy cost for every component access even though readonly enforcement is primarily a development diagnostic.

Caching the copies is not safe because `create()` returns a mutable object that callers may retain. The safer optimization is to keep the current frozen-copy guard in development while returning the original object, typed readonly, in production builds.

## What changed
- Make `deepReadonly` use the existing `__DEV__` runtime flag.
- Preserve the frozen shallow copy in development.
- Return the original component object without allocation in production.
- Add coverage proving the production path preserves object identity.

## Verification
- `node_modules/.bin/jest --colors --forceExit --runInBand --runTestsByPath test/ecs/engineUtils.spec.ts test/ecs/engine.spec.ts` (68 passed, 1 skipped)
- `make lint` (completed; existing unrelated repository warnings/errors remain in untouched files)
- `git diff --check`