### PR TITLE
feat: serve preview asset bundles through the preview server itself (single origin)

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import portfinder from 'portfinder'
 
 import { CliComponents } from '../../components'
 import { printProgressInfo, printProgressStep } from '../../logic/beautiful-logs'
@@ -17,11 +16,6 @@ const PREWARM_FALLBACK_EVERY_TICKS = 4 // seconds-heartbeat cadence when /progre
 const PREWARM_TIMEOUT_MS = 15 * 60_000
 const PREWARM_RETRY_DELAY_MS = 2_000
 
-// abgen's default port, and the Explorer's default `optimized-assets-url`:
-// preferring it lets a connected Unity Editor find the sidecar with zero
-// configuration. Scans upward when taken (the deeplink carries the real URL).
-const PREFERRED_SIDECAR_PORT = 5147
-
 /**
  * Boots an `abgen` sidecar: an ab-cdn-compatible server that JIT-converts the
  * scene being previewed into asset bundles, reading it through the preview's
@@ -29,6 +23,10 @@ const PREFERRED_SIDECAR_PORT = 5147
  * undefined — with a warning — when the binary is missing or never comes up.
  * The binary resolves from $ABGEN_BIN, then a cached copy of the pinned abgen
  * release, then `abgen` on the PATH, and downloads the release only when none exist.
+ *
+ * The sidecar binds an ephemeral port that stays private to sdk-commands:
+ * clients reach it through the preview server's /optimized-assets proxy, so
+ * they only ever see the realm origin they already have.
  */
 export async function runAssetBundlesSidecar(
   components: Pick<CliComponents, 'fetch' | 'logger' | 'spawner' | 'config' | 'fs'>,
@@ -36,7 +34,7 @@ export async function runAssetBundlesSidecar(
   projectRoot: string
 ): Promise<string | undefined> {
   const bin = await resolveAbgenBin(components)
-  const port = await portfinder.getPortPromise({ port: PREFERRED_SIDECAR_PORT }).catch(() => getPort(0))
+  const port = await getPort(0)
   const url = `http://127.0.0.1:${port}`
   const catalystUrl = await getCatalystBaseUrl(components)
   // next to scene.json: converted bundles survive preview restarts (never

--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -37,12 +37,12 @@ export async function runExplorerAlpha(
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
-    assetBundlesUrl?: string
+    assetBundles?: boolean
   }
 ) {
-  const { cwd, realm, baseCoords, isHub, assetBundlesUrl } = opts
+  const { cwd, realm, baseCoords, isHub, assetBundles } = opts
 
-  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args, assetBundlesUrl })) {
+  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args, assetBundles })) {
     return
   }
 
@@ -57,14 +57,14 @@ async function runApp(
     baseCoords,
     isHub,
     args,
-    assetBundlesUrl
+    assetBundles
   }: {
     cwd: string
     realm: string
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
-    assetBundlesUrl?: string
+    assetBundles?: boolean
   }
 ) {
   const cmd = isWindows ? 'start' : 'open'
@@ -93,10 +93,9 @@ async function runApp(
 
     params.set('local-scene', 'true')
 
-    if (assetBundlesUrl) {
-      params.set('optimized-assets-url', assetBundlesUrl)
-      // The scene itself loads asset bundles only with this flag; the url alone
-      // re-bases wearable/registry traffic but leaves scene content on raw GLTFs
+    if (assetBundles) {
+      // the explorer derives the /optimized-assets base from the realm it
+      // already has; this flag makes the scene itself load asset bundles
       params.set('local-ab', 'true')
     }
 

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -303,10 +303,9 @@ export async function main(options: Options) {
           baseCoords,
           isHub,
           args: options.args,
-          // the proxied path on the realm the client already has — never the
-          // sidecar's private origin (migration: explorers derive this from the
-          // realm under local-ab; the explicit param stays as a generic override)
-          assetBundlesUrl: assetBundlesSidecar.url ? `${realm}/optimized-assets` : undefined
+          // the explorer derives the /optimized-assets base from the realm it
+          // already has — the sidecar's private origin is never exposed
+          assetBundles: !!assetBundlesSidecar.url
         })
       }
 

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -219,7 +219,10 @@ export async function main(options: Options) {
         }
       }
 
