### PR TITLE
feat: storage cache, unchanged-write skipping, memoized storage URL

### DIFF
--- a/packages/@dcl/sdk/src/server/index.ts
+++ b/packages/@dcl/sdk/src/server/index.ts
@@ -4,6 +4,7 @@ export {
   IStorage,
   ISceneStorage,
   IPlayerStorage,
+  GetOptions,
   GetValuesOptions,
   GetValuesResult,
   SetOptions,

--- a/packages/@dcl/sdk/src/server/index.ts
+++ b/packages/@dcl/sdk/src/server/index.ts
@@ -1,2 +1,11 @@
 export { EnvVar } from './env-var'
-export { Storage, IStorage, ISceneStorage, IPlayerStorage, GetValuesOptions, GetValuesResult } from './storage'
+export {
+  Storage,
+  IStorage,
+  ISceneStorage,
+  IPlayerStorage,
+  GetValuesOptions,
+  GetValuesResult,
+  SetOptions,
+  StorageOptions
+} from './storage'

--- a/packages/@dcl/sdk/src/server/storage-url.ts
+++ b/packages/@dcl/sdk/src/server/storage-url.ts
@@ -3,16 +3,7 @@ import { getRealm } from '~system/Runtime'
 const STORAGE_SERVER_ORG = 'https://storage.decentraland.org'
 const STORAGE_SERVER_ZONE = 'https://storage.decentraland.zone'
 
-/**
- * Determines the correct storage server URL based on the current realm.
- *
- * - If `isPreview` is true, uses the realm's baseUrl (localhost)
- * - If the realm's baseUrl contains `.zone`, uses storage.decentraland.zone
- * - Otherwise, uses storage.decentraland.org (production)
- *
- * @returns The storage server base URL
- */
-export async function getStorageServerUrl(): Promise<string> {
+async function resolveStorageServerUrl(): Promise<string> {
   const { realmInfo } = await getRealm({})
 
   if (!realmInfo) {
@@ -31,4 +22,28 @@ export async function getStorageServerUrl(): Promise<string> {
 
   // Production environment
   return STORAGE_SERVER_ORG
+}
+
+let memoizedUrl: Promise<string> | null = null
+
+/**
+ * Determines the correct storage server URL based on the current realm.
+ *
+ * - If `isPreview` is true, uses the realm's baseUrl (localhost)
+ * - If the realm's baseUrl contains `.zone`, uses storage.decentraland.zone
+ * - Otherwise, uses storage.decentraland.org (production)
+ *
+ * The realm never changes mid-session, so the result is memoized; a failed
+ * resolution is not memoized so transient getRealm errors can be retried.
+ *
+ * @returns The storage server base URL
+ */
+export function getStorageServerUrl(): Promise<string> {
+  if (!memoizedUrl) {
+    memoizedUrl = resolveStorageServerUrl()
+    memoizedUrl.catch(() => {
+      memoizedUrl = null
+    })
+  }
+  return memoizedUrl
 }

--- a/packages/@dcl/sdk/src/server/storage/constants.ts
+++ b/packages/@dcl/sdk/src/server/storage/constants.ts
@@ -20,3 +20,52 @@ export interface GetValuesResult {
     total: number
   }
 }
+
+/**
+ * Per-call options for Storage set().
+ */
+export interface SetOptions {
+  /**
+   * When true, skips the network write if the serialized value matches the
+   * last value known to be stored for this key (from a previous successful
+   * set() or get()). Overrides the configured default. Default: false.
+   */
+  skipIfUnchanged?: boolean
+}
+
+/**
+ * Module-wide configuration for Storage, applied to both scene-scoped and
+ * player-scoped storage via Storage.configure().
+ */
+export interface StorageOptions {
+  /** Default for set()'s skipIfUnchanged when not passed per call. Default: false. */
+  skipIfUnchanged?: boolean
+  /** Max cached value fingerprints per scope (scene / player) before oldest entries are evicted. Default: 512. */
+  cacheMaxEntries?: number
+  /** Max age of a cache entry in milliseconds; older entries are treated as unknown ("changed"). Default: 300000 (5 minutes). */
+  cacheMaxAgeMs?: number
+}
+
+/**
+ * Fully-resolved storage configuration shared by scene and player storage.
+ * @internal
+ */
+export interface StorageConfigState {
+  skipIfUnchanged: boolean
+  cacheMaxEntries: number
+  cacheMaxAgeMs: number
+}
+
+export const DEFAULT_STORAGE_CONFIG: Readonly<StorageConfigState> = {
+  skipIfUnchanged: false,
+  cacheMaxEntries: 512,
+  cacheMaxAgeMs: 5 * 60 * 1000
+}
+
+/**
+ * Creates a mutable config object, later mutated by Storage.configure().
+ * @internal
+ */
+export function createStorageConfig(overrides?: StorageOptions): StorageConfigState {
+  return { ...DEFAULT_STORAGE_CONFIG, ...overrides }
+}

--- a/packages/@dcl/sdk/src/server/storage/constants.ts
+++ b/packages/@dcl/sdk/src/server/storage/constants.ts
@@ -22,13 +22,25 @@ export interface GetValuesResult {
 }
 
 /**
+ * Per-call options for Storage get().
+ */
+export interface GetOptions {
+  /**
+   * When true, bypasses the read cache and forces a network read (the result
+   * still refreshes the cache). Concurrent gets for the same key still share
+   * one in-flight request. Default: false.
+   */
+  fresh?: boolean
+}
+
+/**
  * Per-call options for Storage set().
  */
 export interface SetOptions {
   /**
    * When true, skips the network write if the serialized value matches the
    * last value known to be stored for this key (from a previous successful
-   * set() or get()). Overrides the configured default. Default: false.
+   * set() or get()). Overrides the configured default. Default: true.
    */
   skipIfUnchanged?: boolean
 }
@@ -38,11 +50,31 @@ export interface SetOptions {
  * player-scoped storage via Storage.configure().
  */
 export interface StorageOptions {
-  /** Default for set()'s skipIfUnchanged when not passed per call. Default: false. */
+  /**
+   * Default for set()'s skipIfUnchanged when not passed per call. A skip only
+   * suppresses a proven no-op: the exact serialized value was confirmed stored
+   * by a previous network round-trip within cacheMaxAgeMs. Default: true.
+   */
   skipIfUnchanged?: boolean
-  /** Max cached value fingerprints per scope (scene / player) before oldest entries are evicted. Default: 512. */
+  /**
+   * When true, get() serves values from the local cache within cacheMaxAgeMs,
+   * including confirmed "not found" results, without a network request.
+   * Out-of-band writers (e.g. CLI storage commands) may not be visible for up
+   * to cacheMaxAgeMs; pass { fresh: true } per call to force a network read.
+   * Default: true.
+   */
+  cacheReads?: boolean
+  /**
+   * Max cache entries per scope (scene / player) before oldest entries are
+   * evicted. Entries hold the serialized value body, so memory scales with
+   * value size — this bounds entry count, not bytes. Default: 512.
+   */
   cacheMaxEntries?: number
-  /** Max age of a cache entry in milliseconds; older entries are treated as unknown ("changed"). Default: 300000 (5 minutes). */
+  /**
+   * Max age of a cache entry in milliseconds, bounding both read-cache
+   * staleness and write-dedup trust; older entries are treated as unknown.
+   * Default: 900000 (15 minutes).
+   */
   cacheMaxAgeMs?: number
 }
 
@@ -52,14 +84,16 @@ export interface StorageOptions {
  */
 export interface StorageConfigState {
   skipIfUnchanged: boolean
+  cacheReads: boolean
   cacheMaxEntries: number
   cacheMaxAgeMs: number
 }
 
 export const DEFAULT_STORAGE_CONFIG: Readonly<StorageConfigState> = {
-  skipIfUnchanged: false,
+  skipIfUnchanged: true,
+  cacheReads: true,
   cacheMaxEntries: 512,
-  cacheMaxAgeMs: 5 * 60 * 1000
+  cacheMaxAgeMs: 15 * 60 * 1000
 }
 
 /**

--- a/packages/@dcl/sdk/src/server/storage/constants.ts
+++ b/packages/@dcl/sdk/src/server/storage/constants.ts
@@ -73,7 +73,9 @@ export interface StorageOptions {
   /**
    * Max age of a cache entry in milliseconds, bounding both read-cache
    * staleness and write-dedup trust; older entries are treated as unknown.
-   * Default: 900000 (15 minutes).
+   * The default is deliberately short so out-of-band writers (CLI storage
+   * commands, dashboards) become visible within a minute, while still
+   * absorbing hot per-frame reads. Default: 60000 (1 minute).
    */
   cacheMaxAgeMs?: number
 }
@@ -97,7 +99,7 @@ export const DEFAULT_STORAGE_CONFIG: Readonly<StorageConfigState> = {
   skipIfUnchanged: true,
   cacheReads: true,
   cacheMaxEntries: 512,
-  cacheMaxAgeMs: 15 * 60 * 1000
+  cacheMaxAgeMs: 60 * 1000
 }
 
 /**

--- a/packages/@dcl/sdk/src/server/storage/constants.ts
+++ b/packages/@dcl/sdk/src/server/storage/constants.ts
@@ -89,6 +89,10 @@ export interface StorageConfigState {
   cacheMaxAgeMs: number
 }
 
+/**
+ * Default values for the resolved storage configuration.
+ * @internal
+ */
 export const DEFAULT_STORAGE_CONFIG: Readonly<StorageConfigState> = {
   skipIfUnchanged: true,
   cacheReads: true,

--- a/packages/@dcl/sdk/src/server/storage/index.ts
+++ b/packages/@dcl/sdk/src/server/storage/index.ts
@@ -1,8 +1,9 @@
+import { createStorageConfig, StorageOptions } from './constants'
 import { createSceneStorage, ISceneStorage } from './scene'
 import { createPlayerStorage, IPlayerStorage } from './player'
 
 // Re-export interfaces and types
-export { GetValuesOptions, GetValuesResult } from './constants'
+export { GetValuesOptions, GetValuesResult, SetOptions, StorageOptions } from './constants'
 export { ISceneStorage } from './scene'
 export { IPlayerStorage } from './player'
 
@@ -12,14 +13,22 @@ export { IPlayerStorage } from './player'
 export interface IStorage extends ISceneStorage {
   /** Player-scoped storage for key-value pairs */
   player: IPlayerStorage
+
+  /**
+   * Sets module-wide defaults for both scene-scoped and player-scoped storage.
+   * Merges the given partial options into the current configuration.
+   * Note: cacheMaxEntries applies per scope (scene and player each keep their own cache).
+   */
+  configure(options: StorageOptions): void
 }
 
 /**
  * Creates the Storage module with scene-scoped and player-scoped storage.
  */
 const createStorage = (): IStorage => {
-  const sceneStorage = createSceneStorage()
-  const playerStorage = createPlayerStorage()
+  const config = createStorageConfig()
+  const sceneStorage = createSceneStorage(config)
+  const playerStorage = createPlayerStorage(config)
 
   return {
     // Spread scene storage methods at top level
@@ -28,7 +37,10 @@ const createStorage = (): IStorage => {
     delete: sceneStorage.delete,
     getValues: sceneStorage.getValues,
     // Keep player as nested property
-    player: playerStorage
+    player: playerStorage,
+    configure(options: StorageOptions): void {
+      Object.assign(config, options)
+    }
   }
 }
 
@@ -38,6 +50,7 @@ const createStorage = (): IStorage => {
  *
  * - Use Storage.get/set/delete/getValues for scene-scoped storage
  * - Use Storage.player.get/set/delete/getValues for player-scoped storage
+ * - Use Storage.configure to change module-wide defaults (e.g. skipIfUnchanged)
  *
  * This module only works when running on server-side scenes.
  */

--- a/packages/@dcl/sdk/src/server/storage/index.ts
+++ b/packages/@dcl/sdk/src/server/storage/index.ts
@@ -3,7 +3,7 @@ import { createSceneStorage, ISceneStorage } from './scene'
 import { createPlayerStorage, IPlayerStorage } from './player'
 
 // Re-export interfaces and types
-export { GetValuesOptions, GetValuesResult, SetOptions, StorageOptions } from './constants'
+export { GetOptions, GetValuesOptions, GetValuesResult, SetOptions, StorageOptions } from './constants'
 export { ISceneStorage } from './scene'
 export { IPlayerStorage } from './player'
 
@@ -17,7 +17,9 @@ export interface IStorage extends ISceneStorage {
   /**
    * Sets module-wide defaults for both scene-scoped and player-scoped storage.
    * Merges the given partial options into the current configuration.
-   * Note: cacheMaxEntries applies per scope (scene and player each keep their own cache).
+   * Note: cacheMaxEntries applies per scope (scene and player each keep their
+   * own cache) and bounds entry count, not bytes (entries hold serialized
+   * value bodies).
    */
   configure(options: StorageOptions): void
 }
@@ -50,7 +52,18 @@ const createStorage = (): IStorage => {
  *
  * - Use Storage.get/set/delete/getValues for scene-scoped storage
  * - Use Storage.player.get/set/delete/getValues for player-scoped storage
- * - Use Storage.configure to change module-wide defaults (e.g. skipIfUnchanged)
+ * - Use Storage.configure to change module-wide defaults (e.g. skipIfUnchanged, cacheReads)
+ *
+ * Reads are cached by default: get() serves values known from a network
+ * round-trip within the last cacheMaxAgeMs (including confirmed "not found"
+ * results) without hitting the service, and concurrent gets for the same key
+ * share one request. Writes are never deferred — set()/delete() always reach
+ * the service; by default (skipIfUnchanged) an unchanged set is skipped, but
+ * only when a previous confirmed round-trip proved the exact value is already
+ * stored. Out-of-band writers (e.g. CLI storage commands)
+ * may not be visible for up to cacheMaxAgeMs; use get(key, { fresh: true })
+ * for an authoritative read or Storage.configure({ cacheReads: false }) to
+ * disable read caching.
  *
  * This module only works when running on server-side scenes.
  */

--- a/packages/@dcl/sdk/src/server/storage/index.ts
+++ b/packages/@dcl/sdk/src/server/storage/index.ts
@@ -41,7 +41,9 @@ const createStorage = (): IStorage => {
     // Keep player as nested property
     player: playerStorage,
     configure(options: StorageOptions): void {
-      Object.assign(config, options)
+      for (const [key, value] of Object.entries(options)) {
+        if (value !== undefined) (config as unknown as Record<string, unknown>)[key] = value
+      }
     }
   }
 }
@@ -57,10 +59,12 @@ const createStorage = (): IStorage => {
  * Reads are cached by default: get() serves values known from a network
  * round-trip within the last cacheMaxAgeMs (including confirmed "not found"
  * results) without hitting the service, and concurrent gets for the same key
- * share one request. Writes are never deferred — set()/delete() always reach
- * the service; by default (skipIfUnchanged) an unchanged set is skipped, but
- * only when a previous confirmed round-trip proved the exact value is already
- * stored. Out-of-band writers (e.g. CLI storage commands)
+ * share one request. Overlapping writes to the same key are serialized so the
+ * service commits them in issue order, and rapid writes coalesce to the
+ * latest value; every set()/delete() resolves once its value (or the newer
+ * value that superseded it) is durably applied. By default (skipIfUnchanged)
+ * an unchanged set is skipped, but only when a previous confirmed round-trip
+ * proved the exact value is already stored. Out-of-band writers (e.g. CLI storage commands)
  * may not be visible for up to cacheMaxAgeMs; use get(key, { fresh: true })
  * for an authoritative read or Storage.configure({ cacheReads: false }) to
  * disable read caching.

--- a/packages/@dcl/sdk/src/server/storage/player.ts
+++ b/packages/@dcl/sdk/src/server/storage/player.ts
@@ -2,6 +2,7 @@ import { getStorageServerUrl } from '../storage-url'
 import { assertIsServer, wrapSignedFetch } from '../utils'
 import {
   createStorageConfig,
+  GetOptions,
   GetValuesOptions,
   GetValuesResult,
   MODULE_NAME,
@@ -17,11 +18,18 @@ import { createValueCache, fingerprint } from './value-cache'
 export interface IPlayerStorage {
   /**
    * Retrieves a value from a player's storage by key from the Server Side Storage service.
+   *
+   * By default (cacheReads), values read or written during the last cacheMaxAgeMs
+   * are served from a local cache without a network request, including confirmed
+   * "not found" results. Concurrent gets for the same player and key share one
+   * request. Out-of-band writers (e.g. CLI storage commands) may not be visible
+   * for up to cacheMaxAgeMs — pass { fresh: true } to force a network read.
    * @param address - The player's wallet address
    * @param key - The key to retrieve
+   * @param options - Optional { fresh } to bypass the read cache
    * @returns A promise that resolves to the parsed JSON value, or null if not found
    */
-  get<T = unknown>(address: string, key: string): Promise<T | null>
+  get<T = unknown>(address: string, key: string, options?: GetOptions): Promise<T | null>
 
   /**
    * Stores a value in a player's storage in the Server Side Storage service.
@@ -58,6 +66,10 @@ export interface IPlayerStorage {
  */
 export const createPlayerStorage = (config: StorageConfigState = createStorageConfig()): IPlayerStorage => {
   const cache = createValueCache(config)
+  // Each in-flight GET is tracked by a wrapper object whose identity marks
+  // ownership: set()/delete() drop the wrapper, detaching the pending GET so
+  // its stale response cannot overwrite the newer cache entry.
+  const inflightGets = new Map<string, { promise: Promise<unknown> }>()
 
   // Ethereum addresses are case-insensitive (checksum casing only), so
   // mixed-case callers must share the same cache entry. The NUL separator
@@ -65,36 +77,72 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
   const cacheKey = (address: string, key: string) => `${address.toLowerCase()}\u0000${key}`
 
   return {
-    async get<T = unknown>(address: string, key: string): Promise<T | null> {
+    async get<T = unknown>(address: string, key: string, options?: GetOptions): Promise<T | null> {
       assertIsServer(MODULE_NAME)
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+      const ck = cacheKey(address, key)
 
-      const [error, data] = await wrapSignedFetch<{ value: T }>({ url })
-
-      if (error) {
-        console.error(`Failed to get player storage value '${key}' for '${address}': ${error}`)
-        return null
+      if (config.cacheReads && !options?.fresh) {
+        const entry = cache.get(ck)
+        if (entry?.absent) return null
+        // Parse per hit so each caller gets a fresh object (no shared mutation).
+        if (entry?.body !== undefined) return JSON.parse(entry.body).value as T
       }
 
-      if (data && data.value !== undefined) {
-        // Same serialization shape as set()'s PUT body, so a read followed by
-        // an unchanged write can be skipped.
-        cache.set(cacheKey(address, key), fingerprint(JSON.stringify({ value: data.value })))
-      }
+      // Coalesce concurrent gets (even fresh ones: an in-flight response is
+      // milliseconds old, not TTL-stale) into a single network request.
+      const joined = inflightGets.get(ck)
+      if (joined) return joined.promise as Promise<T | null>
 
-      return data?.value ?? null
+      const inflight = {} as { promise: Promise<T | null> }
+      inflight.promise = (async () => {
+        try {
+          const baseUrl = await getStorageServerUrl()
+          const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+
+          const [error, data, status] = await wrapSignedFetch<{ value: T }>({ url })
+
+          const isOwner = inflightGets.get(ck) === inflight
+
+          if (error) {
+            // A confirmed 404 is a first-class "absent" outcome, not a failure.
+            if (status === 404) {
+              if (isOwner) cache.setAbsent(ck)
+              return null
+            }
+            console.error(`Failed to get player storage value '${key}' for '${address}': ${error}`)
+            return null
+          }
+
+          if (data && data.value !== undefined) {
+            // Same serialization shape as set()'s PUT body, so a read followed by
+            // an unchanged write can be skipped.
+            const body = JSON.stringify({ value: data.value })
+            if (isOwner) cache.set(ck, { print: fingerprint(body), body })
+            return data.value
+          }
+
+          // 200 with a missing value is ambiguous: neither a confirmed value
+          // nor a confirmed absence, so cache nothing.
+          return null
+        } finally {
+          if (inflightGets.get(ck) === inflight) inflightGets.delete(ck)
+        }
+      })()
+
+      inflightGets.set(ck, inflight)
+      return inflight.promise
     },
 
     async set<T = unknown>(address: string, key: string, value: T, options?: SetOptions): Promise<boolean> {
       assertIsServer(MODULE_NAME)
 
+      const ck = cacheKey(address, key)
       const body = JSON.stringify({ value })
       const print = fingerprint(body)
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(cacheKey(address, key)) === print) {
+      if (skipIfUnchanged && cache.get(ck)?.print === print) {
         return true
       }
 
@@ -112,26 +160,36 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
         }
       })
 
+      // Either way the entry changed server-side (or may have): detach any
+      // overlapping in-flight GET so its stale response is not cached.
+      inflightGets.delete(ck)
+
       if (error) {
+        // The PUT may have reached the server, so the cached body and
+        // fingerprint are no longer reliable.
+        cache.delete(ck)
         console.error(`Failed to set player storage value '${key}' for '${address}': ${error}`)
         return false
       }
 
-      cache.set(cacheKey(address, key), print)
+      cache.set(ck, { print, body })
       return true
     },
 
     async delete(address: string, key: string): Promise<boolean> {
       assertIsServer(MODULE_NAME)
 
+      const ck = cacheKey(address, key)
+
       // Invalidate even if the request fails: the DELETE may have reached the
       // server, and a stale "unchanged" skip would lose a future write.
-      cache.delete(cacheKey(address, key))
+      cache.delete(ck)
+      inflightGets.delete(ck)
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
 
-      const [error] = await wrapSignedFetch({
+      const [error, , status] = await wrapSignedFetch({
         url,
         init: {
           method: 'DELETE',
@@ -139,11 +197,17 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
         }
       })
 
+      // Detach again: a GET may have started while the DELETE was in flight.
+      inflightGets.delete(ck)
+
       if (error) {
+        // A 404 still confirms the key is absent server-side.
+        if (status === 404) cache.setAbsent(ck)
         console.error(`Failed to delete player storage value '${key}' for '${address}': ${error}`)
         return false
       }
 
+      cache.setAbsent(ck)
       return true
     },
 
@@ -179,6 +243,18 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
       }
 
       const data = response?.data ?? []
+
+      // Seed the per-key cache so subsequent get()/set() on returned keys can
+      // skip the network. Absence is never seeded (prefix/pagination make it
+      // non-authoritative). A page larger than cacheMaxEntries churns the
+      // cache; entries repopulate lazily.
+      for (const entry of data) {
+        if (entry.value !== undefined) {
+          const body = JSON.stringify({ value: entry.value })
+          cache.set(cacheKey(address, entry.key), { print: fingerprint(body), body })
+        }
+      }
+
       const requestedOffset = offset ?? 0
       const pagination = {
         offset: response?.pagination?.offset ?? requestedOffset,

--- a/packages/@dcl/sdk/src/server/storage/player.ts
+++ b/packages/@dcl/sdk/src/server/storage/player.ts
@@ -9,7 +9,7 @@ import {
   SetOptions,
   StorageConfigState
 } from './constants'
-import { createValueCache, fingerprint } from './value-cache'
+import { createValueCache } from './value-cache'
 
 /**
  * Player-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -118,7 +118,7 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
             // Same serialization shape as set()'s PUT body, so a read followed by
             // an unchanged write can be skipped.
             const body = JSON.stringify({ value: data.value })
-            if (isOwner) cache.set(ck, { print: fingerprint(body), body })
+            if (isOwner) cache.set(ck, { body })
             return data.value
           }
 
@@ -139,10 +139,9 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
 
       const ck = cacheKey(address, key)
       const body = JSON.stringify({ value })
-      const print = fingerprint(body)
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(ck)?.print === print) {
+      if (skipIfUnchanged && cache.get(ck)?.body === body) {
         return true
       }
 
@@ -165,14 +164,14 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
       inflightGets.delete(ck)
 
       if (error) {
-        // The PUT may have reached the server, so the cached body and
-        // fingerprint are no longer reliable.
+        // The PUT may have reached the server, so the cached body is no
+        // longer reliable.
         cache.delete(ck)
         console.error(`Failed to set player storage value '${key}' for '${address}': ${error}`)
         return false
       }
 
-      cache.set(ck, { print, body })
+      cache.set(ck, { body })
       return true
     },
 
@@ -250,8 +249,7 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
       // cache; entries repopulate lazily.
       for (const entry of data) {
         if (entry.value !== undefined) {
-          const body = JSON.stringify({ value: entry.value })
-          cache.set(cacheKey(address, entry.key), { print: fingerprint(body), body })
+          cache.set(cacheKey(address, entry.key), { body: JSON.stringify({ value: entry.value }) })
         }
       }
 

--- a/packages/@dcl/sdk/src/server/storage/player.ts
+++ b/packages/@dcl/sdk/src/server/storage/player.ts
@@ -1,6 +1,14 @@
 import { getStorageServerUrl } from '../storage-url'
 import { assertIsServer, wrapSignedFetch } from '../utils'
-import { GetValuesOptions, GetValuesResult, MODULE_NAME } from './constants'
+import {
+  createStorageConfig,
+  GetValuesOptions,
+  GetValuesResult,
+  MODULE_NAME,
+  SetOptions,
+  StorageConfigState
+} from './constants'
+import { createValueCache, fingerprint } from './value-cache'
 
 /**
  * Player-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -20,9 +28,10 @@ export interface IPlayerStorage {
    * @param address - The player's wallet address
    * @param key - The key to store the value under
    * @param value - The value to store (will be JSON serialized)
+   * @param options - Optional { skipIfUnchanged } to skip the network write when the value is already stored
    * @returns A promise that resolves to true if successful, false otherwise
    */
-  set<T = unknown>(address: string, key: string, value: T): Promise<boolean>
+  set<T = unknown>(address: string, key: string, value: T, options?: SetOptions): Promise<boolean>
 
   /**
    * Deletes a value from a player's storage in the Server Side Storage service.
@@ -47,7 +56,14 @@ export interface IPlayerStorage {
  * player-specific key-value pairs from the Server Side Storage service.
  * This module only works when running on server-side scenes.
  */
-export const createPlayerStorage = (): IPlayerStorage => {
+export const createPlayerStorage = (config: StorageConfigState = createStorageConfig()): IPlayerStorage => {
+  const cache = createValueCache(config)
+
+  // Ethereum addresses are case-insensitive (checksum casing only), so
+  // mixed-case callers must share the same cache entry. The NUL separator
+  // cannot appear in an address, making the pair unambiguous.
+  const cacheKey = (address: string, key: string) => `${address.toLowerCase()}\u0000${key}`
+
   return {
     async get<T = unknown>(address: string, key: string): Promise<T | null> {
       assertIsServer(MODULE_NAME)
@@ -62,11 +78,25 @@ export const createPlayerStorage = (): IPlayerStorage => {
         return null
       }
 
+      if (data && data.value !== undefined) {
+        // Same serialization shape as set()'s PUT body, so a read followed by
+        // an unchanged write can be skipped.
+        cache.set(cacheKey(address, key), fingerprint(JSON.stringify({ value: data.value })))
+      }
+
       return data?.value ?? null
     },
 
-    async set<T = unknown>(address: string, key: string, value: T): Promise<boolean> {
+    async set<T = unknown>(address: string, key: string, value: T, options?: SetOptions): Promise<boolean> {
       assertIsServer(MODULE_NAME)
+
+      const body = JSON.stringify({ value })
+      const print = fingerprint(body)
+      const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
+
+      if (skipIfUnchanged && cache.get(cacheKey(address, key)) === print) {
+        return true
+      }
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
@@ -78,7 +108,7 @@ export const createPlayerStorage = (): IPlayerStorage => {
           headers: {
             'content-type': 'application/json'
           },
-          body: JSON.stringify({ value })
+          body
         }
       })
 
@@ -87,11 +117,16 @@ export const createPlayerStorage = (): IPlayerStorage => {
         return false
       }
 
+      cache.set(cacheKey(address, key), print)
       return true
     },
 
     async delete(address: string, key: string): Promise<boolean> {
       assertIsServer(MODULE_NAME)
+
+      // Invalidate even if the request fails: the DELETE may have reached the
+      // server, and a stale "unchanged" skip would lose a future write.
+      cache.delete(cacheKey(address, key))
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`

--- a/packages/@dcl/sdk/src/server/storage/player.ts
+++ b/packages/@dcl/sdk/src/server/storage/player.ts
@@ -10,6 +10,7 @@ import {
   StorageConfigState
 } from './constants'
 import { createValueCache } from './value-cache'
+import { createWriteQueue } from './write-queue'
 
 /**
  * Player-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -77,6 +78,69 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
   // cannot appear in an address, making the pair unambiguous.
   const cacheKey = (address: string, key: string) => `${address.toLowerCase()}\u0000${key}`
 
+  // Writes to the same player key are serialized (and rapid ones coalesced to
+  // the latest value) so the service commits them in issue order — overlapping
+  // PUTs would otherwise leave both the kept value and the cached value to
+  // response-order chance. Keyed by the same case-insensitive cache key.
+  const writes = createWriteQueue()
+
+  async function executeSet(address: string, key: string, ck: string, body: string): Promise<boolean> {
+    const baseUrl = await getStorageServerUrl()
+    const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+
+    const [error] = await wrapSignedFetch({
+      url,
+      init: {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body
+      }
+    })
+
+    // Either way the entry changed server-side (or may have): detach any
+    // overlapping in-flight GET so its stale response is not cached.
+    inflightGets.delete(ck)
+
+    if (error) {
+      // The PUT may have reached the server, so the cached body is no
+      // longer reliable.
+      cache.delete(ck)
+      console.error(`Failed to set player storage value '${key}' for '${address}': ${error}`)
+      return false
+    }
+
+    cache.set(ck, { body })
+    return true
+  }
+
+  async function executeDelete(address: string, key: string, ck: string): Promise<boolean> {
+    const baseUrl = await getStorageServerUrl()
+    const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+
+    const [error, , status] = await wrapSignedFetch({
+      url,
+      init: {
+        method: 'DELETE',
+        headers: {}
+      }
+    })
+
+    // Detach again: a GET may have started while the DELETE was in flight.
+    inflightGets.delete(ck)
+
+    if (error) {
+      // A 404 still confirms the key is absent server-side.
+      if (status === 404) cache.setAbsent(ck)
+      console.error(`Failed to delete player storage value '${key}' for '${address}': ${error}`)
+      return false
+    }
+
+    cache.setAbsent(ck)
+    return true
+  }
+
   return {
     async get<T = unknown>(address: string, key: string, options?: GetOptions): Promise<T | null> {
       assertIsServer(MODULE_NAME)
@@ -142,38 +206,14 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
       const body = JSON.stringify({ value })
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(ck)?.body === body) {
+      // Dedup against confirmed state only while no write is pending — a
+      // pending write makes the cache momentarily stale; enqueue() coalesces
+      // against pending writes instead.
+      if (skipIfUnchanged && writes.pending(ck) === undefined && cache.get(ck)?.body === body) {
         return true
       }
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
-
-      const [error] = await wrapSignedFetch({
-        url,
-        init: {
-          method: 'PUT',
-          headers: {
-            'content-type': 'application/json'
-          },
-          body
-        }
-      })
-
-      // Either way the entry changed server-side (or may have): detach any
-      // overlapping in-flight GET so its stale response is not cached.
-      inflightGets.delete(ck)
-
-      if (error) {
-        // The PUT may have reached the server, so the cached body is no
-        // longer reliable.
-        cache.delete(ck)
-        console.error(`Failed to set player storage value '${key}' for '${address}': ${error}`)
-        return false
-      }
-
-      cache.set(ck, { body })
-      return true
+      return writes.enqueue(ck, body, (b) => executeSet(address, key, ck, b as string), skipIfUnchanged)
     },
 
     async delete(address: string, key: string): Promise<boolean> {
@@ -181,34 +221,13 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
 
       const ck = cacheKey(address, key)
 
-      // Invalidate even if the request fails: the DELETE may have reached the
-      // server, and a stale "unchanged" skip would lose a future write.
+      // Invalidate immediately — even while the DELETE waits behind other
+      // writes, reads must not serve the doomed value, and a stale
+      // "unchanged" skip would lose a future write.
       cache.delete(ck)
       inflightGets.delete(ck)
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
-
-      const [error, , status] = await wrapSignedFetch({
-        url,
-        init: {
-          method: 'DELETE',
-          headers: {}
-        }
-      })
-
-      // Detach again: a GET may have started while the DELETE was in flight.
-      inflightGets.delete(ck)
-
-      if (error) {
-        // A 404 still confirms the key is absent server-side.
-        if (status === 404) cache.setAbsent(ck)
-        console.error(`Failed to delete player storage value '${key}' for '${address}': ${error}`)
-        return false
-      }
-
-      cache.setAbsent(ck)
-      return true
+      return writes.enqueue(ck, null, () => executeDelete(address, key, ck), true)
     },
 
     async getValues(address: string, options?: GetValuesOptions): Promise<GetValuesResult> {
@@ -245,12 +264,16 @@ export const createPlayerStorage = (config: StorageConfigState = createStorageCo
       const data = response?.data ?? []
 
       // Seed the per-key cache so subsequent get()/set() on returned keys can
-      // skip the network. Absence is never seeded (prefix/pagination make it
-      // non-authoritative). A page larger than cacheMaxEntries churns the
-      // cache; entries repopulate lazily.
+      // skip the network. Only keys with no live entry and no pending write
+      // are seeded: existing per-key state comes from a confirmed operation
+      // that this page snapshot — whose request started earlier — must not
+      // clobber with stale data. Absence is never seeded (prefix/pagination
+      // make it non-authoritative). A page larger than cacheMaxEntries churns
+      // the cache; entries repopulate lazily.
       for (const entry of data) {
-        if (entry.value !== undefined) {
-          cache.set(cacheKey(address, entry.key), { body: JSON.stringify({ value: entry.value }) })
+        const ck = cacheKey(address, entry.key)
+        if (entry.value !== undefined && !writes.isPending(ck) && cache.get(ck) === undefined) {
+          cache.set(ck, { body: JSON.stringify({ value: entry.value }) })
         }
       }
 

--- a/packages/@dcl/sdk/src/server/storage/player.ts
+++ b/packages/@dcl/sdk/src/server/storage/player.ts
@@ -63,6 +63,7 @@ export interface IPlayerStorage {
  * Creates player-scoped storage that provides methods to interact with
  * player-specific key-value pairs from the Server Side Storage service.
  * This module only works when running on server-side scenes.
+ * @internal
  */
 export const createPlayerStorage = (config: StorageConfigState = createStorageConfig()): IPlayerStorage => {
   const cache = createValueCache(config)

--- a/packages/@dcl/sdk/src/server/storage/scene.ts
+++ b/packages/@dcl/sdk/src/server/storage/scene.ts
@@ -1,6 +1,14 @@
 import { getStorageServerUrl } from '../storage-url'
 import { assertIsServer, wrapSignedFetch } from '../utils'
-import { GetValuesOptions, GetValuesResult, MODULE_NAME } from './constants'
+import {
+  createStorageConfig,
+  GetValuesOptions,
+  GetValuesResult,
+  MODULE_NAME,
+  SetOptions,
+  StorageConfigState
+} from './constants'
+import { createValueCache, fingerprint } from './value-cache'
 
 /**
  * Scene-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -18,8 +26,9 @@ export interface ISceneStorage {
    * Stores a value in scene storage in the Server Side Storage service.
    * @param key - The key to store the value under
    * @param value - The value to store (will be JSON serialized)
+   * @param options - Optional { skipIfUnchanged } to skip the network write when the value is already stored
    */
-  set<T = unknown>(key: string, value: T): Promise<boolean>
+  set<T = unknown>(key: string, value: T, options?: SetOptions): Promise<boolean>
 
   /**
    * Deletes a value from scene storage in the Server Side Storage service.
@@ -42,7 +51,9 @@ export interface ISceneStorage {
  * scene-specific key-value pairs from the Server Side Storage service.
  * This module only works when running on server-side scenes.
  */
-export const createSceneStorage = (): ISceneStorage => {
+export const createSceneStorage = (config: StorageConfigState = createStorageConfig()): ISceneStorage => {
+  const cache = createValueCache(config)
+
   return {
     async get<T = unknown>(key: string): Promise<T | null> {
       assertIsServer(MODULE_NAME)
@@ -57,11 +68,25 @@ export const createSceneStorage = (): ISceneStorage => {
         return null
       }
 
+      if (data && data.value !== undefined) {
+        // Same serialization shape as set()'s PUT body, so a read followed by
+        // an unchanged write can be skipped.
+        cache.set(key, fingerprint(JSON.stringify({ value: data.value })))
+      }
+
       return data?.value ?? null
     },
 
-    async set<T = unknown>(key: string, value: T): Promise<boolean> {
+    async set<T = unknown>(key: string, value: T, options?: SetOptions): Promise<boolean> {
       assertIsServer(MODULE_NAME)
+
+      const body = JSON.stringify({ value })
+      const print = fingerprint(body)
+      const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
+
+      if (skipIfUnchanged && cache.get(key) === print) {
+        return true
+      }
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/values/${encodeURIComponent(key)}`
@@ -73,7 +98,7 @@ export const createSceneStorage = (): ISceneStorage => {
           headers: {
             'content-type': 'application/json'
           },
-          body: JSON.stringify({ value })
+          body
         }
       })
 
@@ -82,11 +107,16 @@ export const createSceneStorage = (): ISceneStorage => {
         return false
       }
 
+      cache.set(key, print)
       return true
     },
 
     async delete(key: string): Promise<boolean> {
       assertIsServer(MODULE_NAME)
+
+      // Invalidate even if the request fails: the DELETE may have reached the
+      // server, and a stale "unchanged" skip would lose a future write.
+      cache.delete(key)
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/values/${encodeURIComponent(key)}`

--- a/packages/@dcl/sdk/src/server/storage/scene.ts
+++ b/packages/@dcl/sdk/src/server/storage/scene.ts
@@ -2,6 +2,7 @@ import { getStorageServerUrl } from '../storage-url'
 import { assertIsServer, wrapSignedFetch } from '../utils'
 import {
   createStorageConfig,
+  GetOptions,
   GetValuesOptions,
   GetValuesResult,
   MODULE_NAME,
@@ -17,10 +18,17 @@ import { createValueCache, fingerprint } from './value-cache'
 export interface ISceneStorage {
   /**
    * Retrieves a value from scene storage by key from the Server Side Storage service.
+   *
+   * By default (cacheReads), values read or written during the last cacheMaxAgeMs
+   * are served from a local cache without a network request, including confirmed
+   * "not found" results. Concurrent gets for the same key share one request.
+   * Out-of-band writers (e.g. CLI storage commands) may not be visible for up to
+   * cacheMaxAgeMs — pass { fresh: true } to force a network read.
    * @param key - The key to retrieve
+   * @param options - Optional { fresh } to bypass the read cache
    * @returns A promise that resolves to the parsed JSON value, or null if not found
    */
-  get<T = unknown>(key: string): Promise<T | null>
+  get<T = unknown>(key: string, options?: GetOptions): Promise<T | null>
 
   /**
    * Stores a value in scene storage in the Server Side Storage service.
@@ -53,28 +61,65 @@ export interface ISceneStorage {
  */
 export const createSceneStorage = (config: StorageConfigState = createStorageConfig()): ISceneStorage => {
   const cache = createValueCache(config)
+  // Each in-flight GET is tracked by a wrapper object whose identity marks
+  // ownership: set()/delete() drop the wrapper, detaching the pending GET so
+  // its stale response cannot overwrite the newer cache entry.
+  const inflightGets = new Map<string, { promise: Promise<unknown> }>()
 
   return {
-    async get<T = unknown>(key: string): Promise<T | null> {
+    async get<T = unknown>(key: string, options?: GetOptions): Promise<T | null> {
       assertIsServer(MODULE_NAME)
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/values/${encodeURIComponent(key)}`
-
-      const [error, data] = await wrapSignedFetch<{ value: T }>({ url })
-
-      if (error) {
-        console.error(`Failed to get storage value '${key}': ${error}`)
-        return null
+      if (config.cacheReads && !options?.fresh) {
+        const entry = cache.get(key)
+        if (entry?.absent) return null
+        // Parse per hit so each caller gets a fresh object (no shared mutation).
+        if (entry?.body !== undefined) return JSON.parse(entry.body).value as T
       }
 
-      if (data && data.value !== undefined) {
-        // Same serialization shape as set()'s PUT body, so a read followed by
-        // an unchanged write can be skipped.
-        cache.set(key, fingerprint(JSON.stringify({ value: data.value })))
-      }
+      // Coalesce concurrent gets (even fresh ones: an in-flight response is
+      // milliseconds old, not TTL-stale) into a single network request.
+      const joined = inflightGets.get(key)
+      if (joined) return joined.promise as Promise<T | null>
 
-      return data?.value ?? null
+      const inflight = {} as { promise: Promise<T | null> }
+      inflight.promise = (async () => {
+        try {
+          const baseUrl = await getStorageServerUrl()
+          const url = `${baseUrl}/values/${encodeURIComponent(key)}`
+
+          const [error, data, status] = await wrapSignedFetch<{ value: T }>({ url })
+
+          const isOwner = inflightGets.get(key) === inflight
+
+          if (error) {
+            // A confirmed 404 is a first-class "absent" outcome, not a failure.
+            if (status === 404) {
+              if (isOwner) cache.setAbsent(key)
+              return null
+            }
+            console.error(`Failed to get storage value '${key}': ${error}`)
+            return null
+          }
+
+          if (data && data.value !== undefined) {
+            // Same serialization shape as set()'s PUT body, so a read followed by
+            // an unchanged write can be skipped.
+            const body = JSON.stringify({ value: data.value })
+            if (isOwner) cache.set(key, { print: fingerprint(body), body })
+            return data.value
+          }
+
+          // 200 with a missing value is ambiguous: neither a confirmed value
+          // nor a confirmed absence, so cache nothing.
+          return null
+        } finally {
+          if (inflightGets.get(key) === inflight) inflightGets.delete(key)
+        }
+      })()
+
+      inflightGets.set(key, inflight)
+      return inflight.promise
     },
 
     async set<T = unknown>(key: string, value: T, options?: SetOptions): Promise<boolean> {
@@ -84,7 +129,7 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       const print = fingerprint(body)
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(key) === print) {
+      if (skipIfUnchanged && cache.get(key)?.print === print) {
         return true
       }
 
@@ -102,12 +147,19 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
         }
       })
 
+      // Either way the entry changed server-side (or may have): detach any
+      // overlapping in-flight GET so its stale response is not cached.
+      inflightGets.delete(key)
+
       if (error) {
+        // The PUT may have reached the server, so the cached body and
+        // fingerprint are no longer reliable.
+        cache.delete(key)
         console.error(`Failed to set storage value '${key}': ${error}`)
         return false
       }
 
-      cache.set(key, print)
+      cache.set(key, { print, body })
       return true
     },
 
@@ -117,11 +169,12 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       // Invalidate even if the request fails: the DELETE may have reached the
       // server, and a stale "unchanged" skip would lose a future write.
       cache.delete(key)
+      inflightGets.delete(key)
 
       const baseUrl = await getStorageServerUrl()
       const url = `${baseUrl}/values/${encodeURIComponent(key)}`
 
-      const [error] = await wrapSignedFetch({
+      const [error, , status] = await wrapSignedFetch({
         url,
         init: {
           method: 'DELETE',
@@ -129,11 +182,17 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
         }
       })
 
+      // Detach again: a GET may have started while the DELETE was in flight.
+      inflightGets.delete(key)
+
       if (error) {
+        // A 404 still confirms the key is absent server-side.
+        if (status === 404) cache.setAbsent(key)
         console.error(`Failed to delete storage value '${key}': ${error}`)
         return false
       }
 
+      cache.setAbsent(key)
       return true
     },
 
@@ -167,6 +226,18 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       }
 
       const data = response?.data ?? []
+
+      // Seed the per-key cache so subsequent get()/set() on returned keys can
+      // skip the network. Absence is never seeded (prefix/pagination make it
+      // non-authoritative). A page larger than cacheMaxEntries churns the
+      // cache; entries repopulate lazily.
+      for (const entry of data) {
+        if (entry.value !== undefined) {
+          const body = JSON.stringify({ value: entry.value })
+          cache.set(entry.key, { print: fingerprint(body), body })
+        }
+      }
+
       const requestedOffset = offset ?? 0
       const pagination = {
         offset: response?.pagination?.offset ?? requestedOffset,

--- a/packages/@dcl/sdk/src/server/storage/scene.ts
+++ b/packages/@dcl/sdk/src/server/storage/scene.ts
@@ -9,7 +9,7 @@ import {
   SetOptions,
   StorageConfigState
 } from './constants'
-import { createValueCache, fingerprint } from './value-cache'
+import { createValueCache } from './value-cache'
 
 /**
  * Scene-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -106,7 +106,7 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
             // Same serialization shape as set()'s PUT body, so a read followed by
             // an unchanged write can be skipped.
             const body = JSON.stringify({ value: data.value })
-            if (isOwner) cache.set(key, { print: fingerprint(body), body })
+            if (isOwner) cache.set(key, { body })
             return data.value
           }
 
@@ -126,10 +126,9 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       assertIsServer(MODULE_NAME)
 
       const body = JSON.stringify({ value })
-      const print = fingerprint(body)
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(key)?.print === print) {
+      if (skipIfUnchanged && cache.get(key)?.body === body) {
         return true
       }
 
@@ -152,14 +151,14 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       inflightGets.delete(key)
 
       if (error) {
-        // The PUT may have reached the server, so the cached body and
-        // fingerprint are no longer reliable.
+        // The PUT may have reached the server, so the cached body is no
+        // longer reliable.
         cache.delete(key)
         console.error(`Failed to set storage value '${key}': ${error}`)
         return false
       }
 
-      cache.set(key, { print, body })
+      cache.set(key, { body })
       return true
     },
 
@@ -233,8 +232,7 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       // cache; entries repopulate lazily.
       for (const entry of data) {
         if (entry.value !== undefined) {
-          const body = JSON.stringify({ value: entry.value })
-          cache.set(entry.key, { print: fingerprint(body), body })
+          cache.set(entry.key, { body: JSON.stringify({ value: entry.value }) })
         }
       }
 

--- a/packages/@dcl/sdk/src/server/storage/scene.ts
+++ b/packages/@dcl/sdk/src/server/storage/scene.ts
@@ -10,6 +10,7 @@ import {
   StorageConfigState
 } from './constants'
 import { createValueCache } from './value-cache'
+import { createWriteQueue } from './write-queue'
 
 /**
  * Scene-scoped storage interface for key-value pairs from the Server Side Storage service.
@@ -66,6 +67,68 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
   // ownership: set()/delete() drop the wrapper, detaching the pending GET so
   // its stale response cannot overwrite the newer cache entry.
   const inflightGets = new Map<string, { promise: Promise<unknown> }>()
+  // Writes to the same key are serialized (and rapid ones coalesced to the
+  // latest value) so the service commits them in issue order — overlapping
+  // PUTs would otherwise leave both the kept value and the cached value to
+  // response-order chance.
+  const writes = createWriteQueue()
+
+  async function executeSet(key: string, body: string): Promise<boolean> {
+    const baseUrl = await getStorageServerUrl()
+    const url = `${baseUrl}/values/${encodeURIComponent(key)}`
+
+    const [error] = await wrapSignedFetch({
+      url,
+      init: {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body
+      }
+    })
+
+    // Either way the entry changed server-side (or may have): detach any
+    // overlapping in-flight GET so its stale response is not cached.
+    inflightGets.delete(key)
+
+    if (error) {
+      // The PUT may have reached the server, so the cached body is no
+      // longer reliable.
+      cache.delete(key)
+      console.error(`Failed to set storage value '${key}': ${error}`)
+      return false
+    }
+
+    cache.set(key, { body })
+    return true
+  }
+
+  async function executeDelete(key: string): Promise<boolean> {
+    const baseUrl = await getStorageServerUrl()
+    const url = `${baseUrl}/values/${encodeURIComponent(key)}`
+
+    const [error, , status] = await wrapSignedFetch({
+      url,
+      init: {
+        method: 'DELETE',
+        headers: {}
+      }
+    })
+
+    // Detach again: a GET may have started while the DELETE was in flight.
+    inflightGets.delete(key)
+
+    if (error) {
+      // A 404 still confirms the key is absent server-side.
+      if (status === 404) cache.setAbsent(key)
+      console.error(`Failed to delete storage value '${key}': ${error}`)
+      return false
+    }
+
+    cache.setAbsent(key)
+    return true
+  }
 
   return {
     async get<T = unknown>(key: string, options?: GetOptions): Promise<T | null> {
@@ -129,71 +192,26 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       const body = JSON.stringify({ value })
       const skipIfUnchanged = options?.skipIfUnchanged ?? config.skipIfUnchanged
 
-      if (skipIfUnchanged && cache.get(key)?.body === body) {
+      // Dedup against confirmed state only while no write is pending — a
+      // pending write makes the cache momentarily stale; enqueue() coalesces
+      // against pending writes instead.
+      if (skipIfUnchanged && writes.pending(key) === undefined && cache.get(key)?.body === body) {
         return true
       }
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/values/${encodeURIComponent(key)}`
-
-      const [error] = await wrapSignedFetch({
-        url,
-        init: {
-          method: 'PUT',
-          headers: {
-            'content-type': 'application/json'
-          },
-          body
-        }
-      })
-
-      // Either way the entry changed server-side (or may have): detach any
-      // overlapping in-flight GET so its stale response is not cached.
-      inflightGets.delete(key)
-
-      if (error) {
-        // The PUT may have reached the server, so the cached body is no
-        // longer reliable.
-        cache.delete(key)
-        console.error(`Failed to set storage value '${key}': ${error}`)
-        return false
-      }
-
-      cache.set(key, { body })
-      return true
+      return writes.enqueue(key, body, (b) => executeSet(key, b as string), skipIfUnchanged)
     },
 
     async delete(key: string): Promise<boolean> {
       assertIsServer(MODULE_NAME)
 
-      // Invalidate even if the request fails: the DELETE may have reached the
-      // server, and a stale "unchanged" skip would lose a future write.
+      // Invalidate immediately — even while the DELETE waits behind other
+      // writes, reads must not serve the doomed value, and a stale
+      // "unchanged" skip would lose a future write.
       cache.delete(key)
       inflightGets.delete(key)
 
-      const baseUrl = await getStorageServerUrl()
-      const url = `${baseUrl}/values/${encodeURIComponent(key)}`
-
-      const [error, , status] = await wrapSignedFetch({
-        url,
-        init: {
-          method: 'DELETE',
-          headers: {}
-        }
-      })
-
-      // Detach again: a GET may have started while the DELETE was in flight.
-      inflightGets.delete(key)
-
-      if (error) {
-        // A 404 still confirms the key is absent server-side.
-        if (status === 404) cache.setAbsent(key)
-        console.error(`Failed to delete storage value '${key}': ${error}`)
-        return false
-      }
-
-      cache.setAbsent(key)
-      return true
+      return writes.enqueue(key, null, () => executeDelete(key), true)
     },
 
     async getValues(options?: GetValuesOptions): Promise<GetValuesResult> {
@@ -228,11 +246,14 @@ export const createSceneStorage = (config: StorageConfigState = createStorageCon
       const data = response?.data ?? []
 
       // Seed the per-key cache so subsequent get()/set() on returned keys can
-      // skip the network. Absence is never seeded (prefix/pagination make it
-      // non-authoritative). A page larger than cacheMaxEntries churns the
-      // cache; entries repopulate lazily.
+      // skip the network. Only keys with no live entry and no pending write
+      // are seeded: existing per-key state comes from a confirmed operation
+      // that this page snapshot — whose request started earlier — must not
+      // clobber with stale data. Absence is never seeded (prefix/pagination
+      // make it non-authoritative). A page larger than cacheMaxEntries churns
+      // the cache; entries repopulate lazily.
       for (const entry of data) {
-        if (entry.value !== undefined) {
+        if (entry.value !== undefined && !writes.isPending(entry.key) && cache.get(entry.key) === undefined) {
           cache.set(entry.key, { body: JSON.stringify({ value: entry.value }) })
         }
       }

--- a/packages/@dcl/sdk/src/server/storage/scene.ts
+++ b/packages/@dcl/sdk/src/server/storage/scene.ts
@@ -58,6 +58,7 @@ export interface ISceneStorage {
  * Creates scene-scoped storage that provides methods to interact with
  * scene-specific key-value pairs from the Server Side Storage service.
  * This module only works when running on server-side scenes.
+ * @internal
  */
 export const createSceneStorage = (config: StorageConfigState = createStorageConfig()): ISceneStorage => {
   const cache = createValueCache(config)

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -1,4 +1,4 @@
-import { StorageConfigState } from './constants'
+import { DEFAULT_STORAGE_CONFIG, StorageConfigState } from './constants'
 
 /**
  * 32-bit FNV-1a hash over a string. The scene runtime (QuickJS) has no native
@@ -61,7 +61,13 @@ export function createValueCache(config: StorageConfigState): ValueCache {
     entries.delete(key)
     entries.set(key, { ...entry, storedAt: Date.now() })
 
-    while (entries.size > config.cacheMaxEntries) {
+    // Guard against misconfiguration: a negative bound would loop forever on
+    // an empty map, and a NaN bound would silently disable eviction.
+    const maxEntries = Number.isFinite(config.cacheMaxEntries)
+      ? Math.max(0, config.cacheMaxEntries)
+      : DEFAULT_STORAGE_CONFIG.cacheMaxEntries
+
+    while (entries.size > maxEntries) {
       entries.delete(entries.keys().next().value!)
     }
   }

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -1,0 +1,72 @@
+import { StorageConfigState } from './constants'
+
+/**
+ * 32-bit FNV-1a hash over a string. The scene runtime (QuickJS) has no native
+ * crypto, so a cheap JS hash is used to fingerprint serialized values.
+ * @internal
+ */
+export function fnv1a(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+}
+
+/**
+ * Cheap fingerprint of a serialized body: fnv1a hash plus length. The length
+ * guards against hash collisions between same-key values.
+ * @internal
+ */
+export function fingerprint(serialized: string): string {
+  return `${fnv1a(serialized).toString(16)}:${serialized.length}`
+}
+
+/**
+ * Bounded, lazily-expiring cache of value fingerprints, used to skip storage
+ * writes whose value is already known to be stored.
+ * @internal
+ */
+export interface ValueCache {
+  /** Returns the stored fingerprint if present and fresh; lazily evicts expired entries. */
+  get(key: string): string | undefined
+  /** Stores or refreshes a fingerprint; evicts oldest entries beyond cacheMaxEntries. */
+  set(key: string, print: string): void
+  delete(key: string): void
+}
+
+export function createValueCache(config: StorageConfigState): ValueCache {
+  const entries = new Map<string, { print: string; storedAt: number }>()
+
+  return {
+    get(key: string): string | undefined {
+      const entry = entries.get(key)
+      if (!entry) return undefined
+
+      // Lazy max-age expiry: storedAt is never refreshed on hits, so the age
+      // bounds the time since the last actual network confirmation.
+      if (Date.now() - entry.storedAt > config.cacheMaxAgeMs) {
+        entries.delete(key)
+        return undefined
+      }
+
+      return entry.print
+    },
+
+    set(key: string, print: string): void {
+      // Delete + re-insert moves refreshed keys to the end of the Map's
+      // insertion order, so eviction below drops the least-recently-written.
+      entries.delete(key)
+      entries.set(key, { print, storedAt: Date.now() })
+
+      while (entries.size > config.cacheMaxEntries) {
+        entries.delete(entries.keys().next().value!)
+      }
+    },
+
+    delete(key: string): void {
+      entries.delete(key)
+    }
+  }
+}

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -24,23 +24,50 @@ export function fingerprint(serialized: string): string {
 }
 
 /**
- * Bounded, lazily-expiring cache of value fingerprints, used to skip storage
- * writes whose value is already known to be stored.
+ * A cached fact about a key's server-side state.
+ * @internal
+ */
+export interface CacheEntry {
+  /** Write-dedup fingerprint of the serialized body; absent for negative entries. */
+  print?: string
+  /** Serialized `{ value }` body; parsed per read hit so callers never share object references. */
+  body?: string
+  /** True when the server confirmed the key does not exist (GET 404 or successful DELETE). */
+  absent?: boolean
+}
+
+/**
+ * Bounded, lazily-expiring cache of key states, backing both write dedup
+ * (skip storage writes whose value is already known to be stored) and read
+ * caching (serve get() without a network request within the TTL).
  * @internal
  */
 export interface ValueCache {
-  /** Returns the stored fingerprint if present and fresh; lazily evicts expired entries. */
-  get(key: string): string | undefined
-  /** Stores or refreshes a fingerprint; evicts oldest entries beyond cacheMaxEntries. */
-  set(key: string, print: string): void
+  /** Returns the entry if present and fresh; lazily evicts expired entries. */
+  get(key: string): CacheEntry | undefined
+  /** Stores or refreshes a known value (fingerprint + serialized body); overwrites negative entries. */
+  set(key: string, entry: { print: string; body: string }): void
+  /** Stores a confirmed-absent (negative) entry, replacing any value entry. */
+  setAbsent(key: string): void
   delete(key: string): void
 }
 
 export function createValueCache(config: StorageConfigState): ValueCache {
-  const entries = new Map<string, { print: string; storedAt: number }>()
+  const entries = new Map<string, CacheEntry & { storedAt: number }>()
+
+  function insert(key: string, entry: CacheEntry): void {
+    // Delete + re-insert moves refreshed keys to the end of the Map's
+    // insertion order, so eviction below drops the least-recently-written.
+    entries.delete(key)
+    entries.set(key, { ...entry, storedAt: Date.now() })
+
+    while (entries.size > config.cacheMaxEntries) {
+      entries.delete(entries.keys().next().value!)
+    }
+  }
 
   return {
-    get(key: string): string | undefined {
+    get(key: string): CacheEntry | undefined {
       const entry = entries.get(key)
       if (!entry) return undefined
 
@@ -51,18 +78,15 @@ export function createValueCache(config: StorageConfigState): ValueCache {
         return undefined
       }
 
-      return entry.print
+      return entry
     },
 
-    set(key: string, print: string): void {
-      // Delete + re-insert moves refreshed keys to the end of the Map's
-      // insertion order, so eviction below drops the least-recently-written.
-      entries.delete(key)
-      entries.set(key, { print, storedAt: Date.now() })
+    set(key: string, entry: { print: string; body: string }): void {
+      insert(key, entry)
+    },
 
-      while (entries.size > config.cacheMaxEntries) {
-        entries.delete(entries.keys().next().value!)
-      }
+    setAbsent(key: string): void {
+      insert(key, { absent: true })
     },
 
     delete(key: string): void {

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -1,36 +1,15 @@
 import { DEFAULT_STORAGE_CONFIG, StorageConfigState } from './constants'
 
 /**
- * 32-bit FNV-1a hash over a string. The scene runtime (QuickJS) has no native
- * crypto, so a cheap JS hash is used to fingerprint serialized values.
- * @internal
- */
-export function fnv1a(input: string): number {
-  let hash = 0x811c9dc5
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i)
-    hash = Math.imul(hash, 0x01000193)
-  }
-  return hash >>> 0
-}
-
-/**
- * Cheap fingerprint of a serialized body: fnv1a hash plus length. The length
- * guards against hash collisions between same-key values.
- * @internal
- */
-export function fingerprint(serialized: string): string {
-  return `${fnv1a(serialized).toString(16)}:${serialized.length}`
-}
-
-/**
  * A cached fact about a key's server-side state.
  * @internal
  */
 export interface CacheEntry {
-  /** Write-dedup fingerprint of the serialized body; absent for negative entries. */
-  print?: string
-  /** Serialized `{ value }` body; parsed per read hit so callers never share object references. */
+  /**
+   * Serialized `{ value }` body; absent for negative entries. Parsed per read
+   * hit so callers never share object references, and compared verbatim for
+   * write dedup (exact equality — no hash-collision risk).
+   */
   body?: string
   /** True when the server confirmed the key does not exist (GET 404 or successful DELETE). */
   absent?: boolean
@@ -45,8 +24,8 @@ export interface CacheEntry {
 export interface ValueCache {
   /** Returns the entry if present and fresh; lazily evicts expired entries. */
   get(key: string): CacheEntry | undefined
-  /** Stores or refreshes a known value (fingerprint + serialized body); overwrites negative entries. */
-  set(key: string, entry: { print: string; body: string }): void
+  /** Stores or refreshes a known value (serialized body); overwrites negative entries. */
+  set(key: string, entry: { body: string }): void
   /** Stores a confirmed-absent (negative) entry, replacing any value entry. */
   setAbsent(key: string): void
   delete(key: string): void
@@ -87,7 +66,7 @@ export function createValueCache(config: StorageConfigState): ValueCache {
       return entry
     },
 
-    set(key: string, entry: { print: string; body: string }): void {
+    set(key: string, entry: { body: string }): void {
       insert(key, entry)
     },
 

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -60,9 +60,16 @@ export function createValueCache(config: StorageConfigState): ValueCache {
       const entry = entries.get(key)
       if (!entry) return undefined
 
+      // Guard against misconfiguration, mirroring cacheMaxEntries: a NaN
+      // bound would silently disable expiry (NaN comparisons are false).
+      // Negative values need no guard — they just expire everything.
+      const maxAgeMs = Number.isFinite(config.cacheMaxAgeMs)
+        ? config.cacheMaxAgeMs
+        : DEFAULT_STORAGE_CONFIG.cacheMaxAgeMs
+
       // Lazy max-age expiry: storedAt is never refreshed on hits, so the age
       // bounds the time since the last actual network confirmation.
-      if (Date.now() - entry.storedAt > config.cacheMaxAgeMs) {
+      if (Date.now() - entry.storedAt > maxAgeMs) {
         entries.delete(key)
         return undefined
       }

--- a/packages/@dcl/sdk/src/server/storage/value-cache.ts
+++ b/packages/@dcl/sdk/src/server/storage/value-cache.ts
@@ -31,6 +31,10 @@ export interface ValueCache {
   delete(key: string): void
 }
 
+/**
+ * Creates the bounded value cache shared by a storage scope.
+ * @internal
+ */
 export function createValueCache(config: StorageConfigState): ValueCache {
   const entries = new Map<string, CacheEntry & { storedAt: number }>()
 

--- a/packages/@dcl/sdk/src/server/storage/write-queue.ts
+++ b/packages/@dcl/sdk/src/server/storage/write-queue.ts
@@ -1,0 +1,131 @@
+/**
+ * A pending write operation. `body` is the serialized PUT payload, or null
+ * for a DELETE. Callers coalesced into the op share its promise.
+ * @internal
+ */
+interface PendingOp {
+  body: string | null
+  execute: (body: string | null) => Promise<boolean>
+  promise: Promise<boolean>
+  resolve: (result: boolean) => void
+}
+
+interface KeyState {
+  /** The op currently on the network. */
+  active: PendingOp
+  /** At most one queued op; later writes replace its payload (latest wins). */
+  queued?: PendingOp
+}
+
+/**
+ * Serializes writes per key so the service commits them in issue order.
+ * Overlapping PUTs from the single scene server would otherwise race: the
+ * server keeps whichever request it processes last, while the local cache
+ * keeps whichever response arrives last — either can disagree with the last
+ * set() issued. With at most one in-flight op per key and a single queued
+ * "latest value" slot, the server's final state always matches the last
+ * write issued, and N rapid writes collapse into at most 2 network calls.
+ * @internal
+ */
+export interface WriteQueue {
+  /**
+   * Body of the latest issued write for the key (the queued op if present,
+   * else the in-flight one): a string for a PUT, null for a DELETE,
+   * undefined when no write is pending.
+   */
+  pending(key: string): string | null | undefined
+  /** True while any write for the key is in flight or queued. */
+  isPending(key: string): boolean
+  /**
+   * Issues a write. If one is in flight, the new op is queued — replacing any
+   * already-queued op, whose callers then follow this op's outcome (their
+   * value was superseded before it could ever be observed). An op identical
+   * to the queued one joins it; `joinActive` additionally allows joining an
+   * identical in-flight op (only valid for dedup-tolerant callers, since that
+   * op was issued before this call).
+   */
+  enqueue(
+    key: string,
+    body: string | null,
+    execute: (body: string | null) => Promise<boolean>,
+    joinActive: boolean
+  ): Promise<boolean>
+}
+
+/**
+ * Creates the per-key write serializer shared by a storage scope.
+ * @internal
+ */
+export function createWriteQueue(): WriteQueue {
+  const keys = new Map<string, KeyState>()
+
+  function makeOp(body: string | null, execute: PendingOp['execute']): PendingOp {
+    let resolve!: (result: boolean) => void
+    const promise = new Promise<boolean>((r) => (resolve = r))
+    return { body, execute, promise, resolve }
+  }
+
+  async function drain(key: string, state: KeyState): Promise<void> {
+    for (;;) {
+      const op = state.active
+      let result = false
+      try {
+        result = await op.execute(op.body)
+      } catch {
+        // Executors report failures via their boolean result; a throw is
+        // unexpected but must not wedge the queue.
+      }
+      op.resolve(result)
+
+      if (state.queued) {
+        state.active = state.queued
+        state.queued = undefined
+      } else {
+        keys.delete(key)
+        return
+      }
+    }
+  }
+
+  return {
+    pending(key: string): string | null | undefined {
+      const state = keys.get(key)
+      if (!state) return undefined
+      return (state.queued ?? state.active).body
+    },
+
+    isPending(key: string): boolean {
+      return keys.has(key)
+    },
+
+    enqueue(key: string, body: string | null, execute: PendingOp['execute'], joinActive: boolean): Promise<boolean> {
+      const state = keys.get(key)
+
+      if (!state) {
+        const op = makeOp(body, execute)
+        const newState: KeyState = { active: op }
+        keys.set(key, newState)
+        void drain(key, newState)
+        return op.promise
+      }
+
+      if (state.queued) {
+        // A queued op has not started, so it is issued "after" this caller
+        // either way: join it when identical, supersede it otherwise.
+        if (state.queued.body !== body) {
+          state.queued.body = body
+          state.queued.execute = execute
+        }
+        return state.queued.promise
+      }
+
+      if (joinActive && state.active.body === body) {
+        return state.active.promise
+      }
+
+      const op = makeOp(body, execute)
+      state.queued = op
+      return op.promise
+    }
+  }
+}

--- a/packages/@dcl/sdk/src/server/utils.ts
+++ b/packages/@dcl/sdk/src/server/utils.ts
@@ -62,9 +62,12 @@ export async function wrapSignedFetch<T = unknown>(signedFetchBody: SignedFetchR
     return [errorMessage, null, response.status]
   }
 
-  const [parseError, body] = await tryCatch<T>(JSON.parse(response.body || '{}'))
-
-  if (parseError) {
+  let body: T
+  try {
+    // JSON.parse throws synchronously, so it can't be wrapped with tryCatch (the
+    // throw would happen while evaluating the argument, rejecting this promise).
+    body = JSON.parse(response.body || '{}')
+  } catch {
     console.error(`Failed to parse response from ${signedFetchBody.url}`)
     return ['Failed to parse response', null, response.status]
   }

--- a/test/sdk/server/storage-url.spec.ts
+++ b/test/sdk/server/storage-url.spec.ts
@@ -1,0 +1,76 @@
+const mockGetRealm = jest.fn()
+
+jest.mock('~system/Runtime', () => ({
+  getRealm: mockGetRealm
+}))
+
+describe('getStorageServerUrl', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetRealm.mockReset()
+  })
+
+  async function loadModule() {
+    return import('../../../packages/@dcl/sdk/src/server/storage-url')
+  }
+
+  function mockRealm(realmInfo: { isPreview: boolean; baseUrl: string } | undefined) {
+    mockGetRealm.mockResolvedValue({ realmInfo })
+  }
+
+  it('returns the realm baseUrl in preview mode', async () => {
+    mockRealm({ isPreview: true, baseUrl: 'http://localhost:8000' })
+    const { getStorageServerUrl } = await loadModule()
+    expect(await getStorageServerUrl()).toBe('http://localhost:8000')
+  })
+
+  it('returns the .zone storage server for staging realms', async () => {
+    mockRealm({ isPreview: false, baseUrl: 'https://realm.decentraland.zone' })
+    const { getStorageServerUrl } = await loadModule()
+    expect(await getStorageServerUrl()).toBe('https://storage.decentraland.zone')
+  })
+
+  it('returns the .org storage server for production realms', async () => {
+    mockRealm({ isPreview: false, baseUrl: 'https://realm.decentraland.org' })
+    const { getStorageServerUrl } = await loadModule()
+    expect(await getStorageServerUrl()).toBe('https://storage.decentraland.org')
+  })
+
+  it('throws when realm information is unavailable', async () => {
+    mockRealm(undefined)
+    const { getStorageServerUrl } = await loadModule()
+    await expect(getStorageServerUrl()).rejects.toThrow('Unable to retrieve realm information')
+  })
+
+  it('memoizes the resolved URL across sequential calls', async () => {
+    mockRealm({ isPreview: false, baseUrl: 'https://realm.decentraland.org' })
+    const { getStorageServerUrl } = await loadModule()
+
+    expect(await getStorageServerUrl()).toBe('https://storage.decentraland.org')
+    expect(await getStorageServerUrl()).toBe('https://storage.decentraland.org')
+
+    expect(mockGetRealm).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses concurrent first calls into a single getRealm request', async () => {
+    mockRealm({ isPreview: false, baseUrl: 'https://realm.decentraland.org' })
+    const { getStorageServerUrl } = await loadModule()
+
+    const [first, second] = await Promise.all([getStorageServerUrl(), getStorageServerUrl()])
+
+    expect(first).toBe('https://storage.decentraland.org')
+    expect(second).toBe('https://storage.decentraland.org')
+    expect(mockGetRealm).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not memoize failures, so a later call can retry', async () => {
+    mockGetRealm.mockRejectedValueOnce(new Error('network down'))
+    const { getStorageServerUrl } = await loadModule()
+
+    await expect(getStorageServerUrl()).rejects.toThrow('network down')
+
+    mockRealm({ isPreview: false, baseUrl: 'https://realm.decentraland.org' })
+    expect(await getStorageServerUrl()).toBe('https://storage.decentraland.org')
+    expect(mockGetRealm).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/sdk/server/storage/player-storage.spec.ts
+++ b/test/sdk/server/storage/player-storage.spec.ts
@@ -14,6 +14,7 @@ jest.mock('../../../../packages/@dcl/sdk/src/server/utils', () => ({
   wrapSignedFetch: (req: { url: string }) => mockWrapSignedFetch(req)
 }))
 
+import { createStorageConfig } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
 import { createPlayerStorage } from '../../../../packages/@dcl/sdk/src/server/storage/player'
 
 describe('player storage', () => {
@@ -88,6 +89,96 @@ describe('player storage', () => {
       const result = await playerStorage.getValues(address)
 
       expect(result).toEqual({ data: [], pagination: { offset: 0, total: 0 } })
+    })
+  })
+
+  describe('set', () => {
+    it('should PUT on every call by default, even for identical values', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      expect(await playerStorage.set(address, 'score', 42)).toBe(true)
+      expect(await playerStorage.set(address, 'score', 42)).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledWith({
+        url: `${baseUrl}/players/${encodeURIComponent(address)}/values/score`,
+        init: {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ value: 42 })
+        }
+      })
+    })
+
+    it('should skip the PUT for an unchanged value when skipIfUnchanged is passed', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      expect(await playerStorage.set(address, 'score', 42, { skipIfUnchanged: true })).toBe(true)
+      expect(await playerStorage.set(address, 'score', 42, { skipIfUnchanged: true })).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not dedupe across different addresses', async () => {
+      const playerStorage = createPlayerStorage()
+      const otherAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await playerStorage.set(address, 'score', 42, { skipIfUnchanged: true })
+      await playerStorage.set(otherAddress, 'score', 42, { skipIfUnchanged: true })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should dedupe addresses case-insensitively', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await playerStorage.set('0xAbCdefAbcdEFabcdefabcdefabcdefabcdefabcd', 'score', 42, { skipIfUnchanged: true })
+      await playerStorage.set('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd', 'score', 42, { skipIfUnchanged: true })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should dedupe by configured default and allow a per-call false to force the PUT', async () => {
+      const playerStorage = createPlayerStorage(createStorageConfig({ skipIfUnchanged: true }))
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await playerStorage.set(address, 'score', 42)
+      await playerStorage.set(address, 'score', 42)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+      await playerStorage.set(address, 'score', 42, { skipIfUnchanged: false })
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('get and set interplay', () => {
+    it('should populate the cache from get so an unchanged write is skipped', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: { hp: 100 } }])
+
+      expect(await playerStorage.get(address, 'state')).toEqual({ hp: 100 })
+      expect(await playerStorage.set(address, 'state', { hp: 100 }, { skipIfUnchanged: true })).toBe(true)
+
+      // Only the GET hit the network.
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('delete', () => {
+    it('should invalidate the cache so a later identical set writes again', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await playerStorage.set(address, 'score', 42, { skipIfUnchanged: true })
+      expect(await playerStorage.delete(address, 'score')).toBe(true)
+      await playerStorage.set(address, 'score', 42, { skipIfUnchanged: true })
+
+      // set + delete + set all hit the network.
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/test/sdk/server/storage/player-storage.spec.ts
+++ b/test/sdk/server/storage/player-storage.spec.ts
@@ -93,14 +93,14 @@ describe('player storage', () => {
   })
 
   describe('set', () => {
-    it('should PUT on every call by default, even for identical values', async () => {
+    it('should skip the PUT for an unchanged value by default', async () => {
       const playerStorage = createPlayerStorage()
       mockWrapSignedFetch.mockResolvedValue([null, {}])
 
       expect(await playerStorage.set(address, 'score', 42)).toBe(true)
       expect(await playerStorage.set(address, 'score', 42)).toBe(true)
 
-      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
       expect(mockWrapSignedFetch).toHaveBeenCalledWith({
         url: `${baseUrl}/players/${encodeURIComponent(address)}/values/score`,
         init: {
@@ -179,6 +179,94 @@ describe('player storage', () => {
 
       // set + delete + set all hit the network.
       expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('get read caching', () => {
+    function deferred<T>() {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>((r) => (resolve = r))
+      return { promise, resolve }
+    }
+
+    it('should serve a repeated get from cache', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: { hp: 100 } }, 200])
+
+      expect(await playerStorage.get(address, 'state')).toEqual({ hp: 100 })
+      expect(await playerStorage.get(address, 'state')).toEqual({ hp: 100 })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should bypass the cache with fresh: true and refresh it with the result', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 'A' }, 200])
+      expect(await playerStorage.get(address, 'key')).toBe('A')
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 'B' }, 200])
+      expect(await playerStorage.get(address, 'key', { fresh: true })).toBe('B')
+
+      expect(await playerStorage.get(address, 'key')).toBe('B')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should cache a confirmed 404 as absent', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce(['404 Not Found', null, 404])
+
+      expect(await playerStorage.get(address, 'missing')).toBeNull()
+      expect(await playerStorage.get(address, 'missing')).toBeNull()
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should serve null from the negative cache after a successful delete', async () => {
+      const playerStorage = createPlayerStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      expect(await playerStorage.get(address, 'key')).toBe(1)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await playerStorage.delete(address, 'key')).toBe(true)
+
+      expect(await playerStorage.get(address, 'key')).toBeNull()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should coalesce concurrent gets case-insensitively per address, never across addresses', async () => {
+      const playerStorage = createPlayerStorage()
+      const mixedCaseAddress = '0xAbCdefAbcdEFabcdefabcdefabcdefabcdefabcd'
+      const lowerCaseAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const request = deferred<[null, { value: number }, number]>()
+      const otherRequest = deferred<[null, { value: number }, number]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => request.promise)
+      mockWrapSignedFetch.mockImplementationOnce(() => otherRequest.promise)
+
+      const gets = Promise.all([
+        playerStorage.get(mixedCaseAddress, 'key'),
+        playerStorage.get(lowerCaseAddress, 'key'),
+        playerStorage.get(address, 'key')
+      ])
+      request.resolve([null, { value: 1 }, 200])
+      otherRequest.resolve([null, { value: 2 }, 200])
+
+      expect(await gets).toEqual([1, 1, 2])
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should seed the per-key cache from getValues, scoped to the address', async () => {
+      const playerStorage = createPlayerStorage()
+      const otherAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { data: [{ key: 'a', value: 1 }] }])
+
+      await playerStorage.getValues(address)
+      expect(await playerStorage.get(address, 'a')).toBe(1)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+      // The seed for one address must not serve another address's reads.
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 2 }, 200])
+      expect(await playerStorage.get(otherAddress, 'a')).toBe(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/test/sdk/server/storage/player-storage.spec.ts
+++ b/test/sdk/server/storage/player-storage.spec.ts
@@ -182,6 +182,75 @@ describe('player storage', () => {
     })
   })
 
+  describe('write serialization', () => {
+    function deferred<T>() {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>((r) => (resolve = r))
+      return { promise, resolve }
+    }
+    const flush = () => new Promise((r) => setTimeout(r, 0))
+
+    it('should serialize overlapping sets per player key and coalesce to the latest value', async () => {
+      const playerStorage = createPlayerStorage()
+      const firstPut = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => firstPut.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const results = Promise.all([
+        playerStorage.set(address, 'key', 1),
+        playerStorage.set(address, 'key', 2),
+        playerStorage.set(address, 'key', 3)
+      ])
+      await flush()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+      firstPut.resolve([null, {}])
+
+      expect(await results).toEqual([true, true, true])
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenLastCalledWith(
+        expect.objectContaining({ init: expect.objectContaining({ body: JSON.stringify({ value: 3 }) }) })
+      )
+
+      expect(await playerStorage.get(address, 'key')).toBe(3)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should serialize writes case-insensitively across address casings', async () => {
+      const playerStorage = createPlayerStorage()
+      const firstPut = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => firstPut.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const first = playerStorage.set(address, 'key', 1)
+      const second = playerStorage.set(address.toUpperCase().replace('0X', '0x'), 'key', 2)
+      await flush()
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+      firstPut.resolve([null, {}])
+
+      expect(await first).toBe(true)
+      expect(await second).toBe(true)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not let a stale getValues page overwrite a newer write', async () => {
+      const playerStorage = createPlayerStorage()
+      const list = deferred<[null, { data: Array<{ key: string; value: unknown }> }]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => list.promise)
+
+      const listing = playerStorage.getValues(address)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await playerStorage.set(address, 'a', 'new')
+
+      list.resolve([null, { data: [{ key: 'a', value: 'stale' }] }])
+      await listing
+
+      expect(await playerStorage.get(address, 'a')).toBe('new')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('get read caching', () => {
     function deferred<T>() {
       let resolve!: (value: T) => void

--- a/test/sdk/server/storage/scene-storage.spec.ts
+++ b/test/sdk/server/storage/scene-storage.spec.ts
@@ -93,14 +93,14 @@ describe('scene storage', () => {
   })
 
   describe('set', () => {
-    it('should PUT on every call by default, even for identical values', async () => {
+    it('should skip the PUT for an unchanged value by default', async () => {
       const storage = createSceneStorage()
       mockWrapSignedFetch.mockResolvedValue([null, {}])
 
       expect(await storage.set('score', 42)).toBe(true)
       expect(await storage.set('score', 42)).toBe(true)
 
-      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
       expect(mockWrapSignedFetch).toHaveBeenCalledWith({
         url: `${baseUrl}/values/score`,
         init: {
@@ -224,6 +224,225 @@ describe('scene storage', () => {
       await storage.set('score', 42, { skipIfUnchanged: true })
 
       expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('get read caching', () => {
+    function deferred<T>() {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>((r) => (resolve = r))
+      return { promise, resolve }
+    }
+
+    it('should serve a repeated get from cache with fresh objects per hit', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: { hp: 100 } }, 200])
+
+      const first = await storage.get<{ hp: number }>('player-state')
+      const second = await storage.get<{ hp: number }>('player-state')
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+      expect(second).toEqual(first)
+      expect(second).not.toBe(first)
+
+      // Mutating a returned object must not leak into later cache hits.
+      first!.hp = 1
+      expect(await storage.get('player-state')).toEqual({ hp: 100 })
+    })
+
+    it('should re-fetch once the cached entry exceeds cacheMaxAgeMs', async () => {
+      const storage = createSceneStorage(createStorageConfig({ cacheMaxAgeMs: 1000 }))
+      mockWrapSignedFetch.mockResolvedValue([null, { value: 1 }, 200])
+      const nowSpy = jest.spyOn(Date, 'now')
+
+      try {
+        nowSpy.mockReturnValue(10_000)
+        await storage.get('score')
+
+        nowSpy.mockReturnValue(11_500)
+        await storage.get('score')
+
+        expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      } finally {
+        nowSpy.mockRestore()
+      }
+    })
+
+    it('should bypass the cache with fresh: true and refresh it with the result', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 'A' }, 200])
+
+      expect(await storage.get('key')).toBe('A')
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 'B' }, 200])
+      expect(await storage.get('key', { fresh: true })).toBe('B')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+
+      // The fresh read refreshed the cache, so a plain get serves B locally.
+      expect(await storage.get('key')).toBe('B')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should coalesce concurrent gets for the same key into one request', async () => {
+      const storage = createSceneStorage()
+      const request = deferred<[null, { value: string }, number]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => request.promise)
+
+      const gets = Promise.all([storage.get('key'), storage.get('key'), storage.get('key')])
+      request.resolve([null, { value: 'shared' }, 200])
+
+      expect(await gets).toEqual(['shared', 'shared', 'shared'])
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should let a fresh get join an already in-flight request', async () => {
+      const storage = createSceneStorage()
+      const request = deferred<[null, { value: number }, number]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => request.promise)
+
+      const plain = storage.get('key')
+      const fresh = storage.get('key', { fresh: true })
+      request.resolve([null, { value: 7 }, 200])
+
+      expect(await plain).toBe(7)
+      expect(await fresh).toBe(7)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should cache a confirmed 404 as absent', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce(['404 Not Found', null, 404])
+
+      expect(await storage.get('missing')).toBeNull()
+      expect(await storage.get('missing')).toBeNull()
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should never cache non-404 errors', async () => {
+      const storage = createSceneStorage()
+
+      mockWrapSignedFetch.mockResolvedValueOnce(['500 Internal Server Error', null, 500])
+      expect(await storage.get('key')).toBeNull()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      expect(await storage.get('key')).toBe(1)
+
+      // Statusless transport errors are not cached either.
+      mockWrapSignedFetch.mockResolvedValueOnce(['network down', null])
+      expect(await storage.get('other')).toBeNull()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 2 }, 200])
+      expect(await storage.get('other')).toBe(2)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(4)
+    })
+
+    it('should overwrite a cached absence with a successful set', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce(['404 Not Found', null, 404])
+      expect(await storage.get('key')).toBeNull()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await storage.set('key', 5)).toBe(true)
+
+      // Served from the write-through cache entry.
+      expect(await storage.get('key')).toBe(5)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should invalidate the read cache when a set fails', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      expect(await storage.get('key')).toBe(1)
+
+      mockWrapSignedFetch.mockResolvedValueOnce(['500 Internal Server Error', null, 500])
+      expect(await storage.set('key', 2)).toBe(false)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      expect(await storage.get('key')).toBe(1)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should serve null from the negative cache after a successful delete', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      expect(await storage.get('key')).toBe(1)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await storage.delete('key')).toBe(true)
+
+      expect(await storage.get('key')).toBeNull()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should seed the per-key cache from getValues for reads and write dedup', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { data: [{ key: 'a', value: 1 }] }])
+
+      await storage.getValues()
+
+      expect(await storage.get('a')).toBe(1)
+      expect(await storage.set('a', 1, { skipIfUnchanged: true })).toBe(true)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should hit the network per get with cacheReads: false while still coalescing', async () => {
+      const storage = createSceneStorage(createStorageConfig({ cacheReads: false }))
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: 1 }, 200])
+
+      expect(await storage.get('key')).toBe(1)
+      expect(await storage.get('key')).toBe(1)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+
+      // Coalescing shares a live request, which is never stale.
+      const request = deferred<[null, { value: number }, number]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => request.promise)
+      const gets = Promise.all([storage.get('key'), storage.get('key')])
+      request.resolve([null, { value: 2 }, 200])
+
+      expect(await gets).toEqual([2, 2])
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should not let a stale in-flight get clobber a newer set', async () => {
+      const storage = createSceneStorage()
+      const staleGet = deferred<[null, { value: string }, number]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => staleGet.promise)
+
+      const pendingGet = storage.get('key')
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await storage.set('key', 'new')).toBe(true)
+
+      staleGet.resolve([null, { value: 'old' }, 200])
+      expect(await pendingGet).toBe('old')
+
+      // The set's write-through entry survived the stale response.
+      expect(await storage.get('key')).toBe('new')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not cache a 200 response with a missing value', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}, 200])
+
+      expect(await storage.get('key')).toBeNull()
+      expect(await storage.get('key')).toBeNull()
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should cache a stored null as a positive entry', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: null }, 200])
+
+      expect(await storage.get('key')).toBeNull()
+      expect(await storage.get('key')).toBeNull()
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/test/sdk/server/storage/scene-storage.spec.ts
+++ b/test/sdk/server/storage/scene-storage.spec.ts
@@ -14,6 +14,7 @@ jest.mock('../../../../packages/@dcl/sdk/src/server/utils', () => ({
   wrapSignedFetch: (req: { url: string }) => mockWrapSignedFetch(req)
 }))
 
+import { createStorageConfig } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
 import { createSceneStorage } from '../../../../packages/@dcl/sdk/src/server/storage/scene'
 
 describe('scene storage', () => {
@@ -88,6 +89,141 @@ describe('scene storage', () => {
       const result = await storage.getValues()
 
       expect(result).toEqual({ data: [], pagination: { offset: 0, total: 0 } })
+    })
+  })
+
+  describe('set', () => {
+    it('should PUT on every call by default, even for identical values', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      expect(await storage.set('score', 42)).toBe(true)
+      expect(await storage.set('score', 42)).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledWith({
+        url: `${baseUrl}/values/score`,
+        init: {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ value: 42 })
+        }
+      })
+    })
+
+    it('should skip the PUT for an unchanged value when skipIfUnchanged is passed', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      expect(await storage.set('score', 42, { skipIfUnchanged: true })).toBe(true)
+      expect(await storage.set('score', 42, { skipIfUnchanged: true })).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should PUT again when the value changed', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await storage.set('score', 42, { skipIfUnchanged: true })
+      await storage.set('score', 43, { skipIfUnchanged: true })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not cache a failed PUT, so the next skipIfUnchanged set retries', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce(['500 Server error', null])
+
+      expect(await storage.set('score', 42, { skipIfUnchanged: true })).toBe(false)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await storage.set('score', 42, { skipIfUnchanged: true })).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should dedupe by configured default and allow a per-call false to force the PUT', async () => {
+      const storage = createSceneStorage(createStorageConfig({ skipIfUnchanged: true }))
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await storage.set('score', 42)
+      await storage.set('score', 42)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+      await storage.set('score', 42, { skipIfUnchanged: false })
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should PUT again once the cache entry exceeds cacheMaxAgeMs', async () => {
+      const storage = createSceneStorage(createStorageConfig({ cacheMaxAgeMs: 1000 }))
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+      const nowSpy = jest.spyOn(Date, 'now')
+
+      try {
+        nowSpy.mockReturnValue(10_000)
+        await storage.set('score', 42, { skipIfUnchanged: true })
+
+        nowSpy.mockReturnValue(11_500)
+        await storage.set('score', 42, { skipIfUnchanged: true })
+
+        expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      } finally {
+        nowSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('get and set interplay', () => {
+    it('should populate the cache from get so an unchanged write is skipped', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, { value: { hp: 100 } }])
+
+      expect(await storage.get('player-state')).toEqual({ hp: 100 })
+      expect(await storage.set('player-state', { hp: 100 }, { skipIfUnchanged: true })).toBe(true)
+
+      // Only the GET hit the network.
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not populate the cache from a failed get', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce(['Server error', null])
+
+      expect(await storage.get('player-state')).toBeNull()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await storage.set('player-state', null, { skipIfUnchanged: true })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('delete', () => {
+    it('should invalidate the cache on a successful delete', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValue([null, {}])
+
+      await storage.set('score', 42, { skipIfUnchanged: true })
+      expect(await storage.delete('score')).toBe(true)
+      await storage.set('score', 42, { skipIfUnchanged: true })
+
+      // set + delete + set all hit the network.
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('should invalidate the cache even when the delete request fails', async () => {
+      const storage = createSceneStorage()
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await storage.set('score', 42, { skipIfUnchanged: true })
+
+      mockWrapSignedFetch.mockResolvedValueOnce(['Server error', null])
+      expect(await storage.delete('score')).toBe(false)
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await storage.set('score', 42, { skipIfUnchanged: true })
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/test/sdk/server/storage/scene-storage.spec.ts
+++ b/test/sdk/server/storage/scene-storage.spec.ts
@@ -227,13 +227,215 @@ describe('scene storage', () => {
     })
   })
 
-  describe('get read caching', () => {
-    function deferred<T>() {
-      let resolve!: (value: T) => void
-      const promise = new Promise<T>((r) => (resolve = r))
-      return { promise, resolve }
-    }
+  function deferred<T>() {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((r) => (resolve = r))
+    return { promise, resolve }
+  }
 
+  /** Lets queued executors advance to their network call. */
+  const flush = () => new Promise((r) => setTimeout(r, 0))
+
+  describe('write serialization', () => {
+    it('should hold a second set for a key until the in-flight PUT lands, preserving issue order', async () => {
+      const storage = createSceneStorage()
+      const firstPut = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => firstPut.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const first = storage.set('key', 'v1')
+      const second = storage.set('key', 'v2')
+      await flush()
+
+      // v2 must not race v1 on the network.
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+      firstPut.resolve([null, {}])
+      expect(await first).toBe(true)
+      expect(await second).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenLastCalledWith({
+        url: `${baseUrl}/values/key`,
+        init: {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ value: 'v2' })
+        }
+      })
+
+      // The cache asserts the last write issued, served locally.
+      expect(await storage.get('key')).toBe('v2')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should coalesce rapid writes into at most two PUTs, keeping the latest value', async () => {
+      const storage = createSceneStorage()
+      const firstPut = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => firstPut.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const results = Promise.all([storage.set('key', 1), storage.set('key', 2), storage.set('key', 3)])
+      await flush()
+      firstPut.resolve([null, {}])
+
+      expect(await results).toEqual([true, true, true])
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenLastCalledWith(
+        expect.objectContaining({ init: expect.objectContaining({ body: JSON.stringify({ value: 3 }) }) })
+      )
+
+      expect(await storage.get('key')).toBe(3)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should join concurrent identical sets into the in-flight PUT', async () => {
+      const storage = createSceneStorage()
+      const put = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => put.promise)
+
+      const first = storage.set('key', 7)
+      const second = storage.set('key', 7)
+      await flush()
+      put.resolve([null, {}])
+
+      expect(await first).toBe(true)
+      expect(await second).toBe(true)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not join the in-flight PUT when skipIfUnchanged is false', async () => {
+      const storage = createSceneStorage()
+      const put = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => put.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const first = storage.set('key', 7)
+      // An always-write caller expects a PUT issued at-or-after its call.
+      const second = storage.set('key', 7, { skipIfUnchanged: false })
+      await flush()
+      put.resolve([null, {}])
+
+      expect(await first).toBe(true)
+      expect(await second).toBe(true)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should serialize a delete behind an in-flight set', async () => {
+      const storage = createSceneStorage()
+      const put = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => put.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+
+      const setting = storage.set('key', 'v')
+      const deleting = storage.delete('key')
+      await flush()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+      put.resolve([null, {}])
+      expect(await setting).toBe(true)
+      expect(await deleting).toBe(true)
+
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+      expect(mockWrapSignedFetch).toHaveBeenLastCalledWith({
+        url: `${baseUrl}/values/key`,
+        init: { method: 'DELETE', headers: {} }
+      })
+
+      // Issue order won: the key ends up absent, served from the negative cache.
+      expect(await storage.get('key')).toBeNull()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should fail coalesced writers and invalidate the cache when their PUT fails', async () => {
+      const storage = createSceneStorage()
+      const firstPut = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => firstPut.promise)
+      mockWrapSignedFetch.mockResolvedValueOnce(['500 Internal Server Error', null])
+
+      const first = storage.set('key', 1)
+      const second = storage.set('key', 2)
+      await flush()
+      firstPut.resolve([null, {}])
+
+      expect(await first).toBe(true)
+      expect(await second).toBe(false)
+
+      // The failed flush invalidated the entry, so the retry hits the network.
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      expect(await storage.set('key', 2)).toBe(true)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('getValues seeding race guard', () => {
+    it('should not let a page overwrite per-key state confirmed while the list was in flight', async () => {
+      const storage = createSceneStorage()
+      const list = deferred<[null, { data: Array<{ key: string; value: unknown }> }]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => list.promise)
+
+      const listing = storage.getValues()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await storage.set('a', 'new')
+
+      list.resolve([
+        null,
+        {
+          data: [
+            { key: 'a', value: 'stale' },
+            { key: 'b', value: 2 }
+          ]
+        }
+      ])
+      await listing
+
+      // 'a' keeps the write-through value; unknown 'b' was seeded.
+      expect(await storage.get('a')).toBe('new')
+      expect(await storage.get('b')).toBe(2)
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not seed keys whose write is still pending when the page lands', async () => {
+      const storage = createSceneStorage()
+      const list = deferred<[null, { data: Array<{ key: string; value: unknown }> }]>()
+      const put = deferred<[null, object]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => list.promise)
+      mockWrapSignedFetch.mockImplementationOnce(() => put.promise)
+
+      const listing = storage.getValues()
+      const setting = storage.set('a', 'new')
+      await flush()
+
+      list.resolve([null, { data: [{ key: 'a', value: 'stale' }] }])
+      await listing
+
+      put.resolve([null, {}])
+      expect(await setting).toBe(true)
+
+      expect(await storage.get('a')).toBe('new')
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("should keep a delete's negative entry over a stale page value", async () => {
+      const storage = createSceneStorage()
+      const list = deferred<[null, { data: Array<{ key: string; value: unknown }> }]>()
+      mockWrapSignedFetch.mockImplementationOnce(() => list.promise)
+
+      const listing = storage.getValues()
+
+      mockWrapSignedFetch.mockResolvedValueOnce([null, {}])
+      await storage.delete('a')
+
+      list.resolve([null, { data: [{ key: 'a', value: 'stale' }] }])
+      await listing
+
+      expect(await storage.get('a')).toBeNull()
+      expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('get read caching', () => {
     it('should serve a repeated get from cache with fresh objects per hit', async () => {
       const storage = createSceneStorage()
       mockWrapSignedFetch.mockResolvedValueOnce([null, { value: { hp: 100 } }, 200])

--- a/test/sdk/server/storage/storage-index.spec.ts
+++ b/test/sdk/server/storage/storage-index.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the Storage singleton: configure() defaults and scene/player
+ * cache isolation. The singleton is created at import time, so each test
+ * resets modules and re-imports it (same pattern as platform.spec.ts).
+ */
+const mockGetStorageServerUrl = jest.fn()
+const mockWrapSignedFetch = jest.fn()
+
+jest.mock('../../../../packages/@dcl/sdk/src/server/storage-url', () => ({
+  getStorageServerUrl: () => mockGetStorageServerUrl()
+}))
+
+jest.mock('../../../../packages/@dcl/sdk/src/server/utils', () => ({
+  assertIsServer: () => {},
+  wrapSignedFetch: (req: { url: string }) => mockWrapSignedFetch(req)
+}))
+
+describe('Storage singleton', () => {
+  const baseUrl = 'https://storage.test'
+  const address = '0x1234567890123456789012345678901234567890'
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    mockGetStorageServerUrl.mockResolvedValue(baseUrl)
+    mockWrapSignedFetch.mockResolvedValue([null, {}])
+  })
+
+  async function loadStorage() {
+    const { Storage } = await import('../../../../packages/@dcl/sdk/src/server/storage/index')
+    return Storage
+  }
+
+  it('configure({ skipIfUnchanged: true }) applies to both scene and player storage', async () => {
+    const Storage = await loadStorage()
+    Storage.configure({ skipIfUnchanged: true })
+
+    await Storage.set('score', 42)
+    await Storage.set('score', 42)
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+    await Storage.player.set(address, 'score', 42)
+    await Storage.player.set(address, 'score', 42)
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not dedupe by default', async () => {
+    const Storage = await loadStorage()
+
+    await Storage.set('score', 42)
+    await Storage.set('score', 42)
+
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('scene and player caches are isolated for the same key and value', async () => {
+    const Storage = await loadStorage()
+    Storage.configure({ skipIfUnchanged: true })
+
+    await Storage.set('score', 42)
+    await Storage.player.set(address, 'score', 42)
+
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/sdk/server/storage/storage-index.spec.ts
+++ b/test/sdk/server/storage/storage-index.spec.ts
@@ -31,9 +31,8 @@ describe('Storage singleton', () => {
     return Storage
   }
 
-  it('configure({ skipIfUnchanged: true }) applies to both scene and player storage', async () => {
+  it('dedupes unchanged writes by default for both scene and player storage', async () => {
     const Storage = await loadStorage()
-    Storage.configure({ skipIfUnchanged: true })
 
     await Storage.set('score', 42)
     await Storage.set('score', 42)
@@ -44,22 +43,49 @@ describe('Storage singleton', () => {
     expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
   })
 
-  it('does not dedupe by default', async () => {
+  it('configure({ skipIfUnchanged: false }) disables write dedup for both scene and player storage', async () => {
     const Storage = await loadStorage()
+    Storage.configure({ skipIfUnchanged: false })
 
     await Storage.set('score', 42)
     await Storage.set('score', 42)
-
     expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+
+    await Storage.player.set(address, 'score', 42)
+    await Storage.player.set(address, 'score', 42)
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(4)
   })
 
   it('scene and player caches are isolated for the same key and value', async () => {
     const Storage = await loadStorage()
-    Storage.configure({ skipIfUnchanged: true })
 
     await Storage.set('score', 42)
     await Storage.player.set(address, 'score', 42)
 
     expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('serves repeated gets from cache by default', async () => {
+    const Storage = await loadStorage()
+    mockWrapSignedFetch.mockResolvedValue([null, { value: 42 }, 200])
+
+    expect(await Storage.get('score')).toBe(42)
+    expect(await Storage.get('score')).toBe(42)
+
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('configure({ cacheReads: false }) disables read caching for both scene and player storage', async () => {
+    const Storage = await loadStorage()
+    Storage.configure({ cacheReads: false })
+    mockWrapSignedFetch.mockResolvedValue([null, { value: 42 }, 200])
+
+    await Storage.get('score')
+    await Storage.get('score')
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+
+    await Storage.player.get(address, 'score')
+    await Storage.player.get(address, 'score')
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(4)
   })
 })

--- a/test/sdk/server/storage/storage-index.spec.ts
+++ b/test/sdk/server/storage/storage-index.spec.ts
@@ -75,6 +75,22 @@ describe('Storage singleton', () => {
     expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
   })
 
+  it('configure() ignores explicitly-undefined options instead of clobbering defaults', async () => {
+    const Storage = await loadStorage()
+    // A forwarded partial options object with undefined members must not
+    // disable dedup/read caching.
+    Storage.configure({ skipIfUnchanged: undefined, cacheReads: undefined })
+
+    await Storage.set('score', 42)
+    await Storage.set('score', 42)
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(1)
+
+    mockWrapSignedFetch.mockResolvedValue([null, { value: 7 }, 200])
+    await Storage.get('other')
+    await Storage.get('other')
+    expect(mockWrapSignedFetch).toHaveBeenCalledTimes(2)
+  })
+
   it('configure({ cacheReads: false }) disables read caching for both scene and player storage', async () => {
     const Storage = await loadStorage()
     Storage.configure({ cacheReads: false })

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -16,8 +16,8 @@ describe('createValueCache', () => {
   it('roundtrips set/get and delete removes entries', () => {
     const cache = createValueCache(createStorageConfig())
 
-    cache.set('a', 'print-a')
-    expect(cache.get('a')).toBe('print-a')
+    cache.set('a', { print: 'print-a', body: 'body-a' })
+    expect(cache.get('a')).toMatchObject({ print: 'print-a', body: 'body-a' })
 
     cache.delete('a')
     expect(cache.get('a')).toBeUndefined()
@@ -26,17 +26,17 @@ describe('createValueCache', () => {
   it('evicts the oldest entry beyond cacheMaxEntries, keeping refreshed keys', () => {
     const cache = createValueCache(createStorageConfig({ cacheMaxEntries: 3 }))
 
-    cache.set('a', '1')
-    cache.set('b', '2')
-    cache.set('c', '3')
+    cache.set('a', { print: '1', body: 'b1' })
+    cache.set('b', { print: '2', body: 'b2' })
+    cache.set('c', { print: '3', body: 'b3' })
     // Refresh 'a' so it moves to the end of the insertion order.
-    cache.set('a', '1b')
-    cache.set('d', '4')
+    cache.set('a', { print: '1b', body: 'b1b' })
+    cache.set('d', { print: '4', body: 'b4' })
 
     expect(cache.get('b')).toBeUndefined()
-    expect(cache.get('a')).toBe('1b')
-    expect(cache.get('c')).toBe('3')
-    expect(cache.get('d')).toBe('4')
+    expect(cache.get('a')?.print).toBe('1b')
+    expect(cache.get('c')?.print).toBe('3')
+    expect(cache.get('d')?.print).toBe('4')
   })
 
   it('expires entries older than cacheMaxAgeMs and removes them', () => {
@@ -45,10 +45,10 @@ describe('createValueCache', () => {
 
     try {
       nowSpy.mockReturnValue(10_000)
-      cache.set('a', 'print-a')
+      cache.set('a', { print: 'print-a', body: 'body-a' })
 
       nowSpy.mockReturnValue(11_000)
-      expect(cache.get('a')).toBe('print-a')
+      expect(cache.get('a')?.print).toBe('print-a')
 
       nowSpy.mockReturnValue(11_001)
       expect(cache.get('a')).toBeUndefined()
@@ -67,11 +67,11 @@ describe('createValueCache', () => {
 
     try {
       nowSpy.mockReturnValue(10_000)
-      cache.set('a', 'print-a')
+      cache.set('a', { print: 'print-a', body: 'body-a' })
 
       // A hit just before expiry must not extend the entry's lifetime.
       nowSpy.mockReturnValue(10_999)
-      expect(cache.get('a')).toBe('print-a')
+      expect(cache.get('a')?.print).toBe('print-a')
 
       nowSpy.mockReturnValue(11_001)
       expect(cache.get('a')).toBeUndefined()
@@ -84,16 +84,82 @@ describe('createValueCache', () => {
     const config = createStorageConfig({ cacheMaxEntries: 10 })
     const cache = createValueCache(config)
 
-    cache.set('a', '1')
-    cache.set('b', '2')
-    cache.set('c', '3')
+    cache.set('a', { print: '1', body: 'b1' })
+    cache.set('b', { print: '2', body: 'b2' })
+    cache.set('c', { print: '3', body: 'b3' })
 
     config.cacheMaxEntries = 2
-    cache.set('d', '4')
+    cache.set('d', { print: '4', body: 'b4' })
 
     expect(cache.get('a')).toBeUndefined()
     expect(cache.get('b')).toBeUndefined()
-    expect(cache.get('c')).toBe('3')
-    expect(cache.get('d')).toBe('4')
+    expect(cache.get('c')?.print).toBe('3')
+    expect(cache.get('d')?.print).toBe('4')
+  })
+
+  describe('negative (absent) entries', () => {
+    it('setAbsent stores an entry with no print or body', () => {
+      const cache = createValueCache(createStorageConfig())
+
+      cache.setAbsent('a')
+
+      const entry = cache.get('a')
+      expect(entry?.absent).toBe(true)
+      expect(entry?.print).toBeUndefined()
+      expect(entry?.body).toBeUndefined()
+    })
+
+    it('negative entries expire past cacheMaxAgeMs', () => {
+      const cache = createValueCache(createStorageConfig({ cacheMaxAgeMs: 1000 }))
+      const nowSpy = jest.spyOn(Date, 'now')
+
+      try {
+        nowSpy.mockReturnValue(10_000)
+        cache.setAbsent('a')
+
+        nowSpy.mockReturnValue(11_000)
+        expect(cache.get('a')?.absent).toBe(true)
+
+        nowSpy.mockReturnValue(11_001)
+        expect(cache.get('a')).toBeUndefined()
+      } finally {
+        nowSpy.mockRestore()
+      }
+    })
+
+    it('set replaces a negative entry and setAbsent replaces a value entry', () => {
+      const cache = createValueCache(createStorageConfig())
+
+      cache.setAbsent('a')
+      cache.set('a', { print: 'p', body: 'b' })
+      expect(cache.get('a')).toMatchObject({ print: 'p', body: 'b' })
+      expect(cache.get('a')?.absent).toBeFalsy()
+
+      cache.setAbsent('a')
+      const entry = cache.get('a')
+      expect(entry?.absent).toBe(true)
+      expect(entry?.print).toBeUndefined()
+    })
+
+    it('negative entries count toward cacheMaxEntries eviction', () => {
+      const cache = createValueCache(createStorageConfig({ cacheMaxEntries: 2 }))
+
+      cache.set('a', { print: '1', body: 'b1' })
+      cache.setAbsent('b')
+      cache.set('c', { print: '3', body: 'b3' })
+
+      expect(cache.get('a')).toBeUndefined()
+      expect(cache.get('b')?.absent).toBe(true)
+      expect(cache.get('c')?.print).toBe('3')
+    })
+
+    it('delete removes negative entries', () => {
+      const cache = createValueCache(createStorageConfig())
+
+      cache.setAbsent('a')
+      cache.delete('a')
+
+      expect(cache.get('a')).toBeUndefined()
+    })
   })
 })

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -1,0 +1,99 @@
+import { createStorageConfig } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
+import { createValueCache, fingerprint, fnv1a } from '../../../../packages/@dcl/sdk/src/server/storage/value-cache'
+
+describe('fnv1a / fingerprint', () => {
+  it('is deterministic and differs for different inputs', () => {
+    expect(fnv1a('hello')).toBe(fnv1a('hello'))
+    expect(fnv1a('hello')).not.toBe(fnv1a('hellp'))
+  })
+
+  it('fingerprint includes the serialized length', () => {
+    expect(fingerprint('abc')).toBe(`${fnv1a('abc').toString(16)}:3`)
+  })
+})
+
+describe('createValueCache', () => {
+  it('roundtrips set/get and delete removes entries', () => {
+    const cache = createValueCache(createStorageConfig())
+
+    cache.set('a', 'print-a')
+    expect(cache.get('a')).toBe('print-a')
+
+    cache.delete('a')
+    expect(cache.get('a')).toBeUndefined()
+  })
+
+  it('evicts the oldest entry beyond cacheMaxEntries, keeping refreshed keys', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxEntries: 3 }))
+
+    cache.set('a', '1')
+    cache.set('b', '2')
+    cache.set('c', '3')
+    // Refresh 'a' so it moves to the end of the insertion order.
+    cache.set('a', '1b')
+    cache.set('d', '4')
+
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('a')).toBe('1b')
+    expect(cache.get('c')).toBe('3')
+    expect(cache.get('d')).toBe('4')
+  })
+
+  it('expires entries older than cacheMaxAgeMs and removes them', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxAgeMs: 1000 }))
+    const nowSpy = jest.spyOn(Date, 'now')
+
+    try {
+      nowSpy.mockReturnValue(10_000)
+      cache.set('a', 'print-a')
+
+      nowSpy.mockReturnValue(11_000)
+      expect(cache.get('a')).toBe('print-a')
+
+      nowSpy.mockReturnValue(11_001)
+      expect(cache.get('a')).toBeUndefined()
+
+      // The expired entry was physically removed, not just hidden.
+      nowSpy.mockReturnValue(10_500)
+      expect(cache.get('a')).toBeUndefined()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('does not refresh storedAt on cache hits', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxAgeMs: 1000 }))
+    const nowSpy = jest.spyOn(Date, 'now')
+
+    try {
+      nowSpy.mockReturnValue(10_000)
+      cache.set('a', 'print-a')
+
+      // A hit just before expiry must not extend the entry's lifetime.
+      nowSpy.mockReturnValue(10_999)
+      expect(cache.get('a')).toBe('print-a')
+
+      nowSpy.mockReturnValue(11_001)
+      expect(cache.get('a')).toBeUndefined()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('applies config mutations to an existing cache', () => {
+    const config = createStorageConfig({ cacheMaxEntries: 10 })
+    const cache = createValueCache(config)
+
+    cache.set('a', '1')
+    cache.set('b', '2')
+    cache.set('c', '3')
+
+    config.cacheMaxEntries = 2
+    cache.set('d', '4')
+
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('c')).toBe('3')
+    expect(cache.get('d')).toBe('4')
+  })
+})

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -80,6 +80,29 @@ describe('createValueCache', () => {
     }
   })
 
+  it('treats a negative cacheMaxEntries as 0 instead of looping forever', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxEntries: -1 }))
+
+    // Must terminate (a negative bound can never be reached by an empty map)
+    // and behave as a disabled cache.
+    cache.set('a', { print: '1', body: 'b1' })
+
+    expect(cache.get('a')).toBeUndefined()
+  })
+
+  it('falls back to the default bound when cacheMaxEntries is not finite', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxEntries: NaN }))
+
+    // Eviction must not be silently disabled: the default bound (512) applies.
+    for (let i = 0; i < 513; i++) {
+      cache.set(`key-${i}`, { print: `${i}`, body: `b${i}` })
+    }
+
+    expect(cache.get('key-0')).toBeUndefined()
+    expect(cache.get('key-1')?.print).toBe('1')
+    expect(cache.get('key-512')?.print).toBe('512')
+  })
+
   it('applies config mutations to an existing cache', () => {
     const config = createStorageConfig({ cacheMaxEntries: 10 })
     const cache = createValueCache(config)

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -1,23 +1,12 @@
 import { createStorageConfig } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
-import { createValueCache, fingerprint, fnv1a } from '../../../../packages/@dcl/sdk/src/server/storage/value-cache'
-
-describe('fnv1a / fingerprint', () => {
-  it('is deterministic and differs for different inputs', () => {
-    expect(fnv1a('hello')).toBe(fnv1a('hello'))
-    expect(fnv1a('hello')).not.toBe(fnv1a('hellp'))
-  })
-
-  it('fingerprint includes the serialized length', () => {
-    expect(fingerprint('abc')).toBe(`${fnv1a('abc').toString(16)}:3`)
-  })
-})
+import { createValueCache } from '../../../../packages/@dcl/sdk/src/server/storage/value-cache'
 
 describe('createValueCache', () => {
   it('roundtrips set/get and delete removes entries', () => {
     const cache = createValueCache(createStorageConfig())
 
-    cache.set('a', { print: 'print-a', body: 'body-a' })
-    expect(cache.get('a')).toMatchObject({ print: 'print-a', body: 'body-a' })
+    cache.set('a', { body: 'body-a' })
+    expect(cache.get('a')).toMatchObject({ body: 'body-a' })
 
     cache.delete('a')
     expect(cache.get('a')).toBeUndefined()
@@ -26,17 +15,17 @@ describe('createValueCache', () => {
   it('evicts the oldest entry beyond cacheMaxEntries, keeping refreshed keys', () => {
     const cache = createValueCache(createStorageConfig({ cacheMaxEntries: 3 }))
 
-    cache.set('a', { print: '1', body: 'b1' })
-    cache.set('b', { print: '2', body: 'b2' })
-    cache.set('c', { print: '3', body: 'b3' })
+    cache.set('a', { body: 'b1' })
+    cache.set('b', { body: 'b2' })
+    cache.set('c', { body: 'b3' })
     // Refresh 'a' so it moves to the end of the insertion order.
-    cache.set('a', { print: '1b', body: 'b1b' })
-    cache.set('d', { print: '4', body: 'b4' })
+    cache.set('a', { body: 'b1b' })
+    cache.set('d', { body: 'b4' })
 
     expect(cache.get('b')).toBeUndefined()
-    expect(cache.get('a')?.print).toBe('1b')
-    expect(cache.get('c')?.print).toBe('3')
-    expect(cache.get('d')?.print).toBe('4')
+    expect(cache.get('a')?.body).toBe('b1b')
+    expect(cache.get('c')?.body).toBe('b3')
+    expect(cache.get('d')?.body).toBe('b4')
   })
 
   it('expires entries older than cacheMaxAgeMs and removes them', () => {
@@ -45,10 +34,10 @@ describe('createValueCache', () => {
 
     try {
       nowSpy.mockReturnValue(10_000)
-      cache.set('a', { print: 'print-a', body: 'body-a' })
+      cache.set('a', { body: 'body-a' })
 
       nowSpy.mockReturnValue(11_000)
-      expect(cache.get('a')?.print).toBe('print-a')
+      expect(cache.get('a')?.body).toBe('body-a')
 
       nowSpy.mockReturnValue(11_001)
       expect(cache.get('a')).toBeUndefined()
@@ -67,11 +56,11 @@ describe('createValueCache', () => {
 
     try {
       nowSpy.mockReturnValue(10_000)
-      cache.set('a', { print: 'print-a', body: 'body-a' })
+      cache.set('a', { body: 'body-a' })
 
       // A hit just before expiry must not extend the entry's lifetime.
       nowSpy.mockReturnValue(10_999)
-      expect(cache.get('a')?.print).toBe('print-a')
+      expect(cache.get('a')?.body).toBe('body-a')
 
       nowSpy.mockReturnValue(11_001)
       expect(cache.get('a')).toBeUndefined()
@@ -85,7 +74,7 @@ describe('createValueCache', () => {
 
     // Must terminate (a negative bound can never be reached by an empty map)
     // and behave as a disabled cache.
-    cache.set('a', { print: '1', body: 'b1' })
+    cache.set('a', { body: 'b1' })
 
     expect(cache.get('a')).toBeUndefined()
   })
@@ -95,40 +84,39 @@ describe('createValueCache', () => {
 
     // Eviction must not be silently disabled: the default bound (512) applies.
     for (let i = 0; i < 513; i++) {
-      cache.set(`key-${i}`, { print: `${i}`, body: `b${i}` })
+      cache.set(`key-${i}`, { body: `b${i}` })
     }
 
     expect(cache.get('key-0')).toBeUndefined()
-    expect(cache.get('key-1')?.print).toBe('1')
-    expect(cache.get('key-512')?.print).toBe('512')
+    expect(cache.get('key-1')?.body).toBe('b1')
+    expect(cache.get('key-512')?.body).toBe('b512')
   })
 
   it('applies config mutations to an existing cache', () => {
     const config = createStorageConfig({ cacheMaxEntries: 10 })
     const cache = createValueCache(config)
 
-    cache.set('a', { print: '1', body: 'b1' })
-    cache.set('b', { print: '2', body: 'b2' })
-    cache.set('c', { print: '3', body: 'b3' })
+    cache.set('a', { body: 'b1' })
+    cache.set('b', { body: 'b2' })
+    cache.set('c', { body: 'b3' })
 
     config.cacheMaxEntries = 2
-    cache.set('d', { print: '4', body: 'b4' })
+    cache.set('d', { body: 'b4' })
 
     expect(cache.get('a')).toBeUndefined()
     expect(cache.get('b')).toBeUndefined()
-    expect(cache.get('c')?.print).toBe('3')
-    expect(cache.get('d')?.print).toBe('4')
+    expect(cache.get('c')?.body).toBe('b3')
+    expect(cache.get('d')?.body).toBe('b4')
   })
 
   describe('negative (absent) entries', () => {
-    it('setAbsent stores an entry with no print or body', () => {
+    it('setAbsent stores an entry with no body', () => {
       const cache = createValueCache(createStorageConfig())
 
       cache.setAbsent('a')
 
       const entry = cache.get('a')
       expect(entry?.absent).toBe(true)
-      expect(entry?.print).toBeUndefined()
       expect(entry?.body).toBeUndefined()
     })
 
@@ -154,26 +142,26 @@ describe('createValueCache', () => {
       const cache = createValueCache(createStorageConfig())
 
       cache.setAbsent('a')
-      cache.set('a', { print: 'p', body: 'b' })
-      expect(cache.get('a')).toMatchObject({ print: 'p', body: 'b' })
+      cache.set('a', { body: 'b' })
+      expect(cache.get('a')).toMatchObject({ body: 'b' })
       expect(cache.get('a')?.absent).toBeFalsy()
 
       cache.setAbsent('a')
       const entry = cache.get('a')
       expect(entry?.absent).toBe(true)
-      expect(entry?.print).toBeUndefined()
+      expect(entry?.body).toBeUndefined()
     })
 
     it('negative entries count toward cacheMaxEntries eviction', () => {
       const cache = createValueCache(createStorageConfig({ cacheMaxEntries: 2 }))
 
-      cache.set('a', { print: '1', body: 'b1' })
+      cache.set('a', { body: 'b1' })
       cache.setAbsent('b')
-      cache.set('c', { print: '3', body: 'b3' })
+      cache.set('c', { body: 'b3' })
 
       expect(cache.get('a')).toBeUndefined()
       expect(cache.get('b')?.absent).toBe(true)
-      expect(cache.get('c')?.print).toBe('3')
+      expect(cache.get('c')?.body).toBe('b3')
     })
 
     it('delete removes negative entries', () => {

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -92,6 +92,25 @@ describe('createValueCache', () => {
     expect(cache.get('key-512')?.body).toBe('b512')
   })
 
+  it('falls back to the default max age when cacheMaxAgeMs is not finite', () => {
+    const cache = createValueCache(createStorageConfig({ cacheMaxAgeMs: NaN }))
+    const nowSpy = jest.spyOn(Date, 'now')
+
+    try {
+      // Expiry must not be silently disabled: the default bound (15 min) applies.
+      nowSpy.mockReturnValue(10_000)
+      cache.set('a', { body: 'b1' })
+
+      nowSpy.mockReturnValue(10_000 + 15 * 60 * 1000)
+      expect(cache.get('a')?.body).toBe('b1')
+
+      nowSpy.mockReturnValue(10_000 + 15 * 60 * 1000 + 1)
+      expect(cache.get('a')).toBeUndefined()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
   it('applies config mutations to an existing cache', () => {
     const config = createStorageConfig({ cacheMaxEntries: 10 })
     const cache = createValueCache(config)

--- a/test/sdk/server/storage/value-cache.spec.ts
+++ b/test/sdk/server/storage/value-cache.spec.ts
@@ -1,4 +1,4 @@
-import { createStorageConfig } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
+import { createStorageConfig, DEFAULT_STORAGE_CONFIG } from '../../../../packages/@dcl/sdk/src/server/storage/constants'
 import { createValueCache } from '../../../../packages/@dcl/sdk/src/server/storage/value-cache'
 
 describe('createValueCache', () => {
@@ -97,14 +97,14 @@ describe('createValueCache', () => {
     const nowSpy = jest.spyOn(Date, 'now')
 
     try {
-      // Expiry must not be silently disabled: the default bound (15 min) applies.
+      // Expiry must not be silently disabled: the default bound applies.
       nowSpy.mockReturnValue(10_000)
       cache.set('a', { body: 'b1' })
 
-      nowSpy.mockReturnValue(10_000 + 15 * 60 * 1000)
+      nowSpy.mockReturnValue(10_000 + DEFAULT_STORAGE_CONFIG.cacheMaxAgeMs)
       expect(cache.get('a')?.body).toBe('b1')
 
-      nowSpy.mockReturnValue(10_000 + 15 * 60 * 1000 + 1)
+      nowSpy.mockReturnValue(10_000 + DEFAULT_STORAGE_CONFIG.cacheMaxAgeMs + 1)
       expect(cache.get('a')).toBeUndefined()
     } finally {
       nowSpy.mockRestore()

--- a/test/sdk/server/utils.spec.ts
+++ b/test/sdk/server/utils.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for wrapSignedFetch error handling, in particular that a malformed
+ * (non-JSON) response body degrades to an error tuple instead of rejecting.
+ */
+const mockSignedFetch = jest.fn()
+
+// virtual: the module only exists inside the scene runtime, so jest cannot resolve it
+jest.mock('~system/SignedFetch', () => ({ signedFetch: (req: unknown) => mockSignedFetch(req) }), { virtual: true })
+
+jest.mock('../../../packages/@dcl/sdk/src/network', () => ({
+  isServer: () => true
+}))
+
+import { wrapSignedFetch } from '../../../packages/@dcl/sdk/src/server/utils'
+
+describe('wrapSignedFetch', () => {
+  beforeEach(() => {
+    mockSignedFetch.mockReset()
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  function mockResponse(body: string, ok = true, status = 200) {
+    mockSignedFetch.mockResolvedValue({ ok, status, statusText: ok ? 'OK' : 'Error', body })
+  }
+
+  it('returns the parsed body and status on success', async () => {
+    mockResponse(JSON.stringify({ value: 42 }))
+
+    const [error, data, status] = await wrapSignedFetch<{ value: number }>({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBeNull()
+    expect(data).toEqual({ value: 42 })
+    expect(status).toBe(200)
+  })
+
+  it('returns an empty object when the response body is empty', async () => {
+    mockResponse('')
+
+    const [error, data] = await wrapSignedFetch({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBeNull()
+    expect(data).toEqual({})
+  })
+
+  it('returns an error tuple instead of throwing when the body is not valid JSON', async () => {
+    mockResponse('<html>502 Bad Gateway</html>')
+
+    const [error, data, status] = await wrapSignedFetch({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBe('Failed to parse response')
+    expect(data).toBeNull()
+    expect(status).toBe(200)
+  })
+
+  it('returns the status error tuple on a non-ok response', async () => {
+    mockResponse('{}', false, 404)
+
+    const [error, data, status] = await wrapSignedFetch({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBe('404 Error')
+    expect(data).toBeNull()
+    expect(status).toBe(404)
+  })
+
+  it('returns the error message when the fetch itself rejects', async () => {
+    mockSignedFetch.mockRejectedValue(new Error('network down'))
+
+    const [error, data, status] = await wrapSignedFetch({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBe('network down')
+    expect(data).toBeNull()
+    expect(status).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

Every `Storage` operation was a signed network round-trip. Authoritative-server scenes read and flush state on tick loops, so the storage service absorbed a `GET` per read and a `PUT` per write even when nothing changed, and `getStorageServerUrl()` resolved the realm on every single operation.

Separately, `wrapSignedFetch` — the transport under every `Storage`/`EnvVar` call — could not survive a non-JSON response body: a storage server returning an HTML error page or a truncated body crashed the caller instead of degrading to the documented `null`/`false` results.

## Changes

`Storage` and `Storage.player` now share a per-scope value cache (TTL'd, bounded, in-memory) that serves reads and suppresses no-op writes. The authoritative server is the sole writer of its keys (`signedFetch` identity is host-selected; write authority is enforced by the storage service), so the cache is coherent within its TTL.

### Read caching (default on)

`get()` serves values known from a network round-trip within the last `cacheMaxAgeMs` without hitting the service:

- Populated by successful `get()`s, `set()` write-through, and `getValues()` pages (returned entries seed only keys with no fresher per-key state — a live cache entry or a pending write always wins over the page snapshot, whose request started earlier; the list request itself is never served from cache).
- Cached bodies are re-parsed per hit, so callers never share mutable object references.
- **Negative caching**: a confirmed `404` (or a successful `delete()`) caches "absent", so hot-looping on a missing key doesn't hammer the service. Only `status === 404` qualifies — transport errors and 5xx are never cached. `get()` no longer logs `console.error` for 404s (it's a first-class "not found" outcome now).
- **In-flight coalescing**: concurrent `get()`s for the same key share one request (player keys coalesce case-insensitively per address, never across addresses). Active even with read caching disabled — a live request is never stale.
- **Race guard**: a `set()`/`delete()` completing while a `GET` is in flight detaches it, so the stale response can't overwrite the newer cache entry.

Escape hatches: `get(key, { fresh: true })` forces an authoritative network read (and refreshes the cache); `Storage.configure({ cacheReads: false })` disables read serving module-wide.

### `skipIfUnchanged` (default on)

`set()` skips the `PUT` (resolving `true`) when the serialized value matches the last value confirmed stored for that key. A skip only suppresses a **proven no-op** — the new serialized body is compared for exact equality against the body confirmed by a previous successful round-trip within the TTL — so writes are never lost: every `set()` resolves once its value (or the newer value that superseded it, see write serialization below) is durably applied. A dedup skip never refreshes the entry's TTL, so a constantly-rewritten value still re-asserts itself with one real `PUT` per TTL window. A failed `PUT` invalidates the cache entry (the write may have reached the server). Opt out per call (`{ skipIfUnchanged: false }`) or via `configure()`.

### Per-key write serialization

Overlapping writes to the same key are serialized with latest-value coalescing: at most one `PUT`/`DELETE` per key is on the network, and writes issued meanwhile collapse into a single queued "latest value" slot. Without this, two fire-and-forget `set()`s from consecutive ticks race twice — the service keeps whichever request it processes last (it's last-write-wins with no version tokens), and the cache keeps whichever response arrives last — so either could disagree with the last `set()` issued, and a wrong cache entry would then be served (and defended by `skipIfUnchanged`) for up to the TTL. With serialization, the server's final state always matches the last write issued, and N rapid writes to a key cost at most 2 network calls — a further win for the tick-loop workload. Semantics:

- Issue order is commit order, per key (`delete()` participates in the same queue).
- A `set()` identical to the pending write joins it (no extra `PUT`) — unless the caller passed `skipIfUnchanged: false`, which always issues its own write.
- Superseded writers resolve with the outcome of the write that replaced theirs (their value was overwritten before it could ever be observed).
- Write dedup against the cache only applies while no write is pending for the key (the cache is momentarily behind the pending write).

### Cache mechanics & configuration

- Entries hold the serialized `{ value }` body, which serves both read hits (re-parsed per hit) and write dedup (exact string comparison). `cacheMaxEntries` (default 512 per scope) bounds entry **count**, not bytes — a large value stays pinned for up to the TTL.
- `cacheMaxAgeMs` default is **1 minute**, bounding both read staleness and write-dedup trust.
- Staleness caveat: out-of-band writers (e.g. the CLI `storage` commands against a live world) may not be visible for up to the TTL — use `{ fresh: true }` where that matters.
- Player cache keys are address-lowercased, so mixed checksum casing shares entries (and the write queue) correctly.
- Misconfiguration guards: non-finite `cacheMaxEntries`/`cacheMaxAgeMs` fall back to the defaults, negative bounds degrade safely, and `configure()` ignores explicitly-`undefined` options (e.g. from a forwarded partial options object), keeping the configured defaults.

New exports from `@dcl/sdk/server`: `GetOptions`, `SetOptions`, `StorageOptions`.

### Memoized `getStorageServerUrl()`

The resolved URL promise is cached: concurrent first calls collapse into a single `getRealm` request, later operations skip it entirely, and failed resolutions are not cached (transient errors retry). `EnvVar` benefits automatically.

### Fix: `wrapSignedFetch` rejects on malformed response bodies

`wrapSignedFetch` parsed responses with `tryCatch(JSON.parse(response.body || '{}'))`. `JSON.parse` throws synchronously while the argument is evaluated — before `tryCatch` can wrap it — so an invalid body rejected the whole `wrapSignedFetch` promise and the `'Failed to parse response'` branch was dead code. Every `Storage.get/set/delete` and `EnvVar.get` then threw instead of returning `null`/`false` as designed. The parse now runs inside a plain try/catch, restoring the intended error tuple (`['Failed to parse response', null, status]`).

## Behavior changes to note

- `get()` may serve cached data by default (bounded by the 1-minute TTL; `{ fresh: true }` / `cacheReads: false` opt out).
- `set()` skips proven-unchanged writes by default (`skipIfUnchanged: false` opts out).
- `get()` no longer logs `console.error` on 404.

## Testing

91 tests across the server suites. Read caching: cache hits (with per-hit object freshness), TTL expiry, `fresh` bypass-and-refresh, coalescing (including `fresh` joining in-flight and per-address isolation), negative 404 caching, non-404 errors never cached, set/delete invalidation and overwrite of negative entries, `getValues` seeding (reads + write dedup, scoped per address, plus the race guard: pages never overwrite state confirmed or pending while the list was in flight), the stale-GET-vs-set race guard, ambiguous 200s not cached, stored `null` as a positive entry, and `configure({ cacheReads: false })` reaching both scopes. Write dedup: default-on skip, per-call/configured overrides, failed-PUT retry, max-age expiry, per-address isolation, case-insensitive addresses. Write serialization: overlapping sets hold until the in-flight PUT lands and preserve issue order, rapid writes coalesce to the latest value in ≤2 PUTs, identical concurrent sets join one PUT (except with `skipIfUnchanged: false`), deletes serialize behind sets, failed coalesced flushes fail their writers and invalidate the entry, and case-insensitive per-address queueing. Config guards: non-finite `cacheMaxEntries`/`cacheMaxAgeMs` fallbacks, negative bounds, `configure()` ignoring explicit `undefined`. Plus cache-primitive tests (eviction, TTL, negative entries), URL memoization (sequential, concurrent, failure-retry), and `wrapSignedFetch` coverage (success, empty body, malformed-JSON regression, non-ok statuses, fetch rejection).
