### PR TITLE
feat: deploy worlds with singleWorldScene instead of a client-side world delete

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/deploy/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/index.ts
@@ -145,8 +145,14 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
 
   options.components.analytics.track('Scene deploy started', trackProps)
 
+  // Whether this deploy will replace OTHER existing scenes in the world. Only then is the
+  // single_world_scene flag sent (which requires world-wide authority server-side) — a plain
+  // redeploy of a world with no other scenes stays a normal deploy that a per-parcel deployer can
+  // still make. The world's place is preserved either way: there is no world-wide delete anymore, so
+  // the flag only controls cleanup of the OTHER scenes, never whether the place survives.
+  let replaceExistingScenes = false
   // Deploying a world without --multi-scene replaces it with this single scene: the content server
-  // deploys this scene and then removes the others (see the singleWorldScene flag below). Warn about
+  // deploys this scene and then removes the others (see the single_world_scene flag below). Warn about
   // any other scenes that will be removed, but note the world — and its place — are preserved.
   if (isWorld && !multiScene && worldName) {
     try {
@@ -175,6 +181,8 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
               throw new CliError('DEPLOY_CANCELLED', 'Deployment cancelled by user.')
             }
           }
+
+          replaceExistingScenes = true
         }
       }
     } catch (e: any) {
@@ -295,7 +303,7 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
       // A default (non-multi-scene) world deploy replaces the world with just this scene. Send the
       // singleWorldScene flag so the content server does that server-side (deploy, then per-scene
       // undeploy of the others) — which preserves the world's place and its bound env variables.
-      const singleWorldScene = isWorld && !multiScene
+      const singleWorldScene = isWorld && !multiScene && replaceExistingScenes
       const response = (
         singleWorldScene
           ? await deployWithSingleWorldScene(client, deployData, url, 600000)

--- a/packages/@dcl/sdk-commands/src/commands/deploy/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/index.ts
@@ -16,8 +16,7 @@ import {
   getAddressAndSignature,
   getCatalyst,
   sceneHasWorldCfg,
-  buildDeleteScenesFromWorldPayload,
-  deleteWorldScenes,
+  deployWithSingleWorldScene,
   fetchWorldScenes,
   getScenesOnOtherParcels,
   checkWorldDeploymentPermission,
@@ -28,7 +27,6 @@ import { getValidWorkspace } from '../../logic/workspace-validations'
 import { LinkerResponse } from '../../linker-dapp/routes'
 import { analyticsFeatures } from './analytics-features'
 import { getInstalledPackageVersion } from '../../logic/config'
-import { drainResponse } from '../../logic/fetch'
 
 interface Options {
   args: Result<typeof args>
@@ -147,7 +145,9 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
 
   options.components.analytics.track('Scene deploy started', trackProps)
 
-  let needsDelete = false
+  // Deploying a world without --multi-scene replaces it with this single scene: the content server
+  // deploys this scene and then removes the others (see the singleWorldScene flag below). Warn about
+  // any other scenes that will be removed, but note the world — and its place — are preserved.
   if (isWorld && !multiScene && worldName) {
     try {
       const existingScenes = await fetchWorldScenes(options.components.logger, worldName, targetContent)
@@ -157,7 +157,8 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
 
         if (scenesOnOtherParcels.length > 0) {
           options.components.logger.warn(
-            `World "${worldName}" has ${scenesOnOtherParcels.length} other scene(s) that will be removed:`
+            `World "${worldName}" has ${scenesOnOtherParcels.length} other scene(s) that will be removed ` +
+              `(the world and its place are preserved; use --multi-scene to keep them):`
           )
 
           for (const scene of scenesOnOtherParcels) {
@@ -167,9 +168,6 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
           }
 
           options.components.logger.log('')
-          options.components.logger.warn(
-            'Deploying without --multi-scene will DELETE all existing scenes in world first.'
-          )
 
           if (!autoYes) {
             const confirmed = await promptUser('Continue? (y/N) ')
@@ -177,7 +175,6 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
               throw new CliError('DEPLOY_CANCELLED', 'Deployment cancelled by user.')
             }
           }
-          needsDelete = true
         }
       }
     } catch (e: any) {
@@ -209,9 +206,8 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
 
   const messageToSign = entityId
 
-  const deleteScenesFromWorldPayload =
-    needsDelete && worldName ? buildDeleteScenesFromWorldPayload(worldName) : undefined
-
+  // Single-scene world replacement now happens server-side (via the singleWorldScene deploy flag), so
+  // the client no longer signs a separate world-delete payload — a plain deploy signature is enough.
   const awaitResponse = future<void>()
   const { program } = await getAddressAndSignature(
     options.components,
@@ -226,7 +222,7 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
       isHttps: !!options.args['--https']
     },
     deployEntity,
-    deleteScenesFromWorldPayload,
+    undefined,
     targetContent,
     multiScene
   )
@@ -285,45 +281,6 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
     // Uploading data
     const { client, url } = await getCatalyst(chainId, options.args['--target'], options.args['--target-content'])
 
-    if (needsDelete && worldName && !linkerResponse.deleteSignature) {
-      throw new CliError(
-        'DEPLOY_DELETE_FAILED',
-        `Cannot delete existing scenes from "${worldName}": missing signature for deleting the scenes.`
-      )
-    }
-
-    if (needsDelete && worldName && linkerResponse.deleteSignature) {
-      options.components.logger.info(`[DEPLOY] deleting scenes for "${worldName}"`)
-
-      try {
-        const deleteResponse = await deleteWorldScenes(
-          options.components,
-          worldName,
-          linkerResponse.deleteSignature,
-          targetContent
-        )
-
-        if (deleteResponse.ok) {
-          await drainResponse(deleteResponse)
-          options.components.logger.info(`[DEPLOY] existing scenes for "${worldName} deleted successfully"`)
-        } else {
-          const errorText = await deleteResponse.text()
-          options.components.logger.info(`[DEPLOY] DELETE FAILED: status=${deleteResponse.status} body=${errorText}`)
-          throw new CliError(
-            'DEPLOY_DELETE_FAILED',
-            `Failed to delete existing scenes from "${worldName}" (status ${deleteResponse.status}): ${errorText}\n`
-          )
-        }
-      } catch (e: any) {
-        if (e instanceof CliError) throw e
-        throw new CliError(
-          'DEPLOY_DELETE_FAILED',
-          `Error deleting existing scenes from "${worldName}": ${e.message}\n` +
-            `Hint: Use --multi-scene to deploy alongside existing scenes without deleting them.`
-        )
-      }
-    }
-
     printProgressInfo(options.components.logger, `Uploading data to: ${url}...`)
 
     const deployData = { entityId, files: entityFiles, authChain }
@@ -335,9 +292,15 @@ export async function main(options: Options): Promise<ProgrammaticDeployResult |
     const sceneUrl = `${domain}/?NETWORK=${network}&position=${position}${worldRealm}`
 
     try {
-      const response = (await client.deploy(deployData, {
-        timeout: 600000
-      })) as any
+      // A default (non-multi-scene) world deploy replaces the world with just this scene. Send the
+      // singleWorldScene flag so the content server does that server-side (deploy, then per-scene
+      // undeploy of the others) — which preserves the world's place and its bound env variables.
+      const singleWorldScene = isWorld && !multiScene
+      const response = (
+        singleWorldScene
+          ? await deployWithSingleWorldScene(client, deployData, url, 600000)
+          : await client.deploy(deployData, { timeout: 600000 })
+      ) as any
 
       let responseData
 

--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -113,7 +113,9 @@ export async function deployWithSingleWorldScene(
   contentUrl: string,
   timeout: number
 ): Promise<undici.Response> {
-  const form = await client.buildEntityFormDataForDeployment(deployData)
+  // Pass the timeout through so the internal hashesAlreadyOnServer check is bounded too, matching
+  // client.deploy (which forwards its request options into buildEntityFormDataForDeployment).
+  const form = await client.buildEntityFormDataForDeployment(deployData, { timeout })
   const url = `${contentUrl.replace(/\/$/, '')}/entities?single_world_scene=true`
   return createFetchComponent().fetch(url, { method: 'POST', body: form as any, timeout })
 }

--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -105,7 +105,7 @@ export async function getCatalyst(
  * world is never emptied, so its place — and any env variables bound to that place's id — is preserved.
  *
  * `client.deploy` POSTs to a fixed `/entities` URL and cannot carry a query param, so this builds the
- * same multipart deployment form the client would and POSTs it to `/entities?singleWorldScene=true`.
+ * same multipart deployment form the client would and POSTs it to `/entities?single_world_scene=true`.
  */
 export async function deployWithSingleWorldScene(
   client: ContentClient,
@@ -114,7 +114,7 @@ export async function deployWithSingleWorldScene(
   timeout: number
 ): Promise<undici.Response> {
   const form = await client.buildEntityFormDataForDeployment(deployData)
-  const url = `${contentUrl.replace(/\/$/, '')}/entities?singleWorldScene=true`
+  const url = `${contentUrl.replace(/\/$/, '')}/entities?single_world_scene=true`
   return createFetchComponent().fetch(url, { method: 'POST', body: form as any, timeout })
 }
 

--- a/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
+++ b/packages/@dcl/sdk-commands/src/commands/deploy/utils.ts
@@ -1,6 +1,5 @@
 import * as readline from 'readline'
 import { ChainId, Scene } from '@dcl/schemas'
-import { AuthChain } from '@dcl/crypto'
 import { Lifecycle } from '@well-known-components/interfaces'
 import { createCatalystClient, createContentClient, CatalystClient, ContentClient } from 'dcl-catalyst-client'
 import { getCatalystServersFromCache } from 'dcl-catalyst-client/dist/contracts-snapshots'
@@ -99,42 +98,24 @@ export async function getCatalyst(
   }
 }
 
-export function buildDeleteScenesFromWorldPayload(worldName: string): string {
-  const encodedName = encodeURIComponent(worldName)
-  const path = `/entities/${encodedName}`
-  const timestamp = String(Date.now())
-  const metadata = '{}'
-  return ['delete', path, timestamp, metadata].join(':').toLowerCase()
-}
-
-export async function deleteWorldScenes(
-  components: Pick<CliComponents, 'logger'>,
-  worldName: string,
-  deleteSignature: string,
-  targetContent?: string
-): Promise<Response> {
-  const { logger } = components
-
-  const encodedName = encodeURIComponent(worldName)
-  const deleteUrl = `${targetContent}/entities/${encodedName}`
-
-  const authChain: AuthChain = JSON.parse(deleteSignature)
-  const lastLink = authChain[authChain.length - 1]
-  const payloadParts = lastLink.payload.split(':')
-  const timestamp = payloadParts[2] || String(Date.now())
-  const metadata = payloadParts[3] || '{}'
-
-  const headers: Record<string, string> = {
-    'x-identity-timestamp': timestamp,
-    'x-identity-metadata': metadata
-  }
-  authChain.forEach((link, i) => {
-    headers[`x-identity-auth-chain-${i}`] = JSON.stringify(link)
-  })
-
-  const response = await fetch(deleteUrl, { method: 'DELETE', headers })
-  logger.info(`[DELETE] deleting world scenes status=${response.status}`)
-  return response
+/**
+ * Deploys a scene to a world with the `singleWorldScene` flag. This tells the worlds content server to
+ * replace the whole world with just this scene: it deploys the scene and then removes any OTHER scenes
+ * via a per-scene undeployment. Unlike the previous "delete the whole world, then redeploy" flow, the
+ * world is never emptied, so its place — and any env variables bound to that place's id — is preserved.
+ *
+ * `client.deploy` POSTs to a fixed `/entities` URL and cannot carry a query param, so this builds the
+ * same multipart deployment form the client would and POSTs it to `/entities?singleWorldScene=true`.
+ */
+export async function deployWithSingleWorldScene(
+  client: ContentClient,
+  deployData: Parameters<ContentClient['buildEntityFormDataForDeployment']>[0],
+  contentUrl: string,
+  timeout: number
+): Promise<undici.Response> {
+  const form = await client.buildEntityFormDataForDeployment(deployData)
+  const url = `${contentUrl.replace(/\/$/, '')}/entities?singleWorldScene=true`
+  return createFetchComponent().fetch(url, { method: 'POST', body: form as any, timeout })
 }
 
 export async function getAddressAndSignature(


### PR DESCRIPTION
## Summary

Changes a default (non-`--multi-scene`) world deploy from a **client-side world-wide delete + reupload** to a single, server-side **single-scene replacement**, so a redeploy no longer tears down the world's place (and orphans anything bound to its `placeId` — notably the world's env variables in `world-storage-service`).

## Background

Today a world deploy without `--multi-scene`:
1. deletes every existing scene via the world-wide undeploy (`DELETE /entities/:worldName`), then
2. uploads the new scene.

Step 1 publishes a `WorldUndeploymentEvent`; the places service reacts by disabling **all** of the world's places. The redeploy then mints a **new `placeId`**, and because `world-storage-service` keys env vars by `placeId`, the world's env vars (Discord webhooks, analytics tokens, …) are silently orphaned (reads 404).

## Change

Send the new `?single_world_scene=true` flag on the deploy. The content server then deploys this scene and removes only the **other** scenes via a **per-scene** undeploy (`WorldScenesUndeploymentEvent`, never `WorldUndeploymentEvent`). The world is never emptied, its place keeps its id, and env vars survive.

Client-side this **removes the world-wide delete entirely**:
- gone: `buildDeleteScenesFromWorldPayload`, `deleteWorldScenes`, and the separate **delete signature** — a plain deploy signature is enough, so **no linker-dapp change** is needed.
- `client.deploy` POSTs to a fixed `/entities` URL and can't carry a query param, so `deployWithSingleWorldScene` builds the same multipart deployment form the client would and POSTs it to `/entities?single_world_scene=true`.
- the pre-deploy warning listing other scenes that will be removed is kept, now noting the **world and its place are preserved** (and to use `--multi-scene` to keep them).

`--multi-scene` (additive, no removal) and Genesis City deploys are unchanged. The query param is named `single_world_scene` to match the worlds-content-server convention for multi-word query params (`authorized_deployer`, `has_deployed_scenes`); the JS variable stays camelCase.

## Requires

`@dcl/worlds-content-server` with `single_world_scene` support: **decentraland/worlds-content-server#509**. Until that ships, the flag is simply ignored by the server (the deploy still succeeds; it just won't clean up other scenes — and no longer tears down the place either).

## Testing

- `tsc` and eslint clean for the package.
- The deploy command has no unit tests in this repo (only a `scene.json` fixture); verified by type-checking + manual reasoning. End-to-end behavior is covered on the content-server side in #509.
