### PR TITLE
feat: convert preview asset bundles in-process instead of via a sidecar

### DIFF
--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/abgen-node": "^0.15.2",
+        "@dcl/abgen-node": "^0.15.4",
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "file:../ecs",
         "@dcl/gltf-validator-ts": "1.0.14",
@@ -125,29 +125,29 @@
       }
     },
     "node_modules/@dcl/abgen-node": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.2.tgz",
-      "integrity": "sha512-Hp+knLVURj762vySyMx27aOptBb9STNURYtloq5znV2CRi6oeoV7cp41ziMz7HWrxvjh6OGNh0AggS0rI6H0Og==",
-      "license": "AGPL-3.0-or-later",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.4.tgz",
+      "integrity": "sha512-jFo+AzztmRyrJhVu6zB33G09o60SwVqChypoE3zbMwdq+4hZ9LFmcvREXWfP6iRpaBfl6hbCXToJFbQ4ALZpIg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@dcl/abgen-node-darwin-arm64": "0.15.2",
-        "@dcl/abgen-node-darwin-x64": "0.15.2",
-        "@dcl/abgen-node-linux-arm64-gnu": "0.15.2",
-        "@dcl/abgen-node-linux-x64-gnu": "0.15.2",
-        "@dcl/abgen-node-win32-x64-msvc": "0.15.2"
+        "@dcl/abgen-node-darwin-arm64": "0.15.4",
+        "@dcl/abgen-node-darwin-x64": "0.15.4",
+        "@dcl/abgen-node-linux-arm64-gnu": "0.15.4",
+        "@dcl/abgen-node-linux-x64-gnu": "0.15.4",
+        "@dcl/abgen-node-win32-x64-msvc": "0.15.4"
       }
     },
     "node_modules/@dcl/abgen-node-darwin-arm64": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-arm64/-/abgen-node-darwin-arm64-0.15.2.tgz",
-      "integrity": "sha512-OyhbR1IvW/+Y1LRXCcB+K9rFG4EQa1dl47+++yiCOxYeex94eO3vXTE69BBgokdJGErU0uyKoE/xnXk6OiQdAA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-arm64/-/abgen-node-darwin-arm64-0.15.4.tgz",
+      "integrity": "sha512-OvcjpOLftuyQavEb78eYu2qsTnNZPJVRyV2bByiLYwYO8ctF1FZEtUWrm9Ma+6S6O+Qq/qmb9LqfyK5G94hf1g==",
       "cpu": [
         "arm64"
       ],
-      "license": "AGPL-3.0-or-later",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -157,13 +157,13 @@
       }
     },
     "node_modules/@dcl/abgen-node-darwin-x64": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-x64/-/abgen-node-darwin-x64-0.15.2.tgz",
-      "integrity": "sha512-+fVAG3j8zFEX3fLS/GIApYS22rxj8zonVW18+/dK0ov+KbgWEQ+VVvPHmeIUH2yfMCv58JO5DiVBZnrXbOI+TQ==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-x64/-/abgen-node-darwin-x64-0.15.4.tgz",
+      "integrity": "sha512-Wal2W7RhNfxJzmgjHJkywoAXPSdLrDkvHULxEdQhej5qoV5D6BT61haxC9MTV8rfZQVVtkEpfr8MOU2FwnOPVg==",
       "cpu": [
         "x64"
       ],
-      "license": "AGPL-3.0-or-later",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -173,16 +173,16 @@
       }
     },
     "node_modules/@dcl/abgen-node-linux-arm64-gnu": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-arm64-gnu/-/abgen-node-linux-arm64-gnu-0.15.2.tgz",
-      "integrity": "sha512-85vsjoNH8365+ziObtr5ULo0G4TManP3Rn6Xno17hCPEV13pR4TTEEx9P+ceAvmaXzfsiRPeIrmitkBd0fBkFA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-arm64-gnu/-/abgen-node-linux-arm64-gnu-0.15.4.tgz",
+      "integrity": "sha512-0WKwwhd29HGjg69fuFDZNN4zdOzY1mQJEKBHiZaaWO5GL6hYvEygFHXUEimB8ZvLK9+BP3QdvzB5I01vpTQowA==",
       "cpu": [
         "arm64"
       ],
       "libc": [
         "glibc"
       ],
-      "license": "AGPL-3.0-or-later",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -192,16 +192,16 @@
       }
     },
     "node_modules/@dcl/abgen-node-linux-x64-gnu": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-x64-gnu/-/abgen-node-linux-x64-gnu-0.15.2.tgz",
-      "integrity": "sha512-Scd9HHNVrU49ErlqjKDW+hNG46eIEk/td8XP9mCF/SZfTEutd8GAWYZtOfzPKAY8+T2vodWr3xqWYXUB/tNBtQ==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-x64-gnu/-/abgen-node-linux-x64-gnu-0.15.4.tgz",
+      "integrity": "sha512-z/Sklhjp1o62YeAM5GuLHy2H2Kw/QBoBdqskbhUpcdP5qjFEanOV3VKOgBUb2z2ByrsRzZiSBEFrjR4n40zCLw==",
       "cpu": [
         "x64"
       ],
       "libc": [
         "glibc"
       ],
-      "license": "AGPL-3.0-or-later",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -211,13 +211,13 @@
       }
     },
     "node_modules/@dcl/abgen-node-win32-x64-msvc": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-win32-x64-msvc/-/abgen-node-win32-x64-msvc-0.15.2.tgz",
-      "integrity": "sha512-FAyw2pGhmKHlBG8qlf/i8iPM6RasgwU8fBHuzXRlX3FHYi0WUrjv/HdZrV+IAim7+Iet0f7PV2v0eer0TkVjUg==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-win32-x64-msvc/-/abgen-node-win32-x64-msvc-0.15.4.tgz",
+      "integrity": "sha512-sAtG8ZbDeXUU1k+7rU7NDm+8M/a+7pmpzyY+3NTxZ5l4l1EmB4aMlDBTbaqvIPsWWL/xs6i4iBa/j3NAWrhfDg==",
       "cpu": [
         "x64"
       ],
-      "license": "AGPL-3.0-or-later",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -56,6 +56,9 @@
         "@types/qrcode": "^1.5.6",
         "@types/uuid": "^9.0.5",
         "@types/ws": "^8.5.4"
+      },
+      "optionalDependencies": {
+        "@dcl/abgen-node": "^0.15.0"
       }
     },
     "../ecs": {
@@ -121,6 +124,109 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dcl/abgen-node": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.0.tgz",
+      "integrity": "sha512-F57tg69zqyz3+PhWpQqKBTDWq/OWrfqTZr8HNEn5Wg62S/gTE6lMKsHzqEJNX53Z83bONwyPRc/DECaRek2uxA==",
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@dcl/abgen-node-darwin-arm64": "0.15.0",
+        "@dcl/abgen-node-darwin-x64": "0.15.0",
+        "@dcl/abgen-node-linux-arm64-gnu": "0.15.0",
+        "@dcl/abgen-node-linux-x64-gnu": "0.15.0",
+        "@dcl/abgen-node-win32-x64-msvc": "0.15.0"
+      }
+    },
+    "node_modules/@dcl/abgen-node-darwin-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-arm64/-/abgen-node-darwin-arm64-0.15.0.tgz",
+      "integrity": "sha512-JMBLztvtXS1HZeubzVNkbP2Qljbeb9Zyd4wX1UYpMFItmsnWzrJ9OLnwxGaxb0y17VhwynqQStPz7HMBNcX8Bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@dcl/abgen-node-darwin-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-x64/-/abgen-node-darwin-x64-0.15.0.tgz",
+      "integrity": "sha512-yHxLAK/e6+gIxvaBEps3nR9goFT3dJzb1hPNbRaWQn2MZ/Emd7xoccKyWrmX6JubgLCT9t5GcdEfRmG6VbBoWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@dcl/abgen-node-linux-arm64-gnu": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-arm64-gnu/-/abgen-node-linux-arm64-gnu-0.15.0.tgz",
+      "integrity": "sha512-r0igA9Dp7/5hSeEj62COe+VKatLlHCwOmKLeTDekjhDsCv6OpM5C1yifvBipk83e2/VNOJl9aJ1UE7IxLsZJMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@dcl/abgen-node-linux-x64-gnu": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-x64-gnu/-/abgen-node-linux-x64-gnu-0.15.0.tgz",
+      "integrity": "sha512-jbg/CBvEEAbCezTmYk9HqIrwyLbStijriD7rw+1uc2X3L8HSQNKne8tfdMtetFy1pJSGf/7cJSVMBz9QDDWbDA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@dcl/abgen-node-win32-x64-msvc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-win32-x64-msvc/-/abgen-node-win32-x64-msvc-0.15.0.tgz",
+      "integrity": "sha512-+MNtYKHtanmHgeLxnDNAR+lWDikf4mCLJ/OgRbiEx25xyseN5t6DV+v3xe596SsFLpvQFMG+9Zi3sKl5klln+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@dcl/catalyst-contracts": {

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/abgen-node": "^0.15.0",
+        "@dcl/abgen-node": "^0.15.2",
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "file:../ecs",
         "@dcl/gltf-validator-ts": "1.0.14",
@@ -125,25 +125,25 @@
       }
     },
     "node_modules/@dcl/abgen-node": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.0.tgz",
-      "integrity": "sha512-F57tg69zqyz3+PhWpQqKBTDWq/OWrfqTZr8HNEn5Wg62S/gTE6lMKsHzqEJNX53Z83bONwyPRc/DECaRek2uxA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.2.tgz",
+      "integrity": "sha512-Hp+knLVURj762vySyMx27aOptBb9STNURYtloq5znV2CRi6oeoV7cp41ziMz7HWrxvjh6OGNh0AggS0rI6H0Og==",
       "license": "AGPL-3.0-or-later",
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@dcl/abgen-node-darwin-arm64": "0.15.0",
-        "@dcl/abgen-node-darwin-x64": "0.15.0",
-        "@dcl/abgen-node-linux-arm64-gnu": "0.15.0",
-        "@dcl/abgen-node-linux-x64-gnu": "0.15.0",
-        "@dcl/abgen-node-win32-x64-msvc": "0.15.0"
+        "@dcl/abgen-node-darwin-arm64": "0.15.2",
+        "@dcl/abgen-node-darwin-x64": "0.15.2",
+        "@dcl/abgen-node-linux-arm64-gnu": "0.15.2",
+        "@dcl/abgen-node-linux-x64-gnu": "0.15.2",
+        "@dcl/abgen-node-win32-x64-msvc": "0.15.2"
       }
     },
     "node_modules/@dcl/abgen-node-darwin-arm64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-arm64/-/abgen-node-darwin-arm64-0.15.0.tgz",
