### PR TITLE
fix: don't mutate immutable fetch response headers in the /content/entities proxy

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
@@ -140,12 +140,14 @@ export async function setupEcs6Endpoints(
     // undici decompresses the body but leaves the original content-encoding /
     // content-length headers in place; forwarding them would make the client
     // re-decode (or truncate to the compressed length) the already-decoded body.
-    res.headers.delete('content-encoding')
-    res.headers.delete('content-length')
+    // fetch() responses carry immutable Headers, so filter instead of delete.
+    const headers = Object.fromEntries(res.headers)
+    delete headers['content-encoding']
+    delete headers['content-length']
 
     return {
       status: res.status,
-      headers: Object.fromEntries(res.headers),
+      headers,
       body: res.body ? Readable.fromWeb(res.body as any) : undefined
     }
   })

--- a/test/sdk-commands/commands/start/endpoints.spec.ts
+++ b/test/sdk-commands/commands/start/endpoints.spec.ts
@@ -1,0 +1,67 @@
+import * as path from 'path'
+
+import { setupEcs6Endpoints } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/endpoints'
+
+// a real package dir where @dcl/sdk and @dcl/explorer resolve, so the static-file
+// routes in setupEcs6Endpoints can register without touching the network
+const sdkCommandsDir = path.resolve(__dirname, '../../../../packages/@dcl/sdk-commands')
+
+async function makeEndpoints() {
+  const fetch = jest.fn()
+  const handlers = new Map<string, (ctx: any) => Promise<any>>()
+  const capture = (method: string) => (route: string, handler: any) => handlers.set(`${method} ${route}`, handler)
+  const router = { get: capture('GET'), post: capture('POST'), all: capture('ALL') }
+  const components = {
+    fetch: { fetch },
+    config: { getString: jest.fn().mockResolvedValue(undefined) },
+    fs: {},
+    logger: { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  }
+  const workspace = { rootWorkingDirectory: sdkCommandsDir, projects: [] }
+  await setupEcs6Endpoints(components as any, router as any, workspace as any)
+  return { fetch, handlers }
+}
+
+async function readBody(stream: AsyncIterable<Buffer | string>): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+describe('start/server/endpoints', () => {
+  it('proxies POST /content/entities to the catalyst without mutating the immutable response headers', async () => {
+    const { fetch, handlers } = await makeEndpoints()
+    const handler = handlers.get('POST /content/entities')!
+    expect(handler).toBeDefined()
+
+    const catalystResponse = new Response('{"creationTimestamp":1}', {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        // undici already decompressed the body: these must not be forwarded
+        'content-encoding': 'gzip',
+        'content-length': '999'
+      }
+    })
+    // real fetch() responses carry immutable Headers (guard "immutable"), unlike
+    // constructed ones (guard "response") — mimic that so a mutation regresses loudly
+    catalystResponse.headers.delete = () => {
+      throw new TypeError('immutable')
+    }
+    fetch.mockResolvedValue(catalystResponse)
+
+    const response = await handler({ request: { body: 'the-deployment' } })
+
+    // stringMatching instead of the exact URL: catalystUrl.toString() carries a
+    // trailing slash on main, so the proxied URL has a pre-existing double slash
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/peer\.decentraland\.org\/+content\/entities$/),
+      expect.objectContaining({ method: 'post', body: 'the-deployment', duplex: 'half' })
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toBe('application/json')
+    expect(response.headers['content-encoding']).toBeUndefined()
+    expect(response.headers['content-length']).toBeUndefined()
+    await expect(readBody(response.body)).resolves.toBe('{"creationTimestamp":1}')
+  })
+})


### PR DESCRIPTION
## What

`POST /content/entities` (the preview server's deploy proxy to the catalyst) currently 500s on `main`:

```
TypeError: immutable
    at Headers.delete (.../undici/lib/fetch/headers.js:301:13)
```

Per the fetch spec, `Headers` on a response returned by `fetch()` carry the `"immutable"` guard, so `res.headers.delete('content-encoding')` throws on every request that reaches the route. The intent of those deletes is correct — undici transparently decompresses the body but leaves the original `content-encoding`/`content-length` in place, so forwarding them would make the client re-decode (or truncate) the already-decoded body — but they must be filtered from a copy, not deleted in place.

## How

Copy the headers into a plain object (`Object.fromEntries(res.headers)`) and delete the two stale keys there. Same shape the handler already returned.

## Why tests didn't catch it

Directly-constructed `new Response(...)` objects get headers with the mutable `"response"` guard, so a mock built that way happily accepts `.delete()`. The new spec overrides the mocked response's `headers.delete` to throw `TypeError: immutable`, faithfully reproducing a real `fetch()` response — verified that the test fails against the unfixed code and passes with the fix.

## Notes

Split out of #1504, which fixes the same pattern in its new `/optimized-assets` proxy — this occurrence predates that work and affects `main` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
