### PR TITLE
fix(ecs): preserve icon in TouchScreenControls hide + add show helpers and tests

### DIFF
--- a/packages/@dcl/ecs/src/components/extended/TouchScreenControls.ts
+++ b/packages/@dcl/ecs/src/components/extended/TouchScreenControls.ts
@@ -25,7 +25,10 @@ export interface TouchScreenControlsComponentDefinitionExtended
   extends LastWriteWinElementSetComponentDefinition<PBTouchScreenControls> {
   /** Hide every on-screen gamepad button. */
   hideAll(): void
-  /** Show every on-screen gamepad button (clears the hide list). */
+  /**
+   * Show every on-screen gamepad button (clears the button hide list).
+   * Does NOT change the joystick/crosshair — use `showJoystick()` / `showCrosshair()` for those.
+   */
   showAll(): void
   /** Hide the given on-screen buttons (merged into the current config). */
   hide(actions: InputAction[]): void
@@ -33,8 +36,12 @@ export interface TouchScreenControlsComponentDefinitionExtended
   setMainAction(action: InputAction): void
   /** Hide the native virtual joystick. */
   hideJoystick(): void
+  /** Show the native virtual joystick. */
+  showJoystick(): void
   /** Hide the on-screen crosshair / reticle. */
   hideCrosshair(): void
+  /** Show the on-screen crosshair / reticle. */
+  showCrosshair(): void
 }
 
 export function defineTouchScreenControlsComponent(
@@ -46,7 +53,9 @@ export function defineTouchScreenControlsComponent(
   function current(): PBTouchScreenControls {
     const value = theComponent.getOrNull(ROOT_ENTITY)
     return {
-      touchInputs: value?.touchInputs ? value.touchInputs.map((t) => ({ ...t })) : [],
+      touchInputs: value?.touchInputs
+        ? value.touchInputs.map((t) => ({ ...t, icon: t.icon ? { ...t.icon } : t.icon }))
+        : [],
       mainAction: value?.mainAction,
       hideJoystick: value?.hideJoystick ?? false,
       hideCrosshair: value?.hideCrosshair ?? false
@@ -57,7 +66,7 @@ export function defineTouchScreenControlsComponent(
     const value = current()
     const byAction = new Map<InputAction, PBTouchScreenControls_TouchInput>()
     for (const input of value.touchInputs) byAction.set(input.inputAction, input)
-    for (const action of actions) byAction.set(action, { inputAction: action, hide: true })
+    for (const action of actions) byAction.set(action, { ...byAction.get(action), inputAction: action, hide: true })
     value.touchInputs = [...byAction.values()]
     theComponent.createOrReplace(ROOT_ENTITY, value)
   }
@@ -85,9 +94,19 @@ export function defineTouchScreenControlsComponent(
       value.hideJoystick = true
       theComponent.createOrReplace(ROOT_ENTITY, value)
     },
+    showJoystick(): void {
+      const value = current()
+      value.hideJoystick = false
+      theComponent.createOrReplace(ROOT_ENTITY, value)
+    },
     hideCrosshair(): void {
       const value = current()
       value.hideCrosshair = true
+      theComponent.createOrReplace(ROOT_ENTITY, value)
+    },
+    showCrosshair(): void {
+      const value = current()
+      value.hideCrosshair = false
       theComponent.createOrReplace(ROOT_ENTITY, value)
     }
   }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5118,6 +5118,8 @@ export interface TouchScreenControlsComponentDefinitionExtended extends LastWrit
     hideJoystick(): void;
     setMainAction(action: InputAction): void;
     showAll(): void;
+    showCrosshair(): void;
+    showJoystick(): void;
 }
 
 // Warning: (ae-missing-release-tag) "Transform" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/test/ecs/components/TouchScreenControls.spec.ts
+++ b/test/ecs/components/TouchScreenControls.spec.ts
@@ -1,5 +1,93 @@
-import { Engine, components, InputAction } from '../../../packages/@dcl/ecs/src'
+import { Engine, Entity, components, InputAction } from '../../../packages/@dcl/ecs/src'
 import { testComponentSerialization } from './assertion'
+
+const ROOT_ENTITY = 0 as Entity
+
+describe('TouchScreenControls convenience helpers', () => {
+  it('hideAll() hides every gamepad button', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    TouchScreenControls.hideAll()
+
+    const value = TouchScreenControls.getOrNull(ROOT_ENTITY)
+    expect(value?.touchInputs.length).toBe(8)
+    expect(value?.touchInputs.every((t) => t.hide)).toBe(true)
+  })
+
+  it('showAll() clears the button hide list but leaves joystick/crosshair untouched', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    TouchScreenControls.hideJoystick()
+    TouchScreenControls.hideCrosshair()
+    TouchScreenControls.hideAll()
+    TouchScreenControls.showAll()
+
+    const value = TouchScreenControls.getOrNull(ROOT_ENTITY)
+    expect(value?.touchInputs).toEqual([])
+    // showAll only affects buttons — joystick/crosshair stay hidden
+    expect(value?.hideJoystick).toBe(true)
+    expect(value?.hideCrosshair).toBe(true)
+  })
+
+  it('hide() merges the given actions into the current config', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    TouchScreenControls.hide([InputAction.IA_JUMP])
+    TouchScreenControls.hide([InputAction.IA_PRIMARY])
+
+    const value = TouchScreenControls.getOrNull(ROOT_ENTITY)
+    const hidden = value?.touchInputs.map((t) => t.inputAction) ?? []
+    expect(hidden).toContain(InputAction.IA_JUMP)
+    expect(hidden).toContain(InputAction.IA_PRIMARY)
+  })
+
+  it('hide() preserves a previously configured icon (no data loss)', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    const icon = { tex: { $case: 'texture' as const, texture: { src: 'custom-jump' } } }
+    TouchScreenControls.createOrReplace(ROOT_ENTITY, {
+      touchInputs: [{ inputAction: InputAction.IA_JUMP, hide: false, icon }],
+      hideJoystick: false,
+      hideCrosshair: false
+    })
+
+    TouchScreenControls.hide([InputAction.IA_JUMP])
+
+    const entry = TouchScreenControls.getOrNull(ROOT_ENTITY)?.touchInputs.find(
+      (t) => t.inputAction === InputAction.IA_JUMP
+    )
+    expect(entry?.hide).toBe(true)
+    expect(entry?.icon).toEqual(icon)
+  })
+
+  it('setMainAction() sets the central button action', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    TouchScreenControls.setMainAction(InputAction.IA_PRIMARY)
+
+    expect(TouchScreenControls.getOrNull(ROOT_ENTITY)?.mainAction).toBe(InputAction.IA_PRIMARY)
+  })
+
+  it('hideJoystick()/showJoystick() and hideCrosshair()/showCrosshair() toggle visibility', () => {
+    const engine = Engine()
+    const TouchScreenControls = components.TouchScreenControls(engine)
+
+    TouchScreenControls.hideJoystick()
+    TouchScreenControls.hideCrosshair()
+    expect(TouchScreenControls.getOrNull(ROOT_ENTITY)?.hideJoystick).toBe(true)
+    expect(TouchScreenControls.getOrNull(ROOT_ENTITY)?.hideCrosshair).toBe(true)
+
+    TouchScreenControls.showJoystick()
+    TouchScreenControls.showCrosshair()
+    expect(TouchScreenControls.getOrNull(ROOT_ENTITY)?.hideJoystick).toBe(false)
+    expect(TouchScreenControls.getOrNull(ROOT_ENTITY)?.hideCrosshair).toBe(false)
+  })
+})
 
 describe('Generated TouchScreenControls ProtoBuf', () => {
   it('should serialize/deserialize TouchScreenControls', () => {


### PR DESCRIPTION
## Follow-up to #1441

  Addresses the post-merge code review on #1441
  (https://github.com/decentraland/js-sdk-toolchain/pull/1441#pullrequestreview-4818481397).
  That PR was already merged, so these fixes land as a separate follow-up.

  ## Review feedback addressed

  | Severity | Finding | Change |
  | --- | --- | --- |
  | **P1** | `setHidden()` dropped a previously configured `icon` when hiding a button (replaced the whole `TouchInput` entry) — silent data loss | Now spreads the existing entry: `{ ...byAction.get(action),   inputAction: action, hide: true }`, so `icon` (and any future fields) survive |
  | **P2** | No `showJoystick()` / `showCrosshair()` counterparts to the `hide*` methods | Added both — the `hide*` methods are now reversible without falling back to raw `createOrReplace()` |
  | **P2** | `current()` shallow-copied each `TouchInput` but not the nested `icon` object, violating the "mutable copy" intent | Hardened `current()` to also copy the `icon` object |
  | **P2** | `showAll()` name implied it reset joystick/crosshair, but it only clears the button hide-list | Kept buttons-only behavior (intentional); clarified the docstring to state it does **not** affect   joystick/crosshair |
  | **P2** | No test coverage for the helper methods — the P1 bug would have been caught by tests | Added targeted tests for every helper, including an explicit icon-preservation regression test |

  ## Changes

  - `packages/@dcl/ecs/src/components/extended/TouchScreenControls.ts`
    - Fix `setHidden()` to preserve existing `TouchInput` fields (P1)
    - Add `showJoystick()` / `showCrosshair()` helpers
    - Deep-copy `icon` in `current()`
    - Clarify `showAll()` docstring
  - `test/ecs/components/TouchScreenControls.spec.ts`
    - New `TouchScreenControls convenience helpers` suite covering `hideAll`, `showAll`, `hide`, `setMainAction`, `hideJoystick`/`showJoystick`, `hideCrosshair`/`showCrosshair`, plus the icon-preservation 
  regression case
  - `packages/@dcl/playground-assets/etc/playground-assets.api.md`
    - Regenerated API report for the two new public methods

  ## Verification

  - `TouchScreenControls` suite: 7/7 pass
  - Coverage on the changed file: 100% statements / branches / functions / lines (meets the `@dcl/ecs` gate)
  - Prettier + `api.md` regenerated (docs check parity)