### PR TITLE
feat: expose openExplorerUi in ~system/RestrictedActions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
+        "@dcl/protocol": "1.0.0-30373157983.commit-2c475cb",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29286492043.commit-0010e70",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
-      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
+      "version": "1.0.0-30373157983.commit-2c475cb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-30373157983.commit-2c475cb.tgz",
+      "integrity": "sha512-mm0///9X0T7Ib3qZkwgiy2WRjSp42sXHyIoUfbcAr7IQylnptGmRfNza8xpaRykHs15HuGdcndLYs+VLPNYzDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
@@ -8385,9 +8385,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-29286492043.commit-0010e70",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
-      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
+      "version": "1.0.0-30373157983.commit-2c475cb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-30373157983.commit-2c475cb.tgz",
+      "integrity": "sha512-mm0///9X0T7Ib3qZkwgiy2WRjSp42sXHyIoUfbcAr7IQylnptGmRfNza8xpaRykHs15HuGdcndLYs+VLPNYzDg==",
       "requires": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/decentraland/js-sdk-toolchain/issues",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
+    "@dcl/protocol": "1.0.0-30373157983.commit-2c475cb",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -732,6 +732,7 @@ export const componentDefinitionByName: {
     "core::RealmInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBRealmInfo>>;
     "core::SkyboxTime": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBSkyboxTime>>;
     "core::TextShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTextShape>>;
+    "core::TouchScreenControls": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTouchScreenControls>>;
     "core::TriggerArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTriggerArea>>;
     "core::TriggerAreaResult": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBTriggerAreaResult>>;
     "core::Tween": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTween>>;
@@ -742,6 +743,7 @@ export const componentDefinitionByName: {
     "core::UiDropdown": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdown>>;
     "core::UiDropdownResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdownResult>>;
     "core::UiInput": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInput>>;
+    "core::UiInputBinding": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputBinding>>;
     "core::UiInputResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputResult>>;
     "core::UiText": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiText>>;
     "core::UiTransform": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiTransform>>;
@@ -3605,6 +3607,38 @@ export namespace PBTextShape {
 }
 
 // @public (undocumented)
+export interface PBTouchScreenControls {
+    hideCrosshair: boolean;
+    hideJoystick: boolean;
+    mainAction?: InputAction | undefined;
+    // (undocumented)
+    touchInputs: PBTouchScreenControls_TouchInput[];
+}
+
+// @public (undocumented)
+export namespace PBTouchScreenControls {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTouchScreenControls;
+    // (undocumented)
+    export function encode(message: PBTouchScreenControls, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBTouchScreenControls_TouchInput {
+    hide: boolean;
+    icon?: TextureUnion | undefined;
+    inputAction: InputAction;
+}
+
+// @public (undocumented)
+export namespace PBTouchScreenControls_TouchInput {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTouchScreenControls_TouchInput;
+    // (undocumented)
+    export function encode(message: PBTouchScreenControls_TouchInput, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBTriggerArea {
     collisionMask?: number | undefined;
     mesh?: TriggerAreaMeshType | undefined;
@@ -3824,6 +3858,19 @@ export namespace PBUiInput {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiInput;
     // (undocumented)
     export function encode(message: PBUiInput, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBUiInputBinding {
+    actions: InputAction[];
+}
+
+// @public (undocumented)
+export namespace PBUiInputBinding {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiInputBinding;
+    // (undocumented)
+    export function encode(message: PBUiInputBinding, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -4057,6 +4104,7 @@ export namespace PBVideoPlayer {
 export interface PBVirtualCamera {
     // (undocumented)
     defaultTransition?: CameraTransition | undefined;
+    fov?: number | undefined;
     // (undocumented)
     lookAtEntity?: number | undefined;
 }
@@ -5055,6 +5103,9 @@ export const ToLinearSpace = 2.2;
 // @public (undocumented)
 export type ToOptional<T> = OnlyOptionalUndefinedTypes<T> & OnlyNonUndefinedTypes<T>;
 
+// @public (undocumented)
+export const TouchScreenControls: LastWriteWinElementSetComponentDefinition<PBTouchScreenControls>;
+
 // Warning: (ae-missing-release-tag) "Transform" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -5299,6 +5350,9 @@ export type UiFontType = 'sans-serif' | 'serif' | 'monospace';
 
 // @public (undocumented)
 export const UiInput: LastWriteWinElementSetComponentDefinition<PBUiInput>;
+
+// @public (undocumented)
+export const UiInputBinding: LastWriteWinElementSetComponentDefinition<PBUiInputBinding>;
 
 // @public (undocumented)
 export interface UiInputProps extends Omit<PBUiInput, 'font' | 'textAlign' | 'fontSize'> {

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
+        "@dcl/protocol": "1.0.0-30373157983.commit-2c475cb",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-29286492043.commit-0010e70",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-29286492043.commit-0010e70.tgz",
-      "integrity": "sha512-P50hvWLEqfy/z2QfKoK7gqbwWr6EOHLJ1casunG+btCLvV2X9a1GhxooRK5rTXZAAJmno/5g59GVbpVNdRhvNw==",
+      "version": "1.0.0-30373157983.commit-2c475cb",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-30373157983.commit-2c475cb.tgz",
+      "integrity": "sha512-mm0///9X0T7Ib3qZkwgiy2WRjSp42sXHyIoUfbcAr7IQylnptGmRfNza8xpaRykHs15HuGdcndLYs+VLPNYzDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
+    "@dcl/protocol": "1.0.0-30373157983.commit-2c475cb",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/ecs/components/VirtualCamera.spec.ts
+++ b/test/ecs/components/VirtualCamera.spec.ts
@@ -11,7 +11,8 @@ describe('VirtualCamera component', () => {
           time: 3
         }
       },
-      lookAtEntity: 35
+      lookAtEntity: 35,
+      fov: 45
     })
   })
 
@@ -22,7 +23,8 @@ describe('VirtualCamera component', () => {
       defaultTransition: {
         transitionMode: vCamera.Transition.Time(6)
       },
-      lookAtEntity: 86
+      lookAtEntity: 86,
+      fov: 50
     })
   })
 
@@ -35,7 +37,8 @@ describe('VirtualCamera component', () => {
           speed: 13
         }
       },
-      lookAtEntity: 86
+      lookAtEntity: 86,
+      fov: 30
     })
   })
 
@@ -46,7 +49,8 @@ describe('VirtualCamera component', () => {
       defaultTransition: {
         transitionMode: vCamera.Transition.Speed(15)
       },
-      lookAtEntity: 86
+      lookAtEntity: 86,
+      fov: 48
     })
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=567.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=575.3k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,9 +11,9 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 73k
-  MALLOC_COUNT = 16329
-  ALIVE_OBJS_DELTA ~= 3.25k
+  OPCODES ~= 74k
+  MALLOC_COUNT = 16530
+  ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1432.77k bytes
+  MEMORY_USAGE_COUNT ~= 1446.63k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=568.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=575.8k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,9 +11,9 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 83k
-  MALLOC_COUNT = 16881
-  ALIVE_OBJS_DELTA ~= 3.40k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 17082
+  ALIVE_OBJS_DELTA ~= 3.45k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1438.53k bytes
+  MEMORY_USAGE_COUNT ~= 1452.39k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=568.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=575.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -11,9 +11,9 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 83k
-  MALLOC_COUNT = 16881
-  ALIVE_OBJS_DELTA ~= 3.40k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 17082
+  ALIVE_OBJS_DELTA ~= 3.45k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1438.54k bytes
+  MEMORY_USAGE_COUNT ~= 1452.40k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -50,7 +50,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-29286492043.commit-0010e70",
+        "@dcl/protocol": "1.0.0-30373157983.commit-2c475cb",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=249.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=252.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 85k
-  MALLOC_COUNT = 15180
-  ALIVE_OBJS_DELTA ~= 3.40k
+  OPCODES ~= 86k
+  MALLOC_COUNT = 15368
+  ALIVE_OBJS_DELTA ~= 3.44k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1072.70k bytes
+  MEMORY_USAGE_COUNT ~= 1083.23k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=293.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 87k
-  MALLOC_COUNT = 17698
-  ALIVE_OBJS_DELTA ~= 3.87k
+  OPCODES ~= 88k
+  MALLOC_COUNT = 17886
+  ALIVE_OBJS_DELTA ~= 3.92k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1258.76k bytes
+  MEMORY_USAGE_COUNT ~= 1269.30k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 76k
-  MALLOC_COUNT = 14300
-  ALIVE_OBJS_DELTA ~= 3.17k
+  OPCODES ~= 77k
+  MALLOC_COUNT = 14488
+  ALIVE_OBJS_DELTA ~= 3.21k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1034.97k bytes
+  MEMORY_USAGE_COUNT ~= 1045.50k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 75k
-  MALLOC_COUNT = 14273
-  ALIVE_OBJS_DELTA ~= 3.16k
+  OPCODES ~= 77k
+  MALLOC_COUNT = 14461
+  ALIVE_OBJS_DELTA ~= 3.21k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1024.72k bytes
+  MEMORY_USAGE_COUNT ~= 1035.26k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=293.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 127k
-  MALLOC_COUNT = 21035
-  ALIVE_OBJS_DELTA ~= 5.16k
+  OPCODES ~= 128k
+  MALLOC_COUNT = 21223
+  ALIVE_OBJS_DELTA ~= 5.21k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1483.24k bytes
+  MEMORY_USAGE_COUNT ~= 1493.77k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=246.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=249.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 77k
-  MALLOC_COUNT = 14566
-  ALIVE_OBJS_DELTA ~= 3.25k
+  OPCODES ~= 78k
+  MALLOC_COUNT = 14754
+  ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1044.42k bytes
+  MEMORY_USAGE_COUNT ~= 1054.96k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 79k
-  MALLOC_COUNT = 14405
-  ALIVE_OBJS_DELTA ~= 3.20k
+  OPCODES ~= 80k
+  MALLOC_COUNT = 14593
+  ALIVE_OBJS_DELTA ~= 3.24k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1027.17k bytes
+  MEMORY_USAGE_COUNT ~= 1037.71k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=407.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=410.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 88k
-  MALLOC_COUNT = 22287
-  ALIVE_OBJS_DELTA ~= 4.50k
+  OPCODES ~= 89k
+  MALLOC_COUNT = 22475
+  ALIVE_OBJS_DELTA ~= 4.54k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 74k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1893.99k bytes
+  MEMORY_USAGE_COUNT ~= 1904.53k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=246.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=249.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,9 +9,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 76k
-  MALLOC_COUNT = 14509
-  ALIVE_OBJS_DELTA ~= 3.21k
+  OPCODES ~= 77k
+  MALLOC_COUNT = 14697
+  ALIVE_OBJS_DELTA ~= 3.26k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1044.20k bytes
+  MEMORY_USAGE_COUNT ~= 1054.74k bytes


### PR DESCRIPTION
## What
Bumps `@dcl/protocol` to the **main** build `1.0.0-30373157983.commit-2c475cb` ([decentraland/protocol#451](https://github.com/decentraland/protocol/pull/451), merged) so `~system/RestrictedActions` regenerates with:
- `openExplorerUi(body: OpenExplorerUiRequest): Promise<OpenExplorerUiResponse>`
- `ExplorerUi` enum (7 sections: `EU_MAP`, `EU_SETTINGS`, `EU_BACKPACK`, `EU_CAMERA_REEL`, `EU_COMMUNITIES`, `EU_PLACES`, `EU_EVENTS`)
- `OpenExplorerUiResult` enum + `OpenExplorerUiResponse`

Main-based counterpart of #1485 (experimental, pinned a protocol branch build): once this lands and main syncs into experimental, #1485 will be closed.

## Why
Lets SDK7 scenes open native Explorer fullscreen panels from a user gesture and receive a typed verdict. Client implementation: [decentraland/unity-explorer#9472](https://github.com/decentraland/unity-explorer/pull/9472). Test world: `flutterecho.dcl.eth` + `sdk7-test-scenes` parcel `80,-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)