### PR TITLE
perf(sdk-commands): import getActionEvents from the asset-packs events

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
+++ b/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 import type { IEngine, Entity } from '@dcl/ecs'
 import { EntityState } from '@dcl/ecs/dist-cjs/engine/entity'
-import { type ActionRef, getActionEvents } from '@dcl/inspector/node_modules/@dcl/asset-packs'
+import type { ActionRef } from '@dcl/inspector/node_modules/@dcl/asset-packs'
+import { getActionEvents } from '@dcl/inspector/node_modules/@dcl/asset-packs/dist/events'
 
 declare global {
   // eslint-disable-next-line no-var

--- a/test/sdk-commands/logic/runtime-script.spec.ts
+++ b/test/sdk-commands/logic/runtime-script.spec.ts
@@ -1,5 +1,5 @@
 jest.mock(
-  '@dcl/inspector/node_modules/@dcl/asset-packs',
+  '@dcl/inspector/node_modules/@dcl/asset-packs/dist/events',
   () => ({
     getActionEvents: jest.fn((entity) => ({
       emit: jest.fn()

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=251.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 102k
-  MALLOC_COUNT = 21131
-  ALIVE_OBJS_DELTA ~= 4.95k
+  OPCODES ~= 77k
+  MALLOC_COUNT = 14730
+  ALIVE_OBJS_DELTA ~= 3.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -21,7 +21,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x201 c=1041 t=1 data={"src":"test.glb"}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   OPCODES ~= 8k
-  MALLOC_COUNT = 96
+  MALLOC_COUNT = 99
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x202 c=1041 t=1 data={"src":"test.glb"}
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1301.17k bytes
+  MEMORY_USAGE_COUNT ~= 1065.41k bytes


### PR DESCRIPTION
Scene bundles drop 40.9KB of unshakeable barrel graph: the @dcl/asset-packs CJS barrel is replaced by a type-only barrel import plus a value import of the self-contained dist/events leaf, letting esbuild shake everything the barrel pinned.