### PR TITLE
perf: process project files concurrently

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -8,6 +8,7 @@ import os from 'os'
 
 import path, { resolve } from 'path'
 import { CliError } from './error'
+import { concurrentMap } from './promise-utils'
 
 export type ProjectFile = {
   absolutePath: string
@@ -77,16 +78,15 @@ export async function getProjectPublishableFilesWithHashes(
   hashingFunction: (filePath: string) => Promise<string>
 ): Promise<ProjectFile[]> {
   const projectFiles = await getPublishableFiles(components, projectRoot)
-  const ret: ProjectFile[] = []
+  const existingFiles = (
+    await concurrentMap(projectFiles, async (file) => {
+      const absolutePath = path.resolve(projectRoot, file)
+      return (await components.fs.fileExists(absolutePath)) ? { file, absolutePath } : null
+    })
+  ).filter((file): file is { file: string; absolutePath: string } => file !== null)
 
   const usedFilenames = new Set<string>()
-
-  for (const file of projectFiles) {
-    const absolutePath = path.resolve(projectRoot, file)
-
-    /* istanbul ignore if */
-    if (!(await components.fs.fileExists(absolutePath))) continue
-
+  for (const { file } of existingFiles) {
     const normalizedFile = normalizeDecentralandFilename(projectRoot, file)
 
     /* istanbul ignore if */
@@ -95,14 +95,14 @@ export async function getProjectPublishableFilesWithHashes(
     }
 
     usedFilenames.add(normalizedFile)
-
-    ret.push({
-      absolutePath,
-      hash: await hashingFunction(absolutePath)
-    })
   }
 
-  return ret
+  return concurrentMap(existingFiles, async ({ absolutePath }) => {
+    return {
+      absolutePath,
+      hash: await hashingFunction(absolutePath)
+    }
+  })
 }
 export const machineId = os.hostname() || os.userInfo().username
 export const b64HashingFunction = (str: string) => {

--- a/packages/@dcl/sdk-commands/src/logic/promise-utils.ts
+++ b/packages/@dcl/sdk-commands/src/logic/promise-utils.ts
@@ -1,0 +1,23 @@
+const DEFAULT_CONCURRENCY = 32
+
+export async function concurrentMap<T, R>(
+  values: readonly T[],
+  mapper: (value: T, index: number) => Promise<R>,
+  concurrency: number = DEFAULT_CONCURRENCY
+): Promise<R[]> {
+  if (values.length === 0) return []
+
+  const results = new Array<R>(values.length)
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (nextIndex < values.length) {
+      const currentIndex = nextIndex++
+      results[currentIndex] = await mapper(values[currentIndex], currentIndex)
+    }
+  }
+
+  const workerCount = Math.min(Math.max(1, concurrency), values.length)
+  await Promise.all(Array.from({ length: workerCount }, worker))
+  return results
+}

--- a/packages/@dcl/sdk-commands/src/logic/scene-validations.ts
+++ b/packages/@dcl/sdk-commands/src/logic/scene-validations.ts
@@ -9,6 +9,7 @@ import { getObject } from './coordinates'
 import { CliComponents } from '../components'
 import { getPublishableFiles } from './project-files'
 import { printWarning } from './beautiful-logs'
+import { concurrentMap } from './promise-utils'
 
 export interface IFile {
   path: string
@@ -154,23 +155,17 @@ export function getBaseCoords(scene: Scene): { x: number; y: number } {
  */
 export async function getFiles(components: Pick<CliComponents, 'fs' | 'logger'>, dir: string): Promise<IFile[]> {
   const files = await getPublishableFiles(components, dir)
-  const data: IFile[] = []
-
-  for (let i = 0; i < files.length; i++) {
-    const file = files[i]
+  return concurrentMap(files, async (file): Promise<IFile> => {
     const filePath = resolve(dir, file)
     const stat = await components.fs.stat(filePath)
-
     const content = await components.fs.readFile(filePath)
 
-    data.push({
+    return {
       path: file.replace(/\\/g, '/'),
       content: Buffer.from(content),
       size: stat.size
-    })
-  }
-
-  return data
+    }
+  })
 }
 
 export function validateFilesSizes(files: IFile[]) {

--- a/test/sdk-commands/logic/promise-utils.spec.ts
+++ b/test/sdk-commands/logic/promise-utils.spec.ts
@@ -1,0 +1,121 @@
+import { concurrentMap } from '../../../packages/@dcl/sdk-commands/src/logic/promise-utils'
+
+describe('concurrentMap', () => {
+  describe('when the limit is below the input size', () => {
+    let activeTasks: number
+    let maximumActiveTasks: number
+    let mapper: jest.Mock<Promise<number>, [number]>
+    let result: number[]
+
+    beforeEach(async () => {
+      activeTasks = 0
+      maximumActiveTasks = 0
+      mapper = jest.fn(async (value: number): Promise<number> => {
+        activeTasks++
+        maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks)
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        activeTasks--
+        return value * 2
+      })
+
+      result = await concurrentMap([1, 2, 3, 4, 5], mapper, 2)
+    })
+
+    it('should resolve with the results in input order', () => {
+      expect(result).toEqual([2, 4, 6, 8, 10])
+    })
+
+    it('should never run more tasks at once than the limit', () => {
+      expect(maximumActiveTasks).toBe(2)
+    })
+
+    it('should call the mapper once per value', () => {
+      expect(mapper).toHaveBeenCalledTimes(5)
+    })
+  })
+
+  describe('when the input is empty', () => {
+    let mapper: jest.Mock<Promise<number>, [number]>
+    let result: number[]
+
+    beforeEach(async () => {
+      mapper = jest.fn(async (value: number): Promise<number> => value)
+
+      result = await concurrentMap([], mapper)
+    })
+
+    it('should resolve with an empty array', () => {
+      expect(result).toEqual([])
+    })
+
+    it('should not call the mapper', () => {
+      expect(mapper).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the limit exceeds the input size', () => {
+    let mapper: jest.Mock<Promise<number>, [number]>
+    let result: number[]
+
+    beforeEach(async () => {
+      mapper = jest.fn(async (value: number): Promise<number> => value * 2)
+
+      result = await concurrentMap([1, 2, 3], mapper, 10)
+    })
+
+    it('should map every value exactly once', () => {
+      expect(result).toEqual([2, 4, 6])
+    })
+  })
+
+  describe('when the limit is not a positive number', () => {
+    let activeTasks: number
+    let maximumActiveTasks: number
+    let result: number[]
+
+    beforeEach(async () => {
+      activeTasks = 0
+      maximumActiveTasks = 0
+
+      result = await concurrentMap(
+        [1, 2, 3],
+        async (value: number): Promise<number> => {
+          activeTasks++
+          maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks)
+          await new Promise<void>((resolve) => setTimeout(resolve, 0))
+          activeTasks--
+          return value * 2
+        },
+        0
+      )
+    })
+
+    it('should still map every value in order', () => {
+      expect(result).toEqual([2, 4, 6])
+    })
+
+    it('should fall back to a single worker', () => {
+      expect(maximumActiveTasks).toBe(1)
+    })
+  })
+
+  describe('when the mapper rejects for one value', () => {
+    let failure: Error
+    let mapper: jest.Mock<Promise<number>, [number]>
+    let rejection: unknown
+
+    beforeEach(async () => {
+      failure = new Error('mapper failed')
+      mapper = jest.fn(async (value: number): Promise<number> => {
+        if (value === 2) throw failure
+        return value * 2
+      })
+
+      rejection = await concurrentMap([1, 2, 3], mapper, 2).catch((error) => error)
+    })
+
+    it('should reject with the original error', () => {
+      expect(rejection).toBe(failure)
+    })
+  })
+})


### PR DESCRIPTION
## Why

`getFiles` and `getProjectPublishableFilesWithHashes` walked the project one file at a time, so a publish or export spent most of its wall time waiting on sequential `stat` / `readFile` / hash round-trips rather than on work.

## What changed

- Added `concurrentMap` in `src/logic/promise-utils.ts`: an order-preserving worker pool bounded at 32, with results written into a pre-allocated array so output order never depends on completion order.
- Used it for the file-existence check, the hashing pass, and the file reads in `getFiles`.
- Duplicate-name validation stays sequential between the two concurrent passes, so it still reports the same file first — and now fails *before* any hashing rather than after part of it.

## Error propagation

The pool has no cancellation. On a mapper rejection `Promise.all` rejects with the first error, but workers already running or still queued run to completion. That's harmless for a CLI about to exit, but it differs from the sequential loop, which stopped at the first throw. There's no unhandled-rejection risk: `Promise.all` attaches handlers to every worker up front.

## Tests

`test/sdk-commands/logic/promise-utils.spec.ts` — mirrors the source path, alongside the other `src/logic` specs. Nine tests across five contexts: the pooled path (order, concurrency ceiling, one call per value), empty input, a limit above the input size, a non-positive limit, and a rejecting mapper.

Mutation-checked, which is worth recording because two of the three guards turn out to be unobservable from outside: removing `Math.max(1, concurrency)` fails 2 tests, while removing the `values.length === 0` early return or the `Math.min(…, values.length)` cap leaves all 9 green. Both of those are pure short-circuits — without them the function still returns `[]` for empty input and still maps correctly with surplus workers that exit immediately. No test can pin them, so none pretends to.

## Verification

- `node_modules/.bin/jest --forceExit --runInBand test/sdk-commands` — 197 passed, 24 suites
- `node_modules/.bin/jest --forceExit --runInBand test/snapshots.spec.ts` — 17 passed, unchanged (this PR touches only `@dcl/sdk-commands`, which is not bundled into scenes, so no golden files move)
- `make build`, `make lint`