-      await wireRouter(components, workspace, dataLayer)
+      // the sidecar boots after the server (it reads the scene through the
+      // preview's own /content endpoints), so the proxy target is late-bound
+      const assetBundlesSidecar: { url?: string } = {}
+      await wireRouter(components, workspace, dataLayer, withAssetBundles ? () => assetBundlesSidecar.url : undefined)
       if (watch) {
         for (const project of workspace.projects) {
           await wireFileWatcherToWebSockets(
@@ -232,15 +235,17 @@ export async function main(options: Options) {
       }
       await startComponents()
 
-      let assetBundlesUrl: string | undefined
       if (withAssetBundles) {
-        assetBundlesUrl = await runAssetBundlesSidecar(
+        assetBundlesSidecar.url = await runAssetBundlesSidecar(
           components,
           port,
           workspace.projects[0]?.workingDirectory || workingDirectory
         )
-        if (assetBundlesUrl) {
-          printProgressInfo(options.components.logger, `Serving asset bundles (abgen JIT): ${assetBundlesUrl}`)
+        if (assetBundlesSidecar.url) {
+          printProgressInfo(
+            options.components.logger,
+            `Serving asset bundles (abgen JIT): http://127.0.0.1:${port}/optimized-assets`
+          )
         }
       }
 
@@ -298,7 +303,10 @@ export async function main(options: Options) {
           baseCoords,
           isHub,
           args: options.args,
-          assetBundlesUrl
+          // the proxied path on the realm the client already has — never the
+          // sidecar's private origin (migration: explorers derive this from the
+          // realm under local-ab; the explicit param stays as a generic override)
+          assetBundlesUrl: assetBundlesSidecar.url ? `${realm}/optimized-assets` : undefined
         })
       }
 

--- a/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
@@ -27,8 +27,20 @@ export function setupAssetBundlesProxy(
     }
 
     const method = ctx.request.method.toUpperCase()
+
+    // forward the client's headers (the sidecar 415s JSON POSTs without their
+    // content-type) minus the per-connection ones, which must describe the
+    // proxy→sidecar leg instead: host/connection are recomputed by fetch, the
+    // re-streamed body invalidates content-length, and accept-encoding is
+    // dropped so undici negotiates (and transparently decodes) its own encoding.
+    const requestHeaders = Object.fromEntries(ctx.request.headers)
+    delete requestHeaders['host']
+    delete requestHeaders['content-length']
+    delete requestHeaders['accept-encoding']
+    requestHeaders['connection'] = 'close'
+
     const response = await components.fetch.fetch(`${sidecarUrl}/${ctx.params.path}${ctx.url.search}`, {
-      headers: { connection: 'close' },
+      headers: requestHeaders,
       method,
       body: method === 'GET' || method === 'HEAD' ? undefined : (ctx.request.body as any),
       duplex: 'half'

--- a/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
@@ -37,12 +37,14 @@ export function setupAssetBundlesProxy(
     // undici decompresses the body but leaves the original content-encoding /
     // content-length headers in place; forwarding them would make the client
     // re-decode (or truncate to the compressed length) the already-decoded body.
-    response.headers.delete('content-encoding')
-    response.headers.delete('content-length')
+    // fetch() responses carry immutable Headers, so filter instead of delete.
+    const headers = Object.fromEntries(response.headers)
+    delete headers['content-encoding']
+    delete headers['content-length']
 
     return {
       status: response.status,
-      headers: Object.fromEntries(response.headers),
+      headers,
       // `response.body` is a web ReadableStream; convert it to a Node stream so
       // the http-server can pipe it (it only handles Node streams / Buffers / strings).
       body: response.body ? Readable.fromWeb(response.body as any) : undefined

--- a/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
@@ -30,14 +30,14 @@ export function setupAssetBundlesProxy(
 
     // forward the client's headers (the sidecar 415s JSON POSTs without their
     // content-type) minus the per-connection ones, which must describe the
-    // proxy→sidecar leg instead: host/connection are recomputed by fetch, the
+    // proxy→sidecar leg instead: undici manages host and keep-alive itself, the
     // re-streamed body invalidates content-length, and accept-encoding is
     // dropped so undici negotiates (and transparently decodes) its own encoding.
     const requestHeaders = Object.fromEntries(ctx.request.headers)
     delete requestHeaders['host']
+    delete requestHeaders['connection']
     delete requestHeaders['content-length']
     delete requestHeaders['accept-encoding']
-    requestHeaders['connection'] = 'close'
 
     const response = await components.fetch.fetch(`${sidecarUrl}/${ctx.params.path}${ctx.url.search}`, {
       headers: requestHeaders,

--- a/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
@@ -1,0 +1,51 @@
+import { Router } from '@well-known-components/http-server'
+import { Readable } from 'stream'
+
+import { CliComponents } from '../../../components'
+import { PreviewComponents } from '../types'
+
+/**
+ * Mounts the abgen sidecar behind the preview server: every request under
+ * /optimized-assets streams through to the sidecar, so clients only ever see
+ * the realm origin they already have — the sidecar's port stays a private
+ * implementation detail of sdk-commands.
+ *
+ * The target URL is late-bound (a getter, not a value) because the sidecar
+ * boots after the preview server is up — it reads the scene through the
+ * preview's own /content endpoints. Until it answers /readyz the route
+ * responds 503.
+ */
+export function setupAssetBundlesProxy(
+  components: Pick<CliComponents, 'fetch'>,
+  router: Router<PreviewComponents>,
+  getSidecarUrl: () => string | undefined
+) {
+  router.all('/optimized-assets/:path+', async (ctx) => {
+    const sidecarUrl = getSidecarUrl()
+    if (!sidecarUrl) {
+      return { status: 503, body: { ok: false, error: 'the asset-bundles sidecar is not running' } }
+    }
+
+    const method = ctx.request.method.toUpperCase()
+    const response = await components.fetch.fetch(`${sidecarUrl}/${ctx.params.path}${ctx.url.search}`, {
+      headers: { connection: 'close' },
+      method,
+      body: method === 'GET' || method === 'HEAD' ? undefined : (ctx.request.body as any),
+      duplex: 'half'
+    } as any)
+
+    // undici decompresses the body but leaves the original content-encoding /
+    // content-length headers in place; forwarding them would make the client
+    // re-decode (or truncate to the compressed length) the already-decoded body.
+    response.headers.delete('content-encoding')
+    response.headers.delete('content-length')
+
+    return {
+      status: response.status,
+      headers: Object.fromEntries(response.headers),
+      // `response.body` is a web ReadableStream; convert it to a Node stream so
+      // the http-server can pipe it (it only handles Node streams / Buffers / strings).
+      body: response.body ? Readable.fromWeb(response.body as any) : undefined
+    }
+  })
+}

--- a/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
@@ -140,12 +140,14 @@ export async function setupEcs6Endpoints(
     // undici decompresses the body but leaves the original content-encoding /
     // content-length headers in place; forwarding them would make the client
     // re-decode (or truncate to the compressed length) the already-decoded body.
-    res.headers.delete('content-encoding')
-    res.headers.delete('content-length')
+    // fetch() responses carry immutable Headers, so filter instead of delete.
+    const headers = Object.fromEntries(res.headers)
+    delete headers['content-encoding']
+    delete headers['content-length']
 
     return {
       status: res.status,
-      headers: Object.fromEntries(res.headers),
+      headers,
       body: res.body ? Readable.fromWeb(res.body as any) : undefined
     }
   })

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -6,13 +6,23 @@ import { Workspace } from '../../../logic/workspace-validations'
 import { DataLayer } from '../data-layer/rpc'
 import { handleDataLayerWs } from '../data-layer/ws'
 import { PreviewComponents } from '../types'
+import { setupAssetBundlesProxy } from './asset-bundles-proxy'
 import { setupEcs6Endpoints } from './endpoints'
 import { setupRealmAndComms } from './realm'
 import { getLanUrl } from '../utils'
 
 export const sceneUpdateClients = new Set<WebSocket>()
-export async function wireRouter(components: PreviewComponents, workspace: Workspace, dataLayer?: DataLayer) {
+export async function wireRouter(
+  components: PreviewComponents,
+  workspace: Workspace,
+  dataLayer?: DataLayer,
+  getAssetBundlesSidecarUrl?: () => string | undefined
+) {
   const router = new Router<PreviewComponents>()
+
+  if (getAssetBundlesSidecarUrl) {
+    setupAssetBundlesProxy(components, router, getAssetBundlesSidecarUrl)
+  }
 
   if (dataLayer) {
     router.get('/data-layer', async (ctx, next) => {

--- a/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
@@ -7,11 +7,11 @@ function makeProxy(getSidecarUrl: () => string | undefined) {
   setupAssetBundlesProxy({ fetch: { fetch } } as any, router as any, getSidecarUrl)
   // requests reach the handler with the /optimized-assets prefix already
   // consumed by the route pattern: ctx.params.path carries the rest
-  const dispatch = (method: string, path: string, search = '', body?: any) =>
+  const dispatch = (method: string, path: string, search = '', body?: any, headers: Record<string, string> = {}) =>
     handler({
       url: new URL(`http://127.0.0.1:8000/optimized-assets/${path}${search}`),
       params: { path },
-      request: { method, body }
+      request: { method, body, headers: new Headers({ host: '127.0.0.1:8000', ...headers }) }
     })
   return { fetch, router, dispatch }
 }
@@ -73,12 +73,22 @@ describe('start/server/asset-bundles-proxy', () => {
     fetch.mockResolvedValue(new Response('nope', { status: 404 }))
 
     const requestBody = 'the-registry-post'
-    const response = await dispatch('POST', 'entities/active', '', requestBody)
+    const response = await dispatch('POST', 'entities/active', '', requestBody, {
+      'content-type': 'application/json',
+      'content-length': '17'
+    })
 
     expect(fetch).toHaveBeenCalledWith(
       'http://127.0.0.1:53211/entities/active',
       expect.objectContaining({ method: 'POST', body: requestBody, duplex: 'half' })
     )
+    // the client's headers ride along (the sidecar 415s JSON posts without their
+    // content-type), while the per-connection ones are replaced for the sidecar leg
+    const forwardedHeaders = fetch.mock.calls[0][1].headers
+    expect(forwardedHeaders['content-type']).toBe('application/json')
+    expect(forwardedHeaders['content-length']).toBeUndefined()
+    expect(forwardedHeaders['host']).toBeUndefined()
+    expect(forwardedHeaders['connection']).toBe('close')
     expect(response.status).toBe(404)
   })
 })

--- a/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
@@ -75,7 +75,8 @@ describe('start/server/asset-bundles-proxy', () => {
     const requestBody = 'the-registry-post'
     const response = await dispatch('POST', 'entities/active', '', requestBody, {
       'content-type': 'application/json',
-      'content-length': '17'
+      'content-length': '17',
+      connection: 'close'
     })
 
     expect(fetch).toHaveBeenCalledWith(
@@ -83,12 +84,13 @@ describe('start/server/asset-bundles-proxy', () => {
       expect.objectContaining({ method: 'POST', body: requestBody, duplex: 'half' })
     )
     // the client's headers ride along (the sidecar 415s JSON posts without their
-    // content-type), while the per-connection ones are replaced for the sidecar leg
+    // content-type), while the per-connection ones are dropped so undici manages
+    // its own leg — a forwarded connection:close would kill sidecar keep-alive
     const forwardedHeaders = fetch.mock.calls[0][1].headers
     expect(forwardedHeaders['content-type']).toBe('application/json')
     expect(forwardedHeaders['content-length']).toBeUndefined()
     expect(forwardedHeaders['host']).toBeUndefined()
-    expect(forwardedHeaders['connection']).toBe('close')
+    expect(forwardedHeaders['connection']).toBeUndefined()
     expect(response.status).toBe(404)
   })
 })

--- a/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
@@ -1,0 +1,80 @@
+import { setupAssetBundlesProxy } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy'
+
+function makeProxy(getSidecarUrl: () => string | undefined) {
+  const fetch = jest.fn()
+  let handler: (ctx: any) => Promise<any>
+  const router = { all: jest.fn((_path: string, h: any) => (handler = h)) }
+  setupAssetBundlesProxy({ fetch: { fetch } } as any, router as any, getSidecarUrl)
+  // requests reach the handler with the /optimized-assets prefix already
+  // consumed by the route pattern: ctx.params.path carries the rest
+  const dispatch = (method: string, path: string, search = '', body?: any) =>
+    handler({
+      url: new URL(`http://127.0.0.1:8000/optimized-assets/${path}${search}`),
+      params: { path },
+      request: { method, body }
+    })
+  return { fetch, router, dispatch }
+}
+
+async function readBody(stream: AsyncIterable<Buffer | string>): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+describe('start/server/asset-bundles-proxy', () => {
+  it('mounts every method under /optimized-assets', () => {
+    const { router } = makeProxy(() => undefined)
+    expect(router.all).toHaveBeenCalledWith('/optimized-assets/:path+', expect.any(Function))
+  })
+
+  it('answers 503 until the sidecar is up', async () => {
+    const { fetch, dispatch } = makeProxy(() => undefined)
+
+    const response = await dispatch('GET', 'manifest/b64-abc_mac.json')
+
+    expect(response.status).toBe(503)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('streams requests through to the sidecar, stripping the mount prefix and keeping the query string', async () => {
+    const { fetch, dispatch } = makeProxy(() => 'http://127.0.0.1:53211')
+    fetch.mockResolvedValue(
+      new Response('bundle-bytes', {
+        status: 200,
+        headers: {
+          'content-type': 'application/octet-stream',
+          // undici already decompressed the body: these must not be forwarded
+          'content-encoding': 'gzip',
+          'content-length': '999'
+        }
+      })
+    )
+
+    const response = await dispatch('GET', 'v49/b64-abc/scene_bundle', '?x=1')
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:53211/v49/b64-abc/scene_bundle?x=1',
+      expect.objectContaining({ method: 'GET', body: undefined })
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toBe('application/octet-stream')
+    expect(response.headers['content-encoding']).toBeUndefined()
+    expect(response.headers['content-length']).toBeUndefined()
+    await expect(readBody(response.body)).resolves.toBe('bundle-bytes')
+  })
+
+  it('forwards non-GET methods with their body and the sidecar status', async () => {
+    const { fetch, dispatch } = makeProxy(() => 'http://127.0.0.1:53211')
+    fetch.mockResolvedValue(new Response('nope', { status: 404 }))
+
+    const requestBody = 'the-registry-post'
+    const response = await dispatch('POST', 'entities/active', '', requestBody)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:53211/entities/active',
+      expect.objectContaining({ method: 'POST', body: requestBody, duplex: 'half' })
+    )
+    expect(response.status).toBe(404)
+  })
+})

--- a/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
@@ -39,17 +39,21 @@ describe('start/server/asset-bundles-proxy', () => {
 
   it('streams requests through to the sidecar, stripping the mount prefix and keeping the query string', async () => {
     const { fetch, dispatch } = makeProxy(() => 'http://127.0.0.1:53211')
-    fetch.mockResolvedValue(
-      new Response('bundle-bytes', {
-        status: 200,
-        headers: {
-          'content-type': 'application/octet-stream',
-          // undici already decompressed the body: these must not be forwarded
-          'content-encoding': 'gzip',
-          'content-length': '999'
-        }
-      })
-    )
+    const sidecarResponse = new Response('bundle-bytes', {
+      status: 200,
+      headers: {
+        'content-type': 'application/octet-stream',
+        // undici already decompressed the body: these must not be forwarded
+        'content-encoding': 'gzip',
+        'content-length': '999'
+      }
+    })
+    // real fetch() responses carry immutable Headers (guard "immutable"), unlike
+    // constructed ones (guard "response") — mimic that so a mutation regresses loudly
+    sidecarResponse.headers.delete = () => {
+      throw new TypeError('immutable')
+    }
+    fetch.mockResolvedValue(sidecarResponse)
 
     const response = await dispatch('GET', 'v49/b64-abc/scene_bundle', '?x=1')
 

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -66,14 +66,16 @@ describe('explorer-alpha', () => {
         baseCoords: { x: 0, y: 0 },
         isHub: false,
         args,
-        assetBundlesUrl: 'http://127.0.0.1:5147'
+        assetBundlesUrl: 'http://127.0.0.1:8000/optimized-assets'
       })
 
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
         expect.arrayContaining([
-          expect.stringContaining(`optimized-assets-url=${encodeURIComponent('http://127.0.0.1:5147')}`)
+          expect.stringContaining(
+            `optimized-assets-url=${encodeURIComponent('http://127.0.0.1:8000/optimized-assets')}`
+          )
         ]),
         { silent: true }
       )

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -57,7 +57,7 @@ describe('explorer-alpha', () => {
       )
     })
 
-    it('should include optimized-assets-url only when an asset bundles url is provided', async () => {
+    it('should include local-ab only when asset bundles are enabled', async () => {
       const args: any = {}
 
       await runExplorerAlpha(mockComponents, {
@@ -66,24 +66,20 @@ describe('explorer-alpha', () => {
         baseCoords: { x: 0, y: 0 },
         isHub: false,
         args,
-        assetBundlesUrl: 'http://127.0.0.1:8000/optimized-assets'
+        assetBundles: true
       })
 
-      expect(mockExec).toHaveBeenCalledWith(
-        '/test',
-        'open',
-        expect.arrayContaining([
-          expect.stringContaining(
-            `optimized-assets-url=${encodeURIComponent('http://127.0.0.1:8000/optimized-assets')}`
-          )
-        ]),
-        { silent: true }
-      )
-      // local-ab makes the scene itself load bundles; it travels with the url
+      // local-ab alone: the explorer derives the /optimized-assets base from the realm
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
         expect.arrayContaining([expect.stringContaining('local-ab=true')]),
+        { silent: true }
+      )
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.not.arrayContaining([expect.stringContaining('optimized-assets-url')]),
         { silent: true }
       )
 
@@ -97,12 +93,6 @@ describe('explorer-alpha', () => {
         args
       })
 
-      expect(mockExec).toHaveBeenCalledWith(
-        '/test',
-        'open',
-        expect.not.arrayContaining([expect.stringContaining('optimized-assets-url')]),
-        { silent: true }
-      )
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',


### PR DESCRIPTION
Implements the sdk-commands side of [decentraland/abgen#21](https://github.com/decentraland/abgen/issues/21) (filed there because issues are disabled in this repo). Stacked on #1498.

## What

Mounts the abgen sidecar behind the preview server as a thin streaming reverse proxy:

```
GET  {realm}/optimized-assets/manifest/{id}_{platform}.json  →  sidecar
GET  {realm}/optimized-assets/v49/{id}/{bundle}              →  sidecar
POST {realm}/optimized-assets/entities/active                →  sidecar
```

Clients now only ever know **one origin — the realm they already have**. The sidecar's port becomes fully private to sdk-commands, and the deep link carries no assets URL at all: `local-ab=true` alone, with the explorer deriving the `/optimized-assets` base from the realm.

## How

- **New `/optimized-assets/:path+` route** (`server/asset-bundles-proxy.ts`), following the existing `/lambdas/:path+` proxy pattern: streams every method through to the sidecar (the explorer's registry POSTs included) and forwards status and headers both ways. The target is late-bound — the sidecar boots *after* the preview server (it reads the scene through the preview's own `/content` endpoints) — so the route answers 503 until the sidecar is up.
  - **Request headers ride along** minus the per-connection ones (`host`, `connection`, `content-length`, `accept-encoding`): without their `content-type`, the sidecar 415s the explorer's JSON registry POSTs, which broke wearable/catalyst entity resolution. Dropping `connection` (rather than forcing `close`) keeps undici's keep-alive pool to the sidecar warm across the hundreds of bundle GETs of a scene load.
  - **Response headers are filtered, not mutated**: `fetch()` responses carry immutable `Headers` in undici — `headers.delete()` threw `TypeError: immutable` on every proxied request — so `content-encoding`/`content-length` (stale after undici's transparent decompression) are dropped from a plain-object copy instead. The same pre-existing bug on `main`'s `/content/entities` deploy proxy is split out as #1506 (with its test); the fix commit is also cherry-picked here so branch builds keep deploying — it resolves to a no-op once #1506 lands.
- **Sidecar port moves back to `getPort(0)`**: the 5147 preferred-port convention existed only so a deeplink-less Unity Editor could guess the sidecar's address; with the proxy, everything derives from the realm origin instead.
- **`optimized-assets-url` deeplink param is gone**: `runExplorerAlpha` takes a plain `assetBundles` boolean and emits only `local-ab=true`. The explorer infers the assets base from the realm, so there is no URL to pass.

## Follow-up (other repos)

- **unity-explorer** (after decentraland/unity-explorer#9459): when `local-ab` is set, derive the assets base from the realm — note the base carries a path prefix (`/optimized-assets`), which the URL-building code must handle. This is now required, not optional: sdk-commands no longer sends an explicit URL.
- **abgen**: nothing — this only changes who fronts it.

## Test plan

- New `asset-bundles-proxy.spec.ts`: mount path, 503 before the sidecar is up, prefix-strip + query-string forwarding + body streaming on GET, method/body/status forwarding on POST, request-header forwarding (client `content-type` kept, per-connection headers replaced), and response-header scrubbing against a fetch-faithful mock whose `Headers.delete` throws `TypeError: immutable`.
- Updated `explorer-alpha.spec.ts`: `local-ab=true` appears exactly when asset bundles are enabled; `optimized-assets-url` never does.
- Validated live against a running preview: wearable URN resolution through `POST /optimized-assets/entities/active` returns the full entity with complete bundle status.
- `npx tsc --noEmit` clean on sdk-commands; all tests under `test/sdk-commands/commands/start` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
