### PR TITLE
perf: cache CRDT transport routing decisions

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,8 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  // Local messages are filtered once while they are serialized and reuse that routing decision below.
+  const localMessageTransports = new WeakMap<object, boolean[]>()
 
   /**
    *
@@ -206,8 +208,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     for (const component of engine.componentsIter()) {
       for (const message of component.getCrdtUpdates()) {
         const offset = buffer.currentWriteOffset()
+        const acceptedTransports = transports.map((transport) => transport.filter(message))
         // Avoid creating messages if there is no transport that will handle it
-        if (transports.some((t) => t.filter(message))) {
+        if (acceptedTransports.some(Boolean)) {
           if (message.type === CrdtMessageType.PUT_COMPONENT) {
             PutComponentOperation.write(message.entityId, message.timestamp, message.componentId, message.data, buffer)
           } else if (message.type === CrdtMessageType.DELETE_COMPONENT) {
@@ -215,10 +218,12 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           } else if (message.type === CrdtMessageType.APPEND_VALUE) {
             AppendValueOperation.write(message.entityId, message.timestamp, message.componentId, message.data, buffer)
           }
-          crdtMessages.push({
+          const serializedMessage = {
             ...message,
             messageBuffer: buffer.buffer().subarray(offset, buffer.currentWriteOffset())
-          })
+          }
+          localMessageTransports.set(serializedMessage, acceptedTransports)
+          crdtMessages.push(serializedMessage)
         }
         if (onProcessEntityComponentChange) {
           const rawValue =
@@ -264,8 +269,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
         // Avoid echo messages
         if (message.transportId === transportIndex) continue
 
-        // Redundant message for the transport
-        if (!transport.filter(message)) continue
+        // Local messages were already filtered before serialization. Received messages still need routing here.
+        const acceptedTransports = localMessageTransports.get(message)
+        if (acceptedTransports ? !acceptedTransports[transportIndex] : !transport.filter(message)) continue
 
         // Check if adding this message would exceed the size limit
         const currentBufferSize = transportBuffer.toBinary().byteLength

--- a/packages/@dcl/sdk/src/network/state.ts
+++ b/packages/@dcl/sdk/src/network/state.ts
@@ -55,11 +55,12 @@ export const NOT_SYNC_COMPONENTS_NAMES: string[] = [
   'asset-packs::Script', // ComponentName from: https://github.com/decentraland/asset-packs/blob/main/src/enums.ts
   'asset-packs::ActionTypes'
 ]
+const NOT_SYNC_COMPONENTS_IDS_SET = new Set(NOT_SYNC_COMPONENTS_IDS)
+const NOT_SYNC_COMPONENTS_NAMES_SET = new Set(NOT_SYNC_COMPONENTS_NAMES)
 
 export function shouldSyncComponent(component: ComponentDefinition<unknown>): boolean {
   return !(
-    NOT_SYNC_COMPONENTS_IDS.includes(component.componentId) ||
-    NOT_SYNC_COMPONENTS_NAMES.includes(component.componentName)
+    NOT_SYNC_COMPONENTS_IDS_SET.has(component.componentId) || NOT_SYNC_COMPONENTS_NAMES_SET.has(component.componentName)
   )
 }
 

--- a/test/ecs/crdt-transport-filter-performance.spec.ts
+++ b/test/ecs/crdt-transport-filter-performance.spec.ts
@@ -1,0 +1,30 @@
+import { Engine, Schemas } from '../../packages/@dcl/ecs/src'
+import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
+
+type FilterMessage = Parameters<Transport['filter']>[0]
+
+describe('when a local CRDT update is accepted by multiple transports', () => {
+  let engine: ReturnType<typeof Engine>
+  let firstFilter: jest.Mock<boolean, [FilterMessage]>
+  let secondFilter: jest.Mock<boolean, [FilterMessage]>
+
+  beforeEach(async () => {
+    firstFilter = jest.fn((_message: FilterMessage) => true)
+    secondFilter = jest.fn((_message: FilterMessage) => true)
+    const transports: Transport[] = [firstFilter, secondFilter].map((filter) => ({
+      filter,
+      send: jest.fn(async () => undefined)
+    }))
+    engine = Engine()
+    transports.forEach(engine.addTransport)
+    const component = engine.defineComponent('test::TransportFilter', { value: Schemas.Int })
+    component.create(engine.addEntity(), { value: 1 })
+
+    await engine.update(1 / 30)
+  })
+
+  it('should evaluate each transport filter only once', () => {
+    expect(firstFilter).toHaveBeenCalledTimes(1)
+    expect(secondFilter).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 73k
-  MALLOC_COUNT = 16305
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 16310
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1428.31k bytes
+  MEMORY_USAGE_COUNT ~= 1427.85k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,13 +12,13 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16867
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   OPCODES ~= 3k
-  MALLOC_COUNT = 56
+  MALLOC_COUNT = 62
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"two way communication"}]}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.07k bytes
+  MEMORY_USAGE_COUNT ~= 1433.87k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,13 +12,13 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 16857
+  MALLOC_COUNT = 16867
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   OPCODES ~= 3k
-  MALLOC_COUNT = 56
+  MALLOC_COUNT = 62
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"two way communication"}]}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1434.08k bytes
+  MEMORY_USAGE_COUNT ~= 1433.87k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,12 +10,12 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 85k
-  MALLOC_COUNT = 15165
+  MALLOC_COUNT = 15173
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
-  MALLOC_COUNT = 90
+  MALLOC_COUNT = 94
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0)
   LOG: ["PointerEventsResult",[{"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}]]
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1070.25k bytes
+  MEMORY_USAGE_COUNT ~= 1069.85k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 17683
+  MALLOC_COUNT = 17684
   ALIVE_OBJS_DELTA ~= 3.87k
 CALL onStart()
   OPCODES ~= 0k
@@ -52,7 +52,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x204 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   Scene: PUT_COMPONENT e=0x205 c=1018 t=1 data={"mesh":{"$case":"plane","plane":{"uvs":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0]}}}
   OPCODES ~= 114k
-  MALLOC_COUNT = 361
+  MALLOC_COUNT = 365
   ALIVE_OBJS_DELTA ~= 0.10k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":3.0420734882354736,"z":1},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":2,"y":2,"z":2},"parent":0}
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1256.31k bytes
+  MEMORY_USAGE_COUNT ~= 1255.74k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 76k
-  MALLOC_COUNT = 14285
+  MALLOC_COUNT = 14288
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -20,8 +20,8 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x201 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
   OPCODES ~= 5k
-  MALLOC_COUNT = 68
-  ALIVE_OBJS_DELTA ~= 0.02k
+  MALLOC_COUNT = 74
+  ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: DELETE_COMPONENT e=0x201 c=1019 t=2 data=null
   Scene: PUT_COMPONENT e=0x202 c=1019 t=1 data={"mesh":{"$case":"box","box":{}}}
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.52k bytes
+  MEMORY_USAGE_COUNT ~= 1032.12k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 14258
+  MALLOC_COUNT = 14261
   ALIVE_OBJS_DELTA ~= 3.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -19,8 +19,8 @@ CALL onStart()
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   OPCODES ~= 4k
-  MALLOC_COUNT = 35
-  ALIVE_OBJS_DELTA ~= 0.01k
+  MALLOC_COUNT = 41
+  ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.28k bytes
+  MEMORY_USAGE_COUNT ~= 1021.88k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 127k
-  MALLOC_COUNT = 21020
+  MALLOC_COUNT = 21021
   ALIVE_OBJS_DELTA ~= 5.16k
 CALL onStart()
   OPCODES ~= 0k
@@ -564,8 +564,8 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1001k
-  MALLOC_COUNT = 6214
+  OPCODES ~= 1007k
+  MALLOC_COUNT = 6218
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":-3,"y":2.7722561359405518,"z":-3},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":0.5,"y":0.5,"z":0.5},"parent":0}
@@ -926,7 +926,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1288,7 +1288,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1650,7 +1650,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 729k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1480.79k bytes
+  MEMORY_USAGE_COUNT ~= 1480.22k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 77k
-  MALLOC_COUNT = 14551
-  ALIVE_OBJS_DELTA ~= 3.24k
+  MALLOC_COUNT = 14554
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -29,8 +29,8 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x201 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x202 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 24k
-  MALLOC_COUNT = 133
+  OPCODES ~= 25k
+  MALLOC_COUNT = 139
   ALIVE_OBJS_DELTA ~= 0.04k
 CALL onUpdate(0.1)
   OPCODES ~= 3k
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1041.98k bytes
+  MEMORY_USAGE_COUNT ~= 1041.58k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14390
+  MALLOC_COUNT = 14393
   ALIVE_OBJS_DELTA ~= 3.19k
 CALL onStart()
   OPCODES ~= 0k
@@ -18,7 +18,7 @@ CALL onStart()
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0)
   OPCODES ~= 3k
-  MALLOC_COUNT = 31
+  MALLOC_COUNT = 33
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
   OPCODES ~= 3k
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.73k bytes
+  MEMORY_USAGE_COUNT ~= 1024.20k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=407.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -11,7 +11,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 22395
+  MALLOC_COUNT = 22397
   ALIVE_OBJS_DELTA ~= 4.52k
 CALL onStart()
   OPCODES ~= 0k
@@ -50,7 +50,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
   OPCODES ~= 145k
-  MALLOC_COUNT = 967
+  MALLOC_COUNT = 971
   ALIVE_OBJS_DELTA ~= 0.31k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -67,4 +67,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1895.34k bytes
+  MEMORY_USAGE_COUNT ~= 1894.87k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21120
+  MALLOC_COUNT = 21123
   ALIVE_OBJS_DELTA ~= 4.95k
 CALL onStart()
   OPCODES ~= 0k
@@ -21,7 +21,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x201 c=1041 t=1 data={"src":"test.glb"}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   OPCODES ~= 8k
-  MALLOC_COUNT = 96
+  MALLOC_COUNT = 100
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x202 c=1041 t=1 data={"src":"test.glb"}
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1300.70k bytes
+  MEMORY_USAGE_COUNT ~= 1300.26k bytes


### PR DESCRIPTION
## Why

Locally generated CRDT updates evaluated transport filters once to decide whether serialization was necessary and then evaluated them again while delivering the serialized message. With multiple transports and many component updates, those repeated predicates add avoidable per-tick work. SDK state export also used linear array membership checks for every component.

## What changed

- Evaluate every transport filter once for each local update and retain the routing result with the serialized message.
- Reuse that result during delivery while continuing to filter received/broadcast messages at delivery time.
- Keep the SDK's exported exclusion arrays compatible while backing hot membership checks with internal `Set`s.
- Add a regression test asserting one filter invocation per transport for a local update.

## Verification

- `node_modules/.bin/jest --colors --forceExit --runInBand --testPathPattern='test/ecs/(transports|crdt-transport-filter-performance)\.spec\.ts|test/sdk/network/state-to-crdt\.spec\.ts'` (6 passed)
- `cd packages/@dcl/ecs && npx tsc --noEmit -p tsconfig.json`
- `cd packages/@dcl/sdk && npx tsc --noEmit -p tsconfig.json`
- `git diff --check`