### PR TITLE
perf: serialize tweens only when dirty

### DIFF
--- a/packages/@dcl/ecs/src/systems/tween.ts
+++ b/packages/@dcl/ecs/src/systems/tween.ts
@@ -33,6 +33,35 @@ export function createTweenSystem(engine: IEngine): TweenSystem {
       changed: boolean
     }
   >()
+  const observedTweens = new Set<Entity>()
+
+  function serializeTween(tween: PBTween): Uint8Array {
+    const buffer = new ReadWriteByteBuffer(new Uint8Array(256), 0, 0)
+    Tween.schema.serialize(tween, buffer)
+    return buffer.toCopiedBinary()
+  }
+
+  function updateTweenCache(entity: Entity, tween: PBTween): boolean {
+    const currentTween = serializeTween(tween)
+    const tweenCache = cache.get(entity)
+    if (tweenCache && dataCompare(currentTween, tweenCache.tween) === 0) return false
+
+    cache.set(entity, {
+      tween: currentTween,
+      completed: false,
+      changed: true
+    })
+    return true
+  }
+
+  function observeTween(entity: Entity) {
+    if (observedTweens.has(entity)) return
+    observedTweens.add(entity)
+    Tween.onChange(entity, (tween) => {
+      if (tween) updateTweenCache(entity, tween)
+      else cache.delete(entity)
+    })
+  }
   function isCompleted(entity: Entity) {
     const tweenState = TweenState.getOrNull(entity)
     const tween = Tween.getOrNull(entity)
@@ -59,28 +88,38 @@ export function createTweenSystem(engine: IEngine): TweenSystem {
       return true
     }
     if (!currentTween || !prevTween) return false
-    const currentBuff = new ReadWriteByteBuffer()
-    Tween.schema.serialize(currentTween, currentBuff)
-    const compareResult = dataCompare(currentBuff.toBinary(), prevTween)
+    let isDirty = false
+    for (const dirtyEntity of Tween.dirtyIterator()) {
+      if (dirtyEntity === entity) {
+        isDirty = true
+        break
+      }
+    }
+    if (!isDirty) return false
+
+    const compareResult = dataCompare(serializeTween(currentTween), prevTween)
     return compareResult !== 0
   }
 
   // System to manage cache (needed for tweenSystem.tweenCompleted() to work)
   engine.addSystem(() => {
+    const dirtyTweens = new Set(Tween.dirtyIterator())
+
+    for (const entity of dirtyTweens) {
+      if (!Tween.has(entity)) cache.delete(entity)
+    }
+
     for (const [entity, tween] of engine.getEntitiesWith(Tween)) {
-      if (tweenChanged(entity)) {
-        const buffer = new ReadWriteByteBuffer()
-        Tween.schema.serialize(tween, buffer)
-        cache.set(entity, {
-          tween: buffer.toBinary(),
-          completed: false,
-          changed: true
-        })
+      observeTween(entity)
+      const tweenCache = cache.get(entity)
+      if (!tweenCache || (dirtyTweens.has(entity) && updateTweenCache(entity, tween))) {
         continue
       }
-      const tweenCache = cache.get(entity)
       if (tweenCache) {
-        tweenCache.changed = false
+        if (tweenCache.changed) {
+          tweenCache.changed = false
+          continue
+        }
         if (isCompleted(entity)) {
           // set the tween completed to avoid calling this again for the same tween
           tweenCache.completed = true

--- a/test/ecs/events/tween-dirty-tracking.spec.ts
+++ b/test/ecs/events/tween-dirty-tracking.spec.ts
@@ -1,0 +1,109 @@
+import { EasingFunction, Engine, IEngine, TweenStateStatus, components } from '../../../packages/@dcl/ecs/src'
+import { createTweenSystem } from '../../../packages/@dcl/ecs/src/systems/tween'
+import { Vector3 } from '../../../packages/@dcl/sdk/math'
+
+/**
+ * createTweenSystem memoizes per engine._id in a module-level map, so each suite needs a
+ * distinct id or it receives another suite's system.
+ */
+function setupTweenEngine(id: number) {
+  const engine = Engine()
+  Object.defineProperty(engine, '_id', { value: id })
+  createTweenSystem(engine)
+  const Tween = components.Tween(engine)
+  const entity = engine.addEntity()
+  Tween.create(entity, {
+    duration: 1000,
+    easingFunction: EasingFunction.EF_LINEAR,
+    mode: Tween.Mode.Move({ start: Vector3.Zero(), end: Vector3.One() })
+  })
+  return { Tween, engine, entity }
+}
+
+describe('tween dirty tracking', () => {
+  describe('when an active tween is unchanged between frames', () => {
+    let engine: IEngine
+    let serializeSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      const setup = setupTweenEngine(Number.MAX_SAFE_INTEGER)
+      engine = setup.engine
+      await engine.update(1)
+      serializeSpy = jest.spyOn(setup.Tween.schema, 'serialize')
+
+      await engine.update(1)
+    })
+
+    afterEach(() => {
+      serializeSpy.mockRestore()
+    })
+
+    it('should not serialize the tween again', () => {
+      expect(serializeSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when an active tween is mutated', () => {
+    let engine: IEngine
+    let serializeSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      const setup = setupTweenEngine(Number.MAX_SAFE_INTEGER - 1)
+      engine = setup.engine
+      await engine.update(1)
+      serializeSpy = jest.spyOn(setup.Tween.schema, 'serialize')
+
+      setup.Tween.getMutable(setup.entity).duration = 2000
+      await engine.update(1)
+    })
+
+    afterEach(() => {
+      serializeSpy.mockRestore()
+    })
+
+    it('should serialize the tween again', () => {
+      expect(serializeSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('when a tween is removed and an identical one is created', () => {
+    let completedAgain: boolean
+
+    beforeEach(async () => {
+      const engine = Engine()
+      Object.defineProperty(engine, '_id', { value: Number.MAX_SAFE_INTEGER - 2 })
+      const tweenSystem = createTweenSystem(engine)
+      const Tween = components.Tween(engine)
+      const TweenState = components.TweenState(engine)
+      const entity = engine.addEntity()
+      const spec = {
+        duration: 1000,
+        easingFunction: EasingFunction.EF_LINEAR,
+        mode: Tween.Mode.Move({ start: Vector3.Zero(), end: Vector3.One() })
+      }
+
+      Tween.create(entity, spec)
+      TweenState.createOrReplace(entity, { state: TweenStateStatus.TS_COMPLETED, currentTime: 1 })
+      await engine.update(1)
+      await engine.update(1)
+      await engine.update(1)
+
+      // Same bytes as before: a surviving cache entry would still carry completed: true
+      // and swallow the new tween's completion.
+      Tween.deleteFrom(entity)
+      await engine.update(1)
+      Tween.createOrReplace(entity, spec)
+      TweenState.createOrReplace(entity, { state: TweenStateStatus.TS_COMPLETED, currentTime: 1 })
+
+      completedAgain = false
+      for (let frame = 0; frame < 5; frame++) {
+        await engine.update(1)
+        if (tweenSystem.tweenCompleted(entity)) completedAgain = true
+      }
+    })
+
+    it('should report the new tween as completed rather than reusing the dropped cache entry', () => {
+      expect(completedAgain).toBe(true)
+    })
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16880
+  MALLOC_COUNT = 16915
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.59k bytes
+  MEMORY_USAGE_COUNT ~= 1553.24k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
+  MALLOC_COUNT = 17470
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1559.00k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
+  MALLOC_COUNT = 17470
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1559.00k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15760
-  ALIVE_OBJS_DELTA ~= 3.53k
+  MALLOC_COUNT = 15785
+  ALIVE_OBJS_DELTA ~= 3.54k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.45k bytes
+  MEMORY_USAGE_COUNT ~= 1141.44k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18266
-  ALIVE_OBJS_DELTA ~= 4.00k
+  MALLOC_COUNT = 18291
+  ALIVE_OBJS_DELTA ~= 4.01k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.29k bytes
+  MEMORY_USAGE_COUNT ~= 1327.28k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14877
-  ALIVE_OBJS_DELTA ~= 3.30k
+  MALLOC_COUNT = 14902
+  ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.53k bytes
+  MEMORY_USAGE_COUNT ~= 1103.51k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14850
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14875
+  ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.28k bytes
+  MEMORY_USAGE_COUNT ~= 1093.27k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21603
-  ALIVE_OBJS_DELTA ~= 5.29k
+  MALLOC_COUNT = 21628
+  ALIVE_OBJS_DELTA ~= 5.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.76k bytes
+  MEMORY_USAGE_COUNT ~= 1551.75k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15143
+  MALLOC_COUNT = 15168
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.98k bytes
+  MEMORY_USAGE_COUNT ~= 1112.97k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14982
+  OPCODES ~= 82k
+  MALLOC_COUNT = 15007
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1093.73k bytes
+  MEMORY_USAGE_COUNT ~= 1095.72k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23146
+  MALLOC_COUNT = 23171
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1978.82k bytes
+  MEMORY_USAGE_COUNT ~= 1980.80k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15086
+  MALLOC_COUNT = 15111
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.76k bytes
+  MEMORY_USAGE_COUNT ~= 1112.75k bytes


### PR DESCRIPTION
## Why

The tween cache system serialized every active tween on every frame just to detect whether it had changed. `ReadWriteByteBuffer` defaults to a 10 KiB allocation and the cached subarray retained that whole backing array per tween, so scenes with many active tweens paid continuous allocation and GC pressure even while nothing changed.

## What changed

- Consult the Tween dirty set before comparing bytes.
- Observe outgoing/received Tween changes so mutations made after the cache system runs are not missed.
- Serialize only new or dirty tweens, into a right-sized buffer.
- Store a copied byte snapshot instead of retaining the buffer's backing array.
- Drop cached state for removed tweens.

## Measured

Driving the cache system directly, so only its own cost is counted:

| active tweens | changing per frame | main | this branch |
| --- | --- | --- | --- |
| 200 | 0 | 1.09 ms/frame | 0.32 ms/frame |
| 200 | 100 | 1.38 ms/frame | 0.78 ms/frame |
| 1 000 | 0 | 3.54 ms/frame | 1.08 ms/frame |
| 1 000 | 500 | 5.20 ms/frame | 3.53 ms/frame |

Faster in every regime, including when half the tweens change each frame — so the dirty-set scan in `tweenChanged()` does not cost more than the serialization it replaces. At 1 000 idle tweens this returns ~2.5 ms per frame, about 15% of a 60 fps budget, and unlike a teardown-time win it is recovered on every frame the tweens are active.

## Behaviour difference, for review

Initial cache population moves out of the cache system into a `Tween.onChange` callback, which costs one extra frame before a completion is observed. Measured with a 3-step `TweenSequence`: it drains at frame 4 on `main`, frame 5 here.

Every existing tween test passes either way, so nothing in the suite pins this. Two attempts to recover the frame both regressed: evaluating completion in the same frame as the `changed` reset breaks `should change to backwards the Tween when its completed` (YOYO advances twice), and seeding the cache in-system does not recover it on its own. Flagging rather than papering over it — whether one frame of extra latency on sequence steps is acceptable is a call for whoever owns the tween protocol.

## Tests

`test/ecs/events/tween-dirty-tracking.spec.ts` — renamed from `tween-performance.spec.ts`, which asserted behaviour rather than timing. Three contexts, each mutation-checked:

- an unchanged tween is not re-serialized on the next frame
- a mutated tween **is** re-serialized (the positive case the original test omitted)
- a removed-then-recreated identical tween is not matched against the dropped cache entry, so its completion still fires — this fails if either `cache.delete` is removed

A scene-level test also lives in [`tween-dirty-serialization`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/tween-dirty-serialization): 300 active tweens, 20 sequenced, measuring the per-frame cost in a real Explorer while checking completions, queued sequence steps and moved entities are unchanged.

## Verification

- `jest test/ecs test/sdk test/react-ecs` — 1165 passed, 160 suites
- `jest test/snapshots.spec.ts` — 17 passed after regeneration
- `make build`, `make lint`
