### PR TITLE
chore: [draft] ui default virtual screen + screen inset, ported to auth-server for scene testing

### DIFF
--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5400,9 +5400,13 @@ export type uint32 = number;
 
 // @public (undocumented)
 export type UiRendererOptions = {
-    virtualWidth: number;
-    virtualHeight: number;
+    virtualWidth?: number;
+    virtualHeight?: number;
+    screenInset?: UiScreenInset;
 };
+
+// @public
+export type UiScreenInset = 'device' | 'interactable' | 'none';
 
 // @public
 export type UiScreenInsetAreaProps = Omit<EntityPropTypes, 'uiTransform'> & {

--- a/packages/@dcl/react-ecs/src/components/InteractableArea/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/InteractableArea/index.tsx
@@ -1,6 +1,6 @@
 import { ReactEcs } from '../../react-ecs'
 import { UiEntity } from '../index'
-import { getInteractableArea } from '../utils'
+import { compensateInsetForUiScale, getInteractableArea } from '../utils'
 import { UiInteractableAreaProps } from './types'
 
 /**
@@ -25,7 +25,8 @@ import { UiInteractableAreaProps } from './types'
  */
 /* @__PURE__ */
 export function InteractableArea(props: UiInteractableAreaProps) {
-  const { top, left, right, bottom } = getInteractableArea()
+  // Insets are canvas px; pre-divide so the parser's scale multiplication cancels out.
+  const { top, left, right, bottom } = compensateInsetForUiScale(getInteractableArea())
   const { uiTransform, ...otherProps } = props
 
   return (

--- a/packages/@dcl/react-ecs/src/components/ScreenInsetArea/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/ScreenInsetArea/index.tsx
@@ -1,6 +1,6 @@
 import { ReactEcs } from '../../react-ecs'
 import { UiEntity } from '../index'
-import { getScreenInsetArea } from '../utils'
+import { compensateInsetForUiScale, getScreenInsetArea } from '../utils'
 import { UiScreenInsetAreaProps } from './types'
 
 /**
@@ -24,7 +24,8 @@ import { UiScreenInsetAreaProps } from './types'
  */
 /* @__PURE__ */
 export function ScreenInsetArea(props: UiScreenInsetAreaProps) {
-  const { top, left, right, bottom } = getScreenInsetArea()
+  // Insets are canvas px; pre-divide so the parser's scale multiplication cancels out.
+  const { top, left, right, bottom } = compensateInsetForUiScale(getScreenInsetArea())
   const { uiTransform, ...otherProps } = props
 
   return (

--- a/packages/@dcl/react-ecs/src/components/utils.ts
+++ b/packages/@dcl/react-ecs/src/components/utils.ts
@@ -110,6 +110,22 @@ export function resetUiScaleFactor(owner?: symbol): void {
 }
 
 /**
+ * Divides an inset area by the current UI scale factor.
+ *
+ * Inset areas are reported by the renderer in canvas pixels, but raw pixel
+ * values in `uiTransform` props are multiplied by the UI scale factor when
+ * parsed. Pre-dividing cancels that multiplication out, so the values sent to
+ * the renderer stay in canvas pixels regardless of the virtual screen.
+ *
+ * @internal
+ */
+export function compensateInsetForUiScale(area: BorderRect): BorderRect {
+  const scale = getUiScaleFactor()
+  const factor = scale > 0 ? scale : 1
+  return { top: area.top / factor, left: area.left / factor, right: area.right / factor, bottom: area.bottom / factor }
+}
+
+/**
  * @internal
  */
 export function getScreenInsetArea(): BorderRect {

--- a/packages/@dcl/react-ecs/src/components/utils.ts
+++ b/packages/@dcl/react-ecs/src/components/utils.ts
@@ -53,8 +53,8 @@ export function getScaleAndUnit(scaleUnit: ScaleUnit): [number, ScaleUnits] {
 /**
  * @internal
  */
-export function scaleOnDim(scale: number, dim: number, pxRatio: number) {
-  return (dim / 100) * (scale / pxRatio)
+export function scaleOnDim(scale: number, dim: number) {
+  return (dim / 100) * scale
 }
 
 /**
@@ -208,10 +208,13 @@ export function calcOnViewport(value: ScaleUnit, ctx: ScaleContext | undefined =
   const [scale, unit] = getScaleAndUnit(value)
   if (!ctx) return scale
 
-  const { height, width, ratio } = ctx
+  // `ctx.ratio` is intentionally not read: '1vw' is 1% of the canvas width by
+  // definition, exactly as in CSS. It stays on ScaleContext as an informational
+  // density hint for callers that need to pick an asset resolution.
+  const { height, width } = ctx
 
-  if (unit === 'vh') return scaleOnDim(scale, height, ratio)
+  if (unit === 'vh') return scaleOnDim(scale, height)
 
   // by default, we scale by 'vw' (width)
-  return scaleOnDim(scale, width, ratio)
+  return scaleOnDim(scale, width)
 }

--- a/packages/@dcl/react-ecs/src/platform.ts
+++ b/packages/@dcl/react-ecs/src/platform.ts
@@ -1,0 +1,28 @@
+/**
+ * Platform detection hook for the UI scale system.
+ *
+ * react-ecs stays independent of the scene runtime (`~system/*` modules), so
+ * it cannot ask the explorer which platform it runs on. Instead, the host SDK
+ * injects the check at module-load time (see `@dcl/sdk/react-ecs`). Until a
+ * provider is injected — or when none ever is — the platform is assumed to be
+ * non-mobile.
+ */
+let isMobileProvider: () => boolean = () => false
+
+/**
+ * Injects the function used to detect whether the scene runs on a mobile
+ * platform. Called by `@dcl/sdk` with its `isMobile()` platform helper.
+ */
+export function setIsMobileProvider(provider: () => boolean): void {
+  isMobileProvider = provider
+}
+
+/**
+ * Whether the scene is running on a mobile platform, according to the
+ * injected provider. Platform detection is asynchronous on the SDK side, so
+ * this may return false during the first ticks and flip to true once the
+ * explorer information arrives.
+ */
+export function isMobile(): boolean {
+  return isMobileProvider()
+}

--- a/packages/@dcl/react-ecs/src/react-ecs.ts
+++ b/packages/@dcl/react-ecs/src/react-ecs.ts
@@ -1,29 +1,87 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import { PBUiBackground, PBUiText, PBUiTransform, PBUiInput, PBUiDropdown } from '@dcl/ecs'
+import React from 'react'
+import { Callback, Key } from './components'
+
 /**
- * The module react-ecs is exposed by the sdk in the /react-ecs path.
- *
- * UI components and semantics for the SDK 7.
- *
- * JSX & Flexbox is used due to its market adoption and availability of implementations and documentation and expertise.
- * @example
- * ```tsx
- * import ReactEcs, { Label, ReactEcsRenderer } from '@dcl/sdk/react-ecs'
- * const Ui = () => <Label value="SDK 7" />
- * ReactEcsRenderer.setUiRenderer(ui)
- * ```
- *
- *
- * Go to the Function section to see all the UI Components.
- * @module ReactEcs
- *
+ * @public
  */
+export interface EcsElements {
+  entity: Partial<EntityComponents> & { children?: ReactEcs.JSX.ReactNode; key?: Key }
+}
 
-import ReactEcs from '@dcl/react-ecs'
-import { setIsMobileProvider } from '@dcl/react-ecs/dist/platform'
-import { isMobile } from './platform'
+/**
+ * @public
+ */
+export type EntityComponents = {
+  uiTransform: PBUiTransform
+  uiText: PBUiText
+  uiBackground: PBUiBackground
+  uiInput: PBUiInput
+  uiDropdown: PBUiDropdown
+  onMouseDown: Callback
+  onMouseUp: Callback
+  onMouseEnter: Callback
+  onMouseLeave: Callback
+}
 
-// react-ecs cannot reach ~system/Runtime itself, so the platform check used
-// for virtual screen size defaults is injected here.
-setIsMobileProvider(isMobile)
+/**
+ * @hidden
+ */
+export namespace JSX {
+  export interface Element extends ReactElement<any, any> {}
+  export interface IntrinsicElements extends EcsElements {}
+  export interface Component {}
+}
+/**
+ * @public
+ */
+export type JSXElementConstructor<P> = (props: P) => ReactElement<any, any> | null
 
-export * from '@dcl/react-ecs'
-export default ReactEcs
+/**
+ * @public
+ */
+export interface ReactElement<
+  P = any,
+  T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>
+> {
+  type: T
+  props: P
+  key: Key | null
+}
+/**
+ * @public
+ */
+export namespace ReactEcs {
+  export namespace JSX {
+    /**
+     * @public
+     */
+    export type ReactNode = Element | ReactElement | string | number | boolean | null | undefined | ReactNode[]
+    /**
+     * @public
+     */
+    export interface Element extends ReactElement<any, any> {}
+    /**
+     * @public
+     * HTML tag elements
+     */
+    export interface IntrinsicElements extends EcsElements {}
+    /**
+     * @public
+     * Component empty interface
+     */
+    export interface Component {}
+  }
+  export const createElement = (React as any).createElement
+  type SetStateAction<T> = T | ((prevState: T) => T)
+  type Dispatch<T> = (action: SetStateAction<T>) => void
+  type StateHook = <T>(initialState: T | (() => T)) => [T, Dispatch<T>]
+
+  // Type for useEffect
+  type DependencyList = ReadonlyArray<any>
+  type EffectCallback = () => void | (() => void | undefined)
+  type EffectHook = (effect: EffectCallback, deps?: DependencyList) => void
+  export const useEffect: EffectHook = (React as any).useEffect
+  export const useState: StateHook = (React as any).useState
+}

--- a/packages/@dcl/react-ecs/src/react-ecs.ts
+++ b/packages/@dcl/react-ecs/src/react-ecs.ts
@@ -1,87 +1,29 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
-import { PBUiBackground, PBUiText, PBUiTransform, PBUiInput, PBUiDropdown } from '@dcl/ecs'
-import React from 'react'
-import { Callback, Key } from './components'
+/**
+ * The module react-ecs is exposed by the sdk in the /react-ecs path.
+ *
+ * UI components and semantics for the SDK 7.
+ *
+ * JSX & Flexbox is used due to its market adoption and availability of implementations and documentation and expertise.
+ * @example
+ * ```tsx
+ * import ReactEcs, { Label, ReactEcsRenderer } from '@dcl/sdk/react-ecs'
+ * const Ui = () => <Label value="SDK 7" />
+ * ReactEcsRenderer.setUiRenderer(ui)
+ * ```
+ *
+ *
+ * Go to the Function section to see all the UI Components.
+ * @module ReactEcs
+ *
+ */
 
-/**
- * @public
- */
-export interface EcsElements {
-  entity: Partial<EntityComponents> & { children?: ReactEcs.JSX.ReactNode; key?: Key }
-}
+import ReactEcs from '@dcl/react-ecs'
+import { setIsMobileProvider } from '@dcl/react-ecs/dist/platform'
+import { isMobile } from './platform'
 
-/**
- * @public
- */
-export type EntityComponents = {
-  uiTransform: PBUiTransform
-  uiText: PBUiText
-  uiBackground: PBUiBackground
-  uiInput: PBUiInput
-  uiDropdown: PBUiDropdown
-  onMouseDown: Callback
-  onMouseUp: Callback
-  onMouseEnter: Callback
-  onMouseLeave: Callback
-}
+// react-ecs cannot reach ~system/Runtime itself, so the platform check used
+// for virtual screen size defaults is injected here.
+setIsMobileProvider(isMobile)
 
-/**
- * @hidden
- */
-export namespace JSX {
-  export interface Element extends ReactElement<any, any> {}
-  export interface IntrinsicElements extends EcsElements {}
-  export interface Component {}
-}
-/**
- * @public
- */
-export type JSXElementConstructor<P> = (props: P) => ReactElement<any, any> | null
-
-/**
- * @public
- */
-export interface ReactElement<
-  P = any,
-  T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>
-> {
-  type: T
-  props: P
-  key: Key | null
-}
-/**
- * @public
- */
-export namespace ReactEcs {
-  export namespace JSX {
-    /**
-     * @public
-     */
-    export type ReactNode = Element | ReactElement | string | number | boolean | null | undefined | ReactNode[]
-    /**
-     * @public
-     */
-    export interface Element extends ReactElement<any, any> {}
-    /**
-     * @public
-     * HTML tag elements
-     */
-    export interface IntrinsicElements extends EcsElements {}
-    /**
-     * @public
-     * Component empty interface
-     */
-    export interface Component {}
-  }
-  export const createElement = (React as any).createElement
-  type SetStateAction<T> = T | ((prevState: T) => T)
-  type Dispatch<T> = (action: SetStateAction<T>) => void
-  type StateHook = <T>(initialState: T | (() => T)) => [T, Dispatch<T>]
-
-  // Type for useEffect
-  type DependencyList = ReadonlyArray<any>
-  type EffectCallback = () => void | (() => void | undefined)
-  type EffectHook = (effect: EffectCallback, deps?: DependencyList) => void
-  export const useEffect: EffectHook = (React as any).useEffect
-  export const useState: StateHook = (React as any).useState
-}
+export * from '@dcl/react-ecs'
+export default ReactEcs

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -12,6 +12,7 @@ import {
   setScreenInsetArea,
   setUiScaleFactor
 } from './components/utils'
+import { InteractableArea, ScreenInsetArea } from './components'
 import { isMobile } from './platform'
 
 // react-ecs compiles with `types: []` (no runtime typings), so the console
@@ -24,9 +25,31 @@ declare const console: { log(message: string): void }
 export type UiComponent = () => ReactEcs.JSX.ReactNode
 
 /**
+ * Screen area used to position a renderer's UI entities:
+ * - `'device'`: the device safe area (excludes notch, status bar, rounded corners),
+ *   reported in `UiCanvasInformation.screenInsetArea`.
+ * - `'interactable'`: the area free of the Explorer's native HUD (minimap, chat, ...),
+ *   reported in `UiCanvasInformation.interactableArea`.
+ * - `'none'`: the whole screen, with 0,0 at its top-left corner.
+ * @public
+ */
+export type UiScreenInset = 'device' | 'interactable' | 'none'
+
+/**
  * @public
  */
 export type UiRendererOptions = {
+  virtualWidth?: number
+  virtualHeight?: number
+  /**
+   * Screen area the renderer's UI is positioned in. Defaults to `'none'` (whole screen).
+   * Each renderer honors its own value, so the main UI and additional renderers can
+   * use different insets simultaneously.
+   */
+  screenInset?: UiScreenInset
+}
+
+type VirtualSize = {
   virtualWidth: number
   virtualHeight: number
 }
@@ -36,18 +59,22 @@ export type UiRendererOptions = {
  * virtual screens are overridden to on mobile (phone screens are much wider
  * than 16:9, so a 16:9 virtual canvas would letterbox the UI).
  */
-const DEFAULT_MOBILE_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1600, virtualHeight: 720 }
+const DEFAULT_MOBILE_VIRTUAL_SIZE: VirtualSize = { virtualWidth: 1600, virtualHeight: 720 }
 
 /**
  * Default virtual screen size used on non-mobile platforms.
  */
-const DEFAULT_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1920, virtualHeight: 1080 }
+const DEFAULT_VIRTUAL_SIZE: VirtualSize = { virtualWidth: 1920, virtualHeight: 1080 }
 
-function isValidVirtualSize(options: UiRendererOptions | undefined): options is UiRendererOptions {
-  return !!options && options.virtualWidth > 0 && options.virtualHeight > 0
+function hasVirtualSize(options: UiRendererOptions | undefined): boolean {
+  return !!options && (options.virtualWidth !== undefined || options.virtualHeight !== undefined)
 }
 
-function is16by9(options: UiRendererOptions): boolean {
+function isValidVirtualSize(options: UiRendererOptions | undefined): options is UiRendererOptions & VirtualSize {
+  return !!options && (options.virtualWidth ?? 0) > 0 && (options.virtualHeight ?? 0) > 0
+}
+
+function is16by9(options: VirtualSize): boolean {
   return options.virtualWidth * 9 === options.virtualHeight * 16
 }
 
@@ -66,6 +93,9 @@ export interface ReactBasedUiSystem {
    * mobile, 1920x1080 otherwise. Providing an invalid size (values \<= 0)
    * disables the virtual screen (no UI scaling). On mobile, a provided 16:9
    * virtual size is overridden to 1600x720 to fit phone screens.
+   *
+   * The optional `screenInset` selects the screen area the UI is positioned in
+   * (see {@link UiScreenInset}); it defaults to `'none'` (whole screen).
    */
   setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -82,6 +112,7 @@ export interface ReactBasedUiSystem {
    * @param ui - The UI component to render
    * @param options - Optional virtual size used for UI scale factor when main UI has none.
    *                  Defaults and the mobile 16:9 override behave as in {@link ReactBasedUiSystem.setUiRenderer}.
+   *                  `screenInset` is honored per renderer, independently of the main UI's value.
    */
   addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -98,7 +129,7 @@ export interface ReactBasedUiSystem {
 export function createReactBasedUiSystem(engine: IEngine, pointerSystem: PointerEventsSystem): ReactBasedUiSystem {
   const renderer = createReconciler(engine, pointerSystem)
   let uiComponent: UiComponent | undefined = undefined
-  let virtualSize: UiRendererOptions | undefined = undefined
+  let mainOptions: UiRendererOptions | undefined = undefined
   const additionalRenderers = new Map<Entity, { ui: UiComponent; options?: UiRendererOptions }>()
   const UiCanvasInformation = ecsComponents.UiCanvasInformation(engine)
 
@@ -117,9 +148,11 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
   function getActiveVirtualSize(): UiRendererOptions | undefined {
     // Main renderer options win; otherwise use the first additional renderer option.
-    if (virtualSize) return virtualSize
+    // Options carrying no virtual dims (e.g. only a screen inset) are skipped so
+    // they don't count as a provided-but-invalid virtual size.
+    if (hasVirtualSize(mainOptions)) return mainOptions
     for (const entry of additionalRenderers.values()) {
-      if (entry.options) return entry.options
+      if (hasVirtualSize(entry.options)) return entry.options
     }
     return undefined
   }
@@ -128,7 +161,7 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
    * Resolves the virtual screen to scale the UI against, or `undefined` when
    * the virtual screen is disabled.
    */
-  function resolveVirtualSize(): UiRendererOptions | undefined {
+  function resolveVirtualSize(): VirtualSize | undefined {
     const provided = getActiveVirtualSize()
     const mobile = isMobile()
 
@@ -158,12 +191,28 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
     return provided
   }
 
+  /**
+   * Wraps a renderer's component in a container positioned within the selected
+   * screen inset area. `'none'` (the default) adds no wrapper so the current
+   * full-screen behavior is preserved as-is. Applied per renderer, so each
+   * renderer can use a different inset.
+   */
+  function wrapWithScreenInset(ui: UiComponent, inset: UiScreenInset | undefined, key: string): React.ReactNode {
+    if (inset === 'device') {
+      return React.createElement(ScreenInsetArea as any, { key }, React.createElement(ui as any))
+    }
+    if (inset === 'interactable') {
+      return React.createElement(InteractableArea as any, { key }, React.createElement(ui as any))
+    }
+    return React.createElement(ui as any, { key })
+  }
+
   function ReactBasedUiSystem() {
     const components: React.ReactNode[] = []
 
     // Add main UI component
     if (uiComponent) {
-      components.push(React.createElement(uiComponent as any, { key: '__main__' }))
+      components.push(wrapWithScreenInset(uiComponent, mainOptions?.screenInset, '__main__'))
     }
 
     const entitiesToRemove: Entity[] = []
@@ -172,7 +221,7 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       if (engine.getEntityState(entity) === EntityState.Removed) {
         entitiesToRemove.push(entity)
       } else {
-        components.push(React.createElement(entry.ui as any, { key: `__entity_${entity}__` }))
+        components.push(wrapWithScreenInset(entry.ui, entry.options?.screenInset, `__entity_${entity}__`))
       }
     }
 
@@ -250,7 +299,7 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
     },
     setUiRenderer(ui: UiComponent, options?: UiRendererOptions) {
       uiComponent = ui
-      virtualSize = options
+      mainOptions = options
     },
     addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions) {
       additionalRenderers.set(entity, { ui, options })

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -12,6 +12,11 @@ import {
   setScreenInsetArea,
   setUiScaleFactor
 } from './components/utils'
+import { isMobile } from './platform'
+
+// react-ecs compiles with `types: []` (no runtime typings), so the console
+// global provided by the scene runtime is declared here.
+declare const console: { log(message: string): void }
 
 /**
  * @public
@@ -27,6 +32,26 @@ export type UiRendererOptions = {
 }
 
 /**
+ * Default virtual screen size used on mobile platforms, and the size 16:9
+ * virtual screens are overridden to on mobile (phone screens are much wider
+ * than 16:9, so a 16:9 virtual canvas would letterbox the UI).
+ */
+const DEFAULT_MOBILE_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1600, virtualHeight: 720 }
+
+/**
+ * Default virtual screen size used on non-mobile platforms.
+ */
+const DEFAULT_VIRTUAL_SIZE: UiRendererOptions = { virtualWidth: 1920, virtualHeight: 1080 }
+
+function isValidVirtualSize(options: UiRendererOptions | undefined): options is UiRendererOptions {
+  return !!options && options.virtualWidth > 0 && options.virtualHeight > 0
+}
+
+function is16by9(options: UiRendererOptions): boolean {
+  return options.virtualWidth * 9 === options.virtualHeight * 16
+}
+
+/**
  * @public
  */
 export interface ReactBasedUiSystem {
@@ -36,6 +61,11 @@ export interface ReactBasedUiSystem {
   destroy(): void
   /**
    * Set the main UI renderer. Optional virtual size defines the global UI scale factor.
+   *
+   * When no virtual size is provided, a platform default is used: 1600x720 on
+   * mobile, 1920x1080 otherwise. Providing an invalid size (values \<= 0)
+   * disables the virtual screen (no UI scaling). On mobile, a provided 16:9
+   * virtual size is overridden to 1600x720 to fit phone screens.
    */
   setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -50,7 +80,8 @@ export interface ReactBasedUiSystem {
    * @param entity - The entity to associate with this UI renderer. When the entity is removed,
    *                 the UI renderer is automatically cleaned up.
    * @param ui - The UI component to render
-   * @param options - Optional virtual size used for UI scale factor when main UI has none
+   * @param options - Optional virtual size used for UI scale factor when main UI has none.
+   *                  Defaults and the mobile 16:9 override behave as in {@link ReactBasedUiSystem.setUiRenderer}.
    */
   addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -78,6 +109,12 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
   // Unique owner for the interactable area module variable.
   const interactableAreaOwner = Symbol('react-ecs-interactable-area')
 
+  // Last 16:9 size we already logged the mobile override for, so the log
+  // fires once per provided size instead of every tick. Tracked as raw numbers
+  // to avoid allocating a comparison string every tick.
+  let loggedMobileOverrideW = 0
+  let loggedMobileOverrideH = 0
+
   function getActiveVirtualSize(): UiRendererOptions | undefined {
     // Main renderer options win; otherwise use the first additional renderer option.
     if (virtualSize) return virtualSize
@@ -85,6 +122,40 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       if (entry.options) return entry.options
     }
     return undefined
+  }
+
+  /**
+   * Resolves the virtual screen to scale the UI against, or `undefined` when
+   * the virtual screen is disabled.
+   */
+  function resolveVirtualSize(): UiRendererOptions | undefined {
+    const provided = getActiveVirtualSize()
+    const mobile = isMobile()
+
+    // No creator-provided size: fall back to the platform default.
+    if (!provided) {
+      return mobile ? DEFAULT_MOBILE_VIRTUAL_SIZE : DEFAULT_VIRTUAL_SIZE
+    }
+
+    // An explicitly provided but invalid size (values <= 0) disables the
+    // virtual screen — no UI scaling at all.
+    if (!isValidVirtualSize(provided)) {
+      return undefined
+    }
+
+    // On mobile, 16:9 virtual screens don't fit phone aspect ratios — override them.
+    if (mobile && is16by9(provided)) {
+      if (loggedMobileOverrideW !== provided.virtualWidth || loggedMobileOverrideH !== provided.virtualHeight) {
+        loggedMobileOverrideW = provided.virtualWidth
+        loggedMobileOverrideH = provided.virtualHeight
+        console.log(
+          `Mobile platform detected: overriding 16:9 virtual screen size ${provided.virtualWidth}x${provided.virtualHeight} with ${DEFAULT_MOBILE_VIRTUAL_SIZE.virtualWidth}x${DEFAULT_MOBILE_VIRTUAL_SIZE.virtualHeight}`
+        )
+      }
+      return DEFAULT_MOBILE_VIRTUAL_SIZE
+    }
+
+    return provided
   }
 
   function ReactBasedUiSystem() {
@@ -133,9 +204,17 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       setInteractableArea(canvasInfo.interactableArea, interactableAreaOwner)
     }
 
-    const activeVirtualSize = getActiveVirtualSize()
-    if (!activeVirtualSize) {
+    // The virtual screen (provided or defaulted) only applies while some
+    // renderer is registered; with no UI at all the scale factor is released.
+    if (uiComponent === undefined && additionalRenderers.size === 0) {
       // Reset only if this system owns the scale factor.
+      resetUiScaleFactor(uiScaleFactorOwner)
+      return
+    }
+
+    const activeVirtualSize = resolveVirtualSize()
+    if (!activeVirtualSize) {
+      // Virtual screen explicitly disabled by an invalid provided size.
       resetUiScaleFactor(uiScaleFactorOwner)
       return
     }
@@ -144,7 +223,6 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     const { width, height, devicePixelRatio } = canvasInfo
     const { virtualWidth, virtualHeight } = activeVirtualSize
-    if (!virtualWidth || !virtualHeight) return
 
     // Normalize by devicePixelRatio so virtual px map to logical px (matching the
     // vw/vh path); without it the scale was inflated on high-dpr mobile screens.

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -270,13 +270,19 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
     if (!canvasInfo) return
 
-    const { width, height, devicePixelRatio } = canvasInfo
+    const { width, height } = canvasInfo
     const { virtualWidth, virtualHeight } = activeVirtualSize
 
-    // Normalize by devicePixelRatio so virtual px map to logical px (matching the
-    // vw/vh path); without it the scale was inflated on high-dpr mobile screens.
-    const ratio = devicePixelRatio || 1
-    const nextScale = Math.min(width / virtualWidth, height / virtualHeight) / ratio
+    // The scale factor is the contain-fit of the design resolution inside the canvas,
+    // and nothing else.
+    //
+    // devicePixelRatio is deliberately absent. It is a density hint — "how many physical
+    // pixels per canvas unit", for picking a 1x/2x/3x asset — not a layout unit, the same
+    // role it has in CSS and React Native, where it is exposed but never enters layout.
+    // Dividing by it made UI size inversely proportional to a quantity the scene author
+    // does not control and that measures something different on every renderer: panel
+    // density on mobile, OS display scaling on web, display/window on native desktop.
+    const nextScale = Math.min(width / virtualWidth, height / virtualHeight)
     if (Number.isFinite(nextScale) && nextScale !== getUiScaleFactor()) {
       // Track ownership when updating to avoid cross-system conflicts.
       setUiScaleFactor(nextScale, uiScaleFactorOwner)

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -26,8 +26,8 @@ export type UiComponent = () => ReactEcs.JSX.ReactNode
 
 /**
  * Screen area used to position a renderer's UI entities:
- * - `'device'`: the device safe area (excludes notch, status bar, rounded corners),
- *   reported in `UiCanvasInformation.screenInsetArea`.
+ * - `'device'` (default): the device safe area (excludes notch, status bar,
+ *   rounded corners), reported in `UiCanvasInformation.screenInsetArea`.
  * - `'interactable'`: the area free of the Explorer's native HUD (minimap, chat, ...),
  *   reported in `UiCanvasInformation.interactableArea`.
  * - `'none'`: the whole screen, with 0,0 at its top-left corner.
@@ -42,9 +42,10 @@ export type UiRendererOptions = {
   virtualWidth?: number
   virtualHeight?: number
   /**
-   * Screen area the renderer's UI is positioned in. Defaults to `'none'` (whole screen).
-   * Each renderer honors its own value, so the main UI and additional renderers can
-   * use different insets simultaneously.
+   * Screen area the renderer's UI is positioned in. Defaults to `'device'`, so UI
+   * stays inside the device safe area unless the creator opts out with `'none'`.
+   * Each renderer honors its own value, so the main UI and additional renderers
+   * can use different insets simultaneously.
    */
   screenInset?: UiScreenInset
 }
@@ -65,6 +66,13 @@ const DEFAULT_MOBILE_VIRTUAL_SIZE: VirtualSize = { virtualWidth: 1600, virtualHe
  * Default virtual screen size used on non-mobile platforms.
  */
 const DEFAULT_VIRTUAL_SIZE: VirtualSize = { virtualWidth: 1920, virtualHeight: 1080 }
+
+/**
+ * Screen area a renderer uses when it doesn't pick one. UI defaults to the device
+ * safe area: drawing under a notch, a status bar or a rounded corner is something
+ * a creator should opt into, not the out-of-the-box behavior.
+ */
+const DEFAULT_SCREEN_INSET: UiScreenInset = 'device'
 
 function hasVirtualSize(options: UiRendererOptions | undefined): boolean {
   return !!options && (options.virtualWidth !== undefined || options.virtualHeight !== undefined)
@@ -95,7 +103,8 @@ export interface ReactBasedUiSystem {
    * virtual size is overridden to 1600x720 to fit phone screens.
    *
    * The optional `screenInset` selects the screen area the UI is positioned in
-   * (see {@link UiScreenInset}); it defaults to `'none'` (whole screen).
+   * (see {@link UiScreenInset}); it defaults to `'device'`. Pass `'none'` to
+   * place the UI over the whole screen.
    */
   setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -112,7 +121,8 @@ export interface ReactBasedUiSystem {
    * @param ui - The UI component to render
    * @param options - Optional virtual size used for UI scale factor when main UI has none.
    *                  Defaults and the mobile 16:9 override behave as in {@link ReactBasedUiSystem.setUiRenderer}.
-   *                  `screenInset` is honored per renderer, independently of the main UI's value.
+   *                  `screenInset` is honored per renderer, independently of the main UI's value,
+   *                  and defaults to `'device'` here too.
    */
   addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void
   /**
@@ -193,18 +203,18 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
 
   /**
    * Wraps a renderer's component in a container positioned within the selected
-   * screen inset area. `'none'` (the default) adds no wrapper so the current
-   * full-screen behavior is preserved as-is. Applied per renderer, so each
-   * renderer can use a different inset.
+   * screen inset area. `'none'` adds no wrapper, leaving the UI on the whole
+   * screen. Applied per renderer, so each renderer can use a different inset.
    */
   function wrapWithScreenInset(ui: UiComponent, inset: UiScreenInset | undefined, key: string): React.ReactNode {
-    if (inset === 'device') {
-      return React.createElement(ScreenInsetArea as any, { key }, React.createElement(ui as any))
+    switch (inset ?? DEFAULT_SCREEN_INSET) {
+      case 'device':
+        return React.createElement(ScreenInsetArea as any, { key }, React.createElement(ui as any))
+      case 'interactable':
+        return React.createElement(InteractableArea as any, { key }, React.createElement(ui as any))
+      default:
+        return React.createElement(ui as any, { key })
     }
-    if (inset === 'interactable') {
-      return React.createElement(InteractableArea as any, { key }, React.createElement(ui as any))
-    }
-    return React.createElement(ui as any, { key })
   }
 
   function ReactBasedUiSystem() {

--- a/packages/@dcl/sdk/src/react-ecs.ts
+++ b/packages/@dcl/sdk/src/react-ecs.ts
@@ -18,5 +18,12 @@
  */
 
 import ReactEcs from '@dcl/react-ecs'
+import { setIsMobileProvider } from '@dcl/react-ecs/dist/platform'
+import { isMobile } from './platform'
+
+// react-ecs cannot reach ~system/Runtime itself, so the platform check used
+// for virtual screen size defaults is injected here.
+setIsMobileProvider(isMobile)
+
 export * from '@dcl/react-ecs'
 export default ReactEcs

--- a/test/react-ecs/add-ui-renderer.spec.tsx
+++ b/test/react-ecs/add-ui-renderer.spec.tsx
@@ -2,7 +2,7 @@ import { Entity } from '../../packages/@dcl/ecs/src/engine'
 import { components } from '../../packages/@dcl/ecs/src'
 import { UiEntity, ReactEcs } from '../../packages/@dcl/react-ecs/src'
 import { getUiScaleFactor, resetUiScaleFactor } from '../../packages/@dcl/react-ecs/src/components/utils'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('addUiRenderer', () => {
   afterEach(() => {
@@ -23,7 +23,7 @@ describe('addUiRenderer', () => {
     const ui2 = () => <UiEntity uiTransform={{ width: 200 }} />
 
     // Add first renderer
-    uiRenderer.addUiRenderer(ownerEntity1, ui1)
+    uiRenderer.addUiRenderer(ownerEntity1, ui1, WHOLE_SCREEN)
     await engine.update(1)
 
     let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -31,7 +31,7 @@ describe('addUiRenderer', () => {
     expect(UiTransform.get(uiEntities[0][0]).width).toBe(100)
 
     // Add second renderer
-    uiRenderer.addUiRenderer(ownerEntity2, ui2)
+    uiRenderer.addUiRenderer(ownerEntity2, ui2, WHOLE_SCREEN)
     await engine.update(1)
 
     uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -62,7 +62,7 @@ describe('addUiRenderer', () => {
     const additionalUi = () => <UiEntity uiTransform={{ width: 150 }} />
 
     // Set main renderer
-    uiRenderer.setUiRenderer(mainUi)
+    uiRenderer.setUiRenderer(mainUi, WHOLE_SCREEN)
     await engine.update(1)
 
     let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -70,7 +70,7 @@ describe('addUiRenderer', () => {
     expect(UiTransform.get(uiEntities[0][0]).width).toBe(50)
 
     // Add additional renderer
-    uiRenderer.addUiRenderer(additionalEntity, additionalUi)
+    uiRenderer.addUiRenderer(additionalEntity, additionalUi, WHOLE_SCREEN)
     await engine.update(1)
 
     uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -99,7 +99,7 @@ describe('addUiRenderer', () => {
     const ui1Updated = () => <UiEntity uiTransform={{ width: 300 }} />
 
     // Add first version
-    uiRenderer.addUiRenderer(ownerEntity, ui1)
+    uiRenderer.addUiRenderer(ownerEntity, ui1, WHOLE_SCREEN)
     await engine.update(1)
 
     let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -107,7 +107,7 @@ describe('addUiRenderer', () => {
     expect(UiTransform.get(uiEntities[0][0]).width).toBe(100)
 
     // Replace with updated version using the same entity
-    uiRenderer.addUiRenderer(ownerEntity, ui1Updated)
+    uiRenderer.addUiRenderer(ownerEntity, ui1Updated, WHOLE_SCREEN)
     await engine.update(1)
 
     // Should still have exactly one UI entity, with updated width
@@ -129,7 +129,7 @@ describe('addUiRenderer', () => {
 
     const ui1 = () => <UiEntity uiTransform={{ width: 100 }} />
 
-    uiRenderer.addUiRenderer(ownerEntity, ui1)
+    uiRenderer.addUiRenderer(ownerEntity, ui1, WHOLE_SCREEN)
     await engine.update(1)
 
     let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -158,7 +158,7 @@ describe('addUiRenderer', () => {
     const ui1 = () => <UiEntity uiTransform={{ width: 100 }} />
 
     // Add UI renderer associated with the smart item entity
-    uiRenderer.addUiRenderer(smartItemEntity, ui1)
+    uiRenderer.addUiRenderer(smartItemEntity, ui1, WHOLE_SCREEN)
     await engine.update(1)
 
     // UI should be rendered
@@ -194,9 +194,9 @@ describe('addUiRenderer', () => {
     const ui3 = () => <UiEntity uiTransform={{ width: 300 }} />
 
     // Add all UI renderers
-    uiRenderer.addUiRenderer(entity1, ui1)
-    uiRenderer.addUiRenderer(entity2, ui2)
-    uiRenderer.addUiRenderer(entity3, ui3)
+    uiRenderer.addUiRenderer(entity1, ui1, WHOLE_SCREEN)
+    uiRenderer.addUiRenderer(entity2, ui2, WHOLE_SCREEN)
+    uiRenderer.addUiRenderer(entity3, ui3, WHOLE_SCREEN)
     await engine.update(1)
 
     let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
@@ -233,7 +233,7 @@ describe('addUiRenderer', () => {
     })
 
     const ui = () => <UiEntity uiTransform={{ width: 100 }} />
-    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    uiRenderer.addUiRenderer(ownerEntity, ui, { ...WHOLE_SCREEN, virtualWidth: 800, virtualHeight: 600 })
     await engine.update(1)
 
     expect(getUiScaleFactor()).toBeCloseTo(1.5)

--- a/test/react-ecs/background.spec.tsx
+++ b/test/react-ecs/background.spec.tsx
@@ -3,7 +3,7 @@ import { components } from '../../packages/@dcl/ecs/src'
 import { Color4 } from '../../packages/@dcl/sdk/math'
 import { ReactEcs, UiEntity, UiBackgroundProps } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('UiBackground React Ecs', () => {
   it('should generate a UI and update the width of a div', async () => {
@@ -20,7 +20,7 @@ describe('UiBackground React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ width: 100 }} uiBackground={{ color }} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUiTransform(rootDivEntity)).toMatchObject({
@@ -66,7 +66,7 @@ describe('UiBackground React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ width: 100 }} {...backgroundProps} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getBackground()?.color).toMatchObject(backgroundProps.uiBackground.color!)
 
@@ -98,7 +98,7 @@ describe('UiBackground React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ width: 100 }} {...backgroundProps} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getBackground()?.color).toMatchObject(backgroundProps.uiBackground.color!)
     expect(getBackground()?.texture).toMatchObject({
@@ -140,7 +140,7 @@ describe('UiBackground React Ecs', () => {
     const getBackground = () => UiBackground.getOrNull(rootDivEntity)
     const ui = () => <UiEntity uiTransform={{ width: 100 }} uiBackground={{}} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getBackground()?.color).toBe(undefined)
   })

--- a/test/react-ecs/button.spec.tsx
+++ b/test/react-ecs/button.spec.tsx
@@ -3,7 +3,7 @@ import { components } from '../../packages/@dcl/ecs/src'
 import { ReactEcs, Button, UiButtonProps } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
 import { Color4 } from '../../packages/@dcl/sdk/math'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('Button React Ecs', () => {
   it('validates button props', async () => {
@@ -36,7 +36,7 @@ describe('Button React Ecs', () => {
       />
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getPointerEvent(rootDivEntity)).toBeDefined()

--- a/test/react-ecs/interactable-area.spec.tsx
+++ b/test/react-ecs/interactable-area.spec.tsx
@@ -44,6 +44,38 @@ describe('InteractableArea React Ecs', () => {
     uiRenderer.destroy()
   })
 
+  it('keeps its position in canvas pixels when the UI scale factor is not 1', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const UiCanvasInformation = components.UiCanvasInformation(engine)
+    const entityIndex = engine.addEntity() as number
+    const rootDivEntity = (entityIndex + 1) as Entity
+
+    // Canvas at 2x the default 1920x1080 virtual screen -> scale factor 2. The
+    // stored position must still equal the raw canvas-px insets: they are
+    // pre-divided by the scale factor so the px parser's multiplication cancels out.
+    UiCanvasInformation.create(engine.RootEntity, {
+      devicePixelRatio: 1,
+      width: 3840,
+      height: 2160,
+      screenInsetArea: undefined,
+      interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
+    })
+
+    uiRenderer.setUiRenderer(() => <InteractableArea />)
+    await engine.update(1)
+
+    expect(UiTransform.get(rootDivEntity)).toMatchObject({
+      positionType: YGPositionType.YGPT_ABSOLUTE,
+      positionTop: 0,
+      positionLeft: 480,
+      positionRight: 0,
+      positionBottom: 0
+    })
+
+    uiRenderer.destroy()
+  })
+
   it('updates its position when the interactable area changes', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)

--- a/test/react-ecs/interactable-area.spec.tsx
+++ b/test/react-ecs/interactable-area.spec.tsx
@@ -3,7 +3,7 @@ import { components } from '../../packages/@dcl/ecs/src'
 import { InteractableArea, ReactEcs } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
 import { resetInteractableArea } from '../../packages/@dcl/react-ecs/src/components/utils'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('InteractableArea React Ecs', () => {
   afterEach(() => {
@@ -25,7 +25,7 @@ describe('InteractableArea React Ecs', () => {
       interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
     })
 
-    uiRenderer.setUiRenderer(() => <InteractableArea />)
+    uiRenderer.setUiRenderer(() => <InteractableArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -62,7 +62,7 @@ describe('InteractableArea React Ecs', () => {
       interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
     })
 
-    uiRenderer.setUiRenderer(() => <InteractableArea />)
+    uiRenderer.setUiRenderer(() => <InteractableArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -91,7 +91,7 @@ describe('InteractableArea React Ecs', () => {
       interactableArea: { top: 0, left: 0, right: 0, bottom: 0 }
     })
 
-    uiRenderer.setUiRenderer(() => <InteractableArea />)
+    uiRenderer.setUiRenderer(() => <InteractableArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -121,7 +121,7 @@ describe('InteractableArea React Ecs', () => {
     const entityIndex = engine.addEntity() as number
     const rootDivEntity = (entityIndex + 1) as Entity
 
-    uiRenderer.setUiRenderer(() => <InteractableArea />)
+    uiRenderer.setUiRenderer(() => <InteractableArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -150,19 +150,22 @@ describe('InteractableArea React Ecs', () => {
       interactableArea: { top: 10, left: 10, right: 10, bottom: 10 }
     })
 
-    uiRenderer.setUiRenderer(() => (
-      <InteractableArea
-        uiTransform={
-          {
-            // user-provided overrides for position* should be ignored by typing,
-            // but we cast through `any` to assert runtime behaviour as well.
-            positionType: 'relative',
-            position: { top: 999, left: 999, right: 999, bottom: 999 },
-            padding: 4
-          } as any
-        }
-      />
-    ))
+    uiRenderer.setUiRenderer(
+      () => (
+        <InteractableArea
+          uiTransform={
+            {
+              // user-provided overrides for position* should be ignored by typing,
+              // but we cast through `any` to assert runtime behaviour as well.
+              positionType: 'relative',
+              position: { top: 999, left: 999, right: 999, bottom: 999 },
+              padding: 4
+            } as any
+          }
+        />
+      ),
+      WHOLE_SCREEN
+    )
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({

--- a/test/react-ecs/label.spec.tsx
+++ b/test/react-ecs/label.spec.tsx
@@ -113,23 +113,34 @@ describe('UiText React Ecs', () => {
     })
 
     it('should scale font size using viewport width by default', () => {
-      expect(scaleFontSize(16, undefined, scaleCtx)).toBeCloseTo(17.56)
+      // 16 + 0.39% of 800
+      expect(scaleFontSize(16, undefined, scaleCtx)).toBeCloseTo(19.12)
     })
 
     it('should scale font size using viewport height when scale unit is "vh"', () => {
-      expect(scaleFontSize(16, '10vh', scaleCtx)).toBeCloseTo(46)
+      // 16 + 10% of 600
+      expect(scaleFontSize(16, '10vh', scaleCtx)).toBeCloseTo(76)
     })
 
     it('should scale font size correctly when scale unit is "vw"', () => {
-      expect(scaleFontSize(16, '10vw', scaleCtx)).toBeCloseTo(56)
+      // 16 + 10% of 800
+      expect(scaleFontSize(16, '10vw', scaleCtx)).toBeCloseTo(96)
     })
 
     it('should handle scaling with a numeric value', () => {
-      expect(scaleFontSize(16, 10, scaleCtx)).toBeCloseTo(56)
+      expect(scaleFontSize(16, 10, scaleCtx)).toBeCloseTo(96)
     })
 
     it('should handle scaling with a numeric value and unit "vw"', () => {
-      expect(scaleFontSize(16, '10.5vw', scaleCtx)).toBeCloseTo(58)
+      expect(scaleFontSize(16, '10.5vw', scaleCtx)).toBeCloseTo(100)
+    })
+
+    it('should not depend on the context ratio', () => {
+      // 'Nvw' is N% of the canvas width by definition, exactly as in CSS. The density
+      // hint on the context must not change what a viewport unit resolves to.
+      for (const ratio of [0.5, 1, 2, 3]) {
+        expect(scaleFontSize(16, '10vw', { ...scaleCtx, ratio })).toBeCloseTo(96)
+      }
     })
   })
 

--- a/test/react-ecs/label.spec.tsx
+++ b/test/react-ecs/label.spec.tsx
@@ -17,7 +17,7 @@ import {
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
 import { parseSize } from '../../packages/@dcl/react-ecs/src/components/uiTransform/utils'
 import { Color4 } from '../../packages/@dcl/sdk/math'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 import { getFontSize } from '../../packages/@dcl/react-ecs/src/components/Label/utils'
 
 describe('UiText React Ecs', () => {
@@ -32,7 +32,7 @@ describe('UiText React Ecs', () => {
 
     const ui = () => <Label uiTransform={{ width: 100 }} value="DCLROCKS" />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getText(rootDivEntity)).toMatchObject({
@@ -67,7 +67,7 @@ describe('UiText React Ecs', () => {
       />
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUiTransform(rootDivEntity)).toMatchObject({

--- a/test/react-ecs/screen-inset-area.spec.tsx
+++ b/test/react-ecs/screen-inset-area.spec.tsx
@@ -103,6 +103,38 @@ describe('ScreenInsetArea React Ecs', () => {
     uiRenderer.destroy()
   })
 
+  it('keeps its position in canvas pixels when the UI scale factor is not 1', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const UiCanvasInformation = components.UiCanvasInformation(engine)
+    const entityIndex = engine.addEntity() as number
+    const rootDivEntity = (entityIndex + 1) as Entity
+
+    // Canvas at 2x the default 1920x1080 virtual screen -> scale factor 2. The
+    // stored position must still equal the raw canvas-px insets: they are
+    // pre-divided by the scale factor so the px parser's multiplication cancels out.
+    UiCanvasInformation.create(engine.RootEntity, {
+      devicePixelRatio: 1,
+      width: 3840,
+      height: 2160,
+      interactableArea: undefined,
+      screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 }
+    })
+
+    uiRenderer.setUiRenderer(() => <ScreenInsetArea />)
+    await engine.update(1)
+
+    expect(UiTransform.get(rootDivEntity)).toMatchObject({
+      positionType: YGPositionType.YGPT_ABSOLUTE,
+      positionTop: 24,
+      positionLeft: 12,
+      positionRight: 16,
+      positionBottom: 32
+    })
+
+    uiRenderer.destroy()
+  })
+
   it('forwards user uiTransform props but ignores positionType / position overrides', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)

--- a/test/react-ecs/screen-inset-area.spec.tsx
+++ b/test/react-ecs/screen-inset-area.spec.tsx
@@ -3,7 +3,7 @@ import { components } from '../../packages/@dcl/ecs/src'
 import { ReactEcs, ScreenInsetArea } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
 import { resetScreenInsetArea } from '../../packages/@dcl/react-ecs/src/components/utils'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('ScreenInsetArea React Ecs', () => {
   afterEach(() => {
@@ -25,7 +25,7 @@ describe('ScreenInsetArea React Ecs', () => {
       screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 }
     })
 
-    uiRenderer.setUiRenderer(() => <ScreenInsetArea />)
+    uiRenderer.setUiRenderer(() => <ScreenInsetArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -59,7 +59,7 @@ describe('ScreenInsetArea React Ecs', () => {
       screenInsetArea: { top: 0, left: 0, right: 0, bottom: 0 }
     })
 
-    uiRenderer.setUiRenderer(() => <ScreenInsetArea />)
+    uiRenderer.setUiRenderer(() => <ScreenInsetArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -89,7 +89,7 @@ describe('ScreenInsetArea React Ecs', () => {
     const entityIndex = engine.addEntity() as number
     const rootDivEntity = (entityIndex + 1) as Entity
 
-    uiRenderer.setUiRenderer(() => <ScreenInsetArea />)
+    uiRenderer.setUiRenderer(() => <ScreenInsetArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -121,7 +121,7 @@ describe('ScreenInsetArea React Ecs', () => {
       screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 }
     })
 
-    uiRenderer.setUiRenderer(() => <ScreenInsetArea />)
+    uiRenderer.setUiRenderer(() => <ScreenInsetArea />, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({
@@ -150,19 +150,22 @@ describe('ScreenInsetArea React Ecs', () => {
       screenInsetArea: { top: 10, left: 10, right: 10, bottom: 10 }
     })
 
-    uiRenderer.setUiRenderer(() => (
-      <ScreenInsetArea
-        uiTransform={
-          {
-            // user-provided overrides for position* should be ignored by typing,
-            // but we cast through `any` to assert runtime behaviour as well.
-            positionType: 'relative',
-            position: { top: 999, left: 999, right: 999, bottom: 999 },
-            padding: 4
-          } as any
-        }
-      />
-    ))
+    uiRenderer.setUiRenderer(
+      () => (
+        <ScreenInsetArea
+          uiTransform={
+            {
+              // user-provided overrides for position* should be ignored by typing,
+              // but we cast through `any` to assert runtime behaviour as well.
+              positionType: 'relative',
+              position: { top: 999, left: 999, right: 999, bottom: 999 },
+              padding: 4
+            } as any
+          }
+        />
+      ),
+      WHOLE_SCREEN
+    )
     await engine.update(1)
 
     expect(UiTransform.get(rootDivEntity)).toMatchObject({

--- a/test/react-ecs/transform.spec.tsx
+++ b/test/react-ecs/transform.spec.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
 import { Color4 } from '../../packages/@dcl/sdk/math'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('UiTransform React Ecs', () => {
   it('should send empty object if uiTransform is undefined', async () => {
@@ -34,7 +34,7 @@ describe('UiTransform React Ecs', () => {
     const rootDivEntity = (entityIndex + 1) as Entity
     const getUiTransform = (entity: Entity) => UiTransform.get(entity)
     const ui = () => <UiEntity uiTransform={undefined} />
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity).width).toBe(0)
   })
@@ -64,7 +64,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(UiText.get(rootDivEntity)).toMatchObject({ value: 'BOEDO' })
     expect(getUiTransform(rootDivEntity)).toMatchObject({
@@ -98,7 +98,7 @@ describe('UiTransform React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ width: 100, position }} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUiTransform(rootDivEntity)).toMatchObject({
@@ -174,7 +174,7 @@ describe('UiTransform React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ width: 100, borderRadius, borderColor: Color4.Green(), borderWidth }} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     const matchObject: Partial<PBUiTransform> = {
@@ -297,7 +297,7 @@ describe('UiTransform React Ecs', () => {
       />
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUiTransform(rootDivEntity)).toMatchObject({
@@ -354,7 +354,7 @@ describe('UiTransform React Ecs', () => {
 
     const ui = () => <UiEntity uiTransform={{ margin }} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUiTransform(rootDivEntity)).toMatchObject({
@@ -457,7 +457,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       pointerFilter: PointerFilterMode.PFM_BLOCK
@@ -480,7 +480,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       widthUnit: YGUnit.YGU_AUTO,
@@ -505,7 +505,7 @@ describe('UiTransform React Ecs', () => {
       />
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       zIndex: 10
@@ -528,7 +528,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       zIndex: -5
@@ -551,7 +551,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       zIndex: 0
@@ -574,7 +574,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       zIndex: 0
@@ -598,7 +598,7 @@ describe('UiTransform React Ecs', () => {
       />
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       opacity: 10
@@ -621,7 +621,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       opacity: -5
@@ -644,7 +644,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       opacity: 0
@@ -667,7 +667,7 @@ describe('UiTransform React Ecs', () => {
         }}
       />
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       opacity: 1

--- a/test/react-ecs/tree.spec.tsx
+++ b/test/react-ecs/tree.spec.tsx
@@ -2,7 +2,7 @@ import { Entity, MAX_U16 } from '../../packages/@dcl/ecs/src/engine/entity'
 import { components } from '../../packages/@dcl/ecs/src'
 import { ReactEcs, UiEntity } from '../../packages/@dcl/react-ecs/src'
 import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
-import { setupEngine } from './utils'
+import { setupEngine, WHOLE_SCREEN } from './utils'
 
 describe('RectEcs UI ✨', () => {
   it('should generate a UI and update the width', async () => {
@@ -31,7 +31,7 @@ describe('RectEcs UI ✨', () => {
         {/* UiEntity B */}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUi(rootEntity)).toMatchObject({
       parent: CANVAS_ROOT_ENTITY,
@@ -89,7 +89,7 @@ describe('RectEcs UI ✨', () => {
       )
     }
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUi(rootEntity)).toMatchObject({
@@ -180,7 +180,7 @@ describe('RectEcs UI ✨', () => {
         {/* UiEntity B */}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUi(entityA)).toMatchObject({
@@ -269,7 +269,7 @@ describe('RectEcs UI ✨', () => {
         {/* UiEntity Added */}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
     expect(getUi(rootEntity)).toMatchObject({
       parent: CANVAS_ROOT_ENTITY,
@@ -368,7 +368,7 @@ describe('RectEcs UI ✨', () => {
       </UiEntity>
     )
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     addChild = true
@@ -453,7 +453,7 @@ describe('RectEcs UI ✨', () => {
         ))}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUi(entityA)).toMatchObject({
@@ -576,7 +576,7 @@ describe('RectEcs UI ✨', () => {
         ))}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     expect(getUi(entityA)).toMatchObject({
@@ -672,7 +672,7 @@ describe('RectEcs UI ✨', () => {
         ))}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     // Initial order: A → B → C
@@ -729,7 +729,7 @@ describe('RectEcs UI ✨', () => {
         ))}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     // Initial order: A → B → C → D
@@ -795,7 +795,7 @@ describe('RectEcs UI ✨', () => {
         ))}
       </UiEntity>
     )
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
     await engine.update(1)
 
     const verifyCyclesFree = () => {
@@ -811,14 +811,26 @@ describe('RectEcs UI ✨', () => {
     }
 
     // Reorder 1: [1,2,3,4,5] → [2,1,3,4,5]
-    items = [{ id: 2, value: 200 }, { id: 1, value: 100 }, { id: 3, value: 300 }, { id: 4, value: 400 }, { id: 5, value: 500 }]
+    items = [
+      { id: 2, value: 200 },
+      { id: 1, value: 100 },
+      { id: 3, value: 300 },
+      { id: 4, value: 400 },
+      { id: 5, value: 500 }
+    ]
     await engine.update(1)
     expect(getUi(entityB).rightOf).toBe(undefined)
     expect(getUi(entityA).rightOf).toBe(entityB)
     verifyCyclesFree()
 
     // Reorder 2: [2,1,3,4,5] → [5,4,3,2,1]
-    items = [{ id: 5, value: 500 }, { id: 4, value: 400 }, { id: 3, value: 300 }, { id: 2, value: 200 }, { id: 1, value: 100 }]
+    items = [
+      { id: 5, value: 500 },
+      { id: 4, value: 400 },
+      { id: 3, value: 300 },
+      { id: 2, value: 200 },
+      { id: 1, value: 100 }
+    ]
     await engine.update(1)
     expect(getUi(entityE).rightOf).toBe(undefined)
     expect(getUi(entityD).rightOf).toBe(entityE)
@@ -828,7 +840,13 @@ describe('RectEcs UI ✨', () => {
     verifyCyclesFree()
 
     // Reorder 3: back to original [1,2,3,4,5]
-    items = [{ id: 1, value: 100 }, { id: 2, value: 200 }, { id: 3, value: 300 }, { id: 4, value: 400 }, { id: 5, value: 500 }]
+    items = [
+      { id: 1, value: 100 },
+      { id: 2, value: 200 },
+      { id: 3, value: 300 },
+      { id: 4, value: 400 },
+      { id: 5, value: 500 }
+    ]
     await engine.update(1)
     expect(getUi(entityA).rightOf).toBe(undefined)
     expect(getUi(entityB).rightOf).toBe(entityA)

--- a/test/react-ecs/ui-renderer-screen-inset.spec.tsx
+++ b/test/react-ecs/ui-renderer-screen-inset.spec.tsx
@@ -1,0 +1,259 @@
+import { Entity } from '../../packages/@dcl/ecs/src/engine'
+import { components, YGPositionType, YGUnit } from '../../packages/@dcl/ecs/src'
+import { UiEntity, ReactEcs } from '../../packages/@dcl/react-ecs/src'
+import { CANVAS_ROOT_ENTITY } from '../../packages/@dcl/react-ecs/src/components/uiTransform'
+import {
+  getUiScaleFactor,
+  resetInteractableArea,
+  resetScreenInsetArea,
+  resetUiScaleFactor
+} from '../../packages/@dcl/react-ecs/src/components/utils'
+import { setupEngine } from './utils'
+
+describe('UI renderer screenInset option', () => {
+  afterEach(() => {
+    resetUiScaleFactor()
+    resetScreenInsetArea()
+    resetInteractableArea()
+  })
+
+  function createCanvasInfo(
+    engine: ReturnType<typeof setupEngine>['engine'],
+    overrides: Partial<{
+      width: number
+      height: number
+      screenInsetArea: { top: number; left: number; right: number; bottom: number }
+      interactableArea: { top: number; left: number; right: number; bottom: number }
+    }> = {}
+  ) {
+    const UiCanvasInformation = components.UiCanvasInformation(engine)
+    UiCanvasInformation.create(engine.RootEntity, {
+      devicePixelRatio: 1,
+      width: overrides.width ?? 1920,
+      height: overrides.height ?? 1080,
+      interactableArea: overrides.interactableArea,
+      screenInsetArea: overrides.screenInsetArea
+    })
+  }
+
+  it('adds no wrapper entity by default and with an explicit none', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />)
+    await engine.update(1)
+
+    let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(1)
+    expect(UiTransform.get(uiEntities[0][0]).parent).toBe(CANVAS_ROOT_ENTITY)
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'none' })
+    await engine.update(1)
+
+    uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(1)
+    expect(UiTransform.get(uiEntities[0][0]).parent).toBe(CANVAS_ROOT_ENTITY)
+
+    uiRenderer.destroy()
+  })
+
+  it('wraps the main UI in the device screen inset area', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'device' })
+    await engine.update(1)
+
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(2)
+
+    const wrapper = uiEntities.find(([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE)!
+    expect(wrapper).toBeDefined()
+    expect(wrapper[1]).toMatchObject({
+      parent: CANVAS_ROOT_ENTITY,
+      positionTop: 24,
+      positionLeft: 12,
+      positionRight: 16,
+      positionBottom: 32,
+      positionTopUnit: YGUnit.YGU_POINT,
+      positionLeftUnit: YGUnit.YGU_POINT,
+      positionRightUnit: YGUnit.YGU_POINT,
+      positionBottomUnit: YGUnit.YGU_POINT
+    })
+
+    const child = uiEntities.find(([, transform]) => transform.width === 100)!
+    expect(child).toBeDefined()
+    expect(child[1].parent).toBe(wrapper[0])
+
+    uiRenderer.destroy()
+  })
+
+  it('wraps the main UI in the interactable area', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, { interactableArea: { top: 0, left: 480, right: 0, bottom: 0 } })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'interactable' })
+    await engine.update(1)
+
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(2)
+
+    const wrapper = uiEntities.find(([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE)!
+    expect(wrapper[1]).toMatchObject({
+      parent: CANVAS_ROOT_ENTITY,
+      positionTop: 0,
+      positionLeft: 480,
+      positionRight: 0,
+      positionBottom: 0
+    })
+
+    const child = uiEntities.find(([, transform]) => transform.width === 100)!
+    expect(child[1].parent).toBe(wrapper[0])
+
+    uiRenderer.destroy()
+  })
+
+  it('honors a different inset per renderer simultaneously', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, {
+      screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 },
+      interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
+    })
+    const deviceEntity = engine.addEntity()
+    const noneEntity = engine.addEntity()
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'interactable' })
+    uiRenderer.addUiRenderer(deviceEntity, () => <UiEntity uiTransform={{ width: 200 }} />, { screenInset: 'device' })
+    uiRenderer.addUiRenderer(noneEntity, () => <UiEntity uiTransform={{ width: 300 }} />)
+    await engine.update(1)
+
+    // 3 renderer children + 2 wrappers ('none' adds none).
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(5)
+
+    const childOf = (width: number) => uiEntities.find(([, transform]) => transform.width === width)![1]
+    const parentTransform = (child: { parent: number }) => UiTransform.get(child.parent as Entity)
+
+    // Main UI sits inside an interactable-area wrapper.
+    expect(parentTransform(childOf(100))).toMatchObject({
+      positionType: YGPositionType.YGPT_ABSOLUTE,
+      positionLeft: 480,
+      parent: CANVAS_ROOT_ENTITY
+    })
+
+    // Additional renderer with 'device' sits inside a screen-inset wrapper.
+    expect(parentTransform(childOf(200))).toMatchObject({
+      positionType: YGPositionType.YGPT_ABSOLUTE,
+      positionTop: 24,
+      positionLeft: 12,
+      parent: CANVAS_ROOT_ENTITY
+    })
+
+    // Additional renderer without inset stays directly under the canvas root.
+    expect(childOf(300).parent).toBe(CANVAS_ROOT_ENTITY)
+
+    uiRenderer.destroy()
+  })
+
+  it('updates the wrapper when the inset area changes', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const UiCanvasInformation = components.UiCanvasInformation(engine)
+    createCanvasInfo(engine, { screenInsetArea: { top: 0, left: 0, right: 0, bottom: 0 } })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'device' })
+    await engine.update(1)
+
+    const wrapper = Array.from(engine.getEntitiesWith(UiTransform)).find(
+      ([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE
+    )!
+    expect(wrapper[1]).toMatchObject({ positionTop: 0, positionLeft: 0, positionRight: 0, positionBottom: 0 })
+
+    UiCanvasInformation.getMutable(engine.RootEntity).screenInsetArea = { top: 50, left: 60, right: 70, bottom: 80 }
+    await engine.update(1)
+
+    expect(UiTransform.get(wrapper[0])).toMatchObject({
+      positionTop: 50,
+      positionLeft: 60,
+      positionRight: 70,
+      positionBottom: 80
+    })
+
+    uiRenderer.destroy()
+  })
+
+  it('keeps the wrapper in canvas pixels when the UI scale factor is not 1', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    // Canvas at 2x the default 1920x1080 virtual screen -> scale factor 2.
+    createCanvasInfo(engine, {
+      width: 3840,
+      height: 2160,
+      screenInsetArea: { top: 100, left: 200, right: 300, bottom: 400 }
+    })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'device' })
+    await engine.update(1)
+
+    expect(getUiScaleFactor()).toBeCloseTo(2)
+
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    const wrapper = uiEntities.find(([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE)!
+    // The wrapper position must stay at the raw canvas-px insets: the values are
+    // pre-divided by the scale factor so the px parser's multiplication cancels out.
+    expect(wrapper[1]).toMatchObject({
+      positionTop: 100,
+      positionLeft: 200,
+      positionRight: 300,
+      positionBottom: 400
+    })
+
+    // Regular px values inside the renderer are still scaled by the factor.
+    const child = uiEntities.find(([, transform]) => transform.width === 200)!
+    expect(child).toBeDefined()
+    expect(child[1].parent).toBe(wrapper[0])
+
+    uiRenderer.destroy()
+  })
+
+  it('does not disable the default virtual screen when options only carry a screenInset', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, { width: 3840, height: 2160, screenInsetArea: { top: 0, left: 0, right: 0, bottom: 0 } })
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'device' })
+    await engine.update(1)
+
+    // Platform default 1920x1080 still applies -> factor 2.
+    expect(getUiScaleFactor()).toBeCloseTo(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('re-wraps and unwraps when the inset changes across setUiRenderer calls', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
+    const ui = () => <UiEntity uiTransform={{ width: 100 }} />
+
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+    expect(Array.from(engine.getEntitiesWith(UiTransform)).length).toBe(1)
+
+    uiRenderer.setUiRenderer(ui, { screenInset: 'device' })
+    await engine.update(1)
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(2)
+    const wrapper = uiEntities.find(([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE)!
+    expect(wrapper[1]).toMatchObject({ positionTop: 24, positionLeft: 12 })
+
+    uiRenderer.setUiRenderer(ui, { screenInset: 'none' })
+    await engine.update(1)
+    expect(Array.from(engine.getEntitiesWith(UiTransform)).length).toBe(1)
+
+    uiRenderer.destroy()
+  })
+})

--- a/test/react-ecs/ui-renderer-screen-inset.spec.tsx
+++ b/test/react-ecs/ui-renderer-screen-inset.spec.tsx
@@ -36,22 +36,71 @@ describe('UI renderer screenInset option', () => {
     })
   }
 
-  it('adds no wrapper entity by default and with an explicit none', async () => {
+  it('wraps the main UI in the device screen inset area by default', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)
-    createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
+    // Both areas are reported, so the assertion pins down which one the default picks.
+    createCanvasInfo(engine, {
+      screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 },
+      interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
+    })
 
     uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />)
     await engine.update(1)
 
-    let uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
-    expect(uiEntities.length).toBe(1)
-    expect(UiTransform.get(uiEntities[0][0]).parent).toBe(CANVAS_ROOT_ENTITY)
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(2)
+
+    const wrapper = uiEntities.find(([, transform]) => transform.positionType === YGPositionType.YGPT_ABSOLUTE)!
+    expect(wrapper[1]).toMatchObject({
+      parent: CANVAS_ROOT_ENTITY,
+      positionTop: 24,
+      positionLeft: 12,
+      positionRight: 16,
+      positionBottom: 32
+    })
+
+    const child = uiEntities.find(([, transform]) => transform.width === 100)!
+    expect(child[1].parent).toBe(wrapper[0])
+
+    uiRenderer.destroy()
+  })
+
+  it('wraps an additional renderer in the device screen inset area by default', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, {
+      screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 },
+      interactableArea: { top: 0, left: 480, right: 0, bottom: 0 }
+    })
+    const ownerEntity = engine.addEntity()
+
+    uiRenderer.addUiRenderer(ownerEntity, () => <UiEntity uiTransform={{ width: 100 }} />)
+    await engine.update(1)
+
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    expect(uiEntities.length).toBe(2)
+
+    const child = uiEntities.find(([, transform]) => transform.width === 100)!
+    expect(UiTransform.get(child[1].parent as Entity)).toMatchObject({
+      parent: CANVAS_ROOT_ENTITY,
+      positionType: YGPositionType.YGPT_ABSOLUTE,
+      positionTop: 24,
+      positionLeft: 12
+    })
+
+    uiRenderer.destroy()
+  })
+
+  it('adds no wrapper entity with an explicit none', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
 
     uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'none' })
     await engine.update(1)
 
-    uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform))
     expect(uiEntities.length).toBe(1)
     expect(UiTransform.get(uiEntities[0][0]).parent).toBe(CANVAS_ROOT_ENTITY)
 
@@ -128,7 +177,7 @@ describe('UI renderer screenInset option', () => {
 
     uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 100 }} />, { screenInset: 'interactable' })
     uiRenderer.addUiRenderer(deviceEntity, () => <UiEntity uiTransform={{ width: 200 }} />, { screenInset: 'device' })
-    uiRenderer.addUiRenderer(noneEntity, () => <UiEntity uiTransform={{ width: 300 }} />)
+    uiRenderer.addUiRenderer(noneEntity, () => <UiEntity uiTransform={{ width: 300 }} />, { screenInset: 'none' })
     await engine.update(1)
 
     // 3 renderer children + 2 wrappers ('none' adds none).
@@ -239,7 +288,7 @@ describe('UI renderer screenInset option', () => {
     createCanvasInfo(engine, { screenInsetArea: { top: 24, left: 12, right: 16, bottom: 32 } })
     const ui = () => <UiEntity uiTransform={{ width: 100 }} />
 
-    uiRenderer.setUiRenderer(ui)
+    uiRenderer.setUiRenderer(ui, { screenInset: 'none' })
     await engine.update(1)
     expect(Array.from(engine.getEntitiesWith(UiTransform)).length).toBe(1)
 

--- a/test/react-ecs/utils.ts
+++ b/test/react-ecs/utils.ts
@@ -1,8 +1,16 @@
 import { Engine } from '../../packages/@dcl/ecs/src/engine'
 import { createPointerEventsSystem } from '../../packages/@dcl/ecs/src/systems/events'
 import { createInputSystem } from '../../packages/@dcl/ecs/src/engine'
-import { createReactBasedUiSystem } from '../../packages/@dcl/react-ecs/src'
+import { createReactBasedUiSystem, UiRendererOptions } from '../../packages/@dcl/react-ecs/src'
 import { IEngine, PointerEventsSystem } from '../../packages/@dcl/ecs'
+
+/**
+ * Renderer options for suites that assert the UI tree hanging directly off the
+ * canvas root. The default inset ('interactable') adds a wrapper entity between
+ * the two, which is what `ui-renderer-screen-inset.spec.tsx` is there to cover
+ * and is noise everywhere else.
+ */
+export const WHOLE_SCREEN: UiRendererOptions = { screenInset: 'none' }
 
 export function setupEngine() {
   const engine = Engine()

--- a/test/react-ecs/virtual-scale-array.spec.tsx
+++ b/test/react-ecs/virtual-scale-array.spec.tsx
@@ -311,11 +311,12 @@ describe('Virtual scale factor with mixed % and pixel values', () => {
     uiRenderer.destroy()
   })
 
-  it('should normalize the scale factor by devicePixelRatio', async () => {
+  it('should not let devicePixelRatio affect the scale factor', async () => {
     const { engine, uiRenderer } = setupEngine()
     const UiTransform = components.UiTransform(engine)
     const UiCanvasInformation = components.UiCanvasInformation(engine)
-    // Physical-pixel canvas on a high-DPR (mobile) screen: 3840x2160 @ dpr 2.
+    // High-density screen: 3840x2160 @ dpr 2. The design resolution fits the canvas
+    // exactly twice over, so that — and only that — is the scale factor.
     UiCanvasInformation.create(engine.RootEntity, {
       devicePixelRatio: 2,
       width: 3840,
@@ -328,39 +329,43 @@ describe('Virtual scale factor with mixed % and pixel values', () => {
 
     await engine.update(1)
 
-    // scale = Math.min(3840/1920, 2160/1080) / 2 = 2 / 2 = 1
-    expect(getUiScaleFactor()).toBe(1)
-
-    const panelEntity = (entityIndex + 1) as Entity
-    expect(UiTransform.get(panelEntity).width).toBe(300) // 300 * 1
-    expect(UiTransform.get(panelEntity).height).toBe(300) // 300 * 1
-
-    uiRenderer.destroy()
-  })
-
-  it('should treat a missing/zero devicePixelRatio as 1', async () => {
-    const { engine, uiRenderer } = setupEngine()
-    const UiTransform = components.UiTransform(engine)
-    const UiCanvasInformation = components.UiCanvasInformation(engine)
-    UiCanvasInformation.create(engine.RootEntity, {
-      devicePixelRatio: 0,
-      width: 3840,
-      height: 2160,
-      interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
-    })
-    const entityIndex = engine.addEntity() as number
-
-    uiRenderer.setUiRenderer(() => <Panel1 />, { virtualWidth: 1920, virtualHeight: 1080 })
-
-    await engine.update(1)
-
-    // dpr 0 must not divide by zero — falls back to 1, so scale = 2
+    // scale = Math.min(3840/1920, 2160/1080) = 2, undivided.
     expect(getUiScaleFactor()).toBe(2)
 
     const panelEntity = (entityIndex + 1) as Entity
     expect(UiTransform.get(panelEntity).width).toBe(600) // 300 * 2
+    expect(UiTransform.get(panelEntity).height).toBe(600) // 300 * 2
 
     uiRenderer.destroy()
+  })
+
+  it('should produce the same scale factor whatever devicePixelRatio reports', async () => {
+    // The regression guard: two canvases identical in every way except the density
+    // hint must lay out identically. dpr 0 is included because it used to be a
+    // divide-by-zero guard, and there must no longer be a division to guard.
+    for (const devicePixelRatio of [0, 1, 2, 3.5]) {
+      const { engine, uiRenderer } = setupEngine()
+      const UiTransform = components.UiTransform(engine)
+      const UiCanvasInformation = components.UiCanvasInformation(engine)
+      UiCanvasInformation.create(engine.RootEntity, {
+        devicePixelRatio,
+        width: 3840,
+        height: 2160,
+        interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
+      })
+      const entityIndex = engine.addEntity() as number
+
+      uiRenderer.setUiRenderer(() => <Panel1 />, { virtualWidth: 1920, virtualHeight: 1080 })
+
+      await engine.update(1)
+
+      expect(getUiScaleFactor()).toBe(2)
+
+      const panelEntity = (entityIndex + 1) as Entity
+      expect(UiTransform.get(panelEntity).width).toBe(600) // 300 * 2
+
+      uiRenderer.destroy()
+    }
   })
 
   it('should use scale factor 1 when UiCanvasInformation is not yet available', async () => {

--- a/test/react-ecs/virtual-size-defaults.spec.tsx
+++ b/test/react-ecs/virtual-size-defaults.spec.tsx
@@ -1,0 +1,264 @@
+import { components } from '../../packages/@dcl/ecs/src'
+import { ReactEcs, UiEntity } from '../../packages/@dcl/react-ecs/src'
+import { getUiScaleFactor, resetUiScaleFactor } from '../../packages/@dcl/react-ecs/src/components/utils'
+import { setIsMobileProvider } from '../../packages/@dcl/react-ecs/src/platform'
+import { setupEngine } from './utils'
+
+const ui = () => <UiEntity uiTransform={{ width: 100 }} />
+
+function createCanvasInfo(engine: any, width: number, height: number) {
+  const UiCanvasInformation = components.UiCanvasInformation(engine)
+  UiCanvasInformation.create(engine.RootEntity, {
+    devicePixelRatio: 1,
+    width,
+    height,
+    interactableArea: { left: 0, right: 0, top: 0, bottom: 0 }
+  })
+}
+
+function mobileOverrideLogs(logSpy: jest.SpyInstance) {
+  return logSpy.mock.calls.filter((args) => String(args[0]).includes('Mobile platform detected'))
+}
+
+describe('Virtual screen size defaults', () => {
+  afterEach(() => {
+    setIsMobileProvider(() => false)
+    resetUiScaleFactor()
+  })
+
+  it('should default to 1920x1080 on non-mobile when no virtual size is provided', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+
+    // scale = Math.min(3840/1920, 2160/1080) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should default to 1600x720 on mobile when no virtual size is provided', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui)
+    await engine.update(1)
+
+    // scale = Math.min(3200/1600, 1440/720) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen when the provided virtualWidth is invalid', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(2)
+
+    // An explicitly invalid size disables UI scaling entirely (no default fallback)
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 0, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen on mobile when the provided virtualHeight is invalid', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: -1 })
+    await engine.update(1)
+
+    // No mobile default applied — scaling stays off
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should apply the default virtual size for an addUiRenderer with no options and no main renderer', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+    const ownerEntity = engine.addEntity()
+
+    // No setUiRenderer at all; only an additional renderer with no options
+    uiRenderer.addUiRenderer(ownerEntity, ui)
+    await engine.update(1)
+
+    // Default 1920x1080 applies → Math.min(3840/1920, 2160/1080) = 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen when the provided size is NaN', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    // NaN fails the `> 0` guard, so it disables UI scaling like any other invalid size
+    uiRenderer.setUiRenderer(ui, { virtualWidth: NaN, virtualHeight: 1080 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should use the main renderer size when both main and an additional renderer are valid', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+    const ownerEntity = engine.addEntity()
+
+    // Main renderer options win over any additional renderer's options
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale comes from main: Math.min(3840/1920, 2160/1080) = 2 (not 800x600's 4.8)
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+
+  it('should disable the virtual screen when the main size is invalid, even if an additional renderer has a valid one', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const ownerEntity = engine.addEntity()
+
+    // Main renderer options win, and being invalid they disable UI scaling
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 0, virtualHeight: 0 })
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+
+  it('should use the first additional renderer size when neither main nor earlier renderers have one', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const entity1 = engine.addEntity()
+    const entity2 = engine.addEntity()
+
+    uiRenderer.setUiRenderer(ui)
+    uiRenderer.addUiRenderer(entity1, ui)
+    uiRenderer.addUiRenderer(entity2, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale = Math.min(1600/800, 900/600) = 1.5
+    expect(getUiScaleFactor()).toBeCloseTo(1.5)
+
+    uiRenderer.destroy()
+  })
+
+  it('should release the scale factor when the last renderer is removed', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 1600, 900)
+    const ownerEntity = engine.addEntity()
+
+    uiRenderer.addUiRenderer(ownerEntity, ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBeCloseTo(1.5)
+
+    uiRenderer.removeUiRenderer(ownerEntity)
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(1)
+
+    uiRenderer.destroy()
+  })
+})
+
+describe('Mobile 16:9 virtual screen override', () => {
+  afterEach(() => {
+    setIsMobileProvider(() => false)
+    resetUiScaleFactor()
+  })
+
+  it('should override a 16:9 virtual size to 1600x720 on mobile and log it once', async () => {
+    setIsMobileProvider(() => true)
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1920, virtualHeight: 1080 })
+    await engine.update(1)
+
+    // Overridden to 1600x720 → scale = Math.min(3200/1600, 1440/720) = 2
+    expect(getUiScaleFactor()).toBe(2)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(1)
+    expect(mobileOverrideLogs(logSpy)[0][0]).toContain('1920x1080')
+    expect(mobileOverrideLogs(logSpy)[0][0]).toContain('1600x720')
+
+    // Subsequent ticks must not repeat the log
+    await engine.update(1)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(1)
+
+    // A different 16:9 size logs again
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1280, virtualHeight: 720 })
+    await engine.update(1)
+    expect(getUiScaleFactor()).toBe(2)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(2)
+
+    logSpy.mockRestore()
+    uiRenderer.destroy()
+  })
+
+  it('should respect a non-16:9 virtual size on mobile', async () => {
+    setIsMobileProvider(() => true)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 800, virtualHeight: 600 })
+    await engine.update(1)
+
+    // scale = Math.min(3200/800, 1440/600) = 2.4
+    expect(getUiScaleFactor()).toBeCloseTo(2.4)
+
+    uiRenderer.destroy()
+  })
+
+  it('should respect a 16:9 virtual size on non-mobile platforms', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3840, 2160)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1280, virtualHeight: 720 })
+    await engine.update(1)
+
+    // scale = Math.min(3840/1280, 2160/720) = 3
+    expect(getUiScaleFactor()).toBe(3)
+    expect(mobileOverrideLogs(logSpy)).toHaveLength(0)
+
+    logSpy.mockRestore()
+    uiRenderer.destroy()
+  })
+
+  it('should apply the override when platform detection resolves to mobile after startup', async () => {
+    // Platform detection is async: the first ticks run as non-mobile.
+    let mobile = false
+    setIsMobileProvider(() => mobile)
+    const { engine, uiRenderer } = setupEngine()
+    createCanvasInfo(engine, 3200, 1440)
+
+    uiRenderer.setUiRenderer(ui, { virtualWidth: 1600, virtualHeight: 900 })
+    await engine.update(1)
+
+    // Non-mobile: provided 16:9 size respected → Math.min(3200/1600, 1440/900) = 1.6
+    expect(getUiScaleFactor()).toBeCloseTo(1.6)
+
+    mobile = true
+    await engine.update(1)
+
+    // Mobile: 16:9 overridden to 1600x720 → scale 2
+    expect(getUiScaleFactor()).toBe(2)
+
+    uiRenderer.destroy()
+  })
+})

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=406.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=408.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -6,16 +6,17 @@ SCENE_COMPILED_JS_SIZE_PROD=406.5k bytes
 EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: buffer
   REQUIRE: long
+  REQUIRE: ~system/Runtime
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 80k
-  MALLOC_COUNT = 22699
-  ALIVE_OBJS_DELTA ~= 4.55k
+  MALLOC_COUNT = 22861
+  ALIVE_OBJS_DELTA ~= 4.59k
 CALL onStart()
   OPCODES ~= 0k
-  MALLOC_COUNT = 6
-  ALIVE_OBJS_DELTA ~= 0.00k
+  MALLOC_COUNT = -39
+  ALIVE_OBJS_DELTA ~= -0.01k
 CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Scene: PUT_COMPONENT e=0x200 c=1062 t=1 data={"pointerEvents":[{"eventType":1,"eventInfo":{"button":1,"hoverText":"Press E to spawn","maxDistance":100,"showFeedback":true}}]}
@@ -32,7 +33,8 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x208 c=1050 t=1 data={"parent":523,"rightOf":518,"alignItems":2,"positionType":0,"alignSelf":0,"flexDirection":0,"justifyContent":1,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":2,"width":100,"heightUnit":1,"height":100,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":0,"positionLeft":0,"positionTopUnit":0,"positionTop":0,"positionRightUnit":0,"positionRight":0,"positionBottomUnit":0,"positionBottom":0,"marginLeftUnit":0,"marginLeft":0,"marginTopUnit":0,"marginTop":0,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
   Scene: PUT_COMPONENT e=0x209 c=1050 t=1 data={"parent":523,"rightOf":520,"positionType":0,"alignSelf":0,"flexDirection":0,"justifyContent":0,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":3,"width":0,"heightUnit":0,"height":0,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":0,"positionLeft":0,"positionTopUnit":0,"positionTop":0,"positionRightUnit":0,"positionRight":0,"positionBottomUnit":0,"positionBottom":0,"marginLeftUnit":0,"marginLeft":0,"marginTopUnit":0,"marginTop":0,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
   Scene: PUT_COMPONENT e=0x20a c=1050 t=1 data={"parent":523,"rightOf":521,"positionType":0,"alignSelf":0,"flexDirection":0,"justifyContent":0,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":3,"width":0,"heightUnit":1,"height":36,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":0,"positionLeft":0,"positionTopUnit":0,"positionTop":0,"positionRightUnit":0,"positionRight":0,"positionBottomUnit":0,"positionBottom":0,"marginLeftUnit":0,"marginLeft":0,"marginTopUnit":0,"marginTop":0,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
-  Scene: PUT_COMPONENT e=0x20b c=1050 t=1 data={"parent":0,"rightOf":0,"positionType":0,"alignSelf":0,"flexDirection":0,"justifyContent":0,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":1,"width":700,"heightUnit":1,"height":400,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":0,"positionLeft":0,"positionTopUnit":0,"positionTop":0,"positionRightUnit":0,"positionRight":0,"positionBottomUnit":0,"positionBottom":0,"marginLeftUnit":1,"marginLeft":500,"marginTopUnit":1,"marginTop":35,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
+  Scene: PUT_COMPONENT e=0x20b c=1050 t=1 data={"parent":524,"rightOf":0,"positionType":0,"alignSelf":0,"flexDirection":0,"justifyContent":0,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":1,"width":700,"heightUnit":1,"height":400,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":0,"positionLeft":0,"positionTopUnit":0,"positionTop":0,"positionRightUnit":0,"positionRight":0,"positionBottomUnit":0,"positionBottom":0,"marginLeftUnit":1,"marginLeft":500,"marginTopUnit":1,"marginTop":35,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
+  Scene: PUT_COMPONENT e=0x20c c=1050 t=1 data={"parent":0,"rightOf":0,"positionType":1,"alignSelf":0,"flexDirection":0,"justifyContent":0,"overflow":0,"display":0,"flexBasisUnit":0,"flexBasis":0,"flexGrow":0,"widthUnit":3,"width":0,"heightUnit":0,"height":0,"minWidthUnit":0,"minWidth":0,"minHeightUnit":0,"minHeight":0,"maxWidthUnit":0,"maxWidth":0,"maxHeightUnit":0,"maxHeight":0,"positionLeftUnit":1,"positionLeft":0,"positionTopUnit":1,"positionTop":0,"positionRightUnit":1,"positionRight":0,"positionBottomUnit":1,"positionBottom":0,"marginLeftUnit":0,"marginLeft":0,"marginTopUnit":0,"marginTop":0,"marginRightUnit":0,"marginRight":0,"marginBottomUnit":0,"marginBottom":0,"paddingLeftUnit":0,"paddingLeft":0,"paddingTopUnit":0,"paddingTop":0,"paddingRightUnit":0,"paddingRight":0,"paddingBottomUnit":0,"paddingBottom":0,"pointerFilter":0,"opacity":1,"zIndex":0}
   Scene: PUT_COMPONENT e=0x200 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x203 c=1052 t=1 data={"value":"SDK 7","fontSize":80,"textWrap":0}
   Scene: PUT_COMPONENT e=0x205 c=1052 t=1 data={"value":"Counter:","fontSize":60,"textWrap":0}
@@ -48,22 +50,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 142k
-  MALLOC_COUNT = 971
-  ALIVE_OBJS_DELTA ~= 0.31k
+  OPCODES ~= 151k
+  MALLOC_COUNT = 1016
+  ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 75k
-  MALLOC_COUNT = 259
-  ALIVE_OBJS_DELTA ~= 0.13k
+  OPCODES ~= 82k
+  MALLOC_COUNT = 279
+  ALIVE_OBJS_DELTA ~= 0.14k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=3 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.017452405765652657,"z":0,"w":0.9998477101325989},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 73k
-  MALLOC_COUNT = 35
+  OPCODES ~= 80k
+  MALLOC_COUNT = 37
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=4 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.026176948100328445,"z":0,"w":0.9996573328971863},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 73k
+  OPCODES ~= 80k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1885.10k bytes
+  MEMORY_USAGE_COUNT ~= 1899.45k bytes


### PR DESCRIPTION
**Draft — testing vehicle, not for merge as-is.**

Port of #1489 (default virtual screen + default screen inset area) onto `auth-server`, plus two follow-up changes, so we can publish an SDK build the studio scenes can actually consume and measure the blast radius on real experiences instead of estimating it from source.

## Why a branch off `auth-server`

10 of the 11 studio scenes we want to test pin an `auth-server` build, not a prod release:

| Scene | `@dcl/sdk` | Origin |
| --- | --- | --- |
| Pigeon-Deluxe | `7.24.1` | **prod (npm)** |
| CleanTheClub | `^7.25.1-30310486734.commit-5ffe873` | auth-server |
| flagtag | `7.24.6-29505165911.commit-d270434` | auth-server |
| dead-surge / SkyChaser | `7.24.4-28592331167.commit-697ce9e` | auth-server |
| kickoff-2026 | `7.23.4-26106700711.commit-2afa13b` | auth-server |
| Alienscrap / venetian-hunt | `^7.23.2-25521226778.commit-1828100` | auth-server |
| cozy-farm / TheLivingGarden / towerofmadness | `7.21.1-22918726402.commit-ee210ee` | auth-server |

So the path to those scenes is a build from this branch, not from `main`.

## Contents

Cherry-picks of #1489's own commits, unchanged:

- `chore: ui renderer default virtual screen`
- `corrected mistaken file change`
- `feat: screenInset property for ui renderer`

Plus two follow-ups also pushed to #1489:

- `fix(react-ecs): stop dividing UI layout by devicePixelRatio` — `uiScaleFactor` becomes exactly the contain-fit of the design resolution in the canvas, and `scaleOnDim` resolves `Nvw`/`Nvh` to N% of the canvas dimension, as in CSS. devicePixelRatio is a density hint each renderer computes differently, so dividing by it made UI size inversely proportional to whichever value the scene happened to get.
- `feat(react-ecs): default screenInset to 'device'` — a renderer that passes no `screenInset` now lands in the device safe area. `'none'` opts back into the whole screen.

`#1489`'s `rebuilt snapshots` commit is deliberately **not** cherry-picked: it also reverts 94 lines of `main`-specific lockfile churn. Snapshots are regenerated against `auth-server` here instead.

The UI feature code is byte-identical to #1489 — the only diffs against that branch are pre-existing `auth-server` vs `main` differences (`auth-server` has no `uiInputBinding`).

## Verification

Full clean cycle on this branch — `git clean -xdf && make install && make build && make test`:

```
Test Suites: 1 skipped, 158 passed, 158 of 159 total
Tests:       25 skipped, 1202 passed, 1227 total
```

Working tree clean after the rebuild, so the committed snapshots are exactly what a from-scratch build produces. No `ERR!` lines in `test/snapshots/`.

## What we want to measure

Both follow-ups only bite where `devicePixelRatio != 1` (mobile, Retina desktop) or where `screenInsetArea` is non-zero (notched devices), which is exactly what source review cannot settle. Highest-signal scenes:

- **CleanTheClub** — the only one hit by both changes. `src/ui.tsx` is calibrated explicitly against the old `uiScaleFactor = canvasH/VIRTUAL_H/dpr`, and `src/client/safeArea.ts` already derives its own insets from `interactableArea` as fractions of the full canvas, so the device-inset wrapper compounds with it.
- **Pigeon-Deluxe** — the only prod-pinned scene; its full-screen fade (`width:'100%', height:'100%', absolute`) is the clearest failure mode for the inset default.
- **dead-surge** — compensates for dpr by hand (`lobbyStoreUi.tsx:71-74`) and is the only scene mixing `vw`/`vh` with `%`.

