### PR TITLE
test(sdk): characterization baseline for the network layer refactor

### DIFF
--- a/test/sdk/network/__snapshots__/characterization-wire.spec.ts.snap
+++ b/test/sdk/network/__snapshots__/characterization-wire.spec.ts.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`wire format characterization events protocol envelope pins the encoded event bytes and the decoded envelope 1`] = `"0400000070696e670068e5cf8b010000020000006869"`;
+
+exports[`wire format characterization server/utils codec conversions localMessageToNetwork pins the network encoding of every regular message 1`] = `
+[
+  {
+    "bytes": "200000000500000000020000d2040000010000000700000004000000deadbeef",
+    "from": "PUT_COMPONENT",
+  },
+  {
+    "bytes": "",
+    "from": "AUTHORITATIVE_PUT_COMPONENT",
+  },
+  {
+    "bytes": "180000000600000000020000d20400000300000007000000",
+    "from": "DELETE_COMPONENT",
+  },
+  {
+    "bytes": "0c000000070000000002000007000000",
+    "from": "DELETE_ENTITY",
+  },
+]
+`;
+
+exports[`wire format characterization server/utils codec conversions networkMessageToLocal pins the local encoding of every network message 1`] = `
+[
+  {
+    "bytes": "1c0000000100000001020000d20400000400000004000000deadbeef",
+    "from": "PUT_COMPONENT_NETWORK",
+    "to": "PUT_COMPONENT",
+  },
+  {
+    "bytes": "140000000200000001020000d204000005000000",
+    "from": "DELETE_COMPONENT_NETWORK",
+    "to": "DELETE_COMPONENT",
+  },
+  {
+    "bytes": "0c0000000300000001020000",
+    "from": "DELETE_ENTITY_NETWORK",
+    "to": "DELETE_ENTITY",
+  },
+]
+`;
+
+exports[`wire format characterization server/utils codec conversions networkMessageToLocal rewrites the Transform parent from NetworkParent 1`] = `
+{
+  "withParent": "44000000010000000102000001000000010000002c0000000000803f00000040000040400000000000000000000000000000803f0000803f0000803f0000803f58020000",
+  "withoutParent": "44000000010000000102000001000000010000002c0000000000803f00000040000040400000000000000000000000000000803f0000803f0000803f0000803f00000000",
+}
+`;
+
+exports[`wire format characterization server/utils codec conversions networkMessageToLocal with forceCorrections emits AUTHORITATIVE_PUT_COMPONENT 1`] = `"1c0000000800000001020000d20400000400000004000000deadbeef"`;
+
+exports[`wire format characterization server/utils readMessages parses every supported message shape and slices the exact source bytes 1`] = `
+[
+  {
+    "bytes": "1c0000000100000000020000d20400000100000004000000deadbeef",
+    "componentId": 1234,
+    "data": "deadbeef",
+    "entityId": 512,
+    "networkId": undefined,
+    "timestamp": 1,
+    "type": "PUT_COMPONENT",
+  },
+  {
+    "bytes": "1c0000000800000000020000d20400000200000004000000deadbeef",
+    "componentId": 1234,
+    "data": "deadbeef",
+    "entityId": 512,
+    "networkId": undefined,
+    "timestamp": 2,
+    "type": "AUTHORITATIVE_PUT_COMPONENT",
+  },
+  {
+    "bytes": "140000000200000000020000d204000003000000",
+    "componentId": 1234,
+    "data": undefined,
+    "entityId": 512,
+    "networkId": undefined,
+    "timestamp": 3,
+    "type": "DELETE_COMPONENT",
+  },
+  {
+    "bytes": "0c0000000300000000020000",
+    "componentId": undefined,
+    "data": undefined,
+    "entityId": 512,
+    "networkId": undefined,
+    "timestamp": undefined,
+    "type": "DELETE_ENTITY",
+  },
+  {
+    "bytes": "200000000500000000020000d2040000040000000700000004000000deadbeef",
+    "componentId": 1234,
+    "data": "deadbeef",
+    "entityId": 512,
+    "networkId": 7,
+    "timestamp": 4,
+    "type": "PUT_COMPONENT_NETWORK",
+  },
+  {
+    "bytes": "180000000600000000020000d20400000500000007000000",
+    "componentId": 1234,
+    "data": undefined,
+    "entityId": 512,
+    "networkId": 7,
+    "timestamp": 5,
+    "type": "DELETE_COMPONENT_NETWORK",
+  },
+  {
+    "bytes": "0c000000070000000002000007000000",
+    "componentId": undefined,
+    "data": undefined,
+    "entityId": 512,
+    "networkId": 7,
+    "timestamp": undefined,
+    "type": "DELETE_ENTITY_NETWORK",
+  },
+]
+`;
+
+exports[`wire format characterization state engineToCrdt dumps only NetworkEntity-tagged entities, as network messages 1`] = `"2800000005000000000200007e0a1d4001000000070000000c0000000700000000000000000200002800000005000000010200007e0a1d4001000000070000000c00000007000000000000000102000028000000050000000002000049d39d8501000000070000000c00000001000000c33771ef0000000028000000050000000102000049d39d8501000000070000000c00000001000000c33771ef00000000250000000500000000020000c33771ef010000000700000009000000050000006669727374260000000500000001020000c33771ef01000000070000000a000000060000007365636f6e64"`;

