### PR TITLE
perf: grow byte buffers geometrically

### DIFF
--- a/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
+++ b/packages/@dcl/ecs/src/serialization/ByteBuffer/index.ts
@@ -1,14 +1,15 @@
 import * as utf8 from '@protobufjs/utf8'
 
 /**
- * Take the max between currentSize and intendedSize and then plus 1024. Then,
- *  find the next nearer multiple of 1024.
+ * Grow geometrically to avoid repeatedly copying the accumulated payload when
+ * a buffer receives many small writes. Large single writes still grow directly
+ * to the required capacity.
  * @param currentSize - number
  * @param intendedSize - number
  * @returns the calculated number
  */
 function getNextSize(currentSize: number, intendedSize: number) {
-  const minNewSize = Math.max(currentSize, intendedSize) + 1024
+  const minNewSize = Math.max(currentSize * 2, intendedSize)
   return Math.ceil(minNewSize / 1024) * 1024
 }
 

--- a/test/ecs/byteBuffer-growth.spec.ts
+++ b/test/ecs/byteBuffer-growth.spec.ts
@@ -1,0 +1,17 @@
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+
+describe('when a ByteBuffer exceeds its current capacity', () => {
+  let buffer: ReadWriteByteBuffer
+  let initialCapacity: number
+
+  beforeEach(() => {
+    buffer = new ReadWriteByteBuffer()
+    initialCapacity = buffer.bufferLength()
+  })
+
+  it('should double its capacity to reduce repeated reallocations', () => {
+    buffer.incrementWriteOffset(initialCapacity + 1)
+
+    expect(buffer.bufferLength()).toBe(initialCapacity * 2)
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
+  MALLOC_COUNT = 16301
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1426.64k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16853
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1432.40k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,7 +12,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16853
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1432.41k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15161
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1069.14k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=288.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17678
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1255.12k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14281
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1031.41k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14254
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1021.16k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21015
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1479.60k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
+  MALLOC_COUNT = 14547
   ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   OPCODES ~= 0k
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1040.87k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14386
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1023.61k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -11,7 +11,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22395
+  MALLOC_COUNT = 22391
   ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
@@ -67,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1895.34k bytes
+  MEMORY_USAGE_COUNT ~= 1894.23k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21120
+  MALLOC_COUNT = 21116
   ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1300.70k bytes
+  MEMORY_USAGE_COUNT ~= 1299.59k bytes


### PR DESCRIPTION
## Why

`ReadWriteByteBuffer` previously grew by only the overflow amount rounded to the next KiB. Repeated appends could therefore trigger many reallocations and copies as CRDT or component payloads grew, making the total copy work approach quadratic behavior.

## What changed

- Double the current buffer capacity whenever growth is required.
- Still grow directly to the requested size when a single large write exceeds the doubled capacity.
- Preserve KiB-aligned capacities.
- Add a focused regression test covering geometric growth after an overflow.

## Verification

- `node_modules/.bin/jest --colors --forceExit --testPathPattern='test/ecs/byteBuffer'` (10 passed)
- `cd packages/@dcl/ecs && npx tsc --noEmit -p tsconfig.json`
- `git diff --check origin/main...HEAD`