### PR TITLE
Default the preview multiplayer server to the bevy engine

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/hammurabi-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/hammurabi-server.ts
@@ -9,7 +9,7 @@ import { isElectronEnvironment, getSpawnEnv, findNpxCliJs, getNpxBin } from './u
 const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
-const BEVY_PACKAGE = '@dcl/bevy-headless-server'
+const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
 const BEVY_VERSION = 'next'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
@@ -21,6 +21,16 @@ type ServerEngine = 'bevy' | 'hammurabi'
 function selectedEngine(): ServerEngine {
   const requested = process.env.DCL_SERVER_ENGINE
   return requested === 'bevy' || requested === 'hammurabi' ? requested : 'hammurabi'
+}
+
+/**
+ * npx accepts a directory or tarball as well as a registry spec, so pointing
+ * DCL_SERVER_PACKAGE at a local build exercises this spawn path without publishing.
+ */
+function packageSpec(engine: ServerEngine): string {
+  const override = process.env.DCL_SERVER_PACKAGE
+  if (override) return override
+  return engine === 'bevy' ? `${BEVY_PACKAGE}@${BEVY_VERSION}` : `${HAMMURABI_PACKAGE}@${HAMMURABI_VERSION}`
 }
 
 /**
@@ -48,7 +58,7 @@ export function startHammurabiServer(
   realm: string,
   engine: ServerEngine = 'hammurabi'
 ): ChildProcess {
-  const pkg = engine === 'bevy' ? `${BEVY_PACKAGE}@${BEVY_VERSION}` : `${HAMMURABI_PACKAGE}@${HAMMURABI_VERSION}`
+  const pkg = packageSpec(engine)
 
   printProgressInfo(
     components.logger,

--- a/packages/@dcl/sdk-commands/src/commands/start/hammurabi-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/hammurabi-server.ts
@@ -9,6 +9,20 @@ import { isElectronEnvironment, getSpawnEnv, findNpxCliJs, getNpxBin } from './u
 const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
+const BEVY_PACKAGE = '@dcl/bevy-headless-server'
+const BEVY_VERSION = 'next'
+
+// The bevy server exits with this when it can never run here (unsupported platform,
+// missing binary, bad arguments), which is our cue to fall back to hammurabi.
+const EXIT_UNAVAILABLE = 78
+
+type ServerEngine = 'bevy' | 'hammurabi'
+
+function selectedEngine(): ServerEngine {
+  const requested = process.env.DCL_SERVER_ENGINE
+  return requested === 'bevy' || requested === 'hammurabi' ? requested : 'hammurabi'
+}
+
 /**
  * Registers cleanup handlers on the global process object
  * Returns a function to remove the handlers
@@ -31,14 +45,17 @@ function registerProcessCleanup(cleanup: () => void): () => void {
 export function startHammurabiServer(
   components: Pick<CliComponents, 'logger'>,
   workingDir: string,
-  realm: string
+  realm: string,
+  engine: ServerEngine = 'hammurabi'
 ): ChildProcess {
+  const pkg = engine === 'bevy' ? `${BEVY_PACKAGE}@${BEVY_VERSION}` : `${HAMMURABI_PACKAGE}@${HAMMURABI_VERSION}`
+
   printProgressInfo(
     components.logger,
-    `Starting ${colors.bold('Multiplayer Server')} with realm: ${colors.bold(realm)}`
+    `Starting ${colors.bold('Multiplayer Server')} (${engine}) with realm: ${colors.bold(realm)}`
   )
 
-  const npxArgs = ['--yes', `${HAMMURABI_PACKAGE}@${HAMMURABI_VERSION}`, `--realm=${realm}`]
+  const npxArgs = ['--yes', pkg, `--realm=${realm}`]
   const npxCliJs = findNpxCliJs()
 
   // In Electron, override npm_config_prefix because npm derives its prefix from process.execPath,
@@ -80,9 +97,12 @@ export function startHammurabiServer(
  * In the auth-server SDK, all scenes are authoritative multiplayer.
  * Uses npx to handle installation and execution in a single step (works in Electron).
  *
+ * Which implementation runs is chosen by DCL_SERVER_ENGINE (bevy | hammurabi). When bevy
+ * reports itself unavailable on this machine, hammurabi is started instead.
+ *
  * @param components - Preview components including logger
  * @param project - The project to start the multiplayer server for
- * @param realm - The realm URL to pass to the hammurabi server
+ * @param realm - The realm URL to pass to the server
  * @returns The ChildProcess if started, undefined otherwise
  */
 export function spawnAuthServer(
@@ -90,8 +110,18 @@ export function spawnAuthServer(
   project: ProjectUnion,
   realm: string
 ): ChildProcess | undefined {
+  const engine = selectedEngine()
   try {
-    return startHammurabiServer(components, project.workingDirectory, realm)
+    const child = startHammurabiServer(components, project.workingDirectory, realm, engine)
+    if (engine === 'bevy') {
+      child.on('close', (code) => {
+        if (code === EXIT_UNAVAILABLE) {
+          printWarning(components.logger, 'Bevy multiplayer server unavailable here — falling back to hammurabi')
+          startHammurabiServer(components, project.workingDirectory, realm, 'hammurabi')
+        }
+      })
+    }
+    return child
   } catch (error: any) {
     printWarning(components.logger, `Failed to start Multiplayer Server: ${error.message}`)
     return undefined

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -29,8 +29,7 @@ import { Result } from 'arg'
 import { startValidations } from '../../logic/project-validations'
 import { runExplorerAlpha } from './explorer-alpha'
 import { getLanUrl } from './utils'
-import { spawnAuthServer } from './hammurabi-server'
-import { ChildProcess } from 'child_process'
+import { spawnAuthServer } from './multiplayer-server'
 
 interface Options {
   args: Result<typeof args>
@@ -222,18 +221,16 @@ export async function main(options: Options) {
       }
       await startComponents()
 
-      // Start Hammurabi server if needed (stored outside components to avoid lifecycle management)
-      let hammurabiServer: ChildProcess | undefined
+      // Start the multiplayer server if needed (kept outside the components object to avoid lifecycle management)
       const project = workspace.projects[0]
       if (project) {
         const realm = `http://localhost:${port}`
-        hammurabiServer = spawnAuthServer(components, project, realm)
+        const multiplayerServer = spawnAuthServer(components, project, realm)
 
-        // Register cleanup handler for hammurabi server
-        if (hammurabiServer) {
+        if (multiplayerServer) {
           const cleanup = () => {
-            if (hammurabiServer && !hammurabiServer.killed) {
-              hammurabiServer.kill('SIGTERM')
+            if (!multiplayerServer.killed) {
+              multiplayerServer.kill('SIGTERM')
             }
           }
           components.signaler.programClosed.then(cleanup).catch(() => {})

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -176,9 +176,12 @@ export async function main(options: Options) {
       const config = createRecordConfigComponent({
         HTTP_SERVER_PORT: port.toString(),
         HTTP_SERVER_HOST: '0.0.0.0',
+        // the embedded comms server (RoomsComponent/LinearProtocol) logs every
+        // connect/disconnect at DEBUG; LOG_LEVEL=DEBUG in the env re-enables it
+        LOG_LEVEL: 'INFO',
         ...process.env
       })
-      const logs = await createConsoleLogComponent({})
+      const logs = await createConsoleLogComponent({ config })
       const ws = await createWsComponent({ logs })
       const server = await createServerComponent<PreviewComponents>({ config, ws: ws.ws, logs }, { cors: {} })
       const rooms = await createRoomsComponent({

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,10 +11,10 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-// Pinned exactly so every push to the engine's main doesn't change what previews
-// run: each sdk-commands release ships a known, tested engine. Bump deliberately.
-// DCL_SERVER_PACKAGE still overrides for local/unpublished builds.
-const BEVY_VERSION = '0.1.0-31482267820.commit-be377f8'
+// `latest` moves only when a proven snapshot is promoted via bevy-explorer's
+// promote-headless workflow — engine pushes to main land on `next` and cannot
+// change what previews run. DCL_SERVER_PACKAGE overrides for local builds.
+const BEVY_VERSION = 'latest'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
 // missing binary, bad arguments). We fail the preview loudly instead of retrying:

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -90,7 +90,7 @@ function colorByLevel(level: string | undefined, message: string): string {
 // engine timestamps are UTC ISO with microseconds; show local wall-clock instead
 function localTime(utcTimestamp: string): string {
   const date = new Date(utcTimestamp + 'Z')
-  return isNaN(date.getTime()) ? '' : colors.gray(date.toTimeString().slice(0, 8)) + ' '
+  return isNaN(date.getTime()) ? '' : colors.dim(date.toTimeString().slice(0, 8)) + ' '
 }
 
 /**
@@ -100,7 +100,7 @@ function localTime(utcTimestamp: string): string {
  */
 function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
   if (!source) return
-  const serverTag = colors.green('[Server]') + ' '
+  const serverTag = colors.greenBright('[Server]') + ' '
   const writeClean = (raw: string) => {
     const line = raw.replace(ANSI_CODES, '')
     if (!line.trim()) return

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -57,6 +57,16 @@ function registerProcessCleanup(cleanup: () => void): () => void {
 // timestamp/level/target prefix the bevy engine's tracing puts on every line
 const TRACING_PREFIX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+(INFO|WARN|ERROR|DEBUG|TRACE)\s+[\w:]+:\s?/
 const HEARTBEAT_LINE = /^\[headless\] alive:/
+// The engine colors its output even when piped, so lines arrive wrapped in ANSI
+// escapes and must be stripped before the prefix regex can match.
+// eslint-disable-next-line no-control-regex
+const ANSI_CODES = /\u001b\[[0-9;]*m/g
+
+function levelMarker(level: string): string {
+  if (level === 'WARN') return colors.yellow('WARN') + ' '
+  if (level === 'ERROR') return colors.redBright('ERROR') + ' '
+  return ''
+}
 
 /**
  * Forwards a bevy child stream line by line, dropping the tracing prefix (keeping
@@ -64,24 +74,25 @@ const HEARTBEAT_LINE = /^\[headless\] alive:/
  */
 function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
   if (!source) return
+  const writeClean = (raw: string) => {
+    const line = raw.replace(ANSI_CODES, '')
+    if (HEARTBEAT_LINE.test(line)) return
+    const match = line.match(TRACING_PREFIX)
+    if (!match) {
+      sink.write(line + '\n')
+    } else {
+      sink.write(levelMarker(match[1]) + line.slice(match[0].length) + '\n')
+    }
+  }
   let pending = ''
   source.setEncoding('utf8')
   source.on('data', (chunk: string) => {
     const lines = (pending + chunk).split('\n')
     pending = lines.pop() ?? ''
-    for (const line of lines) {
-      if (HEARTBEAT_LINE.test(line)) continue
-      const match = line.match(TRACING_PREFIX)
-      if (!match) {
-        sink.write(line + '\n')
-      } else {
-        const message = line.slice(match[0].length)
-        sink.write((match[1] === 'INFO' ? message : `${match[1]} ${message}`) + '\n')
-      }
-    }
+    lines.forEach(writeClean)
   })
   source.on('end', () => {
-    if (pending && !HEARTBEAT_LINE.test(pending)) sink.write(pending + '\n')
+    if (pending) writeClean(pending)
   })
 }
 
@@ -144,7 +155,7 @@ export function startMultiplayerServer(
 
   const removeCleanup = registerProcessCleanup(cleanup)
 
-  serverProcess.on('close', (code) => {
+  serverProcess.on('close', (code, signal) => {
     removeCleanup()
     if (code !== 0 && code !== null) {
       // report abnormal exits (including bevy's exit-78 "can't run here") so we can
@@ -155,6 +166,10 @@ export function startMultiplayerServer(
         unavailable: code === EXIT_UNAVAILABLE
       })
       printWarning(components.logger, `Multiplayer Server exited with code ${code}`)
+    } else if (signal && signal !== 'SIGTERM' && signal !== 'SIGINT') {
+      // SIGTERM/SIGINT are our own shutdown; anything else (SIGSEGV, SIGKILL/OOM)
+      // means the engine died out from under the preview
+      printWarning(components.logger, `Multiplayer Server terminated by signal ${signal}`)
     }
   })
 

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -71,10 +71,11 @@ const ENGINE_NOISE = [/^failed to process gltf/, /^Path not found: \$ipfs/]
 // scene log line; redundant in a single-scene preview
 const SCENE_CONTEXT = /^\[\[-?\d+, -?\d+\] \d+\.\d+\] /
 
-function levelMarker(level: string): string {
-  if (level === 'WARN') return colors.yellow('WARN') + ' '
-  if (level === 'ERROR') return colors.redBright('ERROR') + ' '
-  return ''
+// color alone conveys the level; the LOG/WARN/ERROR words are dropped
+function colorByLevel(level: string | undefined, message: string): string {
+  if (level === 'WARN') return colors.yellow(message)
+  if (level === 'ERROR') return colors.redBright(message)
+  return message
 }
 
 // engine timestamps are UTC ISO with microseconds; show local wall-clock instead
@@ -85,8 +86,8 @@ function localTime(utcTimestamp: string): string {
 
 /**
  * Forwards a bevy child stream line by line, tagged `[Server]` to stand apart from
- * the preview CLI's own output, dropping the tracing prefix (keeping WARN/ERROR
- * markers) and the periodic `[headless] alive:` heartbeat.
+ * the preview CLI's own output, dropping the tracing prefix (warnings yellow,
+ * errors red) and the periodic `[headless] alive:` heartbeat.
  */
 function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
   if (!source) return
@@ -104,11 +105,12 @@ function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
     const message = line.slice(match[0].length)
     if (ENGINE_NOISE.some((pattern) => pattern.test(message))) return
     if (SCENE_CONTEXT.test(message)) {
-      // scene lines carry their own LOG/ERROR tag; just color errors red
-      const sceneMessage = message.replace(SCENE_CONTEXT, '').replace(/^ERROR /, colors.redBright('ERROR') + ' ')
-      sink.write(serverTag + localTime(match[1]) + sceneMessage + '\n')
+      const sceneMessage = message.replace(SCENE_CONTEXT, '')
+      const sceneTag = sceneMessage.match(/^(LOG|WARN|ERROR|DEBUG) /)
+      const body = sceneTag ? sceneMessage.slice(sceneTag[0].length) : sceneMessage
+      sink.write(serverTag + localTime(match[1]) + colorByLevel(sceneTag?.[1], body) + '\n')
     } else {
-      sink.write(serverTag + localTime(match[1]) + levelMarker(match[2]) + message + '\n')
+      sink.write(serverTag + localTime(match[1]) + colorByLevel(match[2], message) + '\n')
     }
   }
   let pending = ''

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -55,17 +55,32 @@ function registerProcessCleanup(cleanup: () => void): () => void {
 
 // `2026-08-11T14:28:33.522058Z  INFO scene_runner::renderer_context: ` — the
 // timestamp/level/target prefix the bevy engine's tracing puts on every line
-const TRACING_PREFIX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+(INFO|WARN|ERROR|DEBUG|TRACE)\s+[\w:]+:\s?/
+const TRACING_PREFIX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.\d+Z\s+(INFO|WARN|ERROR|DEBUG|TRACE)\s+[\w:]+:\s?/
 const HEARTBEAT_LINE = /^\[headless\] alive:/
 // The engine colors its output even when piped, so lines arrive wrapped in ANSI
 // escapes and must be stripped before the prefix regex can match.
 // eslint-disable-next-line no-control-regex
 const ANSI_CODES = /\u001b\[[0-9;]*m/g
 
+// Engine-internal noise in local preview: the asset pipeline hunts dot-prefixed
+// processed gltf paths the preview server never has, and repeats the failure on
+// every scene composition
+const ENGINE_NOISE = [/^failed to process gltf/, /^Path not found: \$ipfs/]
+
+// `[[0, 0] 3.33] ` — parcel coords + scene clock the engine prepends to every
+// scene log line; redundant in a single-scene preview
+const SCENE_CONTEXT = /^\[\[-?\d+, -?\d+\] \d+\.\d+\] /
+
 function levelMarker(level: string): string {
   if (level === 'WARN') return colors.yellow('WARN') + ' '
   if (level === 'ERROR') return colors.redBright('ERROR') + ' '
   return ''
+}
+
+// engine timestamps are UTC ISO with microseconds; show local wall-clock instead
+function localTime(utcTimestamp: string): string {
+  const date = new Date(utcTimestamp + 'Z')
+  return isNaN(date.getTime()) ? '' : colors.gray(date.toTimeString().slice(0, 8)) + ' '
 }
 
 /**
@@ -81,7 +96,11 @@ function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
     if (!match) {
       sink.write(line + '\n')
     } else {
-      sink.write(levelMarker(match[1]) + line.slice(match[0].length) + '\n')
+      const message = line.slice(match[0].length)
+      if (ENGINE_NOISE.some((pattern) => pattern.test(message))) return
+      // scene lines carry their own LOG/ERROR tag, so the engine's level marker is redundant
+      const marker = SCENE_CONTEXT.test(message) ? '' : levelMarker(match[2])
+      sink.write(localTime(match[1]) + marker + message.replace(SCENE_CONTEXT, '') + '\n')
     }
   }
   let pending = ''

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,7 +11,10 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-const BEVY_VERSION = 'next'
+// Pinned exactly so every push to the engine's main doesn't change what previews
+// run: each sdk-commands release ships a known, tested engine. Bump deliberately.
+// DCL_SERVER_PACKAGE still overrides for local/unpublished builds.
+const BEVY_VERSION = '0.1.0-31482267820.commit-be377f8'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
 // missing binary, bad arguments). We fail the preview loudly instead of retrying:

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -1,4 +1,5 @@
-import { spawn, ChildProcess } from 'child_process'
+import { spawn, ChildProcess, StdioOptions } from 'child_process'
+import { Readable } from 'stream'
 import { CliComponents } from '../../components'
 import { printProgressInfo, printWarning } from '../../logic/beautiful-logs'
 import { colors } from '../../components/log'
@@ -52,6 +53,38 @@ function registerProcessCleanup(cleanup: () => void): () => void {
   }
 }
 
+// `2026-08-11T14:28:33.522058Z  INFO scene_runner::renderer_context: ` — the
+// timestamp/level/target prefix the bevy engine's tracing puts on every line
+const TRACING_PREFIX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+(INFO|WARN|ERROR|DEBUG|TRACE)\s+[\w:]+:\s?/
+const HEARTBEAT_LINE = /^\[headless\] alive:/
+
+/**
+ * Forwards a bevy child stream line by line, dropping the tracing prefix (keeping
+ * WARN/ERROR markers) and the periodic `[headless] alive:` heartbeat.
+ */
+function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
+  if (!source) return
+  let pending = ''
+  source.setEncoding('utf8')
+  source.on('data', (chunk: string) => {
+    const lines = (pending + chunk).split('\n')
+    pending = lines.pop() ?? ''
+    for (const line of lines) {
+      if (HEARTBEAT_LINE.test(line)) continue
+      const match = line.match(TRACING_PREFIX)
+      if (!match) {
+        sink.write(line + '\n')
+      } else {
+        const message = line.slice(match[0].length)
+        sink.write((match[1] === 'INFO' ? message : `${match[1]} ${message}`) + '\n')
+      }
+    }
+  })
+  source.on('end', () => {
+    if (pending && !HEARTBEAT_LINE.test(pending)) sink.write(pending + '\n')
+  })
+}
+
 /**
  * Starts the Multiplayer Server process using npx to install and run in one step
  */
@@ -84,11 +117,19 @@ export function startMultiplayerServer(
     env.RUST_LOG = 'warn,scene_runner::renderer_context=info'
   }
 
+  // Bevy output goes through the line filter below; hammurabi keeps the terminal directly.
+  const stdio: StdioOptions = engine === 'bevy' ? ['inherit', 'pipe', 'pipe'] : 'inherit'
+
   // If npx-cli.js was found, run it directly via process.execPath (node in regular env,
   // Electron Helper with ELECTRON_RUN_AS_NODE=1 in Electron). Otherwise fall back to npx binary.
   const serverProcess = npxCliJs
-    ? spawn(process.execPath, [npxCliJs, ...npxArgs], { cwd: workingDir, shell: false, stdio: 'inherit', env })
-    : spawn(getNpxBin(), npxArgs, { cwd: workingDir, shell: false, stdio: 'inherit', env })
+    ? spawn(process.execPath, [npxCliJs, ...npxArgs], { cwd: workingDir, shell: false, stdio, env })
+    : spawn(getNpxBin(), npxArgs, { cwd: workingDir, shell: false, stdio, env })
+
+  if (engine === 'bevy') {
+    forwardEngineLogs(serverProcess.stdout, process.stdout)
+    forwardEngineLogs(serverProcess.stderr, process.stderr)
+  }
 
   serverProcess.on('error', (error) => {
     printWarning(components.logger, `Multiplayer Server process error: ${error.message}`)

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -84,23 +84,31 @@ function localTime(utcTimestamp: string): string {
 }
 
 /**
- * Forwards a bevy child stream line by line, dropping the tracing prefix (keeping
- * WARN/ERROR markers) and the periodic `[headless] alive:` heartbeat.
+ * Forwards a bevy child stream line by line, tagged `[Server]` to stand apart from
+ * the preview CLI's own output, dropping the tracing prefix (keeping WARN/ERROR
+ * markers) and the periodic `[headless] alive:` heartbeat.
  */
 function forwardEngineLogs(source: Readable | null, sink: NodeJS.WriteStream) {
   if (!source) return
+  const serverTag = colors.green('[Server]') + ' '
   const writeClean = (raw: string) => {
     const line = raw.replace(ANSI_CODES, '')
+    if (!line.trim()) return
     if (HEARTBEAT_LINE.test(line)) return
     const match = line.match(TRACING_PREFIX)
     if (!match) {
-      sink.write(line + '\n')
+      // launcher lines ([headless] realm=...): the [Server] tag replaces their own
+      sink.write(serverTag + line.replace(/^\[headless\] /, '') + '\n')
+      return
+    }
+    const message = line.slice(match[0].length)
+    if (ENGINE_NOISE.some((pattern) => pattern.test(message))) return
+    if (SCENE_CONTEXT.test(message)) {
+      // scene lines carry their own LOG/ERROR tag; just color errors red
+      const sceneMessage = message.replace(SCENE_CONTEXT, '').replace(/^ERROR /, colors.redBright('ERROR') + ' ')
+      sink.write(serverTag + localTime(match[1]) + sceneMessage + '\n')
     } else {
-      const message = line.slice(match[0].length)
-      if (ENGINE_NOISE.some((pattern) => pattern.test(message))) return
-      // scene lines carry their own LOG/ERROR tag, so the engine's level marker is redundant
-      const marker = SCENE_CONTEXT.test(message) ? '' : levelMarker(match[2])
-      sink.write(localTime(match[1]) + marker + message.replace(SCENE_CONTEXT, '') + '\n')
+      sink.write(serverTag + localTime(match[1]) + levelMarker(match[2]) + message + '\n')
     }
   }
   let pending = ''

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -18,9 +18,11 @@ const EXIT_UNAVAILABLE = 78
 
 type ServerEngine = 'bevy' | 'hammurabi'
 
+const DEFAULT_ENGINE: ServerEngine = 'bevy'
+
 function selectedEngine(): ServerEngine {
   const requested = process.env.DCL_SERVER_ENGINE
-  return requested === 'bevy' || requested === 'hammurabi' ? requested : 'hammurabi'
+  return requested === 'bevy' || requested === 'hammurabi' ? requested : DEFAULT_ENGINE
 }
 
 /**
@@ -52,11 +54,11 @@ function registerProcessCleanup(cleanup: () => void): () => void {
 /**
  * Starts the Multiplayer Server process using npx to install and run in one step
  */
-export function startHammurabiServer(
+export function startMultiplayerServer(
   components: Pick<CliComponents, 'logger'>,
   workingDir: string,
   realm: string,
-  engine: ServerEngine = 'hammurabi'
+  engine: ServerEngine = DEFAULT_ENGINE
 ): ChildProcess {
   const pkg = packageSpec(engine)
 
@@ -75,31 +77,31 @@ export function startHammurabiServer(
 
   // If npx-cli.js was found, run it directly via process.execPath (node in regular env,
   // Electron Helper with ELECTRON_RUN_AS_NODE=1 in Electron). Otherwise fall back to npx binary.
-  const hammurabiProcess = npxCliJs
+  const serverProcess = npxCliJs
     ? spawn(process.execPath, [npxCliJs, ...npxArgs], { cwd: workingDir, shell: false, stdio: 'inherit', env })
     : spawn(getNpxBin(), npxArgs, { cwd: workingDir, shell: false, stdio: 'inherit', env })
 
-  hammurabiProcess.on('error', (error) => {
+  serverProcess.on('error', (error) => {
     printWarning(components.logger, `Multiplayer Server process error: ${error.message}`)
   })
 
   // Register cleanup handlers
   const cleanup = () => {
-    if (!hammurabiProcess.killed) {
-      hammurabiProcess.kill('SIGTERM')
+    if (!serverProcess.killed) {
+      serverProcess.kill('SIGTERM')
     }
   }
 
   const removeCleanup = registerProcessCleanup(cleanup)
 
-  hammurabiProcess.on('close', (code) => {
+  serverProcess.on('close', (code) => {
     removeCleanup()
     if (code !== 0 && code !== null) {
       printWarning(components.logger, `Multiplayer Server exited with code ${code}`)
     }
   })
 
-  return hammurabiProcess
+  return serverProcess
 }
 
 /**
@@ -107,8 +109,8 @@ export function startHammurabiServer(
  * In the auth-server SDK, all scenes are authoritative multiplayer.
  * Uses npx to handle installation and execution in a single step (works in Electron).
  *
- * Which implementation runs is chosen by DCL_SERVER_ENGINE (bevy | hammurabi). When bevy
- * reports itself unavailable on this machine, hammurabi is started instead.
+ * Which implementation runs is chosen by DCL_SERVER_ENGINE (bevy | hammurabi), defaulting
+ * to bevy. When bevy reports itself unavailable on this machine, hammurabi is started instead.
  *
  * @param components - Preview components including logger
  * @param project - The project to start the multiplayer server for
@@ -122,12 +124,14 @@ export function spawnAuthServer(
 ): ChildProcess | undefined {
   const engine = selectedEngine()
   try {
-    const child = startHammurabiServer(components, project.workingDirectory, realm, engine)
-    if (engine === 'bevy') {
+    const child = startMultiplayerServer(components, project.workingDirectory, realm, engine)
+    // No fallback when DCL_SERVER_PACKAGE is set: packageSpec would resolve the
+    // hammurabi retry to the same overridden package that just exited 78.
+    if (engine === 'bevy' && !process.env.DCL_SERVER_PACKAGE) {
       child.on('close', (code) => {
         if (code === EXIT_UNAVAILABLE) {
           printWarning(components.logger, 'Bevy multiplayer server unavailable here — falling back to hammurabi')
-          startHammurabiServer(components, project.workingDirectory, realm, 'hammurabi')
+          startMultiplayerServer(components, project.workingDirectory, realm, 'hammurabi')
         }
       })
     }

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,8 +11,8 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-// `latest` moves only when a proven snapshot is promoted via bevy-explorer's
-// promote-headless workflow — engine pushes to main land on `next` and cannot
+// `latest` moves only when someone dispatches bevy-explorer's publish-headless
+// workflow with dist_tag=latest — engine pushes to main land on `next` and cannot
 // change what previews run. DCL_SERVER_PACKAGE overrides for local builds.
 const BEVY_VERSION = 'latest'
 

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -13,7 +13,8 @@ const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
 const BEVY_VERSION = 'next'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
-// missing binary, bad arguments), which is our cue to fall back to hammurabi.
+// missing binary, bad arguments). We fail the preview loudly instead of retrying:
+// a silent fallback would hide broken bevy installs from the people shipping them.
 const EXIT_UNAVAILABLE = 78
 
 type ServerEngine = 'bevy' | 'hammurabi'
@@ -55,7 +56,7 @@ function registerProcessCleanup(cleanup: () => void): () => void {
  * Starts the Multiplayer Server process using npx to install and run in one step
  */
 export function startMultiplayerServer(
-  components: Pick<CliComponents, 'logger'>,
+  components: Pick<CliComponents, 'logger' | 'analytics'>,
   workingDir: string,
   realm: string,
   engine: ServerEngine = DEFAULT_ENGINE
@@ -97,6 +98,13 @@ export function startMultiplayerServer(
   serverProcess.on('close', (code) => {
     removeCleanup()
     if (code !== 0 && code !== null) {
+      // report abnormal exits (including bevy's exit-78 "can't run here") so we can
+      // tell from telemetry when the server is failing on users' machines
+      components.analytics.track('Multiplayer server exited', {
+        engine,
+        exitCode: code,
+        unavailable: code === EXIT_UNAVAILABLE
+      })
       printWarning(components.logger, `Multiplayer Server exited with code ${code}`)
     }
   })
@@ -110,7 +118,8 @@ export function startMultiplayerServer(
  * Uses npx to handle installation and execution in a single step (works in Electron).
  *
  * Which implementation runs is chosen by DCL_SERVER_ENGINE (bevy | hammurabi), defaulting
- * to bevy. When bevy reports itself unavailable on this machine, hammurabi is started instead.
+ * to bevy. When bevy reports itself unavailable on this machine (exit 78) the preview is
+ * aborted with instructions to opt into hammurabi — there is no automatic fallback.
  *
  * @param components - Preview components including logger
  * @param project - The project to start the multiplayer server for
@@ -125,14 +134,18 @@ export function spawnAuthServer(
   const engine = selectedEngine()
   try {
     const child = startMultiplayerServer(components, project.workingDirectory, realm, engine)
-    // No fallback when DCL_SERVER_PACKAGE is set: packageSpec would resolve the
-    // hammurabi retry to the same overridden package that just exited 78.
-    if (engine === 'bevy' && !process.env.DCL_SERVER_PACKAGE) {
+    if (engine === 'bevy') {
       child.on('close', (code) => {
-        if (code === EXIT_UNAVAILABLE) {
-          printWarning(components.logger, 'Bevy multiplayer server unavailable here — falling back to hammurabi')
-          startMultiplayerServer(components, project.workingDirectory, realm, 'hammurabi')
-        }
+        if (code !== EXIT_UNAVAILABLE) return
+        const { logger } = components
+        logger.error(
+          `The bevy multiplayer server (${packageSpec(engine)}) cannot run on this machine ` +
+            `(exit ${EXIT_UNAVAILABLE}: unsupported platform or missing binary — ${process.platform}-${process.arch}).`
+        )
+        logger.error(`To run the preview with the hammurabi server instead:`)
+        logger.error(`  DCL_SERVER_ENGINE=hammurabi npm start`)
+        // flush the 'Multiplayer server exited' event before killing the preview
+        void components.analytics.stop().finally(() => process.exit(EXIT_UNAVAILABLE))
       })
     }
     return child

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -74,7 +74,15 @@ export function startMultiplayerServer(
   // In Electron, override npm_config_prefix because npm derives its prefix from process.execPath,
   // which points to the Electron Helper binary. This causes npm to look for a `lib/` directory
   // inside the Helper bundle, which doesn't exist (ENOENT).
-  const env = isElectronEnvironment() ? { ...getSpawnEnv(), npm_config_prefix: workingDir } : getSpawnEnv()
+  const env: { [key: string]: string } = isElectronEnvironment()
+    ? { ...getSpawnEnv(), npm_config_prefix: workingDir }
+    : { ...getSpawnEnv() }
+
+  // Quiet the bevy engine's internal tracing chatter while keeping scene logs
+  // (scene_runner::renderer_context) and real warnings. An explicit RUST_LOG wins.
+  if (engine === 'bevy' && !env.RUST_LOG) {
+    env.RUST_LOG = 'warn,scene_runner::renderer_context=info'
+  }
 
   // If npx-cli.js was found, run it directly via process.execPath (node in regular env,
   // Electron Helper with ELECTRON_RUN_AS_NODE=1 in Electron). Otherwise fall back to npx binary.

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -63,9 +63,15 @@ const HEARTBEAT_LINE = /^\[headless\] alive:/
 const ANSI_CODES = /\u001b\[[0-9;]*m/g
 
 // Engine-internal noise in local preview: the asset pipeline hunts dot-prefixed
-// processed gltf paths the preview server never has, and repeats the failure on
-// every scene composition
-const ENGINE_NOISE = [/^failed to process gltf/, /^Path not found: \$ipfs/]
+// processed gltf paths the preview server never has (repeated on every scene
+// composition), and the headless build's expected gizmo/asset-loader startup
+// complaints about the renderer it deliberately doesn't have
+const ENGINE_NOISE = [
+  /^failed to process gltf/,
+  /^Path not found: \$ipfs/,
+  /^bevy_render feature is enabled but RenderApp was not detected/,
+  /^Could not find an asset loader matching: .* Path: Some\("embedded:\/\//
+]
 
 // `[[0, 0] 3.33] ` — parcel coords + scene clock the engine prepends to every
 // scene log line; redundant in a single-scene preview

--- a/packages/@dcl/sdk-commands/src/commands/start/types.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/types.ts
@@ -9,7 +9,6 @@ import { RoomComponent } from '@dcl/mini-comms/dist/adapters/rooms'
 import { WebSocketComponent } from './server/ws'
 import { CliComponents } from '../../components'
 import { ISignalerComponent } from '../../components/exit-signal'
-import { ChildProcess } from 'child_process'
 
 export type PreviewComponents = CliComponents & {
   logs: ILoggerComponent
@@ -20,6 +19,4 @@ export type PreviewComponents = CliComponents & {
   rooms: RoomComponent
   ws: WebSocketComponent
   signaler: ISignalerComponent
-  /** Authoritative Server process (@dcl/hammurabi-server) */
-  hammurabiServer?: ChildProcess
 }

--- a/packages/@dcl/sdk-commands/src/components/analytics.ts
+++ b/packages/@dcl/sdk-commands/src/components/analytics.ts
@@ -58,6 +58,11 @@ export type Events = {
   'Pack smart wearable': {
     projectHash: string
   }
+  'Multiplayer server exited': {
+    engine: string
+    exitCode: number
+    unavailable: boolean
+  }
   'Quest Created Success': {
     questId: string
     questName: string

--- a/test/sdk-commands/commands/start/file-watch-notifier.spec.ts
+++ b/test/sdk-commands/commands/start/file-watch-notifier.spec.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, realpath, writeFile } from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import chokidar, { FSWatcher } from '../../../../packages/@dcl/sdk-commands/node_modules/chokidar'
+import { WsSceneMessage } from '@dcl/protocol/out-js/decentraland/sdk/development/local_development.gen'
+import { wireFileWatcherToWebSockets } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier'
+import { sceneUpdateClients } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/routes'
+import { b64HashingFunction } from '../../../../packages/@dcl/sdk-commands/src/logic/project-files'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+
+/**
+ * Regression tests for the preview hot-reload wire contract.
+ *
+ * On every scene rebuild the file watcher broadcasts, over the ws at the
+ * server root path, and IN THIS ORDER:
+ *
+ *   1. a BINARY protobuf `WsSceneMessage` frame (new protocol, desktop client)
+ *   2. the legacy TEXT frame: the bare string "update"
+ *   3. the legacy TEXT frame: JSON {"type":"SCENE_UPDATE","payload":{...}}
+ *
+ * The binary-first ordering is load-bearing: bevy clients skip the binary
+ * frame and react only to the legacy TEXT frames. Bevy explorers (including
+ * the headless multiplayer server) speak ONLY the legacy protocol, so the
+ * TEXT frames must not be removed while that is true — dropping them silently
+ * kills hot reload for every bevy client.
+ * See https://github.com/decentraland/bevy-explorer/issues/1083
+ */
+
+const DEBOUNCE_MS = 800
+
+type SentFrame = { data: unknown; binary: boolean }
+type WsClient = typeof sceneUpdateClients extends Set<infer T> ? T : never
+const WS_OPEN = 1 // ws.WebSocket.OPEN
+
+function makeFakeClient() {
+  const frames: SentFrame[] = []
+  const client = {
+    readyState: WS_OPEN,
+    send(data: unknown, opts?: { binary?: boolean }) {
+      frames.push({ data, binary: opts?.binary === true })
+    }
+  } as unknown as WsClient
+  return { client, frames }
+}
+
+async function waitFor(condition: () => boolean, timeoutMs: number) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for condition')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+describe('preview ws hot-reload contract (file-watch-notifier)', () => {
+  const watchers: FSWatcher[] = []
+  let watchSpy: jest.SpyInstance
+  let projectRoot: string
+  let expectedSceneId: string
+
+  beforeAll(() => {
+    // capture the watchers the notifier creates so each test can close them
+    const originalWatch = chokidar.watch.bind(chokidar)
+    watchSpy = jest.spyOn(chokidar, 'watch').mockImplementation((...args: Parameters<typeof chokidar.watch>) => {
+      const watcher = originalWatch(...args)
+      watchers.push(watcher)
+      return watcher
+    })
+  })
+
+  afterAll(() => {
+    watchSpy.mockRestore()
+  })
+
+  afterEach(async () => {
+    await Promise.all(watchers.splice(0).map((watcher) => watcher.close()))
+    // drain any debounce flush already scheduled by a closed watcher so a
+    // stale broadcast can never leak into the next test's client set
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 100))
+    sceneUpdateClients.clear()
+  })
+
+  async function wire() {
+    // realpath: on macOS os.tmpdir() is a symlink (/var -> /private/var)
+    projectRoot = await realpath(await mkdtemp(path.join(os.tmpdir(), 'sdk-ws-contract-')))
+    expectedSceneId = b64HashingFunction(projectRoot)
+    const components = { fs: createFsComponent(), ws: undefined, logger: undefined } as unknown as Parameters<
+      typeof wireFileWatcherToWebSockets
+    >[0]
+    await wireFileWatcherToWebSockets(components, projectRoot, 'scene')
+    // a file event (plus the initial scan, all merged by the 800ms debounce)
+    // triggers one broadcast to every connected client
+    await writeFile(path.join(projectRoot, 'asset.bin'), 'payload')
+  }
+
+  it(
+    'broadcasts binary WsSceneMessage first, then the legacy "update" and SCENE_UPDATE text frames',
+    async () => {
+      const { client, frames } = makeFakeClient()
+      sceneUpdateClients.add(client)
+
+      await wire()
+      await waitFor(() => frames.length >= 3, DEBOUNCE_MS * 2 + 5000)
+
+      const [first, second, third] = frames
+
+      // 1) new protocol: binary frame, decodable as WsSceneMessage, carrying
+      // the b64 sceneId derived from the project root
+      expect(first.binary).toBe(true)
+      const decoded = WsSceneMessage.decode(first.data as Uint8Array)
+      expect(decoded.message).toEqual({ $case: 'updateScene', updateScene: { sceneId: expectedSceneId } })
+      // the sceneId is the documented "b64-..." encoding derived from the project root
+      expect(expectedSceneId).toMatch(/^b64-/)
+      expect(Buffer.from(expectedSceneId.slice('b64-'.length), 'base64').toString('utf-8')).toContain(projectRoot)
+
+      // 2) legacy protocol, frame A: the bare TEXT string "update".
+      // Bevy clients key their reload on exactly this frame.
+      expect(second.binary).toBe(false)
+      expect(second.data).toBe('update')
+
+      // 3) legacy protocol, frame B: the SCENE_UPDATE JSON TEXT frame
+      expect(third.binary).toBe(false)
+      expect(JSON.parse(third.data as string)).toEqual({
+        type: 'SCENE_UPDATE',
+        payload: { sceneId: expectedSceneId, sceneType: 'scene' }
+      })
+    },
+    20000
+  )
+})


### PR DESCRIPTION
## Summary

`sdk-commands start` previously hardcoded `npx @dcl/hammurabi-server@next` as the multiplayer server. This makes the Rust bevy-headless engine (`@dcl-regenesislabs/bevy-headless-server`, decentraland/bevy-explorer#974) serve that role, and — since it is what production multiplayer now runs — makes it the **default**, so previews exercise the same engine:

- `DCL_SERVER_ENGINE=bevy|hammurabi` picks the implementation; unset now means `bevy`. Hammurabi remains fully supported as an explicit opt-out.
- `DCL_SERVER_PACKAGE=<dir|tarball|spec>` overrides the npx package spec — npx accepts a local directory, so an unpublished engine build is testable through the real spawn path.
- If the bevy launcher exits with code 78 (its "permanently unavailable here" signal: unsupported platform, missing binary), the preview **aborts loudly** — no silent hammurabi fallback that would hide broken bevy installs. The error states the reason (platform/arch) and the exact command to opt into hammurabi (`DCL_SERVER_ENGINE=hammurabi npm start`), and the `Multiplayer server exited` analytics event is flushed before exiting so unavailability shows up in telemetry.
- The module is renamed `hammurabi-server.ts` → `multiplayer-server.ts` (`startHammurabiServer` → `startMultiplayerServer`) to match, and the never-populated `PreviewComponents.hammurabiServer` field is dropped.
- **Readable preview output.** The bevy child's stdout/stderr are piped through a line filter: every engine line gets a green `[Server]` tag and a compact local `HH:MM:SS` time; the Rust tracing prefix, ANSI codes, the `[headless] alive` heartbeat, and known headless-build noise (dot-prefixed gltf lookups, `$ipfs` path misses, GizmoPlugin/embedded-asset renderer warnings) are stripped; level is conveyed by color (yellow warnings, red errors) instead of `LOG`/`WARN`/`ERROR` words. The engine also gets a default `RUST_LOG=warn,scene_runner::renderer_context=info` (an explicit `RUST_LOG` wins), a child killed by an unexpected signal (SIGSEGV/OOM) is now surfaced with a warning, and the preview CLI's own logger defaults to `LOG_LEVEL=INFO` so the embedded comms server's per-connection DEBUG chatter stays out (`LOG_LEVEL=DEBUG` re-enables it). Hammurabi's output path is untouched.

- **Hot-reload ws contract test.** The preview file watcher broadcasts both the protobuf binary frame and the legacy text frames (`"update"` + `SCENE_UPDATE` JSON); bevy explorers — the headless server included — speak only the legacy text protocol (see decentraland/bevy-explorer#1083). A jest spec now pins both protocols and their binary-first ordering so the legacy frames can't be dropped silently.

Validated end to end against towerofmadness: `npm start` spawned the Rust engine, the scene ran as SERVER, a client synced (`[Game] Connected to server`), and a full 420s round cycle completed.

## What could break

- **The default engine changes for everyone**: a plain `npm start` in an authoritative scene now installs and runs `@dcl-regenesislabs/bevy-headless-server@next` instead of hammurabi. Anyone who needs the old behavior sets `DCL_SERVER_ENGINE=hammurabi`.
- **On platforms where the bevy binary can't run, the preview now exits with code 78** instead of continuing with a hammurabi fallback. This is deliberate (fail loud, get reports), but it means such users must explicitly set `DCL_SERVER_ENGINE=hammurabi` to keep working.
- The engine is consumed via the npm `latest` dist-tag, which only moves when someone dispatches bevy-explorer's publish-headless workflow with `dist_tag=latest` (decentraland/bevy-explorer#1082) — engine pushes to main land on `next` and can't change previews. Note `latest` currently points at an older snapshot; run a `latest` release after that PR lands.

## How to test

```bash
# in an authoritative scene project:
npm start
# expect:
#   Starting Multiplayer Server (bevy) with realm: http://localhost:8000
#   [Game] Running as SERVER
#   [Server] Ready
pgrep -fl "headless --realm"   # child is the Rust engine, not node

# explicit opt-out spawns hammurabi exactly as before:
DCL_SERVER_ENGINE=hammurabi npm start

# a local unpublished engine build through the real spawn path:
DCL_SERVER_PACKAGE=/path/to/bevy-explorer/deploy/headless/launcher npm start

# unavailability path: point DCL_SERVER_PACKAGE at a build that exits 78 and
# check the preview aborts, printing the platform reason and the hammurabi command
```