--- a/test/sdk/network/characterization-api.spec.ts
+++ b/test/sdk/network/characterization-api.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Characterization: the public surface of `@dcl/sdk/network` and
+ * `@dcl/sdk/network/events`.
+ *
+ * Importing `network/index.ts` has side effects (it boots the sync transport on
+ * the global engine and registers the global room), which is exactly what a
+ * scene gets, so the module is loaded once here and the exported helpers are
+ * driven against the global engine.
+ *
+ * Already covered elsewhere (not duplicated here):
+ *   - `syncEntity` propagating an entity + component through comms and the
+ *     NetworkEntity mapping seen by the other peers:
+ *     `server-client-connectivity.spec.ts`
+ *   - `isStateSyncronized()` flipping to true after the hydration handshake, and
+ *     the room send/onMessage round-trip: `characterization-flow.spec.ts`
+ *
+ * What is new here: the exported name set, the pre-resolution state of the
+ * async runtime APIs (`isServer`, `myProfile`), the local semantics of the
+ * entity helpers (parenting, children, error messages, non-syncable component
+ * stripping) and the `registerMessages`/`getRoom` contract.
+ */
+import type * as NetworkApi from '../../../packages/@dcl/sdk/src/network/index'
+import {
+  Entity,
+  NetworkEntity,
+  NetworkParent,
+  Schemas,
+  SyncComponents,
+  Transform,
+  UiTransform,
+  engine
+} from '../../../packages/@dcl/ecs'
+import { componentNumberFromName } from '../../../packages/@dcl/ecs/dist/components/component-number'
+import type { Room } from '../../../packages/@dcl/sdk/src/network/events/implementation'
+
+const mockSendBinary = jest.fn(async () => ({ data: [] as Uint8Array[] }))
+const mockGetUserData = jest.fn()
+const mockIsServer = jest.fn()
+
+// `~system/*` only exists as ambient type declarations, hence `virtual: true`
+jest.mock('~system/CommunicationsController', () => ({ sendBinary: () => mockSendBinary() }), { virtual: true })
+jest.mock('~system/UserIdentity', () => ({ getUserData: () => mockGetUserData() }), { virtual: true })
+jest.mock('~system/EngineApi', () => ({ isServer: () => mockIsServer() }), { virtual: true })
+
+const USER_ID = '0xsome-user'
+
+/** Compile-time signature pins. Never executed: the body only has to typecheck. */
+function signaturePins() {
+  const api = {} as typeof NetworkApi
+
+  const syncEntity: (entityId: Entity, componentIds: number[], entityEnumId?: number) => void = api.syncEntity
+  const parentEntity: (entity: Entity, parent: Entity) => void = api.parentEntity
+  const getParent: (child: Entity) => Entity | undefined = api.getParent
+  const getChildren: (parent: Entity) => Iterable<Entity> = api.getChildren
+  const getFirstChild: (entity: Entity) => Entity = api.getFirstChild
+  const removeParent: (entity: Entity) => void = api.removeParent
+  const isServer: () => boolean = api.isServer
+  const isStateSyncronized: () => boolean = api.isStateSyncronized
+  const myProfile: { networkId: number; userId: string } = api.myProfile
+  void [syncEntity, parentEntity, getParent, getChildren, getFirstChild, removeParent]
+  void [isServer, isStateSyncronized, myProfile]
+
+  // @ts-expect-error componentIds is required
+  api.syncEntity(0 as Entity)
+  // @ts-expect-error entityEnumId is a number, not a string
+  api.syncEntity(0 as Entity, [], 'enum-id')
+  // @ts-expect-error parentEntity needs both entities
+  api.parentEntity(0 as Entity)
+  // @ts-expect-error myProfile only carries networkId and userId
+  void api.myProfile.address
+}
+
+describe('@dcl/sdk/network public surface characterization', () => {
+  let network: typeof NetworkApi
+  let resolveIsServer!: (value: { isServer: boolean }) => void
+  let resolveUserData!: (value: unknown) => void
+  // one shared deferred per API: `isServer` is queried more than once at boot
+  const isServerResponse = new Promise<{ isServer: boolean }>((resolve) => (resolveIsServer = resolve))
+  const userDataResponse = new Promise<unknown>((resolve) => (resolveUserData = resolve))
+
+  beforeAll(async () => {
+    mockIsServer.mockImplementation(() => isServerResponse)
+    mockGetUserData.mockImplementation(() => userDataResponse)
+    network = await import('../../../packages/@dcl/sdk/src/network/index')
+  })
+
+  it('exports exactly the documented names', async () => {
+    expect(Object.keys(network).sort()).toEqual([
+      'binaryMessageBus',
+      'eventBus',
+      'getChildren',
+      'getFirstChild',
+      'getParent',
+      'getRoom',
+      'isServer',
+      'isStateSyncronized',
+      'myProfile',
+      'parentEntity',
+      'registerMessages',
+      'removeParent',
+      'syncEntity'
+    ])
+    const events = await import('../../../packages/@dcl/sdk/src/network/events')
+    expect(Object.keys(events).sort()).toEqual(['getRoom', 'registerMessages'])
+  })
+
+  // NOTE: declared before the rest on purpose — it settles the runtime APIs the
+  // following tests depend on.
+  it('reports isServer() === false and an empty myProfile until the runtime APIs settle', async () => {
+    expect(network.isServer()).toBe(false)
+    expect(network.myProfile).toEqual({})
+    expect(network.isStateSyncronized()).toBe(false)
+    // the role is asked twice at boot: once for the exported isServer(), once
+    // inside addSyncTransport — two independent atoms over the same answer
+    expect(mockIsServer).toHaveBeenCalledTimes(2)
+    expect(mockGetUserData).toHaveBeenCalledTimes(1)
+
+    resolveIsServer({ isServer: true })
+    resolveUserData({ data: { userId: USER_ID, version: 1, displayName: 'u', hasConnectedWeb3: true } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(network.isServer()).toBe(true)
+    expect(Object.keys(network.myProfile).sort()).toEqual(['networkId', 'userId'])
+    expect(network.myProfile.userId).toBe(USER_ID)
+    // the networkId is derived from the user id, it is not random
+    expect(network.myProfile.networkId).toBe(componentNumberFromName(USER_ID))
+  })
+
+  describe('entity helpers', () => {
+    it('syncEntity tags the entity with NetworkEntity + SyncComponents', () => {
+      const entity = engineEntity()
+      network.syncEntity(entity, [Transform.componentId])
+
+      expect(NetworkEntity.get(entity)).toEqual({ entityId: entity, networkId: network.myProfile.networkId })
+      expect(SyncComponents.get(entity)).toEqual({ componentIds: [Transform.componentId] })
+    })
+
+    it('syncEntity strips components that cannot be synced and warns about them', () => {
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+      const entity = engineEntity()
+      network.syncEntity(entity, [Transform.componentId, UiTransform.componentId])
+
+      expect(SyncComponents.get(entity)).toEqual({ componentIds: [Transform.componentId] })
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("can't be sync through the network"))
+      log.mockRestore()
+    })
+
+    it('syncEntity with an entityEnumId pins networkId 0 and rejects a reused id', () => {
+      const entity = engineEntity()
+      network.syncEntity(entity, [Transform.componentId], 42)
+      expect(NetworkEntity.get(entity)).toEqual({ entityId: 42, networkId: 0 })
+
+      const other = engineEntity()
+      expect(() => network.syncEntity(other, [Transform.componentId], 42)).toThrowError(
+        'syncEntity failed because the id provided is already in use'
+      )
+    })
+
+    it('parentEntity / getParent / getChildren / removeParent operate on the network identity', () => {
+      const parent = engineEntity()
+      const child = engineEntity()
+      network.syncEntity(parent, [Transform.componentId])
+      network.syncEntity(child, [Transform.componentId])
+
+      expect(network.getParent(child)).toBeUndefined()
+      expect(Array.from(network.getChildren(parent))).toEqual([])
+
+      network.parentEntity(child, parent)
+
+      expect(NetworkParent.get(child)).toEqual(NetworkEntity.get(parent))
+      expect(network.getParent(child)).toBe(parent)
+      expect(Array.from(network.getChildren(parent))).toEqual([child])
+      expect(network.getFirstChild(parent)).toBe(child)
+      // parenting always leaves a Transform behind so the renderer gets the parent
+      expect(Transform.has(child)).toBe(true)
+
+      network.removeParent(child)
+      expect(NetworkParent.getOrNull(child)).toBeNull()
+      expect(network.getParent(child)).toBeUndefined()
+      expect(Array.from(network.getChildren(parent))).toEqual([])
+      expect(network.getFirstChild(parent)).toBeUndefined()
+    })
+
+    it('getChildren of a non-synced entity is empty, parentEntity / removeParent throw', () => {
+      const plain = engineEntity()
+      const synced = engineEntity()
+      network.syncEntity(synced, [])
+
+      expect(Array.from(network.getChildren(plain))).toEqual([])
+      expect(() => network.parentEntity(synced, plain)).toThrowError(
+        'Entity is not sync. Call syncEntity on the parent.'
+      )
+      expect(() => network.removeParent(plain)).toThrowError('Entity is not sync')
+    })
+  })
+
+  describe('room messaging surface', () => {
+    it('registerMessages and getRoom hand out the single global room', () => {
+      const first = network.registerMessages({ ping: Schemas.Map({ text: Schemas.String }) })
+      const second = network.registerMessages({ pong: Schemas.Map({ text: Schemas.String }) })
+
+      expect(first).toBe(second)
+      expect(network.getRoom()).toBe(first)
+      expect(network.eventBus).toBe(first)
+    })
+
+    it('onMessage returns an unsubscribe and the room is not ready before comms', () => {
+      const room = network.getRoom() as Room
+      const unsubscribe = room.onMessage('ping', () => {})
+
+      expect(room.listenerCount('ping')).toBe(1)
+      unsubscribe()
+      expect(room.listenerCount('ping')).toBe(0)
+      expect(room.isReady()).toBe(false)
+    })
+  })
+
+  it('pins the exported signatures (compile-time only)', () => {
+    expect(typeof signaturePins).toBe('function')
+  })
+})
+
+/** The network module wires the global engine, so the helpers act on it. */
+function engineEntity(): Entity {
+  return engine.addEntity()
+}

--- a/test/sdk/network/characterization-flow.spec.ts
+++ b/test/sdk/network/characterization-flow.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Characterization: end-to-end message flow over the 3-engine harness
+ * (authoritative server + 2 clients).
+ *
+ * These tests pin CURRENT behavior — including the quirks, which are marked with
+ * `QUIRK(pinned)` and are expected to be deleted/moved once the corresponding
+ * defect is fixed (each quirk has a matching red test in `defects-red.spec.ts`).
+ *
+ * Already covered elsewhere (not duplicated here):
+ *   - client A -> server -> client B propagation of a synced Transform,
+ *     bidirectional updates and server-originated entities:
+ *     `server-client-connectivity.spec.ts`
+ *   - server-side validateBeforeChange / dry-run invocation:
+ *     `server-client-connectivity.spec.ts`
+ *   - 12KB chunking of outgoing CRDT: `crdt-chunking.spec.ts`,
+ *     `chunking-debug.spec.ts`, `network-transport.spec.ts`
+ *
+ * What is new here: the REQ/RES_CRDT_STATE hydration handshake, late-join
+ * hydration, the room (CUSTOM_EVENT) round-trip incl. queueing and targeted
+ * sends, and the convergence oracle applied at the end of every scenario.
+ */
+import { Schemas } from '../../../packages/@dcl/ecs'
+import { CommsMessage } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { registerMessages } from '../../../packages/@dcl/sdk/src/network/events/implementation'
+import { expectConvergence } from './utils/convergence'
+import { CLIENT_A, CLIENT_B, SERVER, createHarness, flush, setRealmConnected } from './utils/harness'
+
+const Messages = {
+  ping: Schemas.Map({ text: Schemas.String }),
+  pong: Schemas.Map({ text: Schemas.String })
+}
+
+describe('network flow characterization', () => {
+  const harness = createHarness()
+  const { clientA, clientB, server } = harness
+
+  it('hydration handshake: clients request state on connect and the server answers each sender', async () => {
+    harness.clear()
+    await harness.connect()
+
+    const requests = harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE)
+    expect(requests.length).toBeGreaterThanOrEqual(1)
+    // QUIRK(pinned): the state request is broadcast to every peer instead of
+    // being addressed to the authoritative server — see defect #1/#10.
+    expect(requests[0].to).toEqual([])
+
+    const responses = harness.sentBy(SERVER, CommsMessage.RES_CRDT_STATE)
+    expect(responses.map((response) => response.to)).toEqual(expect.arrayContaining([[CLIENT_A], [CLIENT_B]]))
+    // the server is empty at this point, so the answer is the empty payload branch
+    expect(responses.every((response) => response.payload.byteLength === 0)).toBe(true)
+
+    expect(clientA.sync.isStateSyncronized()).toBe(true)
+    expect(clientB.sync.isStateSyncronized()).toBe(true)
+    // QUIRK(pinned): the server never receives a RES_CRDT_STATE, so its own
+    // isStateSyncronized() stays false forever — see defect #14.
+    expect(server.sync.isStateSyncronized()).toBe(false)
+    expect(clientA.sync.isRoomReadyAtom.getOrNull()).toBe(true)
+    expect(server.sync.isRoomReadyAtom.getOrNull()).toBe(true)
+  })
+
+  it('client write is validated by the server, broadcast, and converges on the other client', async () => {
+    harness.clear()
+    const entity = clientA.engine.addEntity()
+    clientA.components.Transform.create(entity, { position: { x: 1, y: 2, z: 3 } })
+    clientA.sync.syncEntity(entity, [clientA.components.Transform.componentId])
+
+    await harness.tick()
+
+    const networkId = clientA.sync.myProfile.networkId
+    const [serverEntity] = Array.from(server.engine.getEntitiesWith(server.components.NetworkEntity)).filter(
+      ([, network]) => network.networkId === networkId && network.entityId === entity
+    )[0]
+    expect(server.components.Transform.get(serverEntity).position).toMatchObject({ x: 1, y: 2, z: 3 })
+    // the server records the author of every entity it learns from a client
+    expect(server.components.CreatedBy.get(serverEntity).address).toBe(CLIENT_A)
+
+    const [clientBEntity] = Array.from(clientB.engine.getEntitiesWith(clientB.components.NetworkEntity)).filter(
+      ([, network]) => network.networkId === networkId && network.entityId === entity
+    )[0]
+    expect(clientB.components.Transform.get(clientBEntity).position).toMatchObject({ x: 1, y: 2, z: 3 })
+
+    // QUIRK(pinned): a client emits CRDT with an empty address list (broadcast)
+    // rather than addressing the server — see defect #10.
+    expect(harness.sentBy(CLIENT_A, CommsMessage.CRDT)[0].to).toEqual([])
+    // QUIRK(pinned): the server re-broadcasts to everybody, so the originating
+    // client receives an echo of its own write — see defect #11.
+    expect(harness.sentBy(SERVER, CommsMessage.CRDT)[0].to).toEqual([])
+    expect(harness.deliveredTo(CLIENT_A, CommsMessage.CRDT).length).toBeGreaterThanOrEqual(1)
+
+    expectConvergence({ server: server.engine, clientA: clientA.engine, clientB: clientB.engine })
+  })
+
+  it('late joiner asks for state and the server answers with the full dump targeted to the sender', async () => {
+    const clientC = harness.attach('clientC', false)
+    harness.clear()
+    await flush()
+    setRealmConnected(true)
+    await harness.tick(6)
+
+    const responsesToC = harness
+      .sentBy(SERVER, CommsMessage.RES_CRDT_STATE)
+      .filter((response) => response.to.includes('clientC'))
+    expect(responsesToC.length).toBeGreaterThanOrEqual(1)
+    // targeted to the requester only
+    expect(responsesToC[0].to).toEqual(['clientC'])
+    expect(responsesToC[0].payload.byteLength).toBeGreaterThan(0)
+
+    expect(clientC.sync.isStateSyncronized()).toBe(true)
+    expect(harness.entities(clientC)).toHaveLength(1)
+    expectConvergence({
+      server: server.engine,
+      clientA: clientA.engine,
+      clientB: clientB.engine,
+      clientC: clientC.engine
+    })
+  })
+
+  it('room messages: client -> server carries the sender context, server -> client is filtered by sender', async () => {
+    registerMessages(Messages)
+    harness.clear()
+
+    const serverInbox: { text: string; from?: string }[] = []
+    const clientAInbox: string[] = []
+    const clientBInbox: string[] = []
+    server.sync.eventBus.onMessage('ping', (data: { text: string }, context?: { from: string }) => {
+      serverInbox.push({ text: data.text, from: context?.from })
+    })
+    clientA.sync.eventBus.onMessage('pong', (data: { text: string }) => clientAInbox.push(data.text))
+    clientB.sync.eventBus.onMessage('pong', (data: { text: string }) => clientBInbox.push(data.text))
+
+    await clientA.sync.eventBus.send('ping', { text: 'from-a' })
+    await harness.tick()
+
+    expect(serverInbox).toEqual([{ text: 'from-a', from: CLIENT_A }])
+
+    // SendOptions.to => only the addressed client receives it
+    await server.sync.eventBus.send('pong', { text: 'only-b' }, { to: [CLIENT_B] })
+    await harness.tick()
+    expect(clientBInbox).toEqual(['only-b'])
+    expect(clientAInbox).toEqual([])
+
+    // no options => broadcast to every client
+    await server.sync.eventBus.send('pong', { text: 'everyone' })
+    await harness.tick()
+    expect(clientAInbox).toEqual(['everyone'])
+    expect(clientBInbox).toEqual(['only-b', 'everyone'])
+  })
+
+  it('room messages sent before the room is ready are queued and flushed on readiness', async () => {
+    const queuedHarness = createHarness()
+    registerMessages(Messages)
+    const inbox: string[] = []
+    queuedHarness.server.sync.eventBus.onMessage('ping', (data: { text: string }) => inbox.push(data.text))
+
+    expect(queuedHarness.clientA.sync.eventBus.isReady()).toBe(false)
+    await queuedHarness.clientA.sync.eventBus.send('ping', { text: 'queued' })
+    await queuedHarness.tick()
+
+    expect(queuedHarness.sentBy(CLIENT_A, CommsMessage.CUSTOM_EVENT)).toHaveLength(0)
+    expect(inbox).toEqual([])
+
+    await queuedHarness.connect()
+    await queuedHarness.tick()
+
+    expect(queuedHarness.clientA.sync.eventBus.isReady()).toBe(true)
+    expect(queuedHarness.sentBy(CLIENT_A, CommsMessage.CUSTOM_EVENT)).toHaveLength(1)
+    expect(inbox).toEqual(['queued'])
+  })
+
+  it('QUIRK(pinned): a non-server peer answers REQ_CRDT_STATE — see defect #1', async () => {
+    // will move to the red suite when the responder gets an isServer guard
+    harness.clear()
+    harness.inject(CLIENT_A, CLIENT_B, CommsMessage.REQ_CRDT_STATE, new Uint8Array())
+    await harness.tick()
+
+    expect(harness.sentBy(CLIENT_A, CommsMessage.RES_CRDT_STATE).map((response) => response.to)).toEqual([[CLIENT_B]])
+  })
+})

