### PR TITLE
perf: avoid serializing React props for equality

### DIFF
--- a/packages/@dcl/react-ecs/src/reconciler/utils.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/utils.ts
@@ -99,28 +99,29 @@ export function isEqual<T = unknown>(val1: T, val2: T): boolean {
     return val1 === val2
   }
 
-  if (Array.isArray(val1) && Array.isArray(val2)) {
-    if (val1.length !== val2.length) {
-      return false
-    }
-  }
-
-  if (Object.keys(val1).length !== Object.keys(val2).length) {
+  if (Array.isArray(val1) && Array.isArray(val2) && val1.length !== val2.length) {
     return false
   }
 
-  if (JSON.stringify(val1) === JSON.stringify(val2)) {
-    return true
-  }
+  const first = val1 as Record<string, unknown>
+  const second = val2 as Record<string, unknown>
+  let firstKeyCount = 0
+  let secondKeyCount = 0
 
-  for (const key in val1) {
-    if (!isEqual(val1[key]!, val2[key]!)) {
+  for (const key in first) {
+    if (!Object.prototype.hasOwnProperty.call(first, key)) continue
+    firstKeyCount++
+
+    if (!Object.prototype.hasOwnProperty.call(second, key) || !isEqual(first[key], second[key])) {
       return false
     }
   }
 
-  /* istanbul ignore next */
-  return true
+  for (const key in second) {
+    if (Object.prototype.hasOwnProperty.call(second, key)) secondKeyCount++
+  }
+
+  return firstKeyCount === secondKeyCount
 }
 
 export const isNotUndefined = <T>(val: T | undefined): val is T => {

--- a/test/react-ecs/isequal-performance.spec.ts
+++ b/test/react-ecs/isequal-performance.spec.ts
@@ -1,0 +1,23 @@
+import { isEqual } from '../../packages/@dcl/react-ecs/src/reconciler/utils'
+
+describe('when comparing equivalent nested React ECS props', () => {
+  let stringifySpy: jest.SpyInstance
+  let result: boolean
+
+  beforeEach(() => {
+    stringifySpy = jest.spyOn(JSON, 'stringify')
+    result = isEqual(
+      { dimensions: { width: 100, height: 50 }, colors: ['red', 'blue'] },
+      { colors: ['red', 'blue'], dimensions: { height: 50, width: 100 } }
+    )
+  })
+
+  afterEach(() => {
+    stringifySpy.mockRestore()
+  })
+
+  it('should compare recursively without serializing the prop trees', () => {
+    expect(result).toBe(true)
+    expect(stringifySpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

React ECS compares component props in a reconciliation hot path. The deep-equality helper allocated key arrays and serialized both complete value trees with `JSON.stringify` before recursively comparing them, producing transient strings and duplicate traversal work on UI updates.

## What changed

- Walk enumerable own properties directly instead of allocating `Object.keys` arrays.
- Compare key presence and nested values during the first traversal.
- Count the second object's keys to retain extra/missing-property detection.
- Remove JSON serialization entirely while preserving order-independent object equality and array-length checks.
- Add a regression test that verifies equivalent nested props compare successfully without invoking `JSON.stringify`.

## Verification

- `node_modules/.bin/jest --colors --forceExit --runInBand --testPathPattern='test/react-ecs'` (133 passed)
- `cd packages/@dcl/react-ecs && npx tsc --noEmit -p tsconfig.json`
- `git diff --check`