### PR TITLE
fix(react-ecs): stop dividing UI layout by devicePixelRatio

### DIFF
--- a/packages/@dcl/react-ecs/src/components/utils.ts
+++ b/packages/@dcl/react-ecs/src/components/utils.ts
@@ -53,8 +53,8 @@ export function getScaleAndUnit(scaleUnit: ScaleUnit): [number, ScaleUnits] {
 /**
  * @internal
  */
-export function scaleOnDim(scale: number, dim: number, pxRatio: number) {
-  return (dim / 100) * (scale / pxRatio)
+export function scaleOnDim(scale: number, dim: number) {
+  return (dim / 100) * scale
 }
 
 /**
@@ -192,10 +192,13 @@ export function calcOnViewport(value: ScaleUnit, ctx: ScaleContext | undefined =
   const [scale, unit] = getScaleAndUnit(value)
   if (!ctx) return scale
 
-  const { height, width, ratio } = ctx
+  // `ctx.ratio` is intentionally not read: '1vw' is 1% of the canvas width by
+  // definition, exactly as in CSS. It stays on ScaleContext as an informational
+  // density hint for callers that need to pick an asset resolution.
+  const { height, width } = ctx
 
-  if (unit === 'vh') return scaleOnDim(scale, height, ratio)
+  if (unit === 'vh') return scaleOnDim(scale, height)
 
   // by default, we scale by 'vw' (width)
-  return scaleOnDim(scale, width, ratio)
+  return scaleOnDim(scale, width)
 }

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -142,14 +142,20 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     if (!canvasInfo) return
 
-    const { width, height, devicePixelRatio } = canvasInfo
+    const { width, height } = canvasInfo
     const { virtualWidth, virtualHeight } = activeVirtualSize
     if (!virtualWidth || !virtualHeight) return
 
-    // Normalize by devicePixelRatio so virtual px map to logical px (matching the
-    // vw/vh path); without it the scale was inflated on high-dpr mobile screens.
-    const ratio = devicePixelRatio || 1
-    const nextScale = Math.min(width / virtualWidth, height / virtualHeight) / ratio
+    // The scale factor is the contain-fit of the design resolution inside the canvas,
+    // and nothing else.
+    //
+    // devicePixelRatio is deliberately absent. It is a density hint — "how many physical
+    // pixels per canvas unit", for picking a 1x/2x/3x asset — not a layout unit, the same
+    // role it has in CSS and React Native, where it is exposed but never enters layout.
+    // Dividing by it made UI size inversely proportional to a quantity the scene author
+    // does not control and that measures something different on every renderer: panel
+    // density on mobile, OS display scaling on web, display/window on native desktop.
+    const nextScale = Math.min(width / virtualWidth, height / virtualHeight)
     if (Number.isFinite(nextScale) && nextScale !== getUiScaleFactor()) {
       // Track ownership when updating to avoid cross-system conflicts.
       setUiScaleFactor(nextScale, uiScaleFactorOwner)

--- a/test/react-ecs/label.spec.tsx
+++ b/test/react-ecs/label.spec.tsx
@@ -113,23 +113,34 @@ describe('UiText React Ecs', () => {
     })
 
     it('should scale font size using viewport width by default', () => {
-      expect(scaleFontSize(16, undefined, scaleCtx)).toBeCloseTo(17.56)
+      // 16 + 0.39% of 800
+      expect(scaleFontSize(16, undefined, scaleCtx)).toBeCloseTo(19.12)
     })
 
     it('should scale font size using viewport height when scale unit is "vh"', () => {
-      expect(scaleFontSize(16, '10vh', scaleCtx)).toBeCloseTo(46)
+      // 16 + 10% of 600
+      expect(scaleFontSize(16, '10vh', scaleCtx)).toBeCloseTo(76)
     })
 
     it('should scale font size correctly when scale unit is "vw"', () => {
-      expect(scaleFontSize(16, '10vw', scaleCtx)).toBeCloseTo(56)
+      // 16 + 10% of 800
+      expect(scaleFontSize(16, '10vw', scaleCtx)).toBeCloseTo(96)
     })
 
     it('should handle scaling with a numeric value', () => {
-      expect(scaleFontSize(16, 10, scaleCtx)).toBeCloseTo(56)
+      expect(scaleFontSize(16, 10, scaleCtx)).toBeCloseTo(96)
     })
 
     it('should handle scaling with a numeric value and unit "vw"', () => {
-      expect(scaleFontSize(16, '10.5vw', scaleCtx)).toBeCloseTo(58)
+      expect(scaleFontSize(16, '10.5vw', scaleCtx)).toBeCloseTo(100)
+    })
+
+    it('should not depend on the context ratio', () => {
+      // 'Nvw' is N% of the canvas width by definition, exactly as in CSS. The density
+      // hint on the context must not change what a viewport unit resolves to.
+      for (const ratio of [0.5, 1, 2, 3]) {
+        expect(scaleFontSize(16, '10vw', { ...scaleCtx, ratio })).toBeCloseTo(96)
+      }
     })
   })
 

--- a/test/react-ecs/virtual-scale-array.spec.tsx
+++ b/test/react-ecs/virtual-scale-array.spec.tsx
@@ -311,11 +311,12 @@ describe('Virtual scale factor with mixed % and pixel values', () => {
     uiRenderer.destroy()
   })
 
-  it('should normalize the scale factor by devicePixelRatio', async () => {
+  it('should not let devicePixelRatio affect the scale factor', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)
     const UiCanvasInformation = components.UiCanvasInformation(engine)
-    // Physical-pixel canvas on a high-DPR (mobile) screen: 3840x2160 @ dpr 2.
+    // High-density screen: 3840x2160 @ dpr 2. The design resolution fits the canvas
+    // exactly twice over, so that — and only that — is the scale factor.
     UiCanvasInformation.create(engine.RootEntity, {
       devicePixelRatio: 2,
       width: 3840,
@@ -328,39 +329,43 @@ describe('Virtual scale factor with mixed % and pixel values', () => {
 
     await engine.update(1)
 
-    // scale = Math.min(3840/1920, 2160/1080) / 2 = 2 / 2 = 1
-    expect(getUiScaleFactor()).toBe(1)
-
-    const panelEntity = (entityIndex + 1) as Entity
-    expect(UiTransform.get(panelEntity).width).toBe(300) // 300 * 1
-    expect(UiTransform.get(panelEntity).height).toBe(300) // 300 * 1
-
-    uiRenderer.destroy()
-  })
-
-  it('should treat a missing/zero devicePixelRatio as 1', async () => {
-    const { engine, uiRenderer } = setupEngine()
-    const UiTransform = components.UiTransform(engine)
-    const UiCanvasInformation = components.UiCanvasInformation(engine)
-    UiCanvasInformation.create(engine.RootEntity, {
-      devicePixelRatio: 0,
-      width: 3840,
-      height: 2160,
-      interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
-    })
-    const entityIndex = engine.addEntity() as number
-
-    uiRenderer.setUiRenderer(() => <Panel1 />, { virtualWidth: 1920, virtualHeight: 1080 })
-
-    await engine.update(1)
-
-    // dpr 0 must not divide by zero — falls back to 1, so scale = 2
+    // scale = Math.min(3840/1920, 2160/1080) = 2, undivided.
     expect(getUiScaleFactor()).toBe(2)
 
     const panelEntity = (entityIndex + 1) as Entity
     expect(UiTransform.get(panelEntity).width).toBe(600) // 300 * 2
+    expect(UiTransform.get(panelEntity).height).toBe(600) // 300 * 2
 
     uiRenderer.destroy()
+  })
+
+  it('should produce the same scale factor whatever devicePixelRatio reports', async () => {
+    // The regression guard: two canvases identical in every way except the density
+    // hint must lay out identically. dpr 0 is included because it used to be a
+    // divide-by-zero guard, and there must no longer be a division to guard.
+    for (const devicePixelRatio of [0, 1, 2, 3.5]) {
+      const { engine, uiRenderer } = setupEngine()
+      const UiTransform = components.UiTransform(engine)
+      const UiCanvasInformation = components.UiCanvasInformation(engine)
+      UiCanvasInformation.create(engine.RootEntity, {
+        devicePixelRatio,
+        width: 3840,
+        height: 2160,
+        interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
+      })
+      const entityIndex = engine.addEntity() as number
+
+      uiRenderer.setUiRenderer(() => <Panel1 />, { virtualWidth: 1920, virtualHeight: 1080 })
+
+      await engine.update(1)
+
+      expect(getUiScaleFactor()).toBe(2)
+
+      const panelEntity = (entityIndex + 1) as Entity
+      expect(UiTransform.get(panelEntity).width).toBe(600) // 300 * 2
+
+      uiRenderer.destroy()
+    }
   })
 
   it('should use scale factor 1 when UiCanvasInformation is not yet available', async () => {


### PR DESCRIPTION
## What

Removes `devicePixelRatio` from the two places where it participates in UI **layout**:

- `UiScaleSystem` — `uiScaleFactor` is now exactly the contain-fit of the design resolution inside the canvas.
- `scaleOnDim` — `'Nvw'` / `'Nvh'` and string `fontSize` now resolve to N % of the canvas dimension, as they do in CSS. Note this path applies **even when no virtual size is set**.

The field stays on `PBUiCanvasInformation` and `ScaleContext.ratio` stays in the public API. Nothing about what renderers report changes, and no renderer change is required.

## Why

`devicePixelRatio` answers *"how many physical pixels does one canvas unit occupy?"* — a density hint, for picking a 1x / 2x / 3x asset. Each renderer answers it differently:

| Renderer | How it computes the value | What that gives |
|---|---|---|
| **Bevy** | forwards the platform's real device pixel density — 2.0 on a Retina Mac, the OS display-scaling setting on Windows | A true pixel density; the intended reading of the field. |
| **Godot** | panel pixels ÷ its own normalized canvas | Also answers the question, but against a canvas Godot defines itself. Self-consistent; its own definition. |
| **Unity** | display resolution ÷ window size | Unusual: the value moves when only the *window* moves, on an unchanged screen. |

All three are defensible readings of a density hint. None of them is a layout unit — and dividing the contain-fit by it is what turns whichever one you get into one.

Measured with one scene and one build, an element declared `width: 1600` against a `1600x720` design:

| Target | canvas | dpr | contain-fit | the element covers |
|---|---|---|---|---|
| Bevy · Chrome on a Retina Mac | 1512 × 823 | 2.0 | 0.945 | **50 %** |
| Unity · windowed on a Mac | 2244 × 1332 | 1.3476 | 1.4025 | **74 %** |
| Godot · Galaxy A54 | 1600 × 738 | 1.4625 | 1.0000 | **68 %** |

The Unity row shows the divisor is not a density at all: the window was 2244 px wide on a 3024 px display, and `2244 / 3024` is the reported `1.3476`. Scene UI ended up covering 74 % of its design — the same fraction of the monitor the window happened to occupy. Drag the window and the number moves.

The Godot row is the other end: because that client publishes a canvas normalized to 1600 wide, the contain-fit against a `1600x720` design is exactly `1.0000`, so the entire 32 % shortfall is the divisor.

This also matches CSS and React Native, where the ratio is exposed but never enters layout (`50vw` is half the viewport, never divided by `window.devicePixelRatio`), and the protobuf, which already states: *"the width of the canvas, in virtual pixels; this value does not change when the pixel ratio changes."*

## Impact

Every renderer is internally consistent — each reports the canvas in the same unit in which it interprets `UiTransform` px — so this fixes all of them at once with no client change.

**Breaking** for content calibrated against current behaviour, which will render `devicePixelRatio` times larger. Two things scope it:

- Scenes that pass no virtual size keep `uiScaleFactor === 1` and are unaffected.
- It **reduces** the blast radius of the default-virtual-screen change in #1489 on mobile. With a `1600x720` default on the Godot mobile client, the contain-fit is `1.0000`, so removing the divisor leaves `uiScaleFactor` at 1 — the "scenes not using any virtual screen at all" bucket stops being affected there.

## Tests

- `virtual-scale-array.spec.tsx` — the two tests that pinned the old behaviour now assert the new one, plus a regression guard that sweeps `devicePixelRatio` over `[0, 1, 2, 3.5]` and requires an identical layout. `0` is kept in the sweep because it used to be a divide-by-zero guard, and there must no longer be a division to guard.
- `label.spec.tsx` — `scaleFontSize` expectations updated (`'10vw'` on an 800-wide context is now 10 % of 800), plus a case asserting the result does not depend on `ctx.ratio`.

`npx jest test/react-ecs` — 120 passed. No change to the API report.