--- a/test/sdk/network/characterization-wire.spec.ts
+++ b/test/sdk/network/characterization-wire.spec.ts
@@ -1,0 +1,402 @@
+/**
+ * Characterization: wire format (golden bytes).
+ *
+ * Protects the future codec unification. Every buffer that crosses comms today
+ * is produced by one of the functions pinned here, so a refactor that changes a
+ * single byte will show up as a snapshot diff.
+ *
+ * Already covered elsewhere (not duplicated here):
+ *   - `PutNetworkComponentOperation` / `DeleteComponentNetwork` /
+ *     `DeleteEntityNetwork` read/write round-trips at the @dcl/ecs level:
+ *     `messages.spec.ts`
+ *   - `engineToCrdt` producing a 3-message dump: `state-to-crdt.spec.ts`
+ *   - chunk sizing under load: `crdt-chunking.spec.ts`, `chunking-debug.spec.ts`
+ *
+ * All inputs are fixed (entity ids, timestamps, payloads) so the bytes are
+ * deterministic. `Date.now()` is mocked where the format embeds it.
+ */
+import { Engine, Entity, Schemas } from '../../../packages/@dcl/ecs'
+import * as components from '../../../packages/@dcl/ecs/dist/components'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/dist/serialization/ByteBuffer'
+import {
+  AuthoritativePutComponentOperation,
+  CrdtMessageType,
+  DeleteComponent,
+  DeleteComponentNetwork,
+  DeleteEntity,
+  DeleteEntityNetwork,
+  PutComponentOperation,
+  PutNetworkComponentOperation
+} from '../../../packages/@dcl/ecs/dist/serialization/crdt'
+import {
+  COMPONENT_ID as TransformComponentId,
+  TransformSchema
+} from '../../../packages/@dcl/ecs/dist/components/manual/Transform'
+import {
+  BinaryMessageBus,
+  CommsMessage,
+  craftCommsMessage,
+  decodeCommsMessage,
+  decodeString,
+  encodeString
+} from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { chunkCrdtMessages } from '../../../packages/@dcl/sdk/src/network/chunking'
+import { engineToCrdt } from '../../../packages/@dcl/sdk/src/network/state'
+import {
+  NetworkMessage,
+  RegularMessage,
+  isNetworkMessage,
+  localMessageToNetwork,
+  networkMessageToLocal,
+  readMessages
+} from '../../../packages/@dcl/sdk/src/network/server/utils'
+import { decodeEvent, encodeEvent } from '../../../packages/@dcl/sdk/src/network/events/protocol'
+import { toHex } from './utils/hex'
+
+const ENTITY = 512 as Entity
+const LOCAL_ENTITY = 513 as Entity
+const NETWORK_ID = 7
+const COMPONENT_ID = 1234
+const PAYLOAD = Uint8Array.of(0xde, 0xad, 0xbe, 0xef)
+
+/** One buffer holding every message shape `readMessages` understands. */
+function allMessageShapes(): Uint8Array {
+  const buffer = new ReadWriteByteBuffer()
+  PutComponentOperation.write(ENTITY, 1, COMPONENT_ID, PAYLOAD, buffer)
+  AuthoritativePutComponentOperation.write(ENTITY, 2, COMPONENT_ID, PAYLOAD, buffer)
+  DeleteComponent.write(ENTITY, COMPONENT_ID, 3, buffer)
+  DeleteEntity.write(ENTITY, buffer)
+  PutNetworkComponentOperation.write(ENTITY, 4, COMPONENT_ID, NETWORK_ID, PAYLOAD, buffer)
+  DeleteComponentNetwork.write(ENTITY, COMPONENT_ID, 5, NETWORK_ID, buffer)
+  DeleteEntityNetwork.write(ENTITY, NETWORK_ID, buffer)
+  return buffer.toBinary()
+}
+
+function transformParentOf(buffer: Uint8Array): number {
+  const [message] = readMessages(buffer)
+  if (!('data' in message)) throw new Error(`expected a put message, got ${CrdtMessageType[message.type]}`)
+  return TransformSchema.deserialize(new ReadWriteByteBuffer(message.data)).parent as number
+}
+
+function describeMessage(message: NetworkMessage | RegularMessage) {
+  return {
+    type: CrdtMessageType[message.type],
+    entityId: message.entityId,
+    componentId: 'componentId' in message ? message.componentId : undefined,
+    timestamp: 'timestamp' in message ? message.timestamp : undefined,
+    networkId: 'networkId' in message ? message.networkId : undefined,
+    data: 'data' in message ? toHex(message.data) : undefined,
+    bytes: toHex(message.messageBuffer)
+  }
+}
+
+describe('wire format characterization', () => {
+  describe('server/utils readMessages', () => {
+    it('parses every supported message shape and slices the exact source bytes', () => {
+      const messages = readMessages(allMessageShapes())
+      expect(messages.map(describeMessage)).toMatchSnapshot()
+      expect(messages.map((message) => isNetworkMessage(message))).toEqual([
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
+      ])
+      // the slices concatenated back must reproduce the source buffer byte for byte
+      expect(messages.map((message) => toHex(message.messageBuffer)).join('')).toEqual(toHex(allMessageShapes()))
+    })
+
+    it('consumes unknown message types and stops at a truncated tail', () => {
+      const buffer = new ReadWriteByteBuffer()
+      // unknown message: 8 byte header (length, type) + 4 byte body
+      buffer.writeUint32(12)
+      buffer.writeUint32(0xff)
+      buffer.writeUint32(0)
+      PutComponentOperation.write(ENTITY, 1, COMPONENT_ID, PAYLOAD, buffer)
+      const withUnknown = readMessages(buffer.toBinary())
+      expect(withUnknown).toHaveLength(1)
+      expect(withUnknown[0].type).toBe(CrdtMessageType.PUT_COMPONENT)
+
+      const truncated = allMessageShapes().subarray(0, 10)
+      expect(readMessages(truncated)).toHaveLength(0)
+    })
+  })
+
+  describe('server/utils codec conversions', () => {
+    it('localMessageToNetwork pins the network encoding of every regular message', () => {
+      const regular = readMessages(allMessageShapes()).filter((message) => !isNetworkMessage(message))
+      const encoded = regular.map((message) => {
+        const buffer = new ReadWriteByteBuffer()
+        localMessageToNetwork(message as never, { networkId: NETWORK_ID, entityId: ENTITY }, buffer)
+        return { from: CrdtMessageType[message.type], bytes: toHex(buffer.toBinary()) }
+      })
+      expect(encoded).toMatchSnapshot()
+      // AUTHORITATIVE_PUT_COMPONENT has no network counterpart: it encodes to nothing
+      expect(encoded.find((entry) => entry.from === 'AUTHORITATIVE_PUT_COMPONENT')!.bytes).toBe('')
+    })
+
+    it('networkMessageToLocal pins the local encoding of every network message', () => {
+      const network = readMessages(allMessageShapes()).filter((message) => isNetworkMessage(message))
+      const encoded = network.map((message) => {
+        const buffer = new ReadWriteByteBuffer()
+        const body = networkMessageToLocal(message as never, LOCAL_ENTITY, buffer)
+        return { from: CrdtMessageType[message.type], to: CrdtMessageType[body.type], bytes: toHex(buffer.toBinary()) }
+      })
+      expect(encoded).toMatchSnapshot()
+    })
+
+    it('networkMessageToLocal with forceCorrections emits AUTHORITATIVE_PUT_COMPONENT', () => {
+      const [put] = readMessages(allMessageShapes()).filter(
+        (message) => message.type === CrdtMessageType.PUT_COMPONENT_NETWORK
+      )
+      const buffer = new ReadWriteByteBuffer()
+      const body = networkMessageToLocal(put as never, LOCAL_ENTITY, buffer, undefined, true)
+      expect(body.type).toBe(CrdtMessageType.AUTHORITATIVE_PUT_COMPONENT)
+      expect(toHex(buffer.toBinary())).toMatchSnapshot()
+    })
+
+    it('networkMessageToLocal rewrites the Transform parent from NetworkParent', () => {
+      const engine = Engine()
+      const NetworkParent = components.NetworkParent(engine)
+      NetworkParent.create(LOCAL_ENTITY, { networkId: NETWORK_ID, entityId: 600 as Entity })
+
+      const transformPayload = new ReadWriteByteBuffer()
+      TransformSchema.serialize(
+        {
+          position: { x: 1, y: 2, z: 3 },
+          rotation: { x: 0, y: 0, z: 0, w: 1 },
+          scale: { x: 1, y: 1, z: 1 },
+          parent: 0 as Entity
+        },
+        transformPayload
+      )
+      const source = new ReadWriteByteBuffer()
+      PutNetworkComponentOperation.write(
+        ENTITY,
+        1,
+        TransformComponentId,
+        NETWORK_ID,
+        transformPayload.toBinary(),
+        source
+      )
+      const [message] = readMessages(source.toBinary())
+
+      const withoutParent = new ReadWriteByteBuffer()
+      networkMessageToLocal(message as never, LOCAL_ENTITY, withoutParent)
+      const withParent = new ReadWriteByteBuffer()
+      networkMessageToLocal(message as never, LOCAL_ENTITY, withParent, NetworkParent as never)
+
+      expect(transformParentOf(withoutParent.toBinary())).toBe(0)
+      expect(transformParentOf(withParent.toBinary())).toBe(600)
+      expect({
+        withoutParent: toHex(withoutParent.toBinary()),
+        withParent: toHex(withParent.toBinary())
+      }).toMatchSnapshot()
+    })
+
+    it('round-trips local -> network -> local without changing the bytes', () => {
+      const buffer = new ReadWriteByteBuffer()
+      PutComponentOperation.write(ENTITY, 1, COMPONENT_ID, PAYLOAD, buffer)
+      DeleteComponent.write(ENTITY, COMPONENT_ID, 3, buffer)
+      DeleteEntity.write(ENTITY, buffer)
+      const original = buffer.toBinary()
+
+      const network = new ReadWriteByteBuffer()
+      for (const message of readMessages(original)) {
+        localMessageToNetwork(message as never, { networkId: NETWORK_ID, entityId: ENTITY }, network)
+      }
+      const local = new ReadWriteByteBuffer()
+      for (const message of readMessages(network.toBinary())) {
+        networkMessageToLocal(message as never, ENTITY, local)
+      }
+      expect(toHex(local.toBinary())).toEqual(toHex(original))
+    })
+  })
+
+  describe('chunking', () => {
+    /** Each message is 8 bytes of header + 16 bytes of fields + payload. */
+    function messagesOfSize(count: number, payloadSize: number): Uint8Array {
+      const buffer = new ReadWriteByteBuffer()
+      for (let i = 0; i < count; i++) {
+        PutComponentOperation.write(ENTITY, i + 1, COMPONENT_ID, new Uint8Array(payloadSize), buffer)
+      }
+      return buffer.toBinary()
+    }
+
+    it('respects message boundaries at the 12KB limit', () => {
+      const data = messagesOfSize(12, 2048)
+      const messageSize = readMessages(data)[0].messageBuffer.byteLength
+      expect(messageSize).toBe(2072)
+
+      const chunks = chunkCrdtMessages(data, 12)
+      expect(chunks.map((chunk) => chunk.byteLength)).toEqual([10360, 10360, 4144])
+      // no message is split: every chunk re-parses into whole messages
+      expect(chunks.map((chunk) => readMessages(chunk).length)).toEqual([5, 5, 2])
+      for (const chunk of chunks) {
+        expect(readMessages(chunk).reduce((total, message) => total + message.messageBuffer.byteLength, 0)).toBe(
+          chunk.byteLength
+        )
+      }
+      expect(chunks.reduce((total, chunk) => total + chunk.byteLength, 0)).toBe(data.byteLength)
+      expect(chunkCrdtMessages(new Uint8Array(), 12)).toEqual([])
+    })
+
+    it('drops a single message larger than the limit', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const buffer = new ReadWriteByteBuffer()
+      PutComponentOperation.write(ENTITY, 1, COMPONENT_ID, new Uint8Array(64), buffer)
+      PutComponentOperation.write(ENTITY, 2, COMPONENT_ID, new Uint8Array(13 * 1024), buffer)
+      PutComponentOperation.write(ENTITY, 3, COMPONENT_ID, new Uint8Array(64), buffer)
+
+      const chunks = chunkCrdtMessages(buffer.toBinary(), 12)
+      const timestamps = chunks.flatMap((chunk) =>
+        readMessages(chunk).map((message) => ('timestamp' in message ? message.timestamp : -1))
+      )
+      // the oversized message is silently skipped, the small ones survive
+      expect(timestamps).toEqual([1, 3])
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('Message too large (13336 bytes)'))
+      error.mockRestore()
+    })
+  })
+
+  describe('state engineToCrdt', () => {
+    it('dumps only NetworkEntity-tagged entities, as network messages', async () => {
+      const engine = Engine()
+      const NetworkEntity = components.NetworkEntity(engine)
+      const SyncComponents = components.SyncComponents(engine)
+      const Marker = engine.defineComponent('test::Marker', { id: Schemas.String })
+
+      const first = engine.addEntity()
+      const second = engine.addEntity()
+      const localOnly = engine.addEntity()
+      expect([first, second, localOnly]).toEqual([512, 513, 514])
+
+      for (const [entity, id] of [
+        [first, 'first'],
+        [second, 'second']
+      ] as const) {
+        NetworkEntity.create(entity, { networkId: NETWORK_ID, entityId: entity })
+        SyncComponents.create(entity, { componentIds: [Marker.componentId] })
+        Marker.create(entity, { id })
+      }
+      Marker.create(localOnly, { id: 'local-only' })
+      await engine.update(1)
+
+      const chunks = engineToCrdt(engine)
+      expect(chunks).toHaveLength(1)
+      const dumped = readMessages(chunks[0])
+      expect(dumped.every((message) => message.type === CrdtMessageType.PUT_COMPONENT_NETWORK)).toBe(true)
+      expect(
+        dumped.map((message) => ({
+          entityId: message.entityId,
+          networkId: 'networkId' in message ? message.networkId : undefined,
+          component: engine.getComponent(('componentId' in message && message.componentId) as number).componentName
+        }))
+      ).toEqual([
+        { entityId: first, networkId: NETWORK_ID, component: 'core-schema::Network-Entity' },
+        { entityId: second, networkId: NETWORK_ID, component: 'core-schema::Network-Entity' },
+        { entityId: first, networkId: NETWORK_ID, component: 'core-schema::Sync-Components' },
+        { entityId: second, networkId: NETWORK_ID, component: 'core-schema::Sync-Components' },
+        { entityId: first, networkId: NETWORK_ID, component: 'test::Marker' },
+        { entityId: second, networkId: NETWORK_ID, component: 'test::Marker' }
+      ])
+      expect(toHex(chunks[0])).toMatchSnapshot()
+    })
+  })
+
+  describe('binary-message-bus envelope', () => {
+    it('pins the CommsMessage values', () => {
+      expect({
+        CRDT_SERVER: CommsMessage.CRDT_SERVER,
+        CRDT_AUTHORITATIVE: CommsMessage.CRDT_AUTHORITATIVE,
+        CUSTOM_EVENT: CommsMessage.CUSTOM_EVENT,
+        CRDT: CommsMessage.CRDT,
+        REQ_CRDT_STATE: CommsMessage.REQ_CRDT_STATE,
+        RES_CRDT_STATE: CommsMessage.RES_CRDT_STATE
+      }).toEqual({
+        CRDT_SERVER: 4,
+        CRDT_AUTHORITATIVE: 5,
+        CUSTOM_EVENT: 6,
+        CRDT: 7,
+        REQ_CRDT_STATE: 8,
+        RES_CRDT_STATE: 9
+      })
+    })
+
+    it('crafts [messageType, ...payload] and decodes [senderLength, ...sender, messageType, ...payload]', () => {
+      const crafted = craftCommsMessage(CommsMessage.CRDT, PAYLOAD)
+      expect(toHex(crafted)).toBe('07deadbeef')
+
+      // encodeString drops the length prefix ByteBuffer writes, decodeString adds it back
+      const sender = encodeString('clientA')
+      expect(toHex(sender)).toBe('636c69656e7441')
+      expect(decodeString(sender)).toBe('clientA')
+
+      const framed = new Uint8Array(crafted.byteLength + sender.byteLength + 1)
+      framed.set([sender.byteLength], 0)
+      framed.set(sender, 1)
+      framed.set(crafted, sender.byteLength + 1)
+      expect(toHex(framed)).toBe('07636c69656e744107deadbeef')
+
+      const decoded = decodeCommsMessage(framed)!
+      expect(decoded.sender).toBe('clientA')
+      expect(decoded.messageType).toBe(CommsMessage.CRDT)
+      expect(toHex(decoded.data)).toBe(toHex(PAYLOAD))
+    })
+
+    it('logs and returns undefined for an undecodable envelope', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+      expect(decodeCommsMessage(new Uint8Array())).toBeUndefined()
+      expect(error).toHaveBeenCalledWith('Invalid Comms message', expect.anything())
+      error.mockRestore()
+    })
+
+    it('dispatches by message type, keeping only the last handler registered per type', () => {
+      const outbox: { data: Uint8Array; address?: string[] }[] = []
+      const bus = BinaryMessageBus((data, address) => outbox.push({ data, address }))
+      const first: string[] = []
+      const second: string[] = []
+      bus.on(CommsMessage.CRDT, (value, sender) => first.push(`${sender}:${toHex(value)}`))
+      bus.on(CommsMessage.CRDT, (value, sender) => second.push(`${sender}:${toHex(value)}`))
+
+      bus.emit(CommsMessage.CRDT, PAYLOAD, ['authoritative-server'])
+      expect(outbox).toEqual([
+        { data: craftCommsMessage(CommsMessage.CRDT, PAYLOAD), address: ['authoritative-server'] }
+      ])
+
+      const sender = encodeString('clientB')
+      const crafted = craftCommsMessage(CommsMessage.CRDT, PAYLOAD)
+      const framed = new Uint8Array(crafted.byteLength + sender.byteLength + 1)
+      framed.set([sender.byteLength], 0)
+      framed.set(sender, 1)
+      framed.set(crafted, sender.byteLength + 1)
+      // a REQ_CRDT_STATE envelope with no registered handler is dropped silently
+      const unhandled = new Uint8Array(framed)
+      unhandled[sender.byteLength + 1] = CommsMessage.REQ_CRDT_STATE
+      bus.__processMessages([framed, unhandled])
+
+      expect(first).toEqual([])
+      expect(second).toEqual(['clientB:deadbeef'])
+    })
+  })
+
+  describe('events protocol envelope', () => {
+    it('pins the encoded event bytes and the decoded envelope', () => {
+      const now = jest.spyOn(Date, 'now').mockReturnValue(1700000000000)
+      const registry = { ping: Schemas.Map({ text: Schemas.String }) }
+
+      const encoded = encodeEvent('ping', { text: 'hi' }, registry)
+      expect(toHex(encoded)).toMatchSnapshot()
+      expect(decodeEvent(encoded, registry)).toEqual({
+        eventType: 'ping',
+        payload: { text: 'hi' },
+        timestamp: 1700000000000
+      })
+
+      expect(() => encodeEvent('missing' as never, {} as never, registry)).toThrowError('Unknown event type: missing')
+      now.mockRestore()
+    })
+  })
+})

