### PR TITLE
fix(sdk-commands): replace the dist-cjs leaf import with a literal

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
+++ b/packages/@dcl/sdk-commands/src/logic/runtime-script.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
-import type { IEngine, Entity } from '@dcl/ecs'
-import { EntityState } from '@dcl/ecs/dist-cjs/engine/entity'
+import type { IEngine, Entity, EntityState } from '@dcl/ecs'
 import { type ActionRef, getActionEvents } from '@dcl/inspector/node_modules/@dcl/asset-packs'
 
 declare global {
@@ -48,8 +47,11 @@ type ScriptClassInstance = {
 type ScriptClass = new (src: string, entity: Entity, ...params: unknown[]) => ScriptClassInstance
 type ScriptsByPriority = Record<number, ScriptWithKey[]>
 
+// compiler-checked literal: the @dcl/ecs d.ts pins EntityState.Removed = 2, so drift fails this build with TS2322; a value import would embed ecs runtime code into every scene bundle
+const ENTITY_STATE_REMOVED: EntityState.Removed = 2
+
 function entityIsRemoved(engine: IEngine, entity: Entity) {
-  return engine.getEntityState(entity) === EntityState.Removed
+  return engine.getEntityState(entity) === ENTITY_STATE_REMOVED
 }
 
 /**

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 102k
-  MALLOC_COUNT = 21131
-  ALIVE_OBJS_DELTA ~= 4.95k
+  MALLOC_COUNT = 21031
+  ALIVE_OBJS_DELTA ~= 4.93k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1301.17k bytes
+  MEMORY_USAGE_COUNT ~= 1289.10k bytes


### PR DESCRIPTION
The embedded runtime script reached into @dcl/ecs build output, resolving against the scene-installed ecs and shipping a duplicate CJS closure in every scene bundle. The published d.ts pins EntityState.Removed = 2 as a literal, so a wrong value fails the CLI build with TS2322. Zero runtime ecs imports remain. with-main-function shrinks from 292.4k to 289.9k.