-      "integrity": "sha512-JMBLztvtXS1HZeubzVNkbP2Qljbeb9Zyd4wX1UYpMFItmsnWzrJ9OLnwxGaxb0y17VhwynqQStPz7HMBNcX8Bg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-arm64/-/abgen-node-darwin-arm64-0.15.2.tgz",
+      "integrity": "sha512-OyhbR1IvW/+Y1LRXCcB+K9rFG4EQa1dl47+++yiCOxYeex94eO3vXTE69BBgokdJGErU0uyKoE/xnXk6OiQdAA==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@dcl/abgen-node-darwin-x64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-x64/-/abgen-node-darwin-x64-0.15.0.tgz",
-      "integrity": "sha512-yHxLAK/e6+gIxvaBEps3nR9goFT3dJzb1hPNbRaWQn2MZ/Emd7xoccKyWrmX6JubgLCT9t5GcdEfRmG6VbBoWA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-darwin-x64/-/abgen-node-darwin-x64-0.15.2.tgz",
+      "integrity": "sha512-+fVAG3j8zFEX3fLS/GIApYS22rxj8zonVW18+/dK0ov+KbgWEQ+VVvPHmeIUH2yfMCv58JO5DiVBZnrXbOI+TQ==",
       "cpu": [
         "x64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@dcl/abgen-node-linux-arm64-gnu": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-arm64-gnu/-/abgen-node-linux-arm64-gnu-0.15.0.tgz",
-      "integrity": "sha512-r0igA9Dp7/5hSeEj62COe+VKatLlHCwOmKLeTDekjhDsCv6OpM5C1yifvBipk83e2/VNOJl9aJ1UE7IxLsZJMw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-arm64-gnu/-/abgen-node-linux-arm64-gnu-0.15.2.tgz",
+      "integrity": "sha512-85vsjoNH8365+ziObtr5ULo0G4TManP3Rn6Xno17hCPEV13pR4TTEEx9P+ceAvmaXzfsiRPeIrmitkBd0fBkFA==",
       "cpu": [
         "arm64"
       ],
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@dcl/abgen-node-linux-x64-gnu": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-x64-gnu/-/abgen-node-linux-x64-gnu-0.15.0.tgz",
-      "integrity": "sha512-jbg/CBvEEAbCezTmYk9HqIrwyLbStijriD7rw+1uc2X3L8HSQNKne8tfdMtetFy1pJSGf/7cJSVMBz9QDDWbDA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-linux-x64-gnu/-/abgen-node-linux-x64-gnu-0.15.2.tgz",
+      "integrity": "sha512-Scd9HHNVrU49ErlqjKDW+hNG46eIEk/td8XP9mCF/SZfTEutd8GAWYZtOfzPKAY8+T2vodWr3xqWYXUB/tNBtQ==",
       "cpu": [
         "x64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@dcl/abgen-node-win32-x64-msvc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-win32-x64-msvc/-/abgen-node-win32-x64-msvc-0.15.0.tgz",
-      "integrity": "sha512-+MNtYKHtanmHgeLxnDNAR+lWDikf4mCLJ/OgRbiEx25xyseN5t6DV+v3xe596SsFLpvQFMG+9Zi3sKl5klln+w==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@dcl/abgen-node-win32-x64-msvc/-/abgen-node-win32-x64-msvc-0.15.2.tgz",
+      "integrity": "sha512-FAyw2pGhmKHlBG8qlf/i8iPM6RasgwU8fBHuzXRlX3FHYi0WUrjv/HdZrV+IAim7+Iet0f7PV2v0eer0TkVjUg==",
       "cpu": [
         "x64"
       ],

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@dcl/abgen-node": "^0.15.0",
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "file:../ecs",
         "@dcl/gltf-validator-ts": "1.0.14",
@@ -56,9 +57,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/uuid": "^9.0.5",
         "@types/ws": "^8.5.4"
-      },
-      "optionalDependencies": {
-        "@dcl/abgen-node": "^0.15.0"
       }
     },
     "../ecs": {
@@ -131,7 +129,6 @@
       "resolved": "https://registry.npmjs.org/@dcl/abgen-node/-/abgen-node-0.15.0.tgz",
       "integrity": "sha512-F57tg69zqyz3+PhWpQqKBTDWq/OWrfqTZr8HNEn5Wg62S/gTE6lMKsHzqEJNX53Z83bONwyPRc/DECaRek2uxA==",
       "license": "AGPL-3.0-or-later",
-      "optional": true,
       "engines": {
         "node": ">= 18"
       },

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -7,6 +7,7 @@
     "sdk-commands": "./dist/index.js"
   },
   "dependencies": {
+    "@dcl/abgen-node": "^0.15.0",
     "@dcl/crypto": "^3.4.4",
     "@dcl/ecs": "file:../ecs",
     "@dcl/gltf-validator-ts": "1.0.14",
@@ -76,8 +77,5 @@
     "readmeFile": "./README.md",
     "displayName": "SDK",
     "tsconfig": "./tsconfig.json"
-  },
-  "optionalDependencies": {
-    "@dcl/abgen-node": "^0.15.0"
   }
 }

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -7,7 +7,7 @@
     "sdk-commands": "./dist/index.js"
   },
   "dependencies": {
-    "@dcl/abgen-node": "^0.15.2",
+    "@dcl/abgen-node": "^0.15.4",
     "@dcl/crypto": "^3.4.4",
     "@dcl/ecs": "file:../ecs",
     "@dcl/gltf-validator-ts": "1.0.14",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -7,7 +7,7 @@
     "sdk-commands": "./dist/index.js"
   },
   "dependencies": {
-    "@dcl/abgen-node": "^0.15.0",
+    "@dcl/abgen-node": "^0.15.2",
     "@dcl/crypto": "^3.4.4",
     "@dcl/ecs": "file:../ecs",
     "@dcl/gltf-validator-ts": "1.0.14",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -76,5 +76,8 @@
     "readmeFile": "./README.md",
     "displayName": "SDK",
     "tsconfig": "./tsconfig.json"
+  },
+  "optionalDependencies": {
+    "@dcl/abgen-node": "^0.15.0"
   }
 }

