### PR TITLE
update: @dcl/inspector@7.36.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,9 @@ An `ERR!` line means the QuickJS eval threw mid-execution (commonly a missing mo
 
 `@dcl/asset-packs` is not a direct dependency of this repo — it ships nested inside `@dcl/inspector`, and `packages/@dcl/sdk-commands/src/logic/bundle.ts` resolves it from the inspector's `node_modules`. To bump (prior art: commits `04270ca5`, `8b6bd63d`):
 
-1. Edit the pin in `packages/@dcl/sdk-commands/package.json`.
-2. Regenerate that package's standalone lockfile: `cd packages/@dcl/sdk-commands && npm install --package-lock-only`
-3. `make install && make build` (the build installs the new version into the package's own `node_modules/`).
-4. Regenerate snapshots with a `UPDATE_SNAPSHOTS=true` scoped Jest run — `test/snapshots/package-lock.json` updates itself during this run. Verify no `ERR!` lines (see above).
+1. `cd packages/@dcl/sdk-commands && npm i --save-exact @dcl/inspector@<x.y.z>` — updates the pin, the package's standalone lockfile, and its `node_modules/` in one step (same pattern as the Makefile's `update-protocol` target).
+2. `make build` from the repo root.
+3. Regenerate snapshots with a `UPDATE_SNAPSHOTS=true` scoped Jest run — `test/snapshots/package-lock.json` updates itself during this run. Verify no `ERR!` lines (see above).
 
 Asset-packs injection is gated behind `isEditorScene` (requires `assets/scene/main.composite` — see `packages/@dcl/sdk-commands/src/logic/project-validations.ts`), so inspector bumps no longer change `.crdt` snapshots. An empty snapshot diff is expected, not a stale artifact.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ For deeper context on a specific subsystem (component serialization, CRDT suppre
 
 ## Packages
 
-Six packages under `packages/@dcl/` (npm workspaces):
+Six packages under `packages/@dcl/` (a monorepo layout, but **not** npm workspaces):
 
 | Package | Purpose |
 | --- | --- |
@@ -26,6 +26,8 @@ Six packages under `packages/@dcl/` (npm workspaces):
 | `@dcl/playground-assets` | Browser-compatible SDK bundle |
 
 Internal references use `file:../` paths during development; published versions get pinned semver ranges (managed via syncpack — see `make sync-deps`).
+
+The root `package.json` has no `workspaces` field — root `make install` only installs root-level tooling deps. Each package keeps its own standalone `package-lock.json`, and per-package `node_modules/` are populated by `make build`, which runs `npm i` inside each package (`scripts/build.spec.ts`). Don't expect package deps to be hoisted to the root `node_modules/`.
 
 ## Development commands
 
@@ -72,6 +74,22 @@ grep -rn "ERR!" test/snapshots/        # must return no output
 An `ERR!` line means the QuickJS eval threw mid-execution (commonly a missing mock in `test/snapshots.spec.ts`'s `require` shim — e.g. a new `~system/Runtime` method the SDK started calling at module-load). The resulting snapshot captures a *truncated* run, hides real behavior, and would mask future regressions.
 
 **Anti-pattern:** committing snapshots containing `ERR! Error: Unknown module ...`, `ERR! TypeError: ... is not a function`, or any other `ERR!` trace. Treat them as broken artifacts — fix the mock (or the underlying scene-load failure), regenerate, and re-verify before committing.
+
+### Bumping `@dcl/inspector` (the vehicle for `@dcl/asset-packs`)
+
+`@dcl/asset-packs` is not a direct dependency of this repo — it ships nested inside `@dcl/inspector`, and `packages/@dcl/sdk-commands/src/logic/bundle.ts` resolves it from the inspector's `node_modules`. To bump (prior art: commits `04270ca5`, `8b6bd63d`):
+
+1. Edit the pin in `packages/@dcl/sdk-commands/package.json`.
+2. Regenerate that package's standalone lockfile: `cd packages/@dcl/sdk-commands && npm install --package-lock-only`
+3. `make install && make build` (the build installs the new version into the package's own `node_modules/`).
+4. Regenerate snapshots with a `UPDATE_SNAPSHOTS=true` scoped Jest run — `test/snapshots/package-lock.json` updates itself during this run. Verify no `ERR!` lines (see above).
+
+Asset-packs injection is gated behind `isEditorScene` (requires `assets/scene/main.composite` — see `packages/@dcl/sdk-commands/src/logic/project-validations.ts`), so inspector bumps no longer change `.crdt` snapshots. An empty snapshot diff is expected, not a stale artifact.
+
+## Committing hygiene gotchas
+
+- A newer local npm rewrites committed lockfiles with `"peer": true` / `"dev": true` metadata churn during installs (root and per-package lockfiles). Revert lockfile changes unrelated to your dependency change before committing.
+- `make format` runs prettier over the whole repo, including paths CI's `make lint` does not check (`test/`, `scripts/`, dot-files), where HEAD may carry drift — a blind `make format` can dirty dozens of unrelated files. Check your own files, revert the rest.
 
 ## Code conventions
 

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -14,7 +14,7 @@
         "@dcl/ecs": "file:../ecs",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.34.3",
+        "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
@@ -204,19 +204,19 @@
       }
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.34.3",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.34.3.tgz",
-      "integrity": "sha512-1rZ1HORPK0s3O0Zhh6KH+Heu4tScvtIsvdSKP+9hHGU3S/R7xNAJeRAovGB7uOgvA0rqlR5fHwIUGtl57yCLVw==",
+      "version": "7.36.3",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.36.3.tgz",
+      "integrity": "sha512-EwvXoZlXvDKZsK2qrRYG+Yia7qKHWgQUqbWY7e6zSVMffRDhhjVyS2FEipgrLqL0YMrTkJcfAsHaNnZgZsnP4A==",
       "dependencies": {
         "@babel/parser": "7.28.5",
-        "@dcl/asset-packs": "^2.15.3",
+        "@dcl/asset-packs": "^2.17.0",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.15.3.tgz",
-      "integrity": "sha512-Nmd2EyrWXqHod3v7f+Z4A8v2rhC+81knI2mRWS5RBv56krdqS0NIsj5R9SbXlskEB23+JUQbXtl6FVbVCrpMhQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.17.0.tgz",
+      "integrity": "sha512-0usTWnxx4vRe7vaT7Y5uAm2jiazsqaHJTqhakbE4X6q+f0Na7Zp2J+uiSjESTbJvYDnx0m6yJza4iVq8FNZyZw==",
       "license": "ISC",
       "dependencies": {
         "@types/glob": "^8.1.0",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/ecs": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.23.2.tgz",
-      "integrity": "sha512-Hr3y1+dnRhskL6GxfTLw0BuO8QsnxASMES20fz3aJ/NJNYe9kNQG3L+e57jkxegjk/baml9njp9T8EgT3fGcZw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.24.5.tgz",
+      "integrity": "sha512-wu9MvDu5aM+bFBLqwY86W8tsR8dr82PtFy1gsY4VKSeTzYg4/CH6MovrWx9q/nUStUwsVIEEJYaZ4A57Gtb73A==",
       "license": "Apache-2.0",
       "peer": true
     },
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/lru-cache": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
-      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1565,6 +1565,7 @@
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
       "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -1618,6 +1619,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3800,6 +3802,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -11,7 +11,7 @@
     "@dcl/ecs": "file:../ecs",
     "@dcl/gltf-validator-ts": "1.0.14",
     "@dcl/hashing": "1.1.3",
-    "@dcl/inspector": "7.34.3",
+    "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
     "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -47,7 +47,7 @@
         "@dcl/ecs": "file:../ecs",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.34.3",
+        "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",


### PR DESCRIPTION
## Summary
- Bump `@dcl/inspector` 7.34.3 → 7.36.3 in `@dcl/sdk-commands`, pulling nested `@dcl/asset-packs` 2.15.3 → 2.17.0 (and its `@dcl/ecs` peer copy 7.23.2 → 7.24.5) into scene bundles built from the visual editor.
- Regenerates the sdk-commands standalone lockfile; `test/snapshots/package-lock.json` picks up the new pin through the `file:` dependency.
- No `.crdt` snapshot changes — asset-packs injection is gated behind `isEditorScene` (requires `assets/scene/main.composite`), so snapshot scenes no longer bundle it. Regeneration was run and produced zero diffs with no `ERR!` lines.
- Also documents in `AGENTS.md`: the real (non-workspaces) per-package install model, the inspector/asset-packs bump playbook, and lockfile/format hygiene gotchas.

## Test plan
- [x] `make build` green (38/38)
- [x] Snapshot suite regenerated with `UPDATE_SNAPSHOTS=true` — zero `.crdt` diffs, `grep -rn "ERR!" test/snapshots/` clean
- [x] Full `make test` green (151 suites passed, 1131 tests)
- [x] `make lint` exits 0

https://claude.ai/code/session_016j8x9DZBi2NrUCnGW8mCvx