--- a/test/sdk/network/defects-red.spec.ts
+++ b/test/sdk/network/defects-red.spec.ts
@@ -1,0 +1,297 @@
+/**
+ * Red suite: one test per known defect, each asserting the CORRECT behavior.
+ *
+ * Every test is declared with `it.failing`, so jest expects it to throw today.
+ * When a phase fixes a defect its test starts passing and `it.failing` turns
+ * red — that is the signal to flip it to a plain `it` (and to drop the matching
+ * `QUIRK(pinned)` assertion from the characterization specs).
+ *
+ * Source locations verified against the tree at the time of writing:
+ *   #1  message-bus-sync.ts:117-129   REQ_CRDT_STATE responder, no isServer guard
+ *   #2  message-bus-sync.ts:130-133   RES_CRDT_STATE clears the retry state before checking the sender
+ *   #3  server/index.ts:108-141       validateMessagePermissions: DELETE_ENTITY TODO + default `return true`
+ *   #4  server/index.ts:169-211       sendCorrectionToSender
+ *   #8  state.ts:106-111 (already names the component) + chunking.ts:29-32 (does not)
+ *   #9  message-bus-sync.ts:150-163   CRDT handler reads a possibly-null role
+ *   #10 message-bus-sync.ts:89-91     client emits CRDT with no address
+ *   #11 server/index.ts:143-167       broadcastBatchedMessages ignores excludeSender
+ *   #12 events/implementation.ts:245-253  registerMessages Object.assign over a flat global registry
+ *   #13 players/index.ts:35-57        per-frame diff keyed on `players.length === playerEntities.size`
+ */
+import { Engine, Entity, Schemas, Transform as GlobalTransform } from '../../../packages/@dcl/ecs'
+import * as components from '../../../packages/@dcl/ecs/dist/components'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/dist/serialization/ByteBuffer'
+import { DeleteEntityNetwork, PutComponentOperation } from '../../../packages/@dcl/ecs/dist/serialization/crdt'
+import { CommsMessage } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { chunkCrdtMessages } from '../../../packages/@dcl/sdk/src/network/chunking'
+import { registerMessages } from '../../../packages/@dcl/sdk/src/network/events/implementation'
+import { engineToCrdt } from '../../../packages/@dcl/sdk/src/network/state'
+import { definePlayerHelper } from '../../../packages/@dcl/sdk/src/players'
+import { expectConvergence } from './utils/convergence'
+import {
+  CLIENT_A,
+  CLIENT_B,
+  SERVER,
+  createHarness,
+  defineComponents,
+  findNetworkEntity,
+  flush,
+  setRealmConnected
+} from './utils/harness'
+
+type Tagged = { networkId: number; entityId: Entity; position: { x: number; y: number; z: number } }
+
+/** A RES_CRDT_STATE payload holding exactly the given network entities. */
+async function stateDump(entities: Tagged[]): Promise<Uint8Array> {
+  const engine = Engine()
+  const local = defineComponents(engine)
+  for (const { networkId, entityId, position } of entities) {
+    const entity = engine.addEntity()
+    local.NetworkEntity.create(entity, { networkId, entityId })
+    local.SyncComponents.create(entity, { componentIds: [GlobalTransform.componentId] })
+    local.Transform.create(entity, { position })
+  }
+  await engine.update(1)
+  return engineToCrdt(engine)[0] ?? new Uint8Array()
+}
+
+describe('known defects (red: asserting the correct behavior)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it.failing('#1 only the authoritative server answers REQ_CRDT_STATE', async () => {
+    const harness = createHarness()
+    await flush()
+    harness.clear()
+
+    harness.inject(CLIENT_A, CLIENT_B, CommsMessage.REQ_CRDT_STATE, new Uint8Array())
+    await harness.tick()
+
+    expect(harness.sentBy(CLIENT_A, CommsMessage.RES_CRDT_STATE)).toHaveLength(0)
+  })
+
+  it.failing('#2 a stray RES_CRDT_STATE from a non-server peer must not halt the retry loop', async () => {
+    const harness = createHarness()
+    await flush()
+    setRealmConnected(true)
+    // only the client ticks: nobody answers its request. dt stays well under the
+    // 2s STATE_REQUEST_RETRY_INTERVAL so the stray reply lands before any retry.
+    await harness.clientA.engine.update(0.1)
+    harness.inject(CLIENT_A, CLIENT_B, CommsMessage.RES_CRDT_STATE, new Uint8Array())
+    await harness.clientA.engine.update(0.1)
+    harness.clear()
+
+    // 3 seconds of silence: the retry loop must have fired at least once
+    for (let i = 0; i < 30; i++) await harness.clientA.engine.update(0.1)
+
+    expect(harness.clientA.sync.isStateSyncronized()).toBe(false)
+    expect(harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE).length).toBeGreaterThanOrEqual(1)
+
+    // a later reply from the real server still hydrates (this half works today)
+    harness.inject(CLIENT_A, SERVER, CommsMessage.RES_CRDT_STATE, new Uint8Array())
+    await harness.clientA.engine.update(0.1)
+    expect(harness.clientA.sync.isStateSyncronized()).toBe(true)
+  })
+
+  it.failing('#3 the server rejects a DELETE_ENTITY for an entity the sender did not create', async () => {
+    const harness = createHarness()
+    await flush()
+
+    const entity = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(entity, { position: { x: 1, y: 1, z: 1 } })
+    harness.clientA.sync.syncEntity(entity, [harness.clientA.components.Transform.componentId])
+    await harness.tick()
+
+    const serverEntity = findNetworkEntity(harness.server, harness.clientA.sync.myProfile.networkId, entity)!
+    expect(harness.server.components.CreatedBy.get(serverEntity).address).toBe(CLIENT_A)
+
+    // clientB, which did not create it, asks the server to delete it
+    const deletion = new ReadWriteByteBuffer()
+    DeleteEntityNetwork.write(entity, harness.clientA.sync.myProfile.networkId, deletion)
+    harness.clear()
+    harness.inject(SERVER, CLIENT_B, CommsMessage.CRDT, deletion.toBinary())
+    await harness.tick()
+
+    expect(harness.server.components.NetworkEntity.has(serverEntity)).toBe(true)
+    expect(harness.sentBy(SERVER, CommsMessage.CRDT)).toHaveLength(0)
+  })
+
+  it.failing('#4 a rejected first write is corrected with CRDT_AUTHORITATIVE to the offender', async () => {
+    const harness = createHarness()
+    await flush()
+    harness.server.components.Transform.validateBeforeChange(
+      (value) => !(value.newValue?.position.x ?? 0) || value.newValue!.position.x <= 500
+    )
+
+    const entity = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(entity, { position: { x: 600, y: 0, z: 0 } })
+    harness.clientA.sync.syncEntity(entity, [harness.clientA.components.Transform.componentId])
+    harness.clear()
+    await harness.tick()
+
+    // the server holds no state for the component yet, so getCrdtState() returns
+    // null and the correction is silently skipped
+    const corrections = harness.sentBy(SERVER, CommsMessage.CRDT_AUTHORITATIVE)
+    expect(corrections.map((correction) => correction.to)).toEqual([[CLIENT_A]])
+    expect(harness.clientA.components.Transform.get(entity).position.x).not.toBe(600)
+  })
+
+  it.failing('#6 re-hydration removes network entities missing from the new full state', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    const own = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(own, { position: { x: 1, y: 1, z: 1 } })
+    harness.clientA.sync.syncEntity(own, [harness.clientA.components.Transform.componentId])
+    const ghost = harness.clientB.engine.addEntity()
+    harness.clientB.components.Transform.create(ghost, { position: { x: 2, y: 2, z: 2 } })
+    harness.clientB.sync.syncEntity(ghost, [harness.clientB.components.Transform.componentId])
+    await harness.tick()
+    expect(harness.entities(harness.clientA)).toHaveLength(2)
+
+    // clientA drops out and comes back to a world where `ghost` no longer exists
+    setRealmConnected(false)
+    await harness.clientA.engine.update(1)
+    const dump = await stateDump([
+      { networkId: harness.clientA.sync.myProfile.networkId, entityId: own, position: { x: 1, y: 1, z: 1 } }
+    ])
+    harness.inject(CLIENT_A, SERVER, CommsMessage.RES_CRDT_STATE, dump)
+    await harness.tick()
+
+    expect(harness.entities(harness.clientA)).toHaveLength(1)
+  })
+
+  it.failing('#7 a restarted server makes its clients re-hydrate', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    const stale = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(stale, { position: { x: 1, y: 1, z: 1 } })
+    harness.clientA.sync.syncEntity(stale, [harness.clientA.components.Transform.componentId])
+    await harness.tick()
+
+    // same comms identity, brand new engine, and some fresh state of its own
+    const restarted = harness.attach(SERVER, true)
+    await flush()
+    harness.clear()
+    const fresh = restarted.engine.addEntity()
+    restarted.components.Transform.create(fresh, { position: { x: 9, y: 9, z: 9 } })
+    restarted.sync.syncEntity(fresh, [restarted.components.Transform.componentId])
+    await harness.tick(8)
+
+    expect(harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE).length).toBeGreaterThanOrEqual(1)
+    expectConvergence({ restartedServer: restarted.engine, clientA: harness.clientA.engine })
+  })
+
+  it.failing('#8 dropping an oversized message always names the component and its size', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    // state.ts already names the component and the size
+    const engine = Engine()
+    const local = defineComponents(engine)
+    const Big = engine.defineComponent('test::Big', { blob: Schemas.String })
+    const entity = engine.addEntity()
+    local.NetworkEntity.create(entity, { networkId: 1, entityId: entity })
+    Big.create(entity, { blob: 'x'.repeat(13 * 1024) })
+    await engine.update(1)
+    engineToCrdt(engine)
+    expect(error).toHaveBeenCalledWith(expect.stringContaining(`component ${Big.componentId}`))
+
+    // chunking.ts drops the message without saying which component it belonged to
+    error.mockClear()
+    const oversized = new ReadWriteByteBuffer()
+    PutComponentOperation.write(512 as Entity, 1, GlobalTransform.componentId, new Uint8Array(13 * 1024), oversized)
+    expect(chunkCrdtMessages(oversized.toBinary(), 12)).toEqual([])
+    expect(error).toHaveBeenCalledWith(expect.stringContaining(`component ${GlobalTransform.componentId}`))
+  })
+
+  it.failing('#9 CRDT that arrives before the role resolves is buffered, not dropped', async () => {
+    const harness = createHarness()
+    let resolveRole!: (isServer: boolean) => void
+    const role = new Promise<boolean>((resolve) => (resolveRole = resolve))
+    const late = harness.attach(SERVER, role)
+    await flush()
+
+    const dump = await stateDump([{ networkId: 42, entityId: 512 as Entity, position: { x: 5, y: 5, z: 5 } }])
+    harness.inject(SERVER, CLIENT_A, CommsMessage.CRDT, dump)
+    await harness.tick()
+
+    resolveRole(true)
+    await flush()
+    await harness.tick()
+
+    expect(Array.from(late.engine.getEntitiesWith(late.components.NetworkEntity))).toHaveLength(1)
+  })
+
+  it.failing('#10 a client addresses its CRDT to the authoritative server', async () => {
+    const harness = createHarness()
+    await flush()
+
+    const entity = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(entity, { position: { x: 1, y: 2, z: 3 } })
+    harness.clientA.sync.syncEntity(entity, [harness.clientA.components.Transform.componentId])
+    harness.clear()
+    await harness.tick()
+
+    const crdt = harness.sentBy(CLIENT_A, CommsMessage.CRDT)
+    expect(crdt.length).toBeGreaterThanOrEqual(1)
+    expect(crdt.map((message) => message.to)).toEqual(crdt.map(() => [SERVER]))
+  })
+
+  it.failing('#11 the server broadcast excludes the peer that sent the message', async () => {
+    const harness = createHarness()
+    await flush()
+
+    const entity = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(entity, { position: { x: 1, y: 2, z: 3 } })
+    harness.clientA.sync.syncEntity(entity, [harness.clientA.components.Transform.componentId])
+    harness.clear()
+    await harness.tick()
+
+    expect(harness.deliveredTo(CLIENT_A, CommsMessage.CRDT)).toHaveLength(0)
+    expect(harness.deliveredTo(CLIENT_B, CommsMessage.CRDT).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it.failing('#12 registering the same message key twice reports the collision', async () => {
+    createHarness()
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    registerMessages({ collide: Schemas.Map({ text: Schemas.String }) })
+    registerMessages({ collide: Schemas.Map({ value: Schemas.Int }) })
+
+    expect(warn.mock.calls.length + error.mock.calls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it.failing('#13 a player joining and leaving within one frame fires both callbacks', async () => {
+    const engine = Engine()
+    const players = definePlayerHelper(engine)
+    const PlayerIdentityData = components.PlayerIdentityData(engine)
+    const AvatarBase = components.AvatarBase(engine)
+
+    const entered: string[] = []
+    const left: string[] = []
+    players.onEnterScene((player) => entered.push(player.userId))
+    players.onLeaveScene((userId) => left.push(userId))
+
+    const entity = engine.addEntity()
+    PlayerIdentityData.create(entity, { address: '0xplayer', isGuest: false })
+    AvatarBase.create(entity)
+    // ...and gone before the engine ever ticks
+    AvatarBase.deleteFrom(entity)
+    PlayerIdentityData.deleteFrom(entity)
+    await engine.update(1)
+
+    expect(entered).toEqual(['0xplayer'])
+    expect(left).toEqual(['0xplayer'])
+  })
+
+  it.failing('#14 the server reports a synchronized state once it is ready', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    expect(harness.server.sync.isRoomReadyAtom.getOrNull()).toBe(true)
+    expect(harness.server.sync.isStateSyncronized()).toBe(true)
+  })
+})

--- a/test/sdk/network/utils/convergence.ts
+++ b/test/sdk/network/utils/convergence.ts
@@ -1,0 +1,111 @@
+/**
+ * Convergence oracle.
+ *
+ * Compares engines semantically: every NetworkEntity-tagged entity is keyed by
+ * its network identity (`networkId:entityId`, the identity that survives the
+ * wire) instead of its local `Entity` id, and every syncable component value on
+ * it is compared across engines. Local-only entities are ignored on purpose —
+ * they are invisible to the network layer.
+ */
+import {
+  ComponentDefinition,
+  Entity,
+  IEngine,
+  INetowrkEntity,
+  NetworkEntity as _NetworkEntity
+} from '../../../../packages/@dcl/ecs'
+import { shouldSyncComponent } from '../../../../packages/@dcl/sdk/src/network/state'
+import { toHex } from './hex'
+
+/** Components that carry no scene state worth comparing. */
+const IGNORED = [
+  // redundant: it is the comparison key itself
+  'core-schema::Network-Entity',
+  // server-only bookkeeping, written by the validator when it first sees an entity
+  'core-schema::Created-By'
+]
+
+export type NetworkSnapshot = Record<string, Record<string, string>>
+
+/**
+ * Key order is not semantic: a locally created value keeps the order the scene
+ * wrote it in, a deserialized one follows the schema, so keys are sorted before
+ * comparing.
+ */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : 1))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+    return `{${entries.join(',')}}`
+  }
+  return JSON.stringify(value) ?? 'undefined'
+}
+
+function componentValue(component: ComponentDefinition<unknown>, entity: Entity): string {
+  try {
+    return stableStringify(component.get(entity))
+  } catch {
+    // GrowOnlyValueSet-like components: fall back to the serialized CRDT state
+    const state = component.getCrdtState(entity)
+    return state ? toHex(state.data) : 'null'
+  }
+}
+
+export function networkSnapshot(engine: IEngine, ignore: string[] = []): NetworkSnapshot {
+  const NetworkEntity = engine.getComponent(_NetworkEntity.componentId) as INetowrkEntity
+  const snapshot: NetworkSnapshot = {}
+  for (const [entity, network] of engine.getEntitiesWith(NetworkEntity)) {
+    const values: Record<string, string> = {}
+    for (const component of engine.componentsIter()) {
+      if (!shouldSyncComponent(component)) continue
+      if (IGNORED.includes(component.componentName) || ignore.includes(component.componentName)) continue
+      if (!component.has(entity)) continue
+      values[component.componentName] = componentValue(component, entity)
+    }
+    snapshot[`${network.networkId}:${network.entityId}`] = values
+  }
+  return snapshot
+}
+
+/**
+ * Throws with a readable diff unless every engine holds the same network state.
+ * The first engine of the record is the reference.
+ */
+export function expectConvergence(engines: Record<string, IEngine>, ignore: string[] = []): void {
+  const snapshots = Object.entries(engines).map(([name, engine]) => [name, networkSnapshot(engine, ignore)] as const)
+  const [referenceName, reference] = snapshots[0]
+  const diffs: string[] = []
+
+  for (const [name, snapshot] of snapshots.slice(1)) {
+    const keys = new Set([...Object.keys(reference), ...Object.keys(snapshot)])
+    for (const key of Array.from(keys).sort()) {
+      const left = reference[key]
+      const right = snapshot[key]
+      if (!left) {
+        diffs.push(`  entity ${key}: missing in ${referenceName}, present in ${name} (${JSON.stringify(right)})`)
+        continue
+      }
+      if (!right) {
+        diffs.push(`  entity ${key}: present in ${referenceName} (${JSON.stringify(left)}), missing in ${name}`)
+        continue
+      }
+      const componentNames = new Set([...Object.keys(left), ...Object.keys(right)])
+      for (const componentName of Array.from(componentNames).sort()) {
+        if (left[componentName] !== right[componentName]) {
+          diffs.push(
+            `  entity ${key} component ${componentName}:\n` +
+              `    ${referenceName}: ${left[componentName] ?? '<absent>'}\n` +
+              `    ${name}: ${right[componentName] ?? '<absent>'}`
+          )
+        }
+      }
+    }
+  }
+
+  if (diffs.length) {
+    throw new Error(`Engines diverged (reference: ${referenceName}):\n${diffs.join('\n')}`)
+  }
+}

