### PR TITLE
refactor(sdk-commands): embed runtime-script as TypeScript source

### DIFF
--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -64,7 +64,7 @@
     "directory": "packages/@dcl/sdk-commands"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && rm -rf dist/locales && cp -r src/locales dist/locales && cp src/logic/*.template dist/logic/",
+    "build": "tsc -p tsconfig.json && rm -rf dist/locales && cp -r src/locales dist/locales && cp src/logic/*.template src/logic/runtime-script.ts dist/logic/",
     "start": "tsc -p tsconfig.json --watch && rm -rf dist/locales && cp -r src/locales dist/locales",
     "postinstall": "node scripts/postinstall.js"
   },

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -482,7 +482,7 @@ function compositeLoader(components: BundleComponents, options: SingleProjectOpt
         )
 
         return {
-          loader: 'js',
+          loader: 'ts',
           contents,
           watchFiles,
           resolveDir: options.workingDirectory
@@ -557,26 +557,14 @@ function collectScriptData(
 }
 
 /**
- * Reads and prepares the runtime script code for inlining
+ * Reads the runtime script TypeScript source for inlining as ESM
  */
 async function prepareRuntimeCode(fs: BundleComponents['fs']): Promise<string> {
-  const runtimeCodePath = require.resolve('./runtime-script')
+  const runtimeCodePath = path.join(__dirname, 'runtime-script.ts')
   const runtimeCode = await fs.readFile(runtimeCodePath, 'utf-8')
 
-  // Strip CommonJS/module system code
-  return (
-    runtimeCode
-      .replace(/"use strict";?\s*/g, '')
-      .replace(/Object\.defineProperty\(exports,.*?\);?\s*/g, '')
-      .replace(/exports\.\w+\s*=\s*void 0;?\s*/g, '')
-      .replace(/exports\.\w+\s*=\s*/g, '')
-      .replace(/^export\s+/gm, '')
-      .replace(/^import\s+.*$/gm, '')
-      // fix nested asset-packs path (importing from @dcl/inspector is banned in runtime, but @dcl/asset-packs not)
-      .replace(/@dcl\/inspector\/node_modules\/@dcl\/asset-packs/g, '@dcl/asset-packs')
-      .replace(/\n{3,}/g, '\n\n')
-      .trim()
-  )
+  // fix nested asset-packs path (importing from @dcl/inspector is banned in scene bundles, @dcl/asset-packs is not)
+  return runtimeCode.replace(/@dcl\/inspector\/node_modules\/@dcl\/asset-packs/g, '@dcl/asset-packs')
 }
 
 /**
@@ -636,9 +624,6 @@ export function _initializeScripts(engine) {
   const scriptsArray = ${scriptsArray}
   return runScripts(engine, scriptsArray)
 }
-
-// export helper functions that are defined in the inlined runtime code
-export { getScriptInstance, getScriptInstancesByPath, getAllScriptInstances, callScriptMethod }
 `
 }
 

--- a/scripts/build.spec.ts
+++ b/scripts/build.spec.ts
@@ -110,6 +110,7 @@ flow('build-all', () => {
     it('check files exists', () => {
       ensureFileExists('dist/index.js', SDK_COMMANDS_PATH)
       ensureFileExists('dist/index.d.ts', SDK_COMMANDS_PATH)
+      ensureFileExists('dist/logic/runtime-script.ts', SDK_COMMANDS_PATH)
     })
 
     itExecutes(`chmod +x dist/index.js`, SDK_COMMANDS_PATH)

--- a/test/sdk-commands/commands/build/index.spec.ts
+++ b/test/sdk-commands/commands/build/index.spec.ts
@@ -136,9 +136,10 @@ describe('bundle script utilities', () => {
       expect(result.contents).toContain('export function _initializeScripts(engine)')
       expect(result.contents).toContain('const scriptsArray = []')
       expect(result.contents).toContain('return runScripts(engine, scriptsArray)')
-      expect(result.contents).toContain(
-        'export { getScriptInstance, getScriptInstancesByPath, getAllScriptInstances, callScriptMethod }'
-      )
+      expect(result.contents).toContain('export function getScriptInstance(')
+      expect(result.contents).toContain('export function getScriptInstancesByPath(')
+      expect(result.contents).toContain('export function getAllScriptInstances(')
+      expect(result.contents).toContain('export function callScriptMethod(')
       expect(result.watchFiles).toEqual([])
     })
 
@@ -156,9 +157,10 @@ describe('bundle script utilities', () => {
       expect(result.contents).toContain('export function _initializeScripts(engine)')
       expect(result.contents).toContain('const scriptsArray = []')
       expect(result.contents).toContain('return runScripts(engine, scriptsArray)')
-      expect(result.contents).toContain(
-        'export { getScriptInstance, getScriptInstancesByPath, getAllScriptInstances, callScriptMethod }'
-      )
+      expect(result.contents).toContain('export function getScriptInstance(')
+      expect(result.contents).toContain('export function getScriptInstancesByPath(')
+      expect(result.contents).toContain('export function getAllScriptInstances(')
+      expect(result.contents).toContain('export function callScriptMethod(')
       expect(result.watchFiles).toEqual([])
     })
 

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 102k
-  MALLOC_COUNT = 21131
-  ALIVE_OBJS_DELTA ~= 4.95k
+  OPCODES ~= 90k
+  MALLOC_COUNT = 18420
+  ALIVE_OBJS_DELTA ~= 4.47k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1301.17k bytes
+  MEMORY_USAGE_COUNT ~= 1183.11k bytes


### PR DESCRIPTION
The script-utils virtual module now inlines the runtime-script TypeScript source and loads it with the ts loader. The regex strip layer over compiled CJS is deleted; only the asset-packs specifier rewrite remains. The build copies runtime-script.ts into dist and build.spec.ts guards the copy. Scene bundles shrink 25KB because the asset-packs import becomes a tree-shakeable ESM import instead of a full CJS require.