### PR TITLE
fix: keep sdk-commands start alive when the initial build fails

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -319,9 +319,19 @@ export async function bundleSingleProject(components: BundleComponents, options:
       }
     })
 
-    // Do initial build
-    await context.rebuild()
-    printProgressInfo(components.logger, `Bundle saved ${colors.bold(options.outputFile)}`)
+    // Do initial build. A build error must not kill the process in watch mode:
+    // the watcher above is already running and the preview server can still
+    // start, so report the error and recover on the next file save — the same
+    // contract as a failed re-build. Throwing here left `sdk-commands start`
+    // dead when a scene was opened with a pre-existing syntax error, with no
+    // watcher alive to pick up the fix.
+    try {
+      await context.rebuild()
+      printProgressInfo(components.logger, `Bundle saved ${colors.bold(options.outputFile)}`)
+    } catch (err: any) {
+      /* istanbul ignore next */
+      components.logger.error(err.toString())
+    }
     printProgressInfo(components.logger, `The compiler is watching for changes`)
   } else {
     try {


### PR DESCRIPTION
## Problem

`sdk-commands start` dies when the scene has a build error (e.g. a syntax error) at the moment the server starts:

```
✘ [ERROR] Unterminated string literal
Error: Build failed with 1 error:
src/index.ts:19:20: ERROR: Unterminated string literal
Developer: All errors thrown must be an instance of "CliError"...
(process exits 1)
```

In watch mode the toolchain is one process: bundler, chokidar watcher, preview server, hot reload. A **re-build** error is already handled gracefully (`debouncedRebuild` catches, logs, keeps watching — the server keeps serving the previous bundle). But the **initial** `context.rebuild()` in the watch branch is unguarded, so the same error at startup kills everything — and since the watcher dies with the process, fixing the file recovers nothing. Anyone who opens a project that was left with a syntax error gets a dead server instead of a dev loop.

## Fix

Give the initial build the same report-and-recover contract as re-builds: catch, log the error, keep the watcher and server up. Non-watch mode (`sdk-commands build`, and `start --no-watch`) still throws `BUNDLE_REBUILD_FAILED` — a one-shot build must fail loudly.

## Validation

Verified end-to-end against a real scene with an unterminated string in `src/index.ts` (patched the compiled dist of `7.24.4-28592331167.commit-697ce9e` with this exact change):

- `start` reports `✘ [ERROR] Unterminated string literal`, prints "The compiler is watching for changes", and the preview server comes up (`/about` → 200).
- Fixing the file triggers the watcher: `Bundle saved`, the scene loads and runs — full recovery with no process restart.
- `npx tsc --noEmit` on the package passes.

This also matches what every mainstream dev server (Vite, webpack-dev-server) does with a broken initial build: report, stay alive, recover on save.