--- a/test/sdk/network/utils/harness.ts
+++ b/test/sdk/network/utils/harness.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared 3-engine comms harness (server + 2 clients).
+ *
+ * Extracted from the topology inlined in `server-client-connectivity.spec.ts`
+ * (3 engines + a routeMessage function simulating comms) so the
+ * characterization / red-defect specs can reuse the exact same wiring.
+ *
+ * Routing rules match the production client-server topology:
+ *   - a client can only reach the authoritative server
+ *   - the server reaches the addresses it asks for, or every client when the
+ *     address list is empty (broadcast)
+ */
+import { Engine, Entity, IEngine, RealmInfo, engine as globalEngine } from '../../../../packages/@dcl/ecs'
+import * as components from '../../../../packages/@dcl/ecs/dist/components'
+import { addSyncTransport } from '../../../../packages/@dcl/sdk/src/network/message-bus-sync'
+import {
+  CommsMessage,
+  craftCommsMessage,
+  encodeString
+} from '../../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import type { SendBinaryRequest, SendBinaryResponse } from '~system/CommunicationsController'
+
+export const SERVER = 'authoritative-server'
+export const CLIENT_A = 'clientA'
+export const CLIENT_B = 'clientB'
+
+export type NetworkComponents = ReturnType<typeof defineComponents>
+export type Sync = ReturnType<typeof addSyncTransport>
+
+export type Peer = {
+  id: string
+  engine: IEngine
+  components: NetworkComponents
+  sync: Sync
+}
+
+/** One entry per `sendBinary` peerData payload that crossed the wire. */
+export type SentRecord = {
+  from: string
+  /** the address array the peer asked for; `[]` means "broadcast" */
+  to: string[]
+  type: CommsMessage
+  payload: Uint8Array
+}
+
+export function defineComponents(engine: IEngine) {
+  return {
+    Transform: components.Transform(engine),
+    NetworkEntity: components.NetworkEntity(engine),
+    NetworkParent: components.NetworkParent(engine),
+    SyncComponents: components.SyncComponents(engine),
+    CreatedBy: components.CreatedBy(engine),
+    EngineInfo: components.EngineInfo(engine)
+  }
+}
+
+/** Resolve the local entity a peer uses for a given network identity. */
+export function findNetworkEntity(peer: Peer, networkId: number, entityId: Entity): Entity | undefined {
+  for (const [local, network] of peer.engine.getEntitiesWith(peer.components.NetworkEntity)) {
+    if (network.networkId === networkId && network.entityId === entityId) return local
+  }
+  return undefined
+}
+
+/** Let module-level promises (profile fetch, isServer) settle. */
+export function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * `message-bus-sync` reads/observes `RealmInfo` through the singleton component
+ * bound to the module-level global engine (not the engine passed to
+ * `addSyncTransport`), so a single write here is observed by every peer.
+ * `onChange` callbacks only fire from the CRDT receive path, hence the explicit
+ * `__onChangeCallbacks` call.
+ */
+export function setRealmConnected(isConnectedSceneRoom: boolean): void {
+  const value = {
+    baseUrl: 'http://localhost:8000',
+    realmName: 'test-realm',
+    networkId: 1,
+    commsAdapter: 'offline',
+    isPreview: true,
+    room: 'scene-room',
+    isConnectedSceneRoom
+  }
+  RealmInfo.createOrReplace(globalEngine.RootEntity, value)
+  // `__onChangeCallbacks` is @internal, so it is trimmed from the published types
+  const internal = RealmInfo as unknown as { __onChangeCallbacks(entity: Entity, value: unknown): void }
+  internal.__onChangeCallbacks(globalEngine.RootEntity, value)
+}
+
+export function createHarness() {
+  const queues: Record<string, Uint8Array[]> = {}
+  const peers: Record<string, Peer> = {}
+  const sent: SentRecord[] = []
+  /** every comms message that landed in a peer's inbox */
+  const delivered: { to: string; from: string; type: CommsMessage }[] = []
+
+  function withSender(sender: string, data: Uint8Array): Uint8Array {
+    const senderBytes = encodeString(sender)
+    const out = new Uint8Array(data.byteLength + senderBytes.byteLength + 1)
+    out.set([senderBytes.byteLength], 0)
+    out.set(senderBytes, 1)
+    out.set(data, senderBytes.byteLength + 1)
+    return out
+  }
+
+  function deliver(target: string, sender: string, data: Uint8Array) {
+    if (!(target in queues)) return
+    delivered.push({ to: target, from: sender, type: data[0] as CommsMessage })
+    queues[target].push(withSender(sender, data))
+  }
+
+  function route(data: Uint8Array, addresses: string[], from: string) {
+    sent.push({ from, to: [...addresses], type: data[0] as CommsMessage, payload: data.subarray(1) })
+    const targets =
+      from === SERVER
+        ? addresses.length === 0
+          ? Object.keys(queues).filter((id) => id !== SERVER)
+          : addresses.filter((address) => address !== SERVER)
+        : [SERVER]
+    for (const target of targets) deliver(target, from, data)
+  }
+
+  /** `isServer` may be a pending promise to reproduce a role that resolves late */
+  function attach(id: string, isServer: boolean | Promise<boolean>): Peer {
+    queues[id] = queues[id] ?? []
+    const engine = Engine()
+    const peerComponents = defineComponents(engine)
+    const sendBinary = async (msg: SendBinaryRequest): Promise<SendBinaryResponse> => {
+      for (const peerData of msg.peerData) {
+        for (const data of peerData.data) route(data, peerData.address, id)
+      }
+      const response = [...queues[id]]
+      queues[id].length = 0
+      return { data: response }
+    }
+    const sync = addSyncTransport(
+      engine,
+      sendBinary,
+      async () => ({
+        data: { userId: id, version: 1, displayName: id, hasConnectedWeb3: true, avatar: undefined }
+      }),
+      async () => ({ isServer: await isServer }),
+      id
+    )
+    peers[id] = { id, engine, components: peerComponents, sync }
+    return peers[id]
+  }
+
+  const server = attach(SERVER, true)
+  const clientA = attach(CLIENT_A, false)
+  const clientB = attach(CLIENT_B, false)
+
+  async function tick(rounds = 4, dt = 1) {
+    for (let i = 0; i < rounds; i++) {
+      await Promise.all(Object.values(peers).map((peer) => peer.engine.update(dt)))
+    }
+  }
+
+  return {
+    server,
+    clientA,
+    clientB,
+    peers,
+    sent,
+    delivered,
+    tick,
+    /** also usable to replace a peer with a fresh engine keeping its comms identity */
+    attach,
+    /** push a comms message into a peer's inbox as if `sender` had emitted it */
+    inject(target: string, sender: string, type: CommsMessage, payload: Uint8Array) {
+      deliver(target, sender, craftCommsMessage(type, payload))
+    },
+    sentBy(from: string, type?: CommsMessage) {
+      return sent.filter((record) => record.from === from && (type === undefined || record.type === type))
+    },
+    deliveredTo(to: string, type?: CommsMessage) {
+      return delivered.filter((record) => record.to === to && (type === undefined || record.type === type))
+    },
+    clear() {
+      sent.length = 0
+      delivered.length = 0
+    },
+    async connect() {
+      await flush()
+      setRealmConnected(true)
+      await tick()
+    },
+    entities(peer: Peer): Entity[] {
+      return Array.from(peer.engine.getEntitiesWith(peer.components.NetworkEntity)).map(([entity]) => entity)
+    }
+  }
+}
+
+export type Harness = ReturnType<typeof createHarness>

--- a/test/sdk/network/utils/hex.ts
+++ b/test/sdk/network/utils/hex.ts
@@ -1,0 +1,6 @@
+/** Hex-encode a buffer so golden-byte snapshots stay readable. */
+export function toHex(data: Uint8Array): string {
+  return Array.from(data)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}


### PR DESCRIPTION
Phase T of the authoritative-server network refactor: pin current
behavior before restructuring so the migration is provably invisible.

- characterization-api/wire/flow specs: public API surface, golden-byte
  wire format (translation round-trips, 12KB chunking, engineToCrdt
  dumps, comms envelope), and 3-engine message flow incl. current
  quirks (echo-to-sender, any-peer hydration responder)
- defects-red spec: 13 it.failing tests, one per known defect, each
  asserting the CORRECT behavior and confirmed failing today; phases
  flip them green as fixes land
- shared utils: 3-engine harness extracted from the connectivity spec,
  convergence oracle (cross-engine networked-state equality), hex helper

Claude-Session: https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


---
## 📚 Stack (splits #1505 — merge top-down within each stack)

**Network layer** (each PR is one self-contained, independently-green commit):
1. #1518 test harness — characterization baseline + red defect suite *(this stack's root)*
2. #1519 foundations — cycle break, single isServer, logging discipline
3. #1520 hydration FSM — late-join/reconnect correctness
4. #1521 validator — default-deny, correction path, entity index
5. #1522 codec — parse-once pipeline (wire goldens byte-identical)
6. #1523 topology — targeted sends, registry collisions, players dedupe
7. #1524 boot + host-conformance doc
8. #1525 simplification sweep (−95 lines)

**sdk-commands** (independent of the stack above):
- #1526 world-storage namespacing (pre-existing WIP, carried from the working tree)
- #1527 local dev-server reliability (depends on #1526)

After a parent squash-merges, the child needs `git rebase --onto origin/auth-server <old-parent> <child>` — ping the session and it gets restacked.
