### PR TITLE
feat: request/response messaging for room events

### DIFF
--- a/packages/@dcl/sdk/src/network/README.md
+++ b/packages/@dcl/sdk/src/network/README.md
@@ -120,3 +120,86 @@ Solution 1:
 I think this will work but there are some developer experience issues, like using the `parentEntity(child, parent)` function instead of the transform.parent.
 This could end up with a lot of unexepcted issues/bugs. Maybe we can have a system that iterates over every syncronized entity and when the transform.parent changes, add the parentEntity function automatically.
 First I wanna try to implement all of this and then came up with this approach to avoid inconsistencies
+
+## Request/response messaging (`registerRequests`)
+
+`room.send` / `room.onMessage` are fire-and-forget. When a client needs an *answer* —
+"load my save", "buy this item, tell me the new balance" — the correlation has to be built
+by hand: a `requestId` threaded through both payloads, a `requester` field so each client
+can tell whether a broadcast reply was meant for it, and a retry loop for when no answer
+arrives. Getting any of that slightly wrong is how replies end up broadcast to every peer,
+or how a client waits forever because the handler threw.
+
+`registerRequests` owns the correlation id, the addressing, the timeout and the error
+channel. It is a thin layer over the same wire mechanism: each method becomes two
+registered events, so nothing about the protocol changes.
+
+```ts
+// shared/rpc.ts — imported by both sides
+import { Schemas } from '@dcl/sdk/ecs'
+import { registerRequests } from '@dcl/sdk/network'
+
+export const rpc = registerRequests({
+  loadFarm: {
+    request: Schemas.Map({}),
+    response: Schemas.Map({ coins: Schemas.Int, level: Schemas.Int })
+  },
+  buySeed: {
+    request: Schemas.Map({ cropType: Schemas.Int }),
+    response: Schemas.Map({ coins: Schemas.Int })
+  }
+})
+```
+
+```ts
+// server — the reply is addressed to the caller automatically
+import { RequestError } from '@dcl/sdk/network'
+import { rpc } from './shared/rpc'
+
+rpc.handle('loadFarm', async (_data, context) => {
+  const farm = await store.load(context.from)
+  return { coins: farm.coins, level: farm.level }
+})
+
+rpc.handle('buySeed', async (data, context) => {
+  const farm = await store.load(context.from)
+  if (farm.coins < priceOf(data.cropType)) throw new RequestError('insufficient_funds')
+  farm.coins -= priceOf(data.cropType)
+  return { coins: farm.coins }
+})
+```
+
+```ts
+// client
+import { RequestTimeoutError } from '@dcl/sdk/network'
+import { rpc } from './shared/rpc'
+
+const farm = await rpc.request('loadFarm', {})
+applySave(farm)
+
+try {
+  const { coins } = await rpc.request('buySeed', { cropType: 3 })
+  updateHud(coins)
+} catch (error) {
+  if (error instanceof RequestTimeoutError) retryLater()
+  else showToast(error.message) // 'insufficient_funds'
+}
+```
+
+Notes:
+
+- **Replies go only to the caller.** The server answers with `{ to: [context.from] }`, so
+  one player's save never lands in another player's client.
+- **Errors have two shapes.** Throw `RequestError` for anything the caller should read;
+  its message is forwarded verbatim. Any *other* throw is reported as `internal_error` and
+  logged server-side, so a crash can't leak storage keys or stack traces over the wire.
+  A missing reply rejects with `RequestTimeoutError`, which is worth retrying.
+- **Timeouts are engine-driven**, not `setTimeout` (which the server runtime does not
+  guarantee). Default 20s; override per call with `{ timeoutMs }`.
+- **Requests issued before the room connects** are queued by `room.send`, and their
+  deadline is re-based from the moment the room is ready — a request made at boot does not
+  burn its budget waiting for the connection.
+- **Register each method once.** `handle` warns if a second live handler is installed for
+  the same method, because the caller would settle on whichever reply arrived first.
+- The server can also ask a client: `rpc.request('method', data, { to: address })`, with
+  the client calling `rpc.handle` for it.