--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -1,0 +1,452 @@
+import * as crypto from 'crypto'
+import * as path from 'path'
+
+import { CliComponents } from '../../components'
+import { printProgressInfo } from '../../logic/beautiful-logs'
+import { getCatalystBaseUrl } from '../../logic/config'
+import { b64UrlHashingFunction, getPublishableFiles, normalizeDecentralandFilename } from '../../logic/project-files'
+
+/** Bundles for one entity, keyed by the file name the ab-cdn serves them under. */
+export type ConvertedScene = {
+  entityId: string
+  platform: string
+  manifest: string
+  bundles: Map<string, Buffer>
+}
+
+export type AssetBundles = {
+  /** The previewed scene's entity id, as the preview content server hands it out. */
+  entityId: string
+  /** Where non-local entities (wearables, emotes) stream prebuilt bundles from. */
+  upstreamAbCdn: string
+  /** Always resolves; undefined when the conversion failed or found nothing. */
+  ready: Promise<ConvertedScene | undefined>
+  get(platform: string): ConvertedScene | undefined
+  /**
+   * Marks the converted scene stale. The next `ready` reconverts; until then
+   * nothing runs, so a save touching twenty files costs one conversion and an
+   * idle preview costs none.
+   */
+  invalidate(): void
+}
+
+/** Past this, a lock's owner is presumed dead and its staging is litter. */
+const STALE_LOCK_MS = 10 * 60_000
+/** Past this, converting twice beats waiting any longer on another preview. */
+const WAIT_FOR_LOCK_MS = 2 * 60_000
+const POLL_LOCK_MS = 250
+
+/** "windows" | "mac" | "linux" — the platforms abgen's export lane accepts. */
+export function hostPlatform(): string {
+  return process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'mac' : 'linux'
+}
+
+/**
+ * Converts the previewed scene in-process via @dcl/abgen-node.
+ *
+ * Converted up front, so the explorer's manifest request is a hit and cannot
+ * time out mid-conversion. Results persist under .dcl-optimized-assets, whose
+ * leading dot rides the default dcl-ignore — out of the watcher and out of
+ * deployments — so only a scene's first preview pays the wait.
+ *
+ * Returns undefined with a warning when the addon is not installed; the
+ * explorer degrades to raw GLTFs as it did without the sidecar binary.
+ */
+export async function setupAssetBundles(
+  components: Pick<CliComponents, 'fetch' | 'logger' | 'config' | 'fs'>,
+  projectRoot: string
+): Promise<AssetBundles | undefined> {
+  const abgen = await loadAbgen(components)
+  if (!abgen) return undefined
+
+  const entityId = b64UrlHashingFunction(projectRoot)
+  const catalystUrl = await getCatalystBaseUrl(components)
+  const upstreamAbCdn =
+    process.env.ABGEN_UPSTREAM_AB_CDN ||
+    (catalystUrl.includes('.zone') ? 'https://ab-cdn.decentraland.zone' : 'https://ab-cdn.decentraland.org')
+
+  const cacheRoot = path.join(projectRoot, '.dcl-optimized-assets')
+  const converted = new Map<string, ConvertedScene>()
+  const platform = hostPlatform()
+
+  await sweepStaging(components, cacheRoot)
+
+  // One conversion per distinct content, and only the newest publishes.
+  //
+  // Two separate faults lived here. A second invalidate() while a conversion
+  // was running started a duplicate run over identical bytes, and both wrote
+  // the same cache directory concurrently. And whichever run resolved LAST won
+  // the `converted` map, so a slow pre-edit run overwrote the fast post-edit
+  // one; `stale` was already false, so nothing re-ran, and preview served
+  // pre-edit bundles until the next edit — with `ready` resolving to the new
+  // scene while `get()` returned the old one.
+  //
+  // The digest is the lock: identical files means the same key, so a request
+  // for work already in flight joins it instead of starting a second. It also
+  // identifies the result — a run only publishes if its key is still the one
+  // most recently asked for, which is what makes a superseded run harmless
+  // rather than merely later. Keying on content and not mtime because a touch
+  // with no edit must not re-convert, and readProjectFiles already reads every
+  // byte, so the digest costs nothing extra.
+  const inFlight = new Map<string, Promise<ConvertedScene | undefined>>()
+  let wanted = ''
+
+  // Deciding whether to start a run is itself async — the key comes from
+  // reading the files — so the check and the registration must not be split by
+  // an await, or two callers both resume from readScene, both find the map
+  // empty, and both convert. This gate closes that window. It covers the
+  // decision ONLY, and opens again the moment one is made: held across the
+  // conversion it would serialise the work itself, and a newer edit has to be
+  // free to start while a superseded run is still going.
+  let gate: Promise<unknown> = Promise.resolve()
+
+  const run = (): Promise<ConvertedScene | undefined> => {
+    let opened!: () => void
+    const mine = new Promise<void>((resolve) => (opened = resolve))
+    const previous = gate
+    gate = mine
+
+    return (async () => {
+      await previous
+      try {
+        const scene = await readScene(components, projectRoot)
+        if (!scene) return undefined
+        wanted = scene.contentKey
+
+        const existing = inFlight.get(scene.contentKey)
+        if (existing) return existing
+
+        const task = convertScene(components, abgen, { projectRoot, entityId, platform, cacheRoot }, scene)
+          .then((result) => {
+            // Stale by the time it landed: someone edited while this ran, so a
+            // newer key is wanted and publishing this would undo it.
+            if (wanted !== scene.contentKey) return result
+            converted.clear()
+            if (result) converted.set(result.platform, result)
+            return result
+          })
+          .catch((error: Error) => {
+            components.logger.warn(`asset-bundles: conversion failed (${error.message}); previewing with raw GLTFs`)
+            return undefined
+          })
+          .finally(() => {
+            inFlight.delete(scene.contentKey)
+          })
+
+        inFlight.set(scene.contentKey, task)
+        return task
+      } finally {
+        // Before awaiting the conversion, not after: the decision is what is
+        // exclusive. `finally` also opens the gate when readScene throws, so a
+        // failed read cannot wedge every later run.
+        opened()
+      }
+    })()
+  }
+
+  let current = run()
+  let stale = false
+
+  return {
+    entityId,
+    upstreamAbCdn,
+    // A getter, not a field: reconversion happens on demand, so the caller
+    // that awaits it gets the fresh scene rather than one from before its edit.
+    get ready() {
+      if (stale) {
+        stale = false
+        current = run()
+      }
+      return current
+    },
+    get: (p) => converted.get(p),
+    invalidate() {
+      stale = true
+    }
+  }
+}
+
+/** An optionalDependency: no prebuild for this platform must not fail the preview. */
+async function loadAbgen(components: Pick<CliComponents, 'logger'>): Promise<AbgenModule | undefined> {
+  try {
+    // Through a variable so the build does not require the addon present.
+    const specifier = '@dcl/abgen-node'
+    return (await import(specifier)) as unknown as AbgenModule
+  } catch (error: any) {
+    components.logger.warn(
+      `asset-bundles: @dcl/abgen-node is not available (${error.message}); install it to serve asset bundles in preview, or run without --asset-bundles.`
+    )
+    return undefined
+  }
+}
+
+type SceneFile = { name: string; data: Buffer }
+
+/** What the scene currently is: its files and the key they hash to. */
+async function readScene(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  projectRoot: string
+): Promise<{ files: SceneFile[]; contentKey: string } | undefined> {
+  const files = await readProjectFiles(components, projectRoot)
+  if (!files.length) {
+    components.logger.warn('asset-bundles: the project has no publishable files; nothing to convert')
+    return undefined
+  }
+  // Keyed on what was converted, never on where it lives: a path-keyed entry
+  // served stale bundles for the rest of the scene's life after any edit.
+  // Names are in the digest too, abgen deriving bundle names from them.
+  return { files, contentKey: digestOf(files) }
+}
+
+async function convertScene(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  abgen: AbgenModule,
+  job: { projectRoot: string; entityId: string; platform: string; cacheRoot: string },
+  input: { files: SceneFile[]; contentKey: string }
+): Promise<ConvertedScene | undefined> {
+  const { files, contentKey } = input
+  const full = { ...job, contentKey }
+  const cached = await readCache(components, full)
+  if (cached) {
+    components.logger.log(`asset-bundles: scene already converted (${cached.bundles.size} bundles, cached)`)
+    return cached
+  }
+
+  const lock = await acquireLock(components, full)
+  try {
+    // The lock may have been held by another preview that has since finished,
+    // so the miss above can be out of date by the time we get here.
+    const justFinished = await readCache(components, full)
+    if (justFinished) {
+      components.logger.log(
+        `asset-bundles: scene converted by another preview (${justFinished.bundles.size} bundles, cached)`
+      )
+      return justFinished
+    }
+    return await runConversion(components, abgen, full, files)
+  } finally {
+    await lock.release()
+  }
+}
+
+/**
+ * Keeps a second preview of the same project off work already in progress.
+ *
+ * Advisory only, and deliberately so: every failure mode here — a stale lock, a
+ * timeout, an unwritable directory — degrades to converting twice, which
+ * writeCache's atomic publish already makes safe. Correctness never rests on
+ * the lock, so it can be as approximate as it likes.
+ */
+async function acquireLock(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  job: { cacheRoot: string; platform: string; contentKey: string }
+): Promise<{ release(): Promise<void> }> {
+  const lockPath = `${cacheDir(job)}.lock`
+  const noop = { release: async () => undefined }
+  const drop = {
+    release: async () => {
+      try {
+        await components.fs.unlink(lockPath)
+      } catch {
+        // Someone judged it stale and took it. Theirs to remove now.
+      }
+    }
+  }
+
+  const deadline = Date.now() + WAIT_FOR_LOCK_MS
+  for (;;) {
+    try {
+      await components.fs.mkdir(job.cacheRoot, { recursive: true })
+      await components.fs.writeFile(lockPath, `${process.pid}\n`, { flag: 'wx' })
+      return drop
+    } catch (error: any) {
+      if (error?.code !== 'EEXIST') return noop
+    }
+
+    const age = await lockAge(components, lockPath)
+    if (age === undefined) continue // released while we looked; try to take it
+    if (age > STALE_LOCK_MS) {
+      // Its owner died mid-conversion. Nothing here is transactional enough to
+      // be worth a handshake — the cost of being wrong is a second conversion.
+      try {
+        await components.fs.unlink(lockPath)
+      } catch {
+        // Lost the race to another waiter; it holds the lock now.
+      }
+      continue
+    }
+    if (Date.now() > deadline) {
+      components.logger.warn('asset-bundles: another preview is still converting this scene; converting anyway')
+      return noop
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_LOCK_MS))
+  }
+}
+
+async function lockAge(components: Pick<CliComponents, 'fs'>, lockPath: string): Promise<number | undefined> {
+  try {
+    return Date.now() - (await components.fs.stat(lockPath)).mtimeMs
+  } catch {
+    return undefined
+  }
+}
+
+async function runConversion(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  abgen: AbgenModule,
+  job: { projectRoot: string; entityId: string; platform: string; cacheRoot: string; contentKey: string },
+  files: SceneFile[]
+): Promise<ConvertedScene | undefined> {
+  const started = Date.now()
+  printProgressInfo(components.logger, 'asset-bundles: converting the scene (cached after the first run)...')
+
+  const result = await abgen.convert({ files, platform: job.platform, entityHash: job.entityId })
+
+  const elapsed = Math.round((Date.now() - started) / 1000)
+  if (result.code !== 0 || result.errors.length) {
+    components.logger.warn(
+      `asset-bundles: conversion failed (${
+        result.errors.join('; ') || `code ${result.code}`
+      }); previewing with raw GLTFs`
+    )
+    return undefined
+  }
+
+  // Per-asset failures are not run failures: the explorer falls back to the
+  // raw GLTF for those assets alone.
+  const manifest = result.manifest ?? '{}'
+  if (!/"exitCode"\s*:\s*0/.test(manifest)) {
+    components.logger.warn(
+      'asset-bundles: some assets failed to convert; they will load as raw GLTFs (see the scene manifest)'
+    )
+  }
+
+  const scene: ConvertedScene = {
+    entityId: job.entityId,
+    platform: job.platform,
+    manifest,
+    bundles: new Map(result.bundles.map((b) => [b.name, b.data]))
+  }
+  await writeCache(components, job, scene)
+  components.logger.log(`asset-bundles: scene converted (${scene.bundles.size} bundles, ${elapsed}s)`)
+  return scene
+}
+
+/** Content-path → bytes, exactly the set the preview content server publishes. */
+async function readProjectFiles(
+  components: Pick<CliComponents, 'fs'>,
+  projectRoot: string
+): Promise<Array<{ name: string; data: Buffer }>> {
+  const relatives = await getPublishableFiles(components, projectRoot)
+  const files: Array<{ name: string; data: Buffer }> = []
+  for (const relative of relatives) {
+    const absolute = path.resolve(projectRoot, relative)
+    files.push({
+      name: normalizeDecentralandFilename(projectRoot, absolute),
+      data: await components.fs.readFile(absolute)
+    })
+  }
+  return files
+}
+
+/** sha256 over every publishable file's name and bytes, in a stable order. */
+function digestOf(files: Array<{ name: string; data: Buffer }>): string {
+  const h = crypto.createHash('sha256')
+  for (const { name, data } of [...files].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))) {
+    h.update(name)
+    h.update('\0')
+    h.update(data)
+    h.update('\0')
+  }
+  return h.digest('hex').slice(0, 32)
+}
+
+function cacheDir(job: { cacheRoot: string; platform: string; contentKey: string }): string {
+  return path.join(job.cacheRoot, `${job.contentKey}_${job.platform}`)
+}
+
+async function readCache(
+  components: Pick<CliComponents, 'fs'>,
+  job: { cacheRoot: string; entityId: string; platform: string; contentKey: string }
+): Promise<ConvertedScene | undefined> {
+  const dir = cacheDir(job)
+  const manifestPath = path.join(dir, 'manifest.json')
+  if (!(await components.fs.fileExists(manifestPath))) return undefined
+  try {
+    const manifest = await components.fs.readFile(manifestPath, 'utf8')
+    const bundles = new Map<string, Buffer>()
+    for (const name of await components.fs.readdir(path.join(dir, 'bundles'))) {
+      bundles.set(name, await components.fs.readFile(path.join(dir, 'bundles', name)))
+    }
+    return { entityId: job.entityId, platform: job.platform, manifest, bundles }
+  } catch {
+    // A half-written cache is not worth salvaging; reconvert.
+    return undefined
+  }
+}
+
+/**
+ * Publishes the conversion as one indivisible step.
+ *
+ * Written into a private staging directory and moved into place with a single
+ * rename, which is atomic on every filesystem this runs on. A reader therefore
+ * sees the entry complete or not at all, and two previews converting the same
+ * content race harmlessly: the loser's bytes are identical to the winner's, so
+ * it discards them rather than merging into a directory someone else owns.
+ */
+async function writeCache(
+  components: Pick<CliComponents, 'fs'>,
+  job: { cacheRoot: string; entityId: string; platform: string; contentKey: string },
+  scene: ConvertedScene
+): Promise<void> {
+  const dir = cacheDir(job)
+  const staging = `${dir}.tmp-${crypto.randomBytes(6).toString('hex')}`
+  await components.fs.mkdir(path.join(staging, 'bundles'), { recursive: true })
+  for (const [name, data] of scene.bundles) {
+    await components.fs.writeFile(path.join(staging, 'bundles', name), data)
+  }
+  await components.fs.writeFile(path.join(staging, 'manifest.json'), scene.manifest)
+
+  try {
+    await components.fs.rename(staging, dir)
+  } catch {
+    await components.fs.rm(staging, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Clears staging directories a killed conversion left behind.
+ *
+ * Age-gated because a young one is not litter — it belongs to a preview that is
+ * converting right now, and removing it would delete that conversion's output
+ * from under it.
+ */
+async function sweepStaging(components: Pick<CliComponents, 'fs'>, cacheRoot: string): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await components.fs.readdir(cacheRoot)
+  } catch {
+    return // no cache yet, nothing to sweep
+  }
+  for (const entry of entries) {
+    if (!/\.tmp-[0-9a-f]+$/.test(entry)) continue
+    const full = path.join(cacheRoot, entry)
+    try {
+      if (Date.now() - (await components.fs.stat(full)).mtimeMs < STALE_LOCK_MS) continue
+      await components.fs.rm(full, { recursive: true, force: true })
+    } catch {
+      // Being removed by whoever owns it, or not ours to remove.
+    }
+  }
+}
+
+/** The slice of @dcl/abgen-node this command uses. */
+type AbgenModule = {
+  convert(options: { files: Array<{ name: string; data: Buffer }>; platform?: string; entityHash?: string }): Promise<{
+    code: number
+    bundles: Array<{ name: string; data: Buffer }>
+    events: string[]
+    errors: string[]
+    manifest?: string
+  }>
+}

--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -49,8 +49,8 @@ export function hostPlatform(): string {
  * leading dot rides the default dcl-ignore — out of the watcher and out of
  * deployments — so only a scene's first preview pays the wait.
  *
- * Returns undefined with a warning when the addon is not installed; the
- * explorer degrades to raw GLTFs as it did without the sidecar binary.
+ * Returns undefined with a warning when the native addon is unavailable; the
+ * explorer degrades to raw GLTFs.
  */
 export async function setupAssetBundles(
   components: Pick<CliComponents, 'fetch' | 'logger' | 'config' | 'fs'>,

--- a/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/asset-bundles.ts
@@ -166,7 +166,13 @@ export async function setupAssetBundles(
   }
 }
 
-/** An optionalDependency: no prebuild for this platform must not fail the preview. */
+/**
+ * A plain dependency, so the module is always installed — but the native
+ * binary inside it is not. @dcl/abgen-node carries no os/cpu constraint and
+ * declares its five per-platform binaries as its own optionalDependencies, so
+ * on a platform with no prebuild (musl, win32-arm64) the package resolves and
+ * the require fails. That must degrade the preview, not end it.
+ */
 async function loadAbgen(components: Pick<CliComponents, 'logger'>): Promise<AbgenModule | undefined> {
   try {
     // Through a variable so the build does not require the addon present.
@@ -174,7 +180,8 @@ async function loadAbgen(components: Pick<CliComponents, 'logger'>): Promise<Abg
     return (await import(specifier)) as unknown as AbgenModule
   } catch (error: any) {
     components.logger.warn(
-      `asset-bundles: @dcl/abgen-node is not available (${error.message}); install it to serve asset bundles in preview, or run without --asset-bundles.`
+      `asset-bundles: no @dcl/abgen-node binary for ${process.platform}-${process.arch} (${error.message}); ` +
+        'previewing with raw GLTFs. Run without --asset-bundles to silence this.'
     )
     return undefined
   }

--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -37,11 +37,12 @@ export async function runExplorerAlpha(
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
+    assetBundles?: boolean
   }
 ) {
-  const { cwd, realm, baseCoords, isHub } = opts
+  const { cwd, realm, baseCoords, isHub, assetBundles } = opts
 
-  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args })) {
+  if (await runApp(components, { cwd, realm, baseCoords, isHub, args: opts.args, assetBundles })) {
     return
   }
 
@@ -55,13 +56,15 @@ async function runApp(
     realm: realmValue,
     baseCoords,
     isHub,
-    args
+    args,
+    assetBundles
   }: {
     cwd: string
     realm: string
     baseCoords: { x: number; y: number }
     isHub: boolean
     args: Result<typeof startArgs>
+    assetBundles?: boolean
   }
 ) {
   const cmd = isWindows ? 'start' : 'open'
@@ -89,6 +92,12 @@ async function runApp(
     params.set('dclenv', dclenv)
 
     params.set('local-scene', 'true')
+
+    if (assetBundles) {
+      // the explorer derives the /optimized-assets base from the realm it
+      // already has; this flag makes the scene itself load asset bundles
+      params.set('local-ab', 'true')
+    }
 
     if (isHub) {
       params.set('hub', 'true')

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -28,6 +28,7 @@ import { printCurrentProjectStarting, printProgressInfo, printWarning } from '..
 import { Result } from 'arg'
 import { startValidations } from '../../logic/project-validations'
 import { runExplorerAlpha } from './explorer-alpha'
+import { AssetBundles, setupAssetBundles } from './asset-bundles'
 import { getLanUrl } from './utils'
 
 interface Options {
@@ -69,6 +70,7 @@ export const args = declareArgs({
   '--web': '--bevy-web',
   '--multi-instance': Boolean,
   '--no-client': Boolean,
+  '--asset-bundles': Boolean,
   '--mcp': Boolean,
   '--mcp-port': Number
 })
@@ -99,6 +101,7 @@ export async function help(options: Options) {
       --mobile                          Show QR code for mobile preview on the same network.
       --multi-instance                  Allow running multiple Explorer instances simultaneously.
       --no-client                       Suppress every auto-launch (desktop Explorer deeplink, browser open, mobile QR). The file watcher still notifies a desktop Explorer if it connects on its own — useful when an external tool owns the Explorer process.
+      --asset-bundles                   Convert the scene to asset bundles in-process via @dcl/abgen-node (skipped with a warning when the addon is unavailable).
       --mcp                             Enable the MCP server in the Explorer (forwarded as a deep link parameter).
       --mcp-port                        Port for the MCP server in the Explorer (forwarded as a deep link parameter).
 
@@ -137,6 +140,7 @@ export async function main(options: Options) {
   const explorerAlpha = !bevyWeb
 
   const workspace = await getValidWorkspace(options.components, workingDirectory)
+  const withAssetBundles = !!options.args['--asset-bundles']
 
   /* istanbul ignore if */
   if (workspace.projects.length > 1)
@@ -210,13 +214,31 @@ export async function main(options: Options) {
         }
       }
 
-      await wireRouter(components, workspace, dataLayer)
+      // conversion starts after the server is listening, so the routes read
+      // the handle late
+      const assetBundles: { value?: AssetBundles } = {}
+      await wireRouter(components, workspace, dataLayer, withAssetBundles ? () => assetBundles.value : undefined)
       if (watch) {
         for (const project of workspace.projects) {
-          await wireFileWatcherToWebSockets(components, project.workingDirectory, project.kind)
+          await wireFileWatcherToWebSockets(components, project.workingDirectory, project.kind, () =>
+            assetBundles.value?.invalidate()
+          )
         }
       }
       await startComponents()
+
+      if (withAssetBundles) {
+        assetBundles.value = await setupAssetBundles(
+          components,
+          workspace.projects[0]?.workingDirectory || workingDirectory
+        )
+        if (assetBundles.value) {
+          printProgressInfo(
+            options.components.logger,
+            `Serving asset bundles (abgen, in-process): http://127.0.0.1:${port}/optimized-assets`
+          )
+        }
+      }
 
       const networkInterfaces = os.networkInterfaces()
       const availableURLs: string[] = []
@@ -257,7 +279,16 @@ export async function main(options: Options) {
 
       if (explorerAlpha && !isMobile && !skipClient) {
         const realm = new URL(sortedURLs[0]).origin
-        await runExplorerAlpha(components, { cwd: workingDirectory, realm, baseCoords, isHub, args: options.args })
+        await runExplorerAlpha(components, {
+          cwd: workingDirectory,
+          realm,
+          baseCoords,
+          isHub,
+          args: options.args,
+          // the explorer derives the /optimized-assets base from the realm it
+          // already has
+          assetBundles: !!assetBundles.value
+        })
       }
 
       if (isMobile && !skipClient && lanUrl) {

--- a/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy.ts
@@ -1,0 +1,125 @@
+import { Router } from '@well-known-components/http-server'
+import { Readable } from 'stream'
+
+import { CliComponents } from '../../../components'
+import { AssetBundles } from '../asset-bundles'
+import { PreviewComponents } from '../types'
+
+/**
+ * Serves the ab-cdn surface the explorer expects, under the realm origin:
+ *
+ *   GET {realm}/optimized-assets/manifest/{entity}_{platform}.json
+ *   GET {realm}/optimized-assets/{version}/{cid}/{file}
+ *
+ * The previewed scene is converted in-process (../asset-bundles) and answered
+ * from memory. Everything else — wearables, emotes, any entity that is not the
+ * scene under preview — reads through to the production ab-cdn: the preview
+ * server holds the local scene's files, so converting those here could only
+ * fail.
+ */
+export function setupAssetBundlesProxy(
+  components: Pick<CliComponents, 'fetch'>,
+  router: Router<PreviewComponents>,
+  getAssetBundles: () => AssetBundles | undefined
+) {
+  router.get('/optimized-assets/manifest/:name', async (ctx) => {
+    const assetBundles = getAssetBundles()
+    if (!assetBundles) return { status: 503, body: { ok: false, error: 'asset bundles are not enabled' } }
+
+    const parsed = parseManifestName(ctx.params.name)
+    if (!parsed) return { status: 404, body: { ok: false, error: 'malformed manifest name' } }
+
+    if (parsed.entityId !== assetBundles.entityId) {
+      if (!safeSegments(ctx.params.name)) {
+        return { status: 400, body: { ok: false, error: 'illegal manifest name' } }
+      }
+      return readThrough(components, assetBundles, `manifest/${ctx.params.name}`, ctx.url.search)
+    }
+
+    // The explorer asking early must wait, not see a 404 and fall back to raw
+    // GLTFs for good.
+    await assetBundles.ready
+    const scene = assetBundles.get(parsed.platform)
+    if (!scene) return { status: 404, body: { ok: false, error: 'the scene was not converted' } }
+
+    return {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: scene.manifest
+    }
+  })
+
+  router.get('/optimized-assets/:version/:cid/:file', async (ctx) => {
+    const assetBundles = getAssetBundles()
+    if (!assetBundles) return { status: 503, body: { ok: false, error: 'asset bundles are not enabled' } }
+
+    const { version, cid, file } = ctx.params
+    if (cid === assetBundles.entityId) {
+      await assetBundles.ready
+      for (const platform of platformsOf(assetBundles)) {
+        const data = assetBundles.get(platform)?.bundles.get(file)
+        if (data) {
+          return {
+            status: 200,
+            headers: { 'content-type': 'application/octet-stream' },
+            body: data
+          }
+        }
+      }
+      return { status: 404, body: { ok: false, error: 'no such bundle' } }
+    }
+
+    if (!safeSegments(version, cid, file)) {
+      return { status: 400, body: { ok: false, error: 'illegal bundle path' } }
+    }
+    return readThrough(components, assetBundles, `${version}/${cid}/${file}`, ctx.url.search)
+  })
+}
+
+/** `{entityId}_{platform}.json` — the ab-cdn manifest naming. */
+function parseManifestName(name: string): { entityId: string; platform: string } | undefined {
+  const stem = name.endsWith('.json') ? name.slice(0, -'.json'.length) : undefined
+  if (!stem) return undefined
+  const underscore = stem.lastIndexOf('_')
+  if (underscore <= 0) return undefined
+  return { entityId: stem.slice(0, underscore), platform: stem.slice(underscore + 1) }
+}
+
+function platformsOf(assetBundles: AssetBundles): string[] {
+  return ['windows', 'mac', 'linux', 'webgl'].filter((p) => assetBundles.get(p))
+}
+
+/** ab-cdn path segments are hashes and bundle names; nothing else is legal. */
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/
+
+function safeSegments(...segments: string[]): boolean {
+  return segments.every((seg) => SAFE_SEGMENT.test(seg) && seg !== '.' && seg !== '..')
+}
+
+// The upstream is a third party and this reply carries the realm's origin:
+// forwarding wholesale would let it set cookies and CSP for a preview server
+// that serves Access-Control-Allow-Origin: *.
+const FORWARDED_HEADERS = ['content-type', 'etag', 'cache-control', 'last-modified']
+
+async function readThrough(
+  components: Pick<CliComponents, 'fetch'>,
+  assetBundles: AssetBundles,
+  suffix: string,
+  search: string
+) {
+  const response = await components.fetch.fetch(`${assetBundles.upstreamAbCdn}/${suffix}${search}`)
+
+  const headers: Record<string, string> = {}
+  for (const name of FORWARDED_HEADERS) {
+    const value = response.headers.get(name)
+    if (value) headers[name] = value
+  }
+
+  return {
+    status: response.status,
+    headers,
+    // Streamed: these are tens of MB each and the explorer asks for many at
+    // once, so buffering put every body in the dev server's heap.
+    body: response.body ? Readable.fromWeb(response.body as any) : undefined
+  }
+}

--- a/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/endpoints.ts
@@ -9,9 +9,9 @@ import { PreviewComponents } from '../types'
 import { fetchEntityByPointer } from '../../../logic/catalyst-requests'
 import { CliComponents } from '../../../components'
 import {
-  b64HashingFunction,
+  b64UrlHashDecodingFunction,
+  b64UrlHashingFunction,
   getProjectPublishableFilesWithHashes,
-  machineId,
   projectFilesToContentMappings
 } from '../../../logic/project-files'
 import { getCatalystBaseUrl, getInstalledPackageVersion } from '../../../logic/config'
@@ -199,9 +199,7 @@ async function serveFolders(
 
   router.get('/content/contents/:hash', async (ctx, next) => {
     if (ctx.params.hash && ctx.params.hash.startsWith('b64-')) {
-      const decoded = Buffer.from(ctx.params.hash.replace(/^b64-/, ''), 'base64').toString('utf8')
-      // Strip the machineId suffix that was added during encoding
-      const fullPath = path.resolve(decoded.slice(0, -(machineId.length + 1)))
+      const fullPath = path.resolve(b64UrlHashDecodingFunction(ctx.params.hash))
 
       // find a project that we are talking about. NOTE: this filter is not exhaustive
       //   relative paths should be used instead
@@ -214,7 +212,7 @@ async function serveFolders(
 
       if (path.resolve(fullPath) === path.resolve(baseProject.workingDirectory)) {
         // if we are talking about the root directory, then we must return the json of the entity
-        const entity = await fakeEntityV3FromProject(components, baseProject, async ($) => b64HashingFunction($))
+        const entity = await fakeEntityV3FromProject(components, baseProject, async ($) => b64UrlHashingFunction($))
 
         if (!entity) return { status: 404 }
 
@@ -355,7 +353,7 @@ async function serveWearable(
   }
 
   const projectFiles = await getProjectPublishableFilesWithHashes(components, project.workingDirectory, async ($) =>
-    b64HashingFunction($)
+    b64UrlHashingFunction($)
   )
   const contentFiles = projectFilesToContentMappings(project.workingDirectory, projectFiles)
 
@@ -364,7 +362,7 @@ async function serveWearable(
     thumbnailFiltered.length > 0 && thumbnailFiltered[0]!.hash && `${baseUrl}/${thumbnailFiltered[0].hash}`
 
   // Set wearable ID.
-  const sceneHash = b64HashingFunction(project.workingDirectory)
+  const sceneHash = b64UrlHashingFunction(project.workingDirectory)
   const wearableId = wearableCache.get(sceneHash) ?? `urn:${uuidv4()}`
   wearableCache.set(sceneHash, wearableId)
 
@@ -409,7 +407,7 @@ async function getSceneJson(
 
   const allDeployments = await Promise.all(
     workspace.projects.map((project) =>
-      fakeEntityV3FromProject(components, project, async ($) => b64HashingFunction($))
+      fakeEntityV3FromProject(components, project, async ($) => b64UrlHashingFunction($))
     )
   )
 

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -6,7 +6,7 @@ import { getDCLIgnorePatterns } from '../../../logic/dcl-ignore'
 import { PreviewComponents } from '../types'
 import { sceneUpdateClients } from './routes'
 import { ProjectUnion } from '../../../logic/project-validations'
-import { b64HashingFunction } from '../../../logic/project-files'
+import { b64UrlHashingFunction } from '../../../logic/project-files'
 import {
   WsSceneMessage,
   UpdateModelType
@@ -20,10 +20,25 @@ import { debounce } from '../../../logic/debounce'
 export async function wireFileWatcherToWebSockets(
   components: Pick<PreviewComponents, 'fs' | 'ws' | 'logger'>,
   projectRoot: string,
-  projectKind: ProjectUnion['kind']
+  projectKind: ProjectUnion['kind'],
+  onProjectChanged?: () => void
 ) {
   const ignored = await getDCLIgnorePatterns(components, projectRoot)
-  const sceneId = b64HashingFunction(projectRoot)
+  const sceneId = b64UrlHashingFunction(projectRoot)
+
+  // ignoreInitial is false because the desktop client wants the initial scan,
+  // but asset bundles must not: the first conversion already reads current
+  // content, so an invalidate from the scan re-converts identical input. It
+  // fired on essentially every boot, and if the cold conversion was still
+  // running the two runs wrote the same cache directory concurrently.
+  //
+  // Recorded per event rather than checked inside the debounce: chokidar emits
+  // 'ready' as soon as the scan finishes, which is well inside the 800ms
+  // trailing window, so a flag read in the callback is always true by then.
+  // The undebounced listener is registered first, so it has already run for
+  // each event by the time the debounced one is scheduled.
+  let scanned = false
+  let changedSinceScan = false
 
   chokidar
     .watch(path.resolve(projectRoot), {
@@ -32,12 +47,24 @@ export async function wireFileWatcherToWebSockets(
       ignoreInitial: false,
       cwd: projectRoot
     })
+    .on('ready', () => {
+      scanned = true
+    })
     .on('unlink', (file: string) => {
       removeModel(sceneId, file)
+    })
+    .on('all', () => {
+      if (scanned) changedSinceScan = true
     })
     .on(
       'all',
       debounce(async (_, file) => {
+        // Before the reload notification: whatever the client refetches next
+        // must not be bundles built from the previous version of these files.
+        if (changedSinceScan) {
+          changedSinceScan = false
+          onProjectChanged?.()
+        }
         updateScene(sceneId, file)
         // Legacy JSON protocol: still the only one Bevy and Godot explorers understand.
         // Remove once both consume the protobuf WsSceneMessage.
@@ -56,7 +83,7 @@ function updateScene(sceneId: string, file: string) {
   if (isGLTFModel(file)) {
     message = {
       $case: 'updateModel',
-      updateModel: { hash: b64HashingFunction(file), sceneId, src: file, type: UpdateModelType.UMT_CHANGE }
+      updateModel: { hash: b64UrlHashingFunction(file), sceneId, src: file, type: UpdateModelType.UMT_CHANGE }
     }
   } else {
     message = {
@@ -72,7 +99,7 @@ function removeModel(sceneId: string, file: string) {
     const sceneMessage: WsSceneMessage = {
       message: {
         $case: 'updateModel',
-        updateModel: { sceneId, src: file, hash: b64HashingFunction(file), type: UpdateModelType.UMT_REMOVE }
+        updateModel: { sceneId, src: file, hash: b64UrlHashingFunction(file), type: UpdateModelType.UMT_REMOVE }
       }
     }
 
@@ -97,7 +124,7 @@ export function __LEGACY__updateScene(dir: string, clients: Set<WebSocket>, proj
     if (client.readyState === WebSocket.OPEN) {
       const message: sdk.SceneUpdate = {
         type: sdk.SCENE_UPDATE,
-        payload: { sceneId: b64HashingFunction(dir), sceneType: projectKind }
+        payload: { sceneId: b64UrlHashingFunction(dir), sceneType: projectKind }
       }
 
       client.send(sdk.UPDATE, { binary: false })

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -6,13 +6,24 @@ import { Workspace } from '../../../logic/workspace-validations'
 import { DataLayer } from '../data-layer/rpc'
 import { handleDataLayerWs } from '../data-layer/ws'
 import { PreviewComponents } from '../types'
+import { setupAssetBundlesProxy } from './asset-bundles-proxy'
+import { AssetBundles } from '../asset-bundles'
 import { setupEcs6Endpoints } from './endpoints'
 import { setupRealmAndComms } from './realm'
 import { getLanUrl } from '../utils'
 
 export const sceneUpdateClients = new Set<WebSocket>()
-export async function wireRouter(components: PreviewComponents, workspace: Workspace, dataLayer?: DataLayer) {
+export async function wireRouter(
+  components: PreviewComponents,
+  workspace: Workspace,
+  dataLayer?: DataLayer,
+  getAssetBundles?: () => AssetBundles | undefined
+) {
   const router = new Router<PreviewComponents>()
+
+  if (getAssetBundles) {
+    setupAssetBundlesProxy(components, router, getAssetBundles)
+  }
 
   if (dataLayer) {
     router.get('/data-layer', async (ctx, next) => {

--- a/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
+++ b/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
@@ -49,5 +49,11 @@ export async function getDCLIgnorePatterns(components: Pick<CliComponents, 'fs'>
   // by default many files need to be ignored
   ignored.push('.*', 'node_modules', '**/*.ts', '**/*.tsx', 'node_modules/**', '*.md')
 
+  // The asset-bundle sidecar writes into .dcl-optimized-assets on every manifest
+  // request; `.*` alone does not prune it from the file watcher (chokidar tests
+  // absolute paths), and a watched write here means reload → manifest request →
+  // write → reload, forever. The `**/` form matches regardless of path anchoring.
+  ignored.push('.dcl-optimized-assets', '**/.dcl-optimized-assets/**')
+
   return Array.from(new Set(ignored))
 }

--- a/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
+++ b/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
@@ -49,8 +49,8 @@ export async function getDCLIgnorePatterns(components: Pick<CliComponents, 'fs'>
   // by default many files need to be ignored
   ignored.push('.*', 'node_modules', '**/*.ts', '**/*.tsx', 'node_modules/**', '*.md')
 
-  // The asset-bundle sidecar writes into .dcl-optimized-assets on every manifest
-  // request; `.*` alone does not prune it from the file watcher (chokidar tests
+  // Asset-bundle conversion writes into .dcl-optimized-assets; `.*` alone does
+  // not prune it from the file watcher (chokidar tests
   // absolute paths), and a watched write here means reload → manifest request →
   // write → reload, forever. The `**/` form matches regardless of path anchoring.
   ignored.push('.dcl-optimized-assets', '**/.dcl-optimized-assets/**')

--- a/packages/@dcl/sdk-commands/src/logic/exec.ts
+++ b/packages/@dcl/sdk-commands/src/logic/exec.ts
@@ -3,6 +3,9 @@ import type { spawn } from 'child_process'
 interface Options {
   env: { [key: string]: string }
   silent: boolean
+  // default true; false spawns the binary directly (no shell quoting, and kill() reaches
+  // the binary itself - on Windows killing the wrapping shell leaves grandchildren alive)
+  shell: boolean
 }
 
 export type IProcessSpawnerComponent = {
@@ -11,10 +14,10 @@ export type IProcessSpawnerComponent = {
 
 export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSpawnerComponent {
   return {
-    exec(cwd: string, command: string, args: string[], { env, silent }: Partial<Options> = {}): Promise<void> {
+    exec(cwd: string, command: string, args: string[], { env, silent, shell }: Partial<Options> = {}): Promise<void> {
       return new Promise((resolve, reject) => {
         const child = spawnFn(command, args, {
-          shell: true,
+          shell: shell ?? true,
           cwd,
           env: { ...process.env, NODE_ENV: '', ...env }
         })
@@ -22,6 +25,11 @@ export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSp
         if (!silent) {
           child.stdout.pipe(process.stdout)
           child.stderr.pipe(process.stderr)
+        } else {
+          // the pipes must still be drained: a chatty child fills the ~64KB pipe buffer
+          // and then blocks on its next write, deadlocking at 0% CPU
+          child.stdout.resume()
+          child.stderr.resume()
         }
 
         const cleanup = () => {
@@ -32,10 +40,26 @@ export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSp
         process.on('SIGINT', cleanup)
         process.on('exit', cleanup)
 
-        child.on('close', (code: number) => {
+        const offCleanup = () => {
           process.off('SIGTERM', cleanup)
           process.off('SIGINT', cleanup)
           process.off('exit', cleanup)
+        }
+
+        let settled = false
+
+        // without a shell, a missing binary emits 'error' (ENOENT) and never 'close'
+        child.on('error', (error: Error) => {
+          if (settled) return
+          settled = true
+          offCleanup()
+          reject(new Error(`Command "${command}" failed: ${error.message}`))
+        })
+
+        child.on('close', (code: number) => {
+          if (settled) return
+          settled = true
+          offCleanup()
 
           // Don't reject if we killed the child during shutdown
           if (code !== 0 && !child.killed) {

--- a/packages/@dcl/sdk-commands/src/logic/exec.ts
+++ b/packages/@dcl/sdk-commands/src/logic/exec.ts
@@ -3,9 +3,6 @@ import type { spawn } from 'child_process'
 interface Options {
   env: { [key: string]: string }
   silent: boolean
-  // default true; false spawns the binary directly (no shell quoting, and kill() reaches
-  // the binary itself - on Windows killing the wrapping shell leaves grandchildren alive)
-  shell: boolean
 }
 
 export type IProcessSpawnerComponent = {
@@ -14,10 +11,10 @@ export type IProcessSpawnerComponent = {
 
 export function createProcessSpawnerComponent(spawnFn: typeof spawn): IProcessSpawnerComponent {
   return {
-    exec(cwd: string, command: string, args: string[], { env, silent, shell }: Partial<Options> = {}): Promise<void> {
+    exec(cwd: string, command: string, args: string[], { env, silent }: Partial<Options> = {}): Promise<void> {
       return new Promise((resolve, reject) => {
         const child = spawnFn(command, args, {
-          shell: shell ?? true,
+          shell: true,
           cwd,
           env: { ...process.env, NODE_ENV: '', ...env }
         })

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -107,6 +107,18 @@ export const b64HashingFunction = (str: string) => {
   const unique = `${str}-${machineId}`
   return 'b64-' + Buffer.from(unique).toString('base64')
 }
+
+// The preview content server hands these ids out in URL path segments, and the asset-bundle
+// tooling turns them into directory names. base64url keeps them free of '/', '+' and '='.
+export const b64UrlHashingFunction = (str: string) => {
+  const unique = `${str}-${machineId}`
+  return 'b64-' + Buffer.from(unique).toString('base64url')
+}
+
+export const b64UrlHashDecodingFunction = (hash: string) => {
+  const decoded = Buffer.from(hash.replace(/^b64-/, ''), 'base64url').toString('utf8')
+  return decoded.slice(0, -(machineId.length + 1))
+}
 // export const ipfsHashingFunction = async (str: string) => hashV1(Buffer.from(str, 'utf8'))
 
 interface PackageJson {

--- a/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles-proxy.spec.ts
@@ -1,0 +1,157 @@
+import { setupAssetBundlesProxy } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/asset-bundles-proxy'
+
+const ENTITY = 'b64-scene'
+
+function streamOf(text: string) {
+  const { Readable } = require('stream')
+  return Readable.toWeb(Readable.from([Buffer.from(text)]))
+}
+
+async function readBody(stream: AsyncIterable<Buffer | string>): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function makeRoutes(assetBundles: any) {
+  const fetch = jest.fn()
+  const handlers: Record<string, (ctx: any) => Promise<any>> = {}
+  const router = { get: jest.fn((path: string, h: any) => (handlers[path] = h)) }
+  setupAssetBundlesProxy({ fetch: { fetch } } as any, router as any, () => assetBundles)
+
+  const manifest = (name: string, search = '') =>
+    handlers['/optimized-assets/manifest/:name']({
+      url: new URL(`http://127.0.0.1:8000/optimized-assets/manifest/${name}${search}`),
+      params: { name }
+    })
+
+  const bundle = (version: string, cid: string, file: string, search = '') =>
+    handlers['/optimized-assets/:version/:cid/:file']({
+      url: new URL(`http://127.0.0.1:8000/optimized-assets/${version}/${cid}/${file}${search}`),
+      params: { version, cid, file }
+    })
+
+  return { fetch, router, manifest, bundle }
+}
+
+function converted(overrides: Partial<any> = {}) {
+  const scene = {
+    entityId: ENTITY,
+    platform: 'mac',
+    manifest: '{"exitCode":0,"files":["a_mac"]}',
+    bundles: new Map([['a_mac', Buffer.from('BUNDLE')]])
+  }
+  return {
+    entityId: ENTITY,
+    upstreamAbCdn: 'https://ab-cdn.decentraland.org',
+    ready: Promise.resolve(scene),
+    get: (p: string) => (p === 'mac' ? scene : undefined),
+    ...overrides
+  }
+}
+
+describe('start/server/asset-bundles-proxy', () => {
+  it('mounts the ab-cdn surface under /optimized-assets', () => {
+    const { router } = makeRoutes(converted())
+    expect(router.get).toHaveBeenCalledWith('/optimized-assets/manifest/:name', expect.any(Function))
+    expect(router.get).toHaveBeenCalledWith('/optimized-assets/:version/:cid/:file', expect.any(Function))
+  })
+
+  it('answers 503 while asset bundles are disabled', async () => {
+    const { fetch, manifest } = makeRoutes(undefined)
+
+    expect((await manifest(`${ENTITY}_mac.json`)).status).toBe(503)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('serves the locally converted manifest for the previewed scene', async () => {
+    const { fetch, manifest } = makeRoutes(converted())
+
+    const response = await manifest(`${ENTITY}_mac.json`)
+
+    expect(response.status).toBe(200)
+    expect(response.body).toContain('"exitCode":0')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('serves locally converted bundle bytes', async () => {
+    const { fetch, bundle } = makeRoutes(converted())
+
+    const response = await bundle('v49', ENTITY, 'a_mac')
+
+    expect(response.status).toBe(200)
+    expect(response.body.toString()).toBe('BUNDLE')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('reads through to the ab-cdn for entities that are not the previewed scene', async () => {
+    const { fetch, manifest } = makeRoutes(converted())
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: streamOf('{"upstream":true}')
+    })
+
+    const response = await manifest('bafkrei-wearable_mac.json', '?v=1')
+
+    expect(fetch).toHaveBeenCalledWith('https://ab-cdn.decentraland.org/manifest/bafkrei-wearable_mac.json?v=1')
+    expect(response.status).toBe(200)
+    await expect(readBody(response.body)).resolves.toBe('{"upstream":true}')
+  })
+
+  it('forwards only an allowlist of upstream headers', async () => {
+    const { fetch, bundle } = makeRoutes(converted())
+    fetch.mockResolvedValue({
+      status: 200,
+      headers: new Headers({
+        'content-type': 'application/octet-stream',
+        'cache-control': 'max-age=60',
+        // a third-party CDN must not set cookies or policy on the realm origin
+        'set-cookie': 'evil=1',
+        'content-security-policy': "default-src 'none'",
+        'content-encoding': 'gzip'
+      }),
+      body: streamOf('decoded')
+    })
+
+    const response = await bundle('v49', 'bafkrei-other', 'file_mac')
+
+    expect(response.headers['content-type']).toBe('application/octet-stream')
+    expect(response.headers['cache-control']).toBe('max-age=60')
+    expect(response.headers['set-cookie']).toBeUndefined()
+    expect(response.headers['content-security-policy']).toBeUndefined()
+    expect(response.headers['content-encoding']).toBeUndefined()
+  })
+
+  it('rejects traversal in the read-through path instead of fetching it', async () => {
+    const { fetch, bundle, manifest } = makeRoutes(converted())
+
+    expect((await bundle('v49', '../../etc', 'passwd')).status).toBe(400)
+    expect((await manifest('..%2Fx_mac.json')).status).toBe(400)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('waits for the conversion instead of 404ing an early manifest request', async () => {
+    const scene = { entityId: ENTITY, platform: 'mac', manifest: '{"exitCode":0}', bundles: new Map() }
+    let settle: (v?: unknown) => void = () => {}
+    let current: any
+    const assetBundles = converted({
+      ready: new Promise((resolve) => (settle = resolve)).then(() => (current = scene)),
+      get: () => current
+    })
+    const { manifest } = makeRoutes(assetBundles)
+
+    const pending = manifest(`${ENTITY}_mac.json`)
+    settle()
+    const response = await pending
+
+    expect(response.status).toBe(200)
+  })
+
+  it('404s a malformed manifest name rather than treating it as an entity', async () => {
+    const { fetch, manifest } = makeRoutes(converted())
+
+    expect((await manifest('nounderscore.json')).status).toBe(404)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/test/sdk-commands/commands/start/asset-bundles.spec.ts
+++ b/test/sdk-commands/commands/start/asset-bundles.spec.ts
@@ -1,0 +1,340 @@
+import {
+  hostPlatform,
+  setupAssetBundles
+} from '../../../../packages/@dcl/sdk-commands/src/commands/start/asset-bundles'
+import { b64UrlHashingFunction } from '../../../../packages/@dcl/sdk-commands/src/logic/project-files'
+
+const PROJECT = '/tmp/e2e-scene'
+
+jest.mock('../../../../packages/@dcl/sdk-commands/src/logic/project-files', () => {
+  const actual = jest.requireActual('../../../../packages/@dcl/sdk-commands/src/logic/project-files')
+  return { ...actual, getPublishableFiles: jest.fn(async () => ['scene.json', 'models/a.glb']) }
+})
+
+const convert = jest.fn()
+jest.mock('@dcl/abgen-node', () => ({ convert: (...args: any[]) => convert(...args) }), { virtual: true })
+
+function makeComponents({ cached = false }: { cached?: boolean } = {}) {
+  const logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+  const fs = {
+    fileExists: jest.fn(async () => cached),
+    readFile: jest.fn(async (p: string) => (p.endsWith('manifest.json') ? '{"exitCode":0}' : Buffer.from('bytes'))),
+    readdir: jest.fn(async () => ['a_mac']),
+    mkdir: jest.fn(async (_p: string, _opts?: any) => undefined),
+    writeFile: jest.fn(async (_p: string, _data?: any, _opts?: any) => undefined),
+    rename: jest.fn(async (_from: string, _to: string) => undefined),
+    rm: jest.fn(async (_p: string, _opts?: any) => undefined),
+    unlink: jest.fn(async (_p: string) => undefined),
+    stat: jest.fn(async (_p: string) => ({ mtimeMs: Date.now() }))
+  }
+  const config = { getString: jest.fn(async () => undefined), requireString: jest.fn(), getNumber: jest.fn() }
+  const fetch = { fetch: jest.fn() }
+  return { components: { logger, fs, config, fetch } as any, logger, fs }
+}
+
+describe('start/asset-bundles', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    delete process.env.ABGEN_UPSTREAM_AB_CDN
+  })
+
+  it('converts the scene in-process and exposes it under the preview entity id', async () => {
+    const { components } = makeComponents()
+    convert.mockResolvedValue({
+      code: 0,
+      bundles: [{ name: 'a_mac', data: Buffer.from('BUNDLE') }],
+      events: [],
+      errors: [],
+      manifest: '{"exitCode":0,"files":["a_mac"]}'
+    })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    const scene = await assetBundles!.ready
+
+    expect(assetBundles!.entityId).toBe(b64UrlHashingFunction(PROJECT))
+    // no port, no spawn: the whole conversion is a function call
+    expect(convert).toHaveBeenCalledTimes(1)
+    const job = convert.mock.calls[0][0]
+    expect(job.entityHash).toBe(b64UrlHashingFunction(PROJECT))
+    expect(job.files.map((f: any) => f.name)).toEqual(['scene.json', 'models/a.glb'])
+    expect(scene!.bundles.get('a_mac')!.toString()).toBe('BUNDLE')
+  })
+
+  it('persists the conversion so a second preview of the same scene reuses it', async () => {
+    const { components, fs } = makeComponents({ cached: true })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    const scene = await assetBundles!.ready
+
+    expect(convert).not.toHaveBeenCalled()
+    expect(scene!.manifest).toBe('{"exitCode":0}')
+    expect(fs.readdir).toHaveBeenCalled()
+  })
+
+  it('reads non-local entities through the production CDN, never converting them', async () => {
+    const { components } = makeComponents()
+    convert.mockResolvedValue({ code: 0, bundles: [], events: [], errors: [], manifest: '{"exitCode":0}' })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+
+    expect(assetBundles!.upstreamAbCdn).toBe('https://ab-cdn.decentraland.org')
+  })
+
+  it('degrades with a warning when the conversion fails', async () => {
+    const { components, logger } = makeComponents()
+    convert.mockResolvedValue({ code: 2, bundles: [], events: [], errors: ['boom'], manifest: undefined })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+
+    await expect(assetBundles!.ready).resolves.toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'))
+  })
+
+  it('reconverts after invalidate, so an edited scene is not served stale bundles', async () => {
+    const { components } = makeComponents()
+    convert
+      .mockResolvedValueOnce({
+        code: 0,
+        bundles: [{ name: 'a_mac', data: Buffer.from('BEFORE') }],
+        events: [],
+        errors: [],
+        manifest: '{"exitCode":0}'
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        bundles: [{ name: 'a_mac', data: Buffer.from('AFTER') }],
+        events: [],
+        errors: [],
+        manifest: '{"exitCode":0}'
+      })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    expect((await assetBundles!.ready)!.bundles.get('a_mac')!.toString()).toBe('BEFORE')
+
+    assetBundles!.invalidate()
+
+    expect((await assetBundles!.ready)!.bundles.get('a_mac')!.toString()).toBe('AFTER')
+    expect(convert).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces a burst of invalidations into one reconversion', async () => {
+    const { components } = makeComponents()
+    convert.mockResolvedValue({
+      code: 0,
+      bundles: [{ name: 'a_mac', data: Buffer.from('B') }],
+      events: [],
+      errors: [],
+      manifest: '{"exitCode":0}'
+    })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    await assetBundles!.ready
+
+    // The watcher fires per file; twenty saves must not queue twenty runs.
+    for (let i = 0; i < 20; i++) assetBundles!.invalidate()
+    await assetBundles!.ready
+
+    expect(convert).toHaveBeenCalledTimes(2)
+  })
+
+  it('warns rather than throwing when a per-asset failure is reported', async () => {
+    const { components, logger } = makeComponents()
+    convert.mockResolvedValue({
+      code: 0,
+      bundles: [{ name: 'a_mac', data: Buffer.from('B') }],
+      events: [],
+      errors: [],
+      manifest: '{"exitCode":12}'
+    })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+
+    await expect(assetBundles!.ready).resolves.toBeDefined()
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('raw GLTFs'))
+  })
+})
+
+describe('b64UrlHashingFunction', () => {
+  it('produces URL- and path-safe identifiers', () => {
+    const hash = b64UrlHashingFunction('/home/someone/my scene/with+special_chars')
+    expect(hash.startsWith('b64-')).toBe(true)
+    expect(hash).toMatch(/^b64-[A-Za-z0-9_-]+$/)
+    expect(hash).not.toContain('/')
+    expect(hash).not.toContain('+')
+    expect(hash).not.toContain('=')
+  })
+})
+
+describe('start/asset-bundles reconversion', () => {
+  const files = require('../../../../packages/@dcl/sdk-commands/src/logic/project-files')
+  const publishable = ['scene.json', 'models/a.glb']
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    // clearAllMocks leaves implementations in place, so a test that changes
+    // what the scene contains has to put it back or it leaks into the next.
+    files.getPublishableFiles.mockResolvedValue(publishable)
+  })
+
+  /** Let the serialised decision chain settle before asserting. */
+  const settleDecisions = () => new Promise((r) => setImmediate(r))
+
+  /** A convert() the test resolves by hand, per call. */
+  function deferredConvert() {
+    const gates: Array<(v: any) => void> = []
+    convert.mockImplementation(() => new Promise((resolve) => gates.push(resolve)))
+    return {
+      gates,
+      settle(i: number, name: string) {
+        gates[i]({
+          code: 0,
+          bundles: [{ name, data: Buffer.from(name) }],
+          events: [],
+          errors: [],
+          manifest: `{"exitCode":0,"files":["${name}"]}`
+        })
+      }
+    }
+  }
+
+  it('converts identical content once, however many readers ask', async () => {
+    const { components } = makeComponents()
+    const d = deferredConvert()
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    const a = assetBundles!.ready
+    assetBundles!.invalidate()
+    const b = assetBundles!.ready
+    assetBundles!.invalidate()
+    const c = assetBundles!.ready
+    await settleDecisions()
+
+    // Same files, so the same content key: one conversion, joined by all three.
+    expect(convert).toHaveBeenCalledTimes(1)
+
+    d.settle(0, 'a_mac')
+    expect(await a).toBe(await b)
+    expect(await b).toBe(await c)
+  })
+
+  it('keeps the newest conversion when an edit lands mid-flight', async () => {
+    const { components } = makeComponents()
+    const d = deferredConvert()
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    const slow = assetBundles!.ready
+    await settleDecisions()
+
+    // The scene changes while the first conversion runs, so the second has a
+    // different content key and must win regardless of completion order.
+    files.getPublishableFiles.mockResolvedValue([...publishable, 'models/b.glb'])
+    assetBundles!.invalidate()
+    const fast = assetBundles!.ready
+    await settleDecisions()
+    expect(convert).toHaveBeenCalledTimes(2)
+
+    // Settle the NEWER one first, then let the superseded one land after it.
+    d.settle(1, 'new_mac')
+    await fast
+    d.settle(0, 'old_mac')
+    await slow
+
+    expect(assetBundles!.get(hostPlatform())?.bundles.has('new_mac')).toBe(true)
+    expect(assetBundles!.get(hostPlatform())?.bundles.has('old_mac')).toBeFalsy()
+  })
+})
+
+describe('start/asset-bundles cache publishing', () => {
+  const files = require('../../../../packages/@dcl/sdk-commands/src/logic/project-files')
+  afterEach(() => {
+    jest.clearAllMocks()
+    files.getPublishableFiles.mockResolvedValue(['scene.json', 'models/a.glb'])
+  })
+
+  const ok = {
+    code: 0,
+    bundles: [{ name: 'a_mac', data: Buffer.from('B') }],
+    events: [],
+    errors: [],
+    manifest: '{"exitCode":0}'
+  }
+
+  it('stages the conversion and publishes it with a single rename', async () => {
+    const { components, fs } = makeComponents()
+    convert.mockResolvedValue(ok)
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    await assetBundles!.ready
+
+    // Nothing may be written straight into the directory a reader looks at.
+    const written = fs.writeFile.mock.calls.map((c: any) => c[0])
+    const bundles = written.filter((p: string) => p.includes('bundles'))
+    expect(bundles.length).toBeGreaterThan(0)
+    for (const p of written) {
+      if (p.endsWith('.lock')) continue
+      expect(p).toContain('.tmp-')
+    }
+
+    const [from, to] = fs.rename.mock.calls[0]
+    expect(from).toContain('.tmp-')
+    expect(to).not.toContain('.tmp-')
+    expect(to.endsWith(`_${hostPlatform()}`)).toBe(true)
+  })
+
+  it('discards its own output when another preview published first', async () => {
+    const { components, fs } = makeComponents()
+    convert.mockResolvedValue(ok)
+    fs.rename.mockRejectedValue(Object.assign(new Error('not empty'), { code: 'ENOTEMPTY' }))
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+
+    // The scene still resolves: the winner's bytes are ours byte for byte.
+    await expect(assetBundles!.ready).resolves.toBeDefined()
+    expect(fs.rm).toHaveBeenCalledWith(expect.stringContaining('.tmp-'), { recursive: true, force: true })
+  })
+
+  it('takes over a lock whose owner died', async () => {
+    const { components, fs } = makeComponents()
+    convert.mockResolvedValue(ok)
+    fs.writeFile.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
+    fs.stat.mockResolvedValueOnce({ mtimeMs: Date.now() - 60 * 60_000 })
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+    await assetBundles!.ready
+
+    expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining('.lock'))
+    expect(convert).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses what a live lock holder produced rather than converting again', async () => {
+    const { components, fs } = makeComponents()
+    convert.mockResolvedValue(ok)
+    fs.writeFile.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'EEXIST' }))
+    // Absent for the pre-lock miss, present once the holder has published.
+    fs.fileExists.mockResolvedValueOnce(false).mockResolvedValue(true)
+
+    const assetBundles = await setupAssetBundles(components, PROJECT)
+
+    await expect(assetBundles!.ready).resolves.toBeDefined()
+    expect(convert).not.toHaveBeenCalled()
+    // Held and fresh, so it was waited on. Without this the test passes even
+    // if the lock is ignored outright, since the re-read alone finds the entry.
+    expect(fs.stat).toHaveBeenCalledWith(expect.stringContaining('.lock'))
+  })
+
+  it('sweeps abandoned staging directories but leaves live ones alone', async () => {
+    const { components, fs } = makeComponents()
+    convert.mockResolvedValue(ok)
+    fs.readdir.mockResolvedValue(['abc_mac', 'abc_mac.tmp-0011aabb', 'abc_mac.tmp-ffee2233'])
+    fs.stat.mockImplementation(async (p: string) => ({
+      mtimeMs: p.endsWith('0011aabb') ? Date.now() - 60 * 60_000 : Date.now()
+    }))
+
+    await setupAssetBundles(components, PROJECT)
+
+    const swept = fs.rm.mock.calls.map((c: any) => c[0])
+    expect(swept).toContain(`${PROJECT}/.dcl-optimized-assets/abc_mac.tmp-0011aabb`)
+    expect(swept).not.toContain(`${PROJECT}/.dcl-optimized-assets/abc_mac.tmp-ffee2233`)
+    expect(swept).not.toContain(`${PROJECT}/.dcl-optimized-assets/abc_mac`)
+  })
+})

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -57,6 +57,50 @@ describe('explorer-alpha', () => {
       )
     })
 
+    it('should include local-ab only when asset bundles are enabled', async () => {
+      const args: any = {}
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args,
+        assetBundles: true
+      })
+
+      // local-ab alone: the explorer derives the /optimized-assets base from the realm
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.arrayContaining([expect.stringContaining('local-ab=true')]),
+        { silent: true }
+      )
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.not.arrayContaining([expect.stringContaining('optimized-assets-url')]),
+        { silent: true }
+      )
+
+      mockExec.mockClear()
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args
+      })
+
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.not.arrayContaining([expect.stringContaining('local-ab')]),
+        { silent: true }
+      )
+    })
+
     it('should always include local-scene and debug even when they are false', async () => {
       const args: any = {
         '--local-scene': false,
@@ -137,7 +181,7 @@ describe('explorer-alpha', () => {
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
-        expect.arrayContaining([expect.not.stringContaining('open-deeplink-in-new-instance')]),
+        expect.not.arrayContaining([expect.stringContaining('open-deeplink-in-new-instance')]),
         { silent: true }
       )
     })
@@ -179,7 +223,7 @@ describe('explorer-alpha', () => {
       expect(mockExec).toHaveBeenCalledWith(
         '/test',
         'open',
-        expect.arrayContaining([expect.not.stringContaining('multi-instance')]),
+        expect.not.arrayContaining([expect.stringContaining('multi-instance')]),
         { silent: true }
       )
     })

--- a/test/sdk-commands/logic/dcl-ignore.spec.ts
+++ b/test/sdk-commands/logic/dcl-ignore.spec.ts
@@ -30,5 +30,20 @@ describe('dcl-ignore', () => {
       expect(patterns).toContain('custom-folder')
       expect(patterns).toContain('*.log')
     })
+
+    it('always ignores the asset-bundle sidecar cache, even for scenes with a custom .dclignore', async () => {
+      // A watched write inside .dcl-optimized-assets means reload → manifest
+      // request → revalidation write → reload, forever. The `**/` form is
+      // required because the file watcher tests absolute paths, which the bare
+      // `.*` entry does not prune.
+      const components = {
+        fs: {
+          readFile: jest.fn().mockResolvedValue('node_modules\nbin/*.map')
+        }
+      }
+      const patterns = await getDCLIgnorePatterns(components as any, '/some/dir')
+      expect(patterns).toContain('.dcl-optimized-assets')
+      expect(patterns).toContain('**/.dcl-optimized-assets/**')
+    })
   })
 })

--- a/test/sdk-commands/logic/dcl-ignore.spec.ts
+++ b/test/sdk-commands/logic/dcl-ignore.spec.ts
@@ -31,7 +31,7 @@ describe('dcl-ignore', () => {
       expect(patterns).toContain('*.log')
     })
 
-    it('always ignores the asset-bundle sidecar cache, even for scenes with a custom .dclignore', async () => {
+    it('always ignores the asset-bundle cache, even for scenes with a custom .dclignore', async () => {
       // A watched write inside .dcl-optimized-assets means reload → manifest
       // request → revalidation write → reload, forever. The `**/` form is
       // required because the file watcher tests absolute paths, which the bare

--- a/test/sdk-commands/logic/project-files.spec.ts
+++ b/test/sdk-commands/logic/project-files.spec.ts
@@ -1,0 +1,24 @@
+import {
+  b64UrlHashDecodingFunction,
+  b64UrlHashingFunction
+} from '../../../packages/@dcl/sdk-commands/src/logic/project-files'
+
+describe('project-files b64url hashing', () => {
+  // '~~~' encodes to 'fn5-' (base64url) vs 'fn5+' (base64); '???' to 'Pz8_' vs 'Pz8/'
+  const paths = [
+    '/home/user/project',
+    '/home/user/project/models/tree.glb',
+    'C:\\Users\\user\\project\\scene.json',
+    '/home/user/~~~/???/scene.json',
+    '/home/üser/日本語/scène.ts'
+  ]
+
+  it.each(paths)('round-trips %s through encode and decode', (path) => {
+    expect(b64UrlHashDecodingFunction(b64UrlHashingFunction(path))).toBe(path)
+  })
+
+  it.each(paths)('produces url- and directory-safe hashes for %s', (path) => {
+    const hash = b64UrlHashingFunction(path)
+    expect(hash).toMatch(/^b64-[A-Za-z0-9_-]+$/)
+  })
+})

--- a/test/sdk-commands/utils/commands.spec.ts
+++ b/test/sdk-commands/utils/commands.spec.ts
@@ -37,19 +37,17 @@ describe('utils/commands', () => {
     await runSdkCommand(components, 'help', ['--help'])
   })
 
+  // Imports every command module, so its cost is ts-jest compiling the whole
+  // CLI once, not anything the assertions do. That is seconds on an idle
+  // machine and multiples of that on a loaded one, and the test says nothing
+  // about speed, so it gets a timeout with room rather than the 5s default.
   it('runs a help command over all commands', async () => {
     const components = await initComponents()
 
     const result = await commands.getCommands(components)
 
     for (const command of result) {
-      try {
-        await runSdkCommand(components, command, ['--help'])
-      } catch (e: any) {
-        console.dir(e)
-        console.error(e)
-        throw e
-      }
+      await runSdkCommand(components, command, ['--help'])
     }
-  })
+  }, 120_000)
 })

--- a/test/sdk-commands/utils/exec.spec.ts
+++ b/test/sdk-commands/utils/exec.spec.ts
@@ -22,8 +22,8 @@ describe('utils/exec', () => {
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'])
@@ -35,6 +35,42 @@ describe('utils/exec', () => {
     })
     expect(pipeSpy).toBeCalled()
     expect(res).toBe(undefined)
+  })
+
+  it('spawns without a shell when shell:false is passed', async () => {
+    const spawnMock = {
+      stdout: { on: jest.fn(), pipe: jest.fn() },
+      stderr: { pipe: jest.fn() },
+      on: jest.fn()
+    }
+    const spawnSpy = jest.fn(() => spawnMock as any)
+    const component = execUtils.createProcessSpawnerComponent(spawnSpy)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
+    })
+
+    await component.exec(process.cwd(), '/path with spaces/abgen', [], { shell: false })
+
+    expect(spawnSpy).toBeCalledWith('/path with spaces/abgen', [], {
+      shell: false,
+      cwd: process.cwd(),
+      env: { ...process.env, NODE_ENV: '' }
+    })
+  })
+
+  it('rejects when the child emits a spawn error', async () => {
+    const spawnMock = {
+      stdout: { on: jest.fn(), pipe: jest.fn() },
+      stderr: { pipe: jest.fn() },
+      on: jest.fn()
+    }
+    const spawnSpy = jest.fn(() => spawnMock as any)
+    const component = execUtils.createProcessSpawnerComponent(spawnSpy)
+    spawnMock.on.mockImplementation((event: string, cb: (arg: any) => void) => {
+      if (event === 'error') cb(new Error('spawn abgen ENOENT'))
+    })
+
+    await expect(component.exec(process.cwd(), 'abgen', [], { shell: false })).rejects.toThrow('spawn abgen ENOENT')
   })
 
   it('it should be called with proper params #2', async () => {
@@ -51,8 +87,8 @@ describe('utils/exec', () => {
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'], {
@@ -72,18 +108,20 @@ describe('utils/exec', () => {
     const spawnMock = {
       stdout: {
         on: jest.fn(),
-        pipe: jest.fn()
+        pipe: jest.fn(),
+        resume: jest.fn()
       },
       stderr: {
-        pipe: jest.fn()
+        pipe: jest.fn(),
+        resume: jest.fn()
       },
       on: jest.fn()
     }
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
     const pipeSpy = jest.spyOn(spawnMock.stderr, 'pipe')
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(0)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(0)
     })
 
     const res = await component.exec(process.cwd(), 'run', ['some', 'test'], {
@@ -97,6 +135,10 @@ describe('utils/exec', () => {
       env: { ...process.env, NODE_ENV: '', someKey: '1' }
     })
     expect(pipeSpy).not.toBeCalled()
+    // silent must still drain the pipes: a chatty child would otherwise fill the
+    // pipe buffer and deadlock on its next write
+    expect(spawnMock.stdout.resume).toBeCalled()
+    expect(spawnMock.stderr.resume).toBeCalled()
     expect(res).toBe(undefined)
   })
 
@@ -113,8 +155,8 @@ describe('utils/exec', () => {
     }
     const spawnSpy = jest.fn(() => spawnMock as any)
     const component = execUtils.createProcessSpawnerComponent(spawnSpy)
-    spawnMock.on.mockImplementation((_: string, cb: (code: number) => void) => {
-      cb(1)
+    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
+      if (event === 'close') cb(1)
     })
 
     let error

--- a/test/sdk-commands/utils/exec.spec.ts
+++ b/test/sdk-commands/utils/exec.spec.ts
@@ -37,26 +37,6 @@ describe('utils/exec', () => {
     expect(res).toBe(undefined)
   })
 
-  it('spawns without a shell when shell:false is passed', async () => {
-    const spawnMock = {
-      stdout: { on: jest.fn(), pipe: jest.fn() },
-      stderr: { pipe: jest.fn() },
-      on: jest.fn()
-    }
-    const spawnSpy = jest.fn(() => spawnMock as any)
-    const component = execUtils.createProcessSpawnerComponent(spawnSpy)
-    spawnMock.on.mockImplementation((event: string, cb: (code: number) => void) => {
-      if (event === 'close') cb(0)
-    })
-
-    await component.exec(process.cwd(), '/path with spaces/abgen', [], { shell: false })
-
-    expect(spawnSpy).toBeCalledWith('/path with spaces/abgen', [], {
-      shell: false,
-      cwd: process.cwd(),
-      env: { ...process.env, NODE_ENV: '' }
-    })
-  })
 
   it('rejects when the child emits a spawn error', async () => {
     const spawnMock = {
@@ -70,7 +50,7 @@ describe('utils/exec', () => {
       if (event === 'error') cb(new Error('spawn abgen ENOENT'))
     })
 
-    await expect(component.exec(process.cwd(), 'abgen', [], { shell: false })).rejects.toThrow('spawn abgen ENOENT')
+    await expect(component.exec(process.cwd(), 'abgen', [])).rejects.toThrow('spawn abgen ENOENT')
   })
 
   it('it should be called with proper params #2', async () => {

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -88,6 +88,9 @@
         "@types/qrcode": "^1.5.6",
         "@types/uuid": "^9.0.5",
         "@types/ws": "^8.5.4"
+      },
+      "optionalDependencies": {
+        "@dcl/abgen-node": "^0.15.0"
       }
     },
     "node_modules/@dcl/ecs": {


### PR DESCRIPTION
Preview converts asset bundles by calling `@dcl/abgen-node`, not by running a
sidecar. No spawned process, no port to allocate, no binary to resolve or
download, no proxy hop — and `abgen-binary.ts`, 160 lines of
resolve-cache-download, is deleted, because getting a binary onto the box is
what an npm dependency does.

|  | before | here |
| --- | --- | --- |
| conversion | sidecar process | in-process call |
| port | `getPort(0)` | none |
| binary | `ABGEN_BIN` / cached release / PATH / download | npm dependency |
| `/optimized-assets` | streaming proxy | served directly |
| single origin | achieved by proxying | structural — no second origin exists |

The previewed scene converts in-process and is answered from memory. Every
other entity — wearables, emotes, anything the preview server does not host —
reads through to the production ab-cdn, which already has prebuilt bundles.
That mirrors the sidecar, and for the same reason: the preview server serves
the local scene's files, so converting remote entities locally could only 404.

## Reconversion is content-keyed

Editing a scene has to rebuild its bundles, and the obvious implementation is
wrong in two ways that only appear under a fast editor.

Conversion is keyed on a **sha256 of the publishable files**. Identical content
means the same key, so a request for work already in flight joins it instead of
starting a second run over the same bytes into the same directory. The key also
decides publication: a run stores its result only if its key is still the one
most recently asked for. Without that, a slow pre-edit conversion finishing
after a fast post-edit one would overwrite it, `stale` was already false so
nothing re-ran, and preview served pre-edit bundles until the next save — with
`ready` resolving to the new scene while `get()` returned the old one.

Keyed on content rather than mtime because a touch with no edit must not
reconvert, and `readProjectFiles` already reads every byte, so the digest is
free.

Deciding whether to start a run is itself async — the key comes from reading
the files — so a gate holds read-compare-register and opens the moment a
decision is made. Held across the conversion it would serialise the work, and a
newer edit has to be free to start while a superseded run finishes.

## The cache is safe across processes

A second `sdk-commands start` on the same project — another terminal, a stale
process, CI running preview twice — used to interleave bundle files into one
directory that a reader was about to serve.

Conversions now stage into a private directory and publish with a single
`rename`, atomic on every filesystem this runs on. A reader sees the entry whole
or not at all, and two previews racing the same content produce identical bytes,
so the loser discards its own rather than merging into a directory it does not
own. An advisory lock keeps the second preview off work already running; every
failure mode in it — stale lock, timeout, unwritable directory — degrades to
converting twice, which the atomic publish already makes safe, so correctness
never rests on the lock. A killed conversion's staging is swept on the next
start, age-gated so a live conversion's directory is never removed from under
it.

## Startup and degradation

Conversion runs once at startup and persists under `.dcl-optimized-assets`, so
the explorer's manifest request is always a hit and only a scene's first preview
pays the wait. A manifest request arriving mid-conversion waits on it rather
than 404ing into a permanent raw-GLTF fallback.

A missing addon, a failed conversion, and a per-asset failure all fall back to
raw GLTFs. `@dcl/abgen-node` is a plain dependency, not an optional one: it
declares no `os`/`cpu` constraint and its per-platform binaries are optional
*inside it*, so the JavaScript always installs and only the native addon can be
missing. Marking the wrapper optional bought nothing and let an install skip it
for unrelated reasons — a preview quietly serving raw GLTFs with no cause anyone
could name. The load is still guarded, and now names the platform that has no
prebuild instead of telling you to install a package that is already there.

## Rebase note

Rebased onto `main` after #1502. Two conflicts, both resolved in main's favour:

- `wireFileWatcherToWebSockets` — main sends `updateScene` unconditionally
  because the legacy JSON protocol is the only one Bevy and Godot understand.
  This branch had gated it behind a `desktopClient` flag, which would have
  regressed Bevy Web; the flag is dropped and only the `onProjectChanged`
  invalidation is layered on.
- its `unlink` handler — main's `(file)` signature is correct. This branch read
  `(_, file)`, leaving `file` undefined, since chokidar emits the path first.

The 38 commits are collapsed into one because they included an entire sidecar
implementation that later commits delete; replaying them would have meant
resolving conflicts in code that does not survive.

## Tests

52 passing across the four `start` suites. `asset-bundles.spec.ts` covers
in-process conversion, on-disk cache reuse, CDN read-through, both degrade
paths, the content-keyed dedup, latest-wins, the atomic publish, lock takeover
and the staging sweep; `asset-bundles-proxy.spec.ts` covers local serving,
read-through header scrubbing, wait-for-conversion and malformed names.
`abgen-binary.spec.ts` is removed with the module.

Each locking mechanism is mutation-checked — disabling the in-flight join, the
staleness check, the lock-age inspection or the sweep's age gate each fails its
own test and no other.

`tsc --noEmit` reports no errors in any changed file; the pre-existing
`@dcl/ecs/dist-cjs` resolution errors are the unbuilt sibling package.