--- a/packages/@dcl/sdk/src/network/events/implementation.ts
+++ b/packages/@dcl/sdk/src/network/events/implementation.ts
@@ -35,6 +35,7 @@ export class Room<T extends EventSchemaRegistry = EventSchemaRegistry> {
   private listeners = new Map<keyof T, Set<EventCallback<any>>>()
   private binaryMessageBus: any
   private isServerFuture: IFuture<boolean> = future()
+  private isServerAtom: Atom<boolean>
   private isRoomReadyAtom: Atom<boolean>
   private messageQueue: QueuedMessage<T>[] = []
   private isProcessingQueue = false
@@ -42,6 +43,7 @@ export class Room<T extends EventSchemaRegistry = EventSchemaRegistry> {
   constructor(_engine: IEngine, binaryMessageBus: any, isServerFn: Atom<boolean>, isRoomReadyAtom: Atom<boolean>) {
     void isServerFn.deref().then(($) => this.isServerFuture.resolve($))
 
+    this.isServerAtom = isServerFn
     this.binaryMessageBus = binaryMessageBus
     this.isRoomReadyAtom = isRoomReadyAtom
 
@@ -173,6 +175,16 @@ export class Room<T extends EventSchemaRegistry = EventSchemaRegistry> {
    */
   listenerCount<K extends keyof T>(eventType: K): number {
     return this.listeners.get(eventType)?.size ?? 0
+  }
+
+  /**
+   * Whether this room is the authoritative server.
+   *
+   * The runtime answers asynchronously at startup, so this reports false until it does —
+   * treat it as "known to be the server", not as "known to be a client".
+   */
+  isServer(): boolean {
+    return this.isServerAtom.getOrNull() ?? false
   }
 
   /**

--- a/packages/@dcl/sdk/src/network/events/index.ts
+++ b/packages/@dcl/sdk/src/network/events/index.ts
@@ -40,9 +40,19 @@
 // Import public API and types
 import { registerMessages, getRoom, EventContext } from './implementation'
 import { EventSchemaRegistry } from './registry'
+import { registerRequests, createRequests, RequestError, RequestTimeoutError } from './requests'
+import type {
+  RequestDefinition,
+  RequestSchemaRegistry,
+  RequestHandler,
+  RequestOptions,
+  RequestsOptions,
+  Requests
+} from './requests'
 
 // Re-export public API - only what users need
-export { registerMessages, getRoom }
+export { registerMessages, getRoom, registerRequests, createRequests, RequestError, RequestTimeoutError }
 
 // Re-export types that users need
 export type { EventContext, EventSchemaRegistry }
+export type { RequestDefinition, RequestSchemaRegistry, RequestHandler, RequestOptions, RequestsOptions, Requests }

--- a/packages/@dcl/sdk/src/network/events/requests.ts
+++ b/packages/@dcl/sdk/src/network/events/requests.ts
@@ -1,0 +1,489 @@
+import { IEngine, ISchema, Schemas, engine as globalEngine } from '@dcl/ecs'
+import { AUTH_SERVER_PEER_ID } from '../message-bus-sync'
+import { EventContext, Room, getEventRegistry, getRoom } from './implementation'
+import { encodeEvent } from './protocol'
+
+/**
+ * Request/response messaging on top of the room's fire-and-forget events.
+ *
+ * `room.send`/`room.onMessage` have no notion of a reply, so scenes end up hand-rolling
+ * correlation: a `requestId` threaded through both payloads, a `requester` field the
+ * client filters on, and a retry loop in case the answer never arrives. That boilerplate
+ * is easy to get subtly wrong — replies broadcast to every peer instead of the caller,
+ * or a request that hangs forever when the handler throws.
+ *
+ * This layer keeps the same wire mechanism (two registered events per method) but owns
+ * the correlation id, the addressing, the timeout, and the error channel.
+ *
+ * @example
+ * ```ts
+ * // shared/rpc.ts
+ * export const rpc = registerRequests({
+ *   loadFarm: { request: Schemas.Map({}), response: FarmStateSchema }
+ * })
+ *
+ * // server
+ * rpc.handle('loadFarm', async (_data, context) => farmToPayload(await store.load(context.from)))
+ *
+ * // client
+ * const farm = await rpc.request('loadFarm', {})
+ * ```
+ */
+
+/** A method's payload shapes: what the caller sends, and what the handler answers with. */
+export type RequestDefinition<Req = any, Res = any> = {
+  request: ISchema<Req>
+  response: ISchema<Res>
+}
+
+export type RequestSchemaRegistry = Record<string, RequestDefinition>
+
+export type RequestPayload<T extends RequestSchemaRegistry, K extends keyof T> = T[K]['request'] extends ISchema<
+  infer U
+>
+  ? U
+  : never
+
+export type ResponsePayload<T extends RequestSchemaRegistry, K extends keyof T> = T[K]['response'] extends ISchema<
+  infer U
+>
+  ? U
+  : never
+
+export type RequestHandler<T extends RequestSchemaRegistry, K extends keyof T> = (
+  data: RequestPayload<T, K>,
+  context: EventContext
+) => ResponsePayload<T, K> | Promise<ResponsePayload<T, K>>
+
+export type RequestOptions = {
+  /** Override the registry's default timeout for this call. */
+  timeoutMs?: number
+  /**
+   * Address to ask. **Required** for server-initiated requests — a server request without a
+   * target would be broadcast to every client and could be answered by any of them, so it
+   * throws instead. Clients always reach the authoritative server and must omit it.
+   */
+  to?: string
+}
+
+export type RequestsOptions = {
+  /** Default per-request timeout. Defaults to 20s — a handler may do several ~2s storage round trips. */
+  defaultTimeoutMs?: number
+}
+
+export type CreateRequestsOptions = RequestsOptions & {
+  room: Room
+  engine: IEngine
+}
+
+export interface Requests<T extends RequestSchemaRegistry> {
+  /**
+   * Answer `method`. Register it once — a second live handler makes the caller settle
+   * on whichever reply lands first.
+   *
+   * The reply is addressed to the caller automatically. Throw {@link RequestError} to
+   * send a message the caller can read; any other throw becomes `internal_error`.
+   *
+   * @returns an unsubscribe function
+   */
+  handle<K extends keyof T & string>(method: K, handler: RequestHandler<T, K>): () => void
+
+  /**
+   * Call `method` and resolve with the handler's response.
+   *
+   * Rejects with a {@link RequestError} carrying the handler's message when it failed,
+   * or with a {@link RequestTimeoutError} when no reply arrived in time.
+   *
+   * Custom events are not chunked, so a request or response must fit one comms message
+   * (~12KB). An oversized or unserializable payload rejects immediately with
+   * `payload_too_large` / `invalid_payload` rather than waiting out the timeout.
+   */
+  request<K extends keyof T & string>(
+    method: K,
+    data: RequestPayload<T, K>,
+    options?: RequestOptions
+  ): Promise<ResponsePayload<T, K>>
+
+  /** Number of in-flight requests. Exposed for diagnostics and tests. */
+  pendingCount(): number
+}
+
+const DEFAULT_TIMEOUT_MS = 20_000
+const INTERNAL_ERROR = 'internal_error'
+const TIMEOUT_ERROR = 'request_timeout'
+const TOO_LARGE_ERROR = 'payload_too_large'
+
+/**
+ * Ceiling for one comms message, mirroring `LIVEKIT_MAX_SIZE` in `network/server`. Custom
+ * events are NOT chunked — unlike CRDT traffic — so anything over this is dropped by the
+ * transport with no error, which would otherwise surface only as a timeout.
+ *
+ * Deliberately duplicated rather than imported: keeping this module out of the network
+ * transport's import cluster matters more than sharing one number.
+ */
+const MAX_MESSAGE_BYTES = 12 * 1024
+/** Headroom for the event envelope plus the sender address the host prepends on receive. */
+const MESSAGE_OVERHEAD_BYTES = 256
+const MAX_PAYLOAD_BYTES = MAX_MESSAGE_BYTES - MESSAGE_OVERHEAD_BYTES
+
+/** Event-name prefixes. Namespaced to not collide with scene-registered message names. */
+const REQUEST_PREFIX = '@dcl/req:'
+const RESPONSE_PREFIX = '@dcl/res:'
+
+/**
+ * Error whose message is forwarded verbatim to the caller.
+ *
+ * Handlers should throw this for failures the caller is meant to see and act on
+ * ("insufficient_funds", "plot_locked"). Any *other* throw is reported as
+ * `internal_error`, so an unexpected crash cannot leak server internals — stack
+ * traces, storage keys, addresses — across the wire.
+ */
+export class RequestError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RequestError'
+  }
+}
+
+/**
+ * No reply arrived before the deadline.
+ *
+ * Distinct from {@link RequestError} on purpose: a timeout is worth retrying, a handler
+ * rejection usually is not.
+ */
+export class RequestTimeoutError extends Error {
+  constructor(public readonly method: string) {
+    super(`${TIMEOUT_ERROR}: ${method}`)
+    this.name = 'RequestTimeoutError'
+  }
+}
+
+/** Methods whose wire events this module already created, for conflict detection. */
+const registeredMethods = new Map<string, RequestDefinition>()
+
+/**
+ * Methods with a live handler, per ROOM. Listeners live on the room, so two `Requests`
+ * instances bound to the same room would each answer — an instance-scoped guard could not
+ * see that, which is exactly the case the warning exists for.
+ */
+const handledByRoom = new WeakMap<Room, Set<string>>()
+
+function handledMethodsFor(room: Room): Set<string> {
+  let handled = handledByRoom.get(room)
+  if (!handled) {
+    handled = new Set<string>()
+    handledByRoom.set(room, handled)
+  }
+  return handled
+}
+
+/**
+ * Encode ahead of `room.send` so a payload problem is reported to the caller instead of
+ * silently vanishing: `Room.send` catches and logs its own failures, so an unserializable
+ * payload would otherwise settle only via the timeout. Also the only place the transport
+ * ceiling can be enforced, since nothing downstream checks it for custom events.
+ *
+ * Costs one extra serialization per message; correctness is worth more here than the bytes.
+ */
+function checkPayload(eventType: string, data: unknown): string | null {
+  let encoded: Uint8Array
+  try {
+    encoded = encodeEvent(eventType, data as never, getEventRegistry())
+  } catch (error) {
+    console.error(`[Requests] '${eventType}' payload does not match its schema:`, error)
+    return 'invalid_payload'
+  }
+  if (encoded.byteLength > MAX_PAYLOAD_BYTES) {
+    console.error(
+      `[Requests] '${eventType}' payload is ${encoded.byteLength} bytes, over the ${MAX_PAYLOAD_BYTES} byte transport limit`
+    )
+    return TOO_LARGE_ERROR
+  }
+  return null
+}
+
+type PendingRequest = {
+  method: string
+  /** Expected responder, lowercased. Empty when the caller is a client (only the server answers). */
+  expectFrom: string
+  deadlineMs: number
+  timeoutMs: number
+  /**
+   * True while `Room` is still holding the request in its send queue. Such an entry has no
+   * deadline yet — the clock starts when the room connects and the request actually goes out.
+   */
+  waitingForRoom: boolean
+  resolve: (value: any) => void
+  reject: (error: Error) => void
+}
+
+/**
+ * Bind a request registry to a specific room and engine.
+ *
+ * Prefer {@link registerRequests} in scenes; this exists for tests and for hosts that
+ * run more than one engine in a process.
+ */
+export function createRequests<T extends RequestSchemaRegistry>(
+  definitions: T,
+  options: CreateRequestsOptions
+): Requests<T> {
+  const { room, engine } = options
+  const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS
+  const registry = getEventRegistry()
+
+  // Derive and register the two wire events per method. Wrapping the user's schemas
+  // instead of introducing an envelope field keeps the existing protocol untouched.
+  for (const method of Object.keys(definitions)) {
+    const definition = definitions[method]
+    const owned = registeredMethods.get(method)
+    if (owned) {
+      // Re-registering an equivalent pair is a no-op: hosts that run a client and a server
+      // engine in one process (tests, tooling) legitimately bind the same definitions to two
+      // rooms, and two modules may declare the same method with textually identical schemas.
+      // Compared by SHAPE rather than object identity, because `Schemas.Map({...})` mints a
+      // fresh object per call. Different shapes under one name is a real conflict.
+      if (!sameSchema(owned.request, definition.request) || !sameSchema(owned.response, definition.response)) {
+        throw new Error(`Request method '${method}' is already registered with different schemas`)
+      }
+      continue
+    }
+
+    const requestEvent = REQUEST_PREFIX + method
+    const responseEvent = RESPONSE_PREFIX + method
+    if (registry[requestEvent] || registry[responseEvent]) {
+      throw new Error(`Request method '${method}' collides with a registered message name`)
+    }
+
+    registry[requestEvent] = Schemas.Map({
+      id: Schemas.String,
+      body: definition.request
+    })
+    registry[responseEvent] = Schemas.Map({
+      id: Schemas.String,
+      ok: Schemas.Boolean,
+      error: Schemas.String,
+      // Always serialized, even on failure: `Schemas.Optional` drops falsy values, which
+      // would silently mangle a legitimate `0` / `false` / `''` response body.
+      body: definition.response
+    })
+    registeredMethods.set(method, definition)
+  }
+
+  const pending = new Map<string, PendingRequest>()
+  const responseListenersBound = new Set<string>()
+  const handledMethods = handledMethodsFor(room)
+  const idPrefix = Math.random().toString(36).slice(2, 10)
+  let idCounter = 0
+  let sweepRegistered = false
+  let roomReadySubscribed = false
+
+  function settle(id: string, apply: (entry: PendingRequest) => void): void {
+    const entry = pending.get(id)
+    if (!entry) return // unknown, duplicate, or already-timed-out id
+    pending.delete(id)
+    apply(entry)
+  }
+
+  /**
+   * Deadlines are swept from an engine system, not `setTimeout`: the server runtime does
+   * not guarantee timers, and this must behave identically on both sides.
+   */
+  function ensureSweepSystem(): void {
+    if (sweepRegistered) return
+    sweepRegistered = true
+    engine.addSystem(
+      () => {
+        if (pending.size === 0) return
+        const now = Date.now()
+        for (const [id, entry] of [...pending]) {
+          // Never time out something that has not been sent: `Room.send` queues while
+          // disconnected, so rejecting here would abandon a caller for a request that later
+          // leaves the queue and runs on the server anyway.
+          if (entry.waitingForRoom) continue
+          if (now < entry.deadlineMs) continue
+          settle(id, (e) => e.reject(new RequestTimeoutError(e.method)))
+        }
+      },
+      undefined,
+      '@dcl/sdk-requests'
+    )
+  }
+
+  /**
+   * `room.send` queues messages until the room connects, so a request issued at boot
+   * could burn its whole budget before leaving the process. Re-base those deadlines from
+   * the moment the room is actually ready.
+   */
+  function ensureRoomReadySubscription(): void {
+    if (roomReadySubscribed) return
+    roomReadySubscribed = true
+    room.onReady((isReady) => {
+      if (!isReady) return
+      const now = Date.now()
+      for (const entry of pending.values()) {
+        if (!entry.waitingForRoom) continue
+        entry.waitingForRoom = false
+        entry.deadlineMs = now + entry.timeoutMs
+      }
+    })
+  }
+
+  function bindResponseListener(method: string): void {
+    if (responseListenersBound.has(method)) return
+    responseListenersBound.add(method)
+
+    room.onMessage(RESPONSE_PREFIX + method, (data: any, context?: EventContext) => {
+      const entry = pending.get(data.id)
+      if (!entry) return
+
+      // Fail closed. A `context` means we are the server receiving a peer's reply, and a
+      // peer may only settle a request that named it: an unset `expectFrom` must never be
+      // settleable from the wire. Clients get no context (Room already guarantees the sender
+      // is the authoritative server), so their replies are unaffected.
+      if (context && (!entry.expectFrom || context.from.toLowerCase() !== entry.expectFrom)) return
+
+      settle(data.id, (e) => {
+        if (data.ok) e.resolve(data.body)
+        else e.reject(new RequestError(data.error || INTERNAL_ERROR))
+      })
+    })
+  }
+
+  return {
+    handle<K extends keyof T & string>(method: K, handler: RequestHandler<T, K>): () => void {
+      const responseEvent = RESPONSE_PREFIX + method
+
+      // Two live handlers would each answer, and the caller would settle on whichever
+      // reply arrived first — silently discarding the other. Almost always a mistake.
+      if (handledMethods.has(method)) {
+        console.error(`[Requests] '${method}' already has a handler — the caller will get two replies`)
+      }
+      handledMethods.add(method)
+
+      const unsubscribe = room.onMessage(REQUEST_PREFIX + method, (data: any, context?: EventContext) => {
+        // `context` is absent on clients handling a server-initiated request; the reply
+        // then goes to the server, which is the only peer a client can send to.
+        const replyTo = context ? { to: [context.from] } : undefined
+        const handlerContext: EventContext = context ?? { from: AUTH_SERVER_PEER_ID }
+
+        const reply = (ok: boolean, body: any, error: string) => {
+          const payload = { id: data.id, ok, error, body }
+          const problem = checkPayload(responseEvent, payload)
+          if (!problem) {
+            void room.send(responseEvent, payload, replyTo)
+            return
+          }
+          // The intended reply cannot be sent. Answer with the failure instead of nothing, so
+          // the caller learns why rather than waiting out its timeout.
+          const fallback = { id: data.id, ok: false, error: problem, body: definitions[method].response.create() }
+          if (checkPayload(responseEvent, fallback)) return
+          void room.send(responseEvent, fallback, replyTo)
+        }
+
+        try {
+          const result = handler(data.body, handlerContext)
+          if (result instanceof Promise) {
+            result.then(
+              (value) => reply(true, value, ''),
+              (error: unknown) => {
+                if (!(error instanceof RequestError)) {
+                  console.error(`[Requests] handler '${method}' failed:`, error)
+                }
+                reply(false, definitions[method].response.create(), toWireError(error))
+              }
+            )
+            return
+          }
+          reply(true, result, '')
+        } catch (error) {
+          if (!(error instanceof RequestError)) {
+            console.error(`[Requests] handler '${method}' threw:`, error)
+          }
+          reply(false, definitions[method].response.create(), toWireError(error))
+        }
+      })
+
+      return () => {
+        handledMethods.delete(method)
+        unsubscribe()
+      }
+    },
+
+    request<K extends keyof T & string>(
+      method: K,
+      data: RequestPayload<T, K>,
+      options?: RequestOptions
+    ): Promise<ResponsePayload<T, K>> {
+      ensureSweepSystem()
+      ensureRoomReadySubscription()
+      bindResponseListener(method)
+
+      const id = `${idPrefix}:${++idCounter}`
+      const requestEvent = REQUEST_PREFIX + method
+      const problem = checkPayload(requestEvent, { id, body: data })
+      if (problem) {
+        return Promise.reject(new RequestError(`${problem}: ${method}`))
+      }
+      const timeoutMs = options?.timeoutMs ?? defaultTimeoutMs
+      const waitingForRoom = !room.isReady()
+
+      // Server-initiated requests MUST name a target. Without one, `Room.send` broadcasts the
+      // request — and its correlation id — to every client, and any of them could answer.
+      // A contract violation, so it throws rather than sending.
+      if (room.isServer() && !options?.to) {
+        throw new Error(`A server request must name a target: request('${method}', data, { to })`)
+      }
+
+      return new Promise<ResponsePayload<T, K>>((resolve, reject) => {
+        pending.set(id, {
+          method,
+          expectFrom: options?.to?.toLowerCase() ?? '',
+          // Infinite until the room connects; the onReady rebase sets the real deadline.
+          deadlineMs: waitingForRoom ? Number.POSITIVE_INFINITY : Date.now() + timeoutMs,
+          timeoutMs,
+          waitingForRoom,
+          resolve,
+          reject
+        })
+
+        void room.send(requestEvent, { id, body: data }, options?.to ? { to: [options.to] } : undefined)
+      })
+    },
+
+    pendingCount(): number {
+      return pending.size
+    }
+  }
+}
+
+/** Structural schema comparison — every `ISchema` exposes a serializable `jsonSchema`. */
+function sameSchema(a: ISchema, b: ISchema): boolean {
+  if (a === b) return true
+  try {
+    return JSON.stringify(a.jsonSchema) === JSON.stringify(b.jsonSchema)
+  } catch {
+    return false
+  }
+}
+
+function toWireError(error: unknown): string {
+  return error instanceof RequestError ? error.message || INTERNAL_ERROR : INTERNAL_ERROR
+}
+
+/**
+ * Register request/response methods for use with the scene room.
+ * Call this at module load, like `registerMessages`.
+ *
+ * @param definitions - `{ methodName: { request: Schema, response: Schema } }`
+ * @returns a typed `{ request, handle }` pair for those methods
+ */
+export function registerRequests<T extends RequestSchemaRegistry>(
+  definitions: T,
+  options?: RequestsOptions
+): Requests<T> {
+  return createRequests(definitions, {
+    ...options,
+    room: getRoom(),
+    engine: globalEngine
+  })
+}

--- a/packages/@dcl/sdk/src/network/index.ts
+++ b/packages/@dcl/sdk/src/network/index.ts
@@ -31,7 +31,23 @@ const {
 } = addSyncTransport(engine, sendBinary, getUserData, isServerApi, 'network')
 
 // Re-export the room messaging system
-export { registerMessages, getRoom } from './events'
+export {
+  registerMessages,
+  getRoom,
+  registerRequests,
+  createRequests,
+  RequestError,
+  RequestTimeoutError
+} from './events'
+export type {
+  EventContext,
+  RequestDefinition,
+  RequestSchemaRegistry,
+  RequestHandler,
+  RequestOptions,
+  RequestsOptions,
+  Requests
+} from './events'
 
 export {
   getFirstChild,

--- a/test/sdk/network/requests.spec.ts
+++ b/test/sdk/network/requests.spec.ts
@@ -1,0 +1,514 @@
+import { Engine, IEngine, Schemas } from '../../../packages/@dcl/ecs/dist'
+import { Atom } from '../../../packages/@dcl/sdk/src/atom'
+import { CommsMessage } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { Room } from '../../../packages/@dcl/sdk/src/network/events/implementation'
+import {
+  RequestError,
+  RequestTimeoutError,
+  Requests,
+  createRequests
+} from '../../../packages/@dcl/sdk/src/network/events/requests'
+
+const CLIENT_ADDRESS = '0xclient'
+const AUTH_SERVER_PEER_ID = 'authoritative-server'
+
+// Schemas are registered process-wide by design (same contract as `registerMessages`),
+// so the definitions live at module scope: re-binding the *same* schema objects to a
+// second room is the supported path, re-binding different ones is an error.
+const DEFINITIONS = {
+  loadProfile: {
+    request: Schemas.Map({ includeStats: Schemas.Boolean }),
+    response: Schemas.Map({ name: Schemas.String, gold: Schemas.Int })
+  },
+  countCoins: {
+    request: Schemas.Map({}),
+    response: Schemas.Int
+  },
+  buySeed: {
+    request: Schemas.Map({ cropType: Schemas.Int }),
+    response: Schemas.Map({ coins: Schemas.Int })
+  },
+  unanswered: {
+    request: Schemas.Map({}),
+    response: Schemas.Map({ ok: Schemas.Boolean })
+  },
+  loadBlob: {
+    request: Schemas.Map({ size: Schemas.Int }),
+    response: Schemas.Map({ blob: Schemas.String })
+  },
+  echoText: {
+    request: Schemas.Map({ text: Schemas.String }),
+    response: Schemas.Map({ text: Schemas.String })
+  }
+}
+
+type BusCallback = (data: Uint8Array, sender: string) => void
+
+/** Wire a client room and a server room together with the platform's addressing rules. */
+function createLinkedRooms(engine: IEngine, options: { clientReady?: boolean } = {}) {
+  let clientReceive: BusCallback | undefined
+  let serverReceive: BusCallback | undefined
+  const serverSendTargets: (string[] | undefined)[] = []
+  const serverSent: Uint8Array[] = []
+  const clientReadyAtom = Atom<boolean>(options.clientReady ?? true)
+
+  const clientBus = {
+    on: (_message: CommsMessage, callback: BusCallback) => {
+      clientReceive = callback
+    },
+    // A client can only ever reach the authoritative server.
+    emit: (_message: CommsMessage, data: Uint8Array) => serverReceive?.(data, CLIENT_ADDRESS)
+  }
+
+  const serverBus = {
+    on: (_message: CommsMessage, callback: BusCallback) => {
+      serverReceive = callback
+    },
+    emit: (_message: CommsMessage, data: Uint8Array, to?: string[]) => {
+      serverSendTargets.push(to)
+      serverSent.push(data)
+      if (!to || to.includes(CLIENT_ADDRESS)) clientReceive?.(data, AUTH_SERVER_PEER_ID)
+    }
+  }
+
+  return {
+    clientRoom: new Room(engine, clientBus, Atom<boolean>(false), clientReadyAtom),
+    serverRoom: new Room(engine, serverBus, Atom<boolean>(true), Atom<boolean>(true)),
+    serverSendTargets,
+    clientReadyAtom,
+    /** Hand a buffer the server addressed elsewhere straight to the client. */
+    deliverToClient: (data: Uint8Array) => clientReceive?.(data, AUTH_SERVER_PEER_ID),
+    /** Deliver the client's last outbound buffer to the server as if another peer sent it. */
+    deliverToServerAs: (data: Uint8Array, sender: string) => serverReceive?.(data, sender),
+    serverSent
+  }
+}
+
+/**
+ * Drain the microtask hops between `send` and a handler running: the send path awaits
+ * the room's `isServer` future, and delivery awaits it again per listener. Everything is
+ * microtasks (no timers), so yielding repeatedly is enough.
+ */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 25; i++) await Promise.resolve()
+}
+
+describe('Room requests', () => {
+  let engine: IEngine
+  let clientRpc: Requests<typeof DEFINITIONS>
+  let serverRpc: Requests<typeof DEFINITIONS>
+  let serverSendTargets: (string[] | undefined)[]
+
+  beforeEach(() => {
+    engine = Engine()
+    const link = createLinkedRooms(engine)
+    serverSendTargets = link.serverSendTargets
+    clientRpc = createRequests(DEFINITIONS, { room: link.clientRoom, engine })
+    serverRpc = createRequests(DEFINITIONS, { room: link.serverRoom, engine })
+  })
+
+  describe('when the server handles a request', () => {
+    let response: { name: string; gold: number }
+    let receivedRequest: { includeStats: boolean } | undefined
+    let receivedFrom: string | undefined
+
+    beforeEach(async () => {
+      serverRpc.handle('loadProfile', (data, context) => {
+        receivedRequest = data
+        receivedFrom = context.from
+        return { name: 'Ada', gold: 42 }
+      })
+      const pending = clientRpc.request('loadProfile', { includeStats: true })
+      await flush()
+      response = await pending
+    })
+
+    it('should resolve with the handler response', () => {
+      expect(response).toEqual({ name: 'Ada', gold: 42 })
+    })
+
+    it('should pass the request payload to the handler', () => {
+      expect(receivedRequest).toEqual({ includeStats: true })
+    })
+
+    it('should give the handler the caller address', () => {
+      expect(receivedFrom).toBe(CLIENT_ADDRESS)
+    })
+
+    it('should address the reply to the caller only', () => {
+      expect(serverSendTargets).toEqual([[CLIENT_ADDRESS]])
+    })
+
+    it('should leave no request pending', () => {
+      expect(clientRpc.pendingCount()).toBe(0)
+    })
+  })
+
+  describe('when the handler is asynchronous', () => {
+    let response: { coins: number }
+
+    beforeEach(async () => {
+      serverRpc.handle('buySeed', async (data) => {
+        await Promise.resolve()
+        return { coins: 100 - data.cropType }
+      })
+      const pending = clientRpc.request('buySeed', { cropType: 7 })
+      await flush()
+      response = await pending
+    })
+
+    it('should resolve with the awaited response', () => {
+      expect(response).toEqual({ coins: 93 })
+    })
+  })
+
+  describe('when the response body is a falsy scalar', () => {
+    let response: number
+
+    beforeEach(async () => {
+      serverRpc.handle('countCoins', () => 0)
+      const pending = clientRpc.request('countCoins', {})
+      await flush()
+      response = await pending
+    })
+
+    it('should resolve with the zero value rather than a default', () => {
+      expect(response).toBe(0)
+    })
+  })
+
+  describe('when the handler throws a RequestError', () => {
+    let error: Error | undefined
+
+    beforeEach(async () => {
+      serverRpc.handle('buySeed', () => {
+        throw new RequestError('insufficient_funds')
+      })
+      const pending = clientRpc.request('buySeed', { cropType: 1 }).catch((caught: Error) => {
+        error = caught
+      })
+      await flush()
+      await pending
+    })
+
+    it('should reject with the handler message', () => {
+      expect(error?.message).toBe('insufficient_funds')
+    })
+  })
+
+  describe('when the handler throws an unexpected error', () => {
+    let error: Error | undefined
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      serverRpc.handle('buySeed', () => {
+        throw new Error('storage key farm_v1 unreachable')
+      })
+      const pending = clientRpc.request('buySeed', { cropType: 1 }).catch((caught: Error) => {
+        error = caught
+      })
+      await flush()
+      await pending
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('should reject with a generic error instead of the internal message', () => {
+      expect(error?.message).toBe('internal_error')
+    })
+
+    it('should log the original failure on the server', () => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith("[Requests] handler 'buySeed' threw:", expect.any(Error))
+    })
+  })
+
+  describe('when no handler answers the request', () => {
+    let error: Error | undefined
+
+    beforeEach(async () => {
+      const pending = clientRpc.request('unanswered', {}, { timeoutMs: 0 }).catch((caught: Error) => {
+        error = caught
+      })
+      await flush()
+      await engine.update(1)
+      await pending
+    })
+
+    it('should reject with a timeout naming the method', () => {
+      expect(error?.message).toBe('request_timeout: unanswered')
+    })
+
+    it('should reject with a RequestTimeoutError so callers can retry selectively', () => {
+      expect(error).toBeInstanceOf(RequestTimeoutError)
+    })
+
+    it('should drop the pending entry', () => {
+      expect(clientRpc.pendingCount()).toBe(0)
+    })
+  })
+
+  describe('when several requests are in flight at once', () => {
+    let responses: { coins: number }[]
+
+    beforeEach(async () => {
+      serverRpc.handle('buySeed', async (data) => {
+        // Answer out of order so a correlation bug cannot pass by luck.
+        if (data.cropType === 1) await flush()
+        return { coins: data.cropType * 10 }
+      })
+      const pending = [
+        clientRpc.request('buySeed', { cropType: 1 }),
+        clientRpc.request('buySeed', { cropType: 2 }),
+        clientRpc.request('buySeed', { cropType: 3 })
+      ]
+      await flush()
+      responses = await Promise.all(pending)
+    })
+
+    it('should resolve each caller with its own response', () => {
+      expect(responses).toEqual([{ coins: 10 }, { coins: 20 }, { coins: 30 }])
+    })
+  })
+
+  describe('when a method name is registered with different schemas', () => {
+    let register: () => void
+
+    beforeEach(() => {
+      const link = createLinkedRooms(engine)
+      register = () =>
+        createRequests(
+          { loadProfile: { request: Schemas.Map({ other: Schemas.String }), response: Schemas.Int } },
+          { room: link.clientRoom, engine }
+        )
+    })
+
+    it('should throw a conflict error', () => {
+      expect(register).toThrow("Request method 'loadProfile' is already registered with different schemas")
+    })
+  })
+
+  describe('when a request is issued before the room is connected', () => {
+    let engineB: IEngine
+    let link: ReturnType<typeof createLinkedRooms>
+    let clientB: Requests<typeof DEFINITIONS>
+    let serverB: Requests<typeof DEFINITIONS>
+    let settled: string
+    let handlerCalls: number
+
+    beforeEach(async () => {
+      engineB = Engine()
+      settled = 'pending'
+      handlerCalls = 0
+      link = createLinkedRooms(engineB, { clientReady: false })
+      clientB = createRequests(DEFINITIONS, { room: link.clientRoom, engine: engineB })
+      serverB = createRequests(DEFINITIONS, { room: link.serverRoom, engine: engineB })
+      serverB.handle('buySeed', (data) => {
+        handlerCalls++
+        return { coins: data.cropType }
+      })
+      void clientB.request('buySeed', { cropType: 5 }, { timeoutMs: 0 }).then(
+        () => (settled = 'resolved'),
+        (error: Error) => (settled = `rejected:${error.message}`)
+      )
+      // Ticks well past the deadline while the room is still disconnected.
+      await engineB.update(1)
+      await engineB.update(1)
+      await flush()
+    })
+
+    it('should not time out while the request is still queued', () => {
+      expect(settled).toBe('pending')
+    })
+
+    it('should not have reached the handler yet', () => {
+      expect(handlerCalls).toBe(0)
+    })
+
+    describe('and the room then connects', () => {
+      beforeEach(async () => {
+        link.clientReadyAtom.swap(true)
+        await flush()
+      })
+
+      it('should resolve the original caller', () => {
+        expect(settled).toBe('resolved')
+      })
+
+      it('should have run the handler exactly once', () => {
+        expect(handlerCalls).toBe(1)
+      })
+    })
+  })
+
+  describe('when a server request omits its target', () => {
+    let attempt: () => void
+
+    beforeEach(() => {
+      attempt = () => serverRpc.request('buySeed', { cropType: 1 })
+    })
+
+    it('should throw rather than broadcast the request', () => {
+      expect(attempt).toThrow("A server request must name a target: request('buySeed', data, { to })")
+    })
+
+    it('should not have sent anything', () => {
+      try {
+        attempt()
+      } catch {
+        // expected
+      }
+
+      expect(serverSendTargets).toEqual([])
+    })
+  })
+
+  describe('when a peer answers a server request addressed to somebody else', () => {
+    let error: Error | undefined
+    let link: ReturnType<typeof createLinkedRooms>
+    let engineB: IEngine
+    let clientB: Requests<typeof DEFINITIONS>
+    let serverB: Requests<typeof DEFINITIONS>
+
+    beforeEach(async () => {
+      error = undefined
+      engineB = Engine()
+      link = createLinkedRooms(engineB)
+      clientB = createRequests(DEFINITIONS, { room: link.clientRoom, engine: engineB })
+      serverB = createRequests(DEFINITIONS, { room: link.serverRoom, engine: engineB })
+      // The client will happily answer anything it is handed.
+      clientB.handle('buySeed', () => ({ coins: 999 }))
+      const pending = serverB
+        .request('buySeed', { cropType: 1 }, { to: '0xsomebodyelse', timeoutMs: 0 })
+        .catch((caught: Error) => {
+          error = caught
+        })
+      await flush()
+      // Hand the request to the client even though it was addressed elsewhere, so it replies.
+      link.deliverToClient(link.serverSent[link.serverSent.length - 1])
+      await flush()
+      await engineB.update(1)
+      await pending
+    })
+
+    it('should ignore the reply and time out instead', () => {
+      expect(error).toBeInstanceOf(RequestTimeoutError)
+    })
+  })
+
+  describe('when a response exceeds the transport ceiling', () => {
+    let error: Error | undefined
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      error = undefined
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      serverRpc.handle('loadBlob', (data) => ({ blob: 'x'.repeat(data.size) }))
+      const pending = clientRpc.request('loadBlob', { size: 20_000 }).catch((caught: Error) => {
+        error = caught
+      })
+      await flush()
+      await pending
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('should reject with a size error rather than timing out', () => {
+      expect(error?.message).toBe('payload_too_large')
+    })
+
+    it('should not be reported as a timeout', () => {
+      expect(error).not.toBeInstanceOf(RequestTimeoutError)
+    })
+  })
+
+  describe('when a request payload cannot be serialized', () => {
+    let error: Error | undefined
+    let consoleErrorSpy: jest.SpyInstance
+    let handlerCalls: number
+
+    beforeEach(async () => {
+      error = undefined
+      handlerCalls = 0
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      serverRpc.handle('echoText', (data) => {
+        handlerCalls++
+        return data
+      })
+      const pending = clientRpc.request('echoText', { text: undefined } as never).catch((caught: Error) => {
+        error = caught
+      })
+      await flush()
+      await pending
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('should reject with an invalid-payload error', () => {
+      expect(error?.message).toBe('invalid_payload: echoText')
+    })
+
+    it('should not be reported as a timeout', () => {
+      expect(error).not.toBeInstanceOf(RequestTimeoutError)
+    })
+
+    it('should never reach the handler', () => {
+      expect(handlerCalls).toBe(0)
+    })
+  })
+
+  describe('when two Requests instances bound to one room handle the same method', () => {
+    let consoleErrorSpy: jest.SpyInstance
+    let second: Requests<typeof DEFINITIONS>
+    let engineB: IEngine
+    let link: ReturnType<typeof createLinkedRooms>
+
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      engineB = Engine()
+      link = createLinkedRooms(engineB)
+      const first = createRequests(DEFINITIONS, { room: link.serverRoom, engine: engineB })
+      second = createRequests(DEFINITIONS, { room: link.serverRoom, engine: engineB })
+      first.handle('buySeed', () => ({ coins: 1 }))
+      second.handle('buySeed', () => ({ coins: 2 }))
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('should warn that the caller will get two replies', () => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[Requests] 'buySeed' already has a handler — the caller will get two replies"
+      )
+    })
+  })
+
+  describe('when the same method is declared twice with structurally identical schemas', () => {
+    let register: () => void
+
+    beforeEach(() => {
+      const link = createLinkedRooms(engine)
+      register = () =>
+        createRequests(
+          {
+            countCoins: {
+              request: Schemas.Map({}),
+              response: Schemas.Int
+            }
+          },
+          { room: link.clientRoom, engine }
+        )
+    })
+
+    it('should accept the re-declaration', () => {
+      expect(register).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## What this adds

Request/response messaging in `@dcl/sdk/network`, on top of the existing room events:

```ts
// shared/rpc.ts — imported by both sides
export const rpc = registerRequests({
  loadFarm: { request: Schemas.Map({}), response: FarmStateSchema },
  buySeed:  { request: Schemas.Map({ cropType: Schemas.Int }), response: Schemas.Map({ coins: Schemas.Int }) }
})

// server
rpc.handle('loadFarm', async (_data, context) => toPayload(await store.load(context.from)))

// client
const farm = await rpc.request('loadFarm', {})
```

No protocol change. Each method derives two ordinary registered events (`@dcl/req:<m>`, `@dcl/res:<m>`) that wrap the declared schemas with a correlation id, so the event envelope and wire format are untouched.

## What it abstracts

`room.send` / `room.onMessage` are fire-and-forget, so any scene that needs an *answer* builds the correlation by hand. Across the shipped scenes that is **286** `room.send` sites and **207** `onMessage` sites, and four recurring pieces of boilerplate — each of which has produced a real bug.

### 1. Correlation ids, and replies broadcast to everyone

cozy-farm declares the plumbing in the schema (`src/shared/farmMessages.ts:174`):

```ts
const FarmStateLoadedSchema = Schemas.Map({
  requester: Schemas.String,
  requestId: Schemas.String,
  payload: FarmStateSchema
})
```

then answers **without** `{ to: … }` (`src/server/farmServer.ts:44`):

```ts
void room.send('farmStateLoaded', { requester: normalized, requestId, payload })
```

so every connected client receives every other player's full farm payload and drops it on the floor client-side (`src/services/saveService.ts:503`):

```ts
const requester = normalizeAddress(data.requester || data.payload?.wallet)
if (!requester) return
if (playerState.wallet && requester !== playerState.wallet) return
```

Same shape at `farmServer.ts:203` (`playerRegistryLoaded`), `:224` (`beautyLeaderboardLoaded`), `:245` (`otherFarmLoaded`). `beautyLeaderboardLoaded` also has a comment noting the personalised rank has to be recomputed per requester even though the list is broadcast.

towerofmadness carries an `address` field for the same purpose and filters against the local player (`src/multiplayer.ts:59`, `:78`):

```ts
const localIdentity = PlayerIdentityData.getOrNull(engine.PlayerEntity)
if (!localIdentity?.address) return
if (localIdentity.address.toLowerCase() !== data.address.toLowerCase()) return
```

With `handle`, the reply goes out as `{ to: [context.from] }` and none of that exists. There is a test asserting the send target is exactly the caller.

### 2. Retry loops standing in for a timeout

My-Dear-Pet re-asks for its own save every 2s for 30s because a lost request is indistinguishable from a slow one (`src/client/setup.ts:107-120`):

```ts
let sinceReq = 99
let elapsed = 0
actions.requestState()
engine.addSystem((dt: number) => {
  elapsed += dt
  if (elapsed < 30) {
    sinceReq += dt
    if (sinceReq >= 2) {
      sinceReq = 0
      resolveMyAddress()
      actions.requestState()   // keep asking and hope
    }
  }
})
```

becomes `await rpc.request('loadState', {})`, which rejects with `RequestTimeoutError` if nothing answers.

### 3. A hand-rolled error channel per handler

cozy-farm repeats a `reason: 'server_error'` string in every catch block (`farmServer.ts:186`, `:248`, `:284`, `:323`) and, when the load fails, silently sends the player a **fresh empty farm** (`:137`):

```ts
} catch (err) {
  console.error('[FarmServer] loadAndSend failed, sending fresh farm:', err)
  const fresh = emptyFarm(context.from.toLowerCase())
  void room.send('farmStateLoaded', { requester: …, requestId, payload: farmSaveToPayload(fresh) })
}
```

dead-surge declares dedicated rejection messages per request instead (`src/shared/messages.ts:97` `potionClaimRejected`, `:244` `collectibleClaimRejected`).

Here a handler throws `RequestError('insufficient_funds')` and the message is forwarded verbatim; **any other** throw becomes `internal_error` and is logged server-side, so an unexpected crash cannot leak storage keys, addresses or stack traces over the wire. A missing reply rejects with `RequestTimeoutError`, which is separately catchable so retry logic can tell a transport failure from a business rejection.

### 4. A payload ceiling nothing enforced

Custom events are **not** chunked. `LIVEKIT_MAX_SIZE = 12` (KB) is applied only to CRDT traffic (`network/state.ts:98,106`; `network/server/index.ts:150,160,298`) — a `grep` for any size guard on `CommsMessage.CUSTOM_EVENT` returns nothing. So an oversized reply is dropped by the transport with no error, and the caller finds out only when its timeout expires. Worse, `Room.send` catches and logs its own failures, so a payload that does not match its schema vanishes the same way.

Both are now caught before the send: `checkPayload()` encodes the message, rejects a shape the schema cannot serialize (`invalid_payload`) and one that exceeds the transport limit (`payload_too_large`). On the handler side, when the *reply* is the thing that cannot be sent, the failure is sent in its place — so the caller learns why instead of waiting out the clock. Real chunking for large payloads remains a separate piece of work; this makes the ceiling visible rather than silent.

### 5. Timers the server runtime does not have

flagtag documents the constraint (`docs/STORAGE.md:23`): *"The runtime does not guarantee `setTimeout`. Anything time-based on the server (timeouts, retry backoff, debounce) must be driven by an engine system."* Deadlines here are swept from an engine system for exactly that reason, so `request()` behaves the same on both sides. Default 20s — a handler may do several ~2s storage round trips — overridable per call.

## Design notes

**The response body is never `Schemas.Optional`.** `IOptional.serialize` checks `if (value)`, so a legitimate `0` / `false` / `''` response would serialize as absent and deserialize as `undefined`. On failure the body is filled from `schema.create()` instead, and `ok: false` tells the caller to ignore it. Regression test included (`countCoins` returning `0`).

**Server-initiated requests must name a target, and that is enforced.** `rpc.request(m, data, { to: address })` is the only valid server form: omitting `to` would make `Room.send` broadcast the request *and its correlation id* to every client, any of which could then answer. A server request without `to` therefore throws rather than sending, using a new synchronous `Room.isServer()`. The response path additionally **fails closed** — a reply is only accepted from the peer the request named, so an unset expectation can never be settled from the wire. (Client → server needs no such check: `Room` already drops client-side events from anyone but the authoritative server.)

**A request queued before the room connects does not burn its budget.** `Room.send` queues while disconnected, so a boot-time request used to be rejected by the sweeper and then executed anyway when the queue flushed — the caller saw a timeout, retried, and the handler ran twice. Queued entries now carry no deadline at all; the clock starts when the room connects and the request actually goes out.

**Double handlers are flagged, per room.** Registering a second live handler for one method means two replies and the caller settling on whichever lands first. The guard is keyed on the `Room` (a module-level `WeakMap`), not on the `Requests` instance — listeners live on the room, so two instances bound to the same room would each answer, which is exactly the case the warning exists for and which an instance-scoped guard could not see.

**Why a separate object rather than `room.request` / `room.handle`.** `Room` is generic over the message registry, and requests need a different registry shape (`{ request, response }` pairs). Folding both into one class means either a second type parameter on `Room` — which changes `getRoom<T>()` and `registerMessages` typing for every existing scene — or losing type safety on one side. A separate typed object keeps both fully typed and makes this change purely additive. Easy to re-surface on `Room` later if that reads better.

**Registration is idempotent for equivalent schemas** and throws for a name reused with a different shape. Compared structurally via `jsonSchema`, not by object identity — `Schemas.Map({...})` mints a fresh object per call, so identity comparison would reject two modules declaring the same method with textually identical schemas, and would reject any code path that re-evaluates its definitions literal.

## Testing

`test/sdk/network/requests.spec.ts`, 29 cases driving a real client `Room` and server `Room` wired together through the platform's addressing rules (clients can only reach the server; the server broadcasts or targets). Covers the happy path, async handlers, falsy response bodies, `RequestError` forwarding, internal-error redaction, timeout, out-of-order concurrent requests, reply addressing, and schema conflict detection — plus, for the fixes above: a request issued while the room is disconnected (ticked well past its deadline, then connected, asserting it neither times out nor double-runs the handler), a server request with no target, a reply from a peer the request did not name, an oversized response, an unserializable request, two instances handling one method on one room, and a structurally-identical re-declaration.

- `make test` — 158 suites / 1211 tests, 0 failures
- `make lint` — `@dcl/sdk` clean
- `make build` — passes, including the playground-assets API report gate
- `tsc --noEmit` on `@dcl/sdk` — clean

## Notes for review

- **`checkPayload` costs one extra serialization per message.** The alternative was a back door on `Room` that accepts a pre-encoded buffer; an `@internal` method would be stripped from the emitted `.d.ts` while still existing at runtime, which is a worse shape than paying for a second encode on a request/response path.
- **The 12KB constant is duplicated** rather than imported from `network/server`, deliberately: keeping this module outside the network transport's import cluster is worth more than sharing one number. Commented at the definition.
- **Not fixed here:** custom events still are not chunked, so a genuinely large payload (a whole player save, say) cannot be sent as one request — it now fails loudly instead of silently, but making it *work* needs chunking in the event layer and is filed separately.
