### PR TITLE
[DO NOT MERGE] feat(sdk): hydration FSM — deterministic late-join and reconnect convergence

### DIFF
--- a/packages/@dcl/sdk/src/network/binary-message-bus.ts
+++ b/packages/@dcl/sdk/src/network/binary-message-bus.ts
@@ -6,7 +6,9 @@ export enum CommsMessage {
   RES_CRDT_STATE = 9,
   CRDT_SERVER = 4,
   CRDT_AUTHORITATIVE = 5,
-  CUSTOM_EVENT = 6
+  CUSTOM_EVENT = 6,
+  /** authoritative server announcing which run of it is on the air */
+  SERVER_ANNOUNCE = 10
 }
 
 export function BinaryMessageBus<T extends CommsMessage>(

--- a/packages/@dcl/sdk/src/network/hydration.ts
+++ b/packages/@dcl/sdk/src/network/hydration.ts
@@ -1,0 +1,158 @@
+// Hydration state machine.
+//
+// Pure logic: no engine, no comms, no clock. `message-bus-sync` translates comms
+// and engine signals into events and runs the effects handed back, which is what
+// makes every transition testable without a running engine.
+//
+//   DISCONNECTED --realm connected--> CONNECTED --role client--> REQUESTING_STATE
+//        ^                                |                            |
+//        |                                +--role server--> SYNCED <---+ state dump
+//        +---------------- realm disconnected ----------------+
+//
+// A SYNCED client goes back to REQUESTING_STATE when the authoritative peer
+// announces a generation other than the one it hydrated from (server restart).
+
+import { AUTH_SERVER_PEER_ID } from './constants'
+
+/** seconds to wait for a state dump before asking again */
+export const STATE_REQUEST_RETRY_INTERVAL = 2.0
+
+export type HydrationState = 'DISCONNECTED' | 'CONNECTED' | 'REQUESTING_STATE' | 'SYNCED'
+
+export type HydrationEffect =
+  /** emit REQ_CRDT_STATE */
+  | 'requestState'
+  /** the peer now holds the authoritative world */
+  | 'markSynced'
+  /** the dump being applied replaces a world we already had: drop what it omits */
+  | 'reconcile'
+  /** broadcast this peer's server generation */
+  | 'announce'
+
+// Minting a `stateReceived` event requires this symbol, and only `stateResponse`
+// has it. A RES_CRDT_STATE from a peer that is not the authoritative server can
+// therefore not be turned into an event at all, let alone reset the retry timer.
+const FROM_AUTHORITATIVE_SERVER: unique symbol = Symbol('from-authoritative-server')
+
+export type HydrationEvent =
+  | { type: 'roleResolved'; isServer: boolean }
+  | { type: 'realmConnected' }
+  | { type: 'realmDisconnected' }
+  | { type: 'ownPlayerEntered' }
+  | { type: 'serverAnnounced'; generation: number }
+  | { type: 'tick'; dt: number }
+  | { type: 'stateReceived'; [FROM_AUTHORITATIVE_SERVER]: true }
+
+/** The only constructor of a `stateReceived` event. */
+export function stateResponse(sender: string): HydrationEvent | null {
+  return sender === AUTH_SERVER_PEER_ID ? { type: 'stateReceived', [FROM_AUTHORITATIVE_SERVER]: true } : null
+}
+
+export type Hydration = {
+  state(): HydrationState
+  isSynced(): boolean
+  /** `null` is accepted so callers can forward a rejected `stateResponse()` as-is */
+  send(event: HydrationEvent | null): HydrationEffect[]
+}
+
+export function createHydration(): Hydration {
+  let state: HydrationState = 'DISCONNECTED'
+  let role: 'unknown' | 'server' | 'client' = 'unknown'
+  let elapsedSinceRequest = 0
+  /** a dump has already been applied: the next one replaces a world we had */
+  let hydrated = false
+  /** generation of the authoritative peer we are talking to */
+  let generation: number | null = null
+
+  function requestState(): HydrationEffect[] {
+    state = 'REQUESTING_STATE'
+    elapsedSinceRequest = 0
+    return ['requestState']
+  }
+
+  function serverIsReady(): HydrationEffect[] {
+    if (state === 'SYNCED') return []
+    state = 'SYNCED'
+    return ['markSynced', 'announce']
+  }
+
+  /** realm is up: what happens next only depends on the role */
+  function onLine(): HydrationEffect[] {
+    if (role === 'unknown') {
+      state = 'CONNECTED'
+      return []
+    }
+    return role === 'server' ? serverIsReady() : requestState()
+  }
+
+  function send(event: HydrationEvent | null): HydrationEffect[] {
+    if (!event) return []
+    switch (event.type) {
+      case 'roleResolved':
+        role = event.isServer ? 'server' : 'client'
+        // a server is authoritative by definition, it never hydrates from anyone
+        if (role === 'server') return serverIsReady()
+        return state === 'CONNECTED' ? requestState() : []
+
+      case 'realmConnected':
+        return state === 'DISCONNECTED' ? onLine() : []
+
+      case 'realmDisconnected':
+        if (role === 'server' || state === 'DISCONNECTED') return []
+        state = 'DISCONNECTED'
+        return []
+
+      case 'ownPlayerEntered':
+        // the trigger that covers a room whose readiness landed before the profile
+        return state === 'CONNECTED' ? onLine() : []
+
+      case 'serverAnnounced': {
+        const known = generation
+        generation = event.generation
+        if (role !== 'client') return []
+        // the first announcement only names the world we are hydrating from; a
+        // *different* generation is what means that world is gone
+        if (known === null || known === event.generation) return []
+        return state === 'SYNCED' ? requestState() : []
+      }
+
+      case 'tick':
+        if (state !== 'REQUESTING_STATE') return []
+        elapsedSinceRequest += event.dt
+        if (elapsedSinceRequest < STATE_REQUEST_RETRY_INTERVAL) return []
+        elapsedSinceRequest = 0
+        return ['requestState']
+
+      case 'stateReceived': {
+        if (role === 'server') return []
+        const effects: HydrationEffect[] = hydrated ? ['reconcile'] : []
+        hydrated = true
+        state = 'SYNCED'
+        elapsedSinceRequest = 0
+        return [...effects, 'markSynced']
+      }
+    }
+  }
+
+  return {
+    state: () => state,
+    isSynced: () => state === 'SYNCED',
+    send
+  }
+}
+
+/** identifies one run of an authoritative server, so a restart is visible to its clients */
+export function newGeneration(): number {
+  return Math.floor(Math.random() * 0xffffffff)
+}
+
+export function encodeGeneration(generation: number): Uint8Array {
+  const payload = new Uint8Array(4)
+  new DataView(payload.buffer).setUint32(0, generation)
+  return payload
+}
+
+export function decodeGeneration(payload: Uint8Array): number {
+  if (payload.byteLength < 4) return 0
+  return new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0)
+}

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -1,4 +1,4 @@
-import { IEngine, Transport, RealmInfo } from '@dcl/ecs'
+import { Entity, IEngine, Transport } from '@dcl/ecs'
 import { type SendBinaryRequest, type SendBinaryResponse } from '~system/CommunicationsController'
 
 import { syncFilter } from './filter'
@@ -14,9 +14,21 @@ import { IsServerRequest, IsServerResponse } from '~system/EngineApi'
 import { AUTH_SERVER_PEER_ID, DEBUG_NETWORK_MESSAGES, IProfile } from './constants'
 import { createRuntimeContext } from './runtime-context'
 import { setGlobalRoom, Room } from './events/implementation'
+import { components } from './ecs-adapter'
+import {
+  HydrationEffect,
+  createHydration,
+  decodeGeneration,
+  encodeGeneration,
+  newGeneration,
+  stateResponse
+} from './hydration'
 
 export { AUTH_SERVER_PEER_ID, DEBUG_NETWORK_MESSAGES } from './constants'
 export type { IProfile } from './constants'
+
+/** how much comms may pile up while the peer does not know its own role yet */
+const MAX_BUFFERED_COMMS = 256
 
 // Test environment detection without 'as any'
 const isTestEnvironment = (): boolean => {
@@ -59,7 +71,11 @@ export function addSyncTransport(
   }
   const players = definePlayerHelper(engine)
 
-  let stateIsSyncronized = false
+  const RealmInfo = components.RealmInfo(engine)
+  const NetworkEntity = components.NetworkEntity(engine)
+  const hydration = createHydration()
+  /** names this run of the peer; only an authoritative server ever announces it */
+  const generation = newGeneration()
 
   /**
    * We need to wait till 2 ticks that is when the engine is ready to send new messages.
@@ -117,9 +133,76 @@ export function addSyncTransport(
   engine.addTransport(transport)
   // End add sync transport
 
+  /**
+   * Comms that lands before `isServerAtom` resolves cannot be routed — the server
+   * and the client path are different — so it waits here and is replayed in
+   * arrival order once the role is known.
+   *
+   * ponytail: a fixed cap and a loud drop instead of back-pressure. The window is
+   * one runtime round-trip, so an overflow already means something upstream is
+   * broken. Upgrade path: hold off polling comms until the role is known.
+   */
+  const bufferedComms: (() => void)[] = []
+
+  function onComms(message: CommsMessage, handler: (value: Uint8Array, sender: string) => void) {
+    binaryMessageBus.on(message, (value, sender) => {
+      if (isServerAtom.getOrNull() !== null) return handler(value, sender)
+      if (bufferedComms.length >= MAX_BUFFERED_COMMS) {
+        console.error(`[network] role still unresolved and the comms buffer is full, dropping ${CommsMessage[message]}`)
+        return
+      }
+      bufferedComms.push(() => handler(value, sender))
+    })
+  }
+
+  function applyEffects(effects: HydrationEffect[]) {
+    for (const effect of effects) {
+      if (effect === 'requestState') {
+        DEBUG_NETWORK_MESSAGES() && console.log('Requesting state...')
+        binaryMessageBus.emit(CommsMessage.REQ_CRDT_STATE, new Uint8Array())
+      } else if (effect === 'markSynced') {
+        // the room only counts as ready once comms has answered at least once
+        if (RealmInfo.getOrNull(engine.RootEntity)) {
+          DEBUG_NETWORK_MESSAGES() && console.log('[isRoomReady] Marking room as ready after state sync')
+          isRoomReadyAtom.swap(true)
+        }
+      } else if (effect === 'announce') {
+        binaryMessageBus.emit(CommsMessage.SERVER_ANNOUNCE, encodeGeneration(generation))
+      }
+      // 'reconcile' is applied by the RES_CRDT_STATE handler, the only place that
+      // holds the dump it has to be reconciled against
+    }
+  }
+
+  /** the state dump being applied; the server may split one over several chunks */
+  let dump: { entities: Set<Entity>; reconcile: boolean; quiet: boolean } | null = null
+
+  /**
+   * A re-hydration dump is the authoritative world in full, so a network entity it
+   * does not name no longer exists. Only NetworkEntity-tagged entities are looked
+   * at — local-only entities are invisible to the network layer and never touched.
+   * Dropping the tag before removing the entity is what keeps the removal local:
+   * `syncFilter` forwards a DELETE_ENTITY only for entities that still carry it.
+   */
+  function reconcileWithDump(present: Set<Entity>) {
+    const stale = Array.from(engine.getEntitiesWith(NetworkEntity))
+      .map(([entity]) => entity)
+      .filter((entity) => !present.has(entity))
+    for (const entity of stale) {
+      DEBUG_NETWORK_MESSAGES() && console.log('[reconcile] dropping entity absent from the state dump', entity)
+      NetworkEntity.deleteFrom(entity)
+      engine.removeEntity(entity)
+    }
+  }
+
   // Receive & Process CRDT_STATE
-  binaryMessageBus.on(CommsMessage.REQ_CRDT_STATE, async (data, sender) => {
+  onComms(CommsMessage.REQ_CRDT_STATE, (_data, sender) => {
+    // only the authoritative peer owns the world: a client answering here would
+    // hand its own partial view to another client
+    if (!isServerAtom.getOrNull()) return
     DEBUG_NETWORK_MESSAGES() && console.log('[REQ_CRDT_STATE]', sender, Date.now())
+    // name the world before shipping it, so the requester can tell a later restart apart
+    binaryMessageBus.emit(CommsMessage.SERVER_ANNOUNCE, encodeGeneration(generation), [sender])
     const chunks = engineToCrdt(engine)
     if (chunks.length === 0) {
       DEBUG_NETWORK_MESSAGES() && console.log('[Emiting empty state:]', sender, Date.now())
@@ -131,27 +214,31 @@ export function addSyncTransport(
       }
     }
   })
-  binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, async (data, sender) => {
-    requestingState = false
-    elapsedTimeSinceRequest = 0
-    if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
+  onComms(CommsMessage.RES_CRDT_STATE, (data, sender) => {
+    const event = stateResponse(sender)
+    if (!event || isServerAtom.getOrNull()) return
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
-    if (data.byteLength > 0) {
-      deliverToEngine(serverValidator.processClientMessages(data, sender))
-    }
-    stateIsSyncronized = true
 
-    // IMPORTANT: Only mark room as ready AFTER state is synchronized
-    // This ensures comms is truly connected and working
-    const realmInfo = RealmInfo.getOrNull(engine.RootEntity)
-    if (realmInfo) {
-      DEBUG_NETWORK_MESSAGES() && console.log('[isRoomReady] Marking room as ready after state sync')
-      isRoomReadyAtom.swap(true)
+    const firstChunk = dump === null
+    const current = (dump = dump ?? { entities: new Set<Entity>(), reconcile: false, quiet: false })
+    current.quiet = false
+    if (data.byteLength > 0) {
+      deliverToEngine(serverValidator.processClientMessages(data, sender, false, current.entities))
     }
+
+    const effects = hydration.send(event)
+    // only the head of a dump decides: every chunk after it describes the same world
+    if (firstChunk) current.reconcile = effects.includes('reconcile')
+    applyEffects(effects)
+  })
+
+  onComms(CommsMessage.SERVER_ANNOUNCE, (data, sender) => {
+    if (sender !== AUTH_SERVER_PEER_ID) return
+    applyEffects(hydration.send({ type: 'serverAnnounced', generation: decodeGeneration(data) }))
   })
 
   // received message from the network
-  binaryMessageBus.on(CommsMessage.CRDT, (value, sender) => {
+  onComms(CommsMessage.CRDT, (value, sender) => {
     const isServer = isServerAtom.getOrNull()
     DEBUG_NETWORK_MESSAGES() &&
       console.log(
@@ -168,7 +255,7 @@ export function addSyncTransport(
   })
 
   // received authoritative message from server - force apply to fix invalid local state
-  binaryMessageBus.on(CommsMessage.CRDT_AUTHORITATIVE, (value, sender) => {
+  onComms(CommsMessage.CRDT_AUTHORITATIVE, (value, sender) => {
     // Only accept authoritative messages from authoritative server
     if (sender !== AUTH_SERVER_PEER_ID) return
 
@@ -189,86 +276,63 @@ export function addSyncTransport(
 
   players.onEnterScene((player) => {
     DEBUG_NETWORK_MESSAGES() && console.log('[onEnterScene]', player.userId)
-    if (!isServerAtom.getOrNull() && myProfile.userId === player.userId) {
-      requestState()
-    }
+    if (myProfile.userId === player.userId) applyEffects(hydration.send({ type: 'ownPlayerEntered' }))
   })
 
-  // Asks for the REQ_CRDT_STATE when its connected to comms
+  /**
+   * Why ask for the state when the server already pushes it to whoever joins?
+   * The server does send it on the livekit JOIN_PARTICIPANT event, but unity takes
+   * long enough getting there that the push is not delivered. So the client asks
+   * once comms is up, and the server answers.
+   */
   RealmInfo.onChange(engine.RootEntity, (value) => {
-    const isServer = isServerAtom.getOrNull()
-
-    if (!value?.isConnectedSceneRoom) {
-      // Only react when actually transitioning from ready to not ready
-      if (isRoomReadyAtom.getOrNull() === true) {
-        DEBUG_NETWORK_MESSAGES() && console.log('Disconnected from comms')
-        isRoomReadyAtom.swap(false)
-        if (!isServer) {
-          stateIsSyncronized = false
-        }
-      }
-    }
-
     if (value?.isConnectedSceneRoom) {
-      requestState()
-
-      // For servers, mark as ready immediately when connected
-      // (servers don't need to sync state from anyone)
-      if (isServer && isRoomReadyAtom.getOrNull() === false) {
+      applyEffects(hydration.send({ type: 'realmConnected' }))
+      // a server hydrates from nobody, so being on comms is all it waits for
+      if (isServerAtom.getOrNull() && isRoomReadyAtom.getOrNull() === false) {
         DEBUG_NETWORK_MESSAGES() && console.log('[isRoomReady] Server marking room as ready')
         isRoomReadyAtom.swap(true)
       }
-      // For clients, room will be marked ready after receiving CRDT state (above)
+      return
+    }
+    // only react when actually transitioning from ready to not ready
+    if (isRoomReadyAtom.getOrNull() === true) {
+      DEBUG_NETWORK_MESSAGES() && console.log('Disconnected from comms')
+      isRoomReadyAtom.swap(false)
+      applyEffects(hydration.send({ type: 'realmDisconnected' }))
     }
   })
 
-  let requestingState = false
-  let elapsedTimeSinceRequest = 0
-  const STATE_REQUEST_RETRY_INTERVAL = 2.0 // seconds
-
-  /**
-   * Why we have to request the state if we have a server that can send us the state when we joined?
-   * The thing is that when the server detects a new JOIN_PARTICIPANT on livekit room, it sends automatically the state to that peer.
-   * But in unity, it takes more time, so that message is not being delivered to the client.
-   * So instead, when we are finally connected to the room, we request the state, and then the server answers with the state :)
-   *
-   * If no response is received within 2 seconds, the request is automatically retried.
-   */
-  function requestState() {
-    if (isServerAtom.getOrNull()) return
-    if (RealmInfo.getOrNull(engine.RootEntity)?.isConnectedSceneRoom && !requestingState) {
-      requestingState = true
-      elapsedTimeSinceRequest = 0
-      DEBUG_NETWORK_MESSAGES() && console.log('Requesting state...')
-      binaryMessageBus.emit(CommsMessage.REQ_CRDT_STATE, new Uint8Array())
-    }
-  }
-
-  // System to retry state request if no response is received within the retry interval
+  // drives the state-request retry, and closes a dump once its chunks stop coming
   engine.addSystem((dt: number) => {
-    if (requestingState && !stateIsSyncronized) {
-      elapsedTimeSinceRequest += dt
-      if (elapsedTimeSinceRequest >= STATE_REQUEST_RETRY_INTERVAL) {
-        DEBUG_NETWORK_MESSAGES() && console.log('State request timed out, retrying...')
-        elapsedTimeSinceRequest = 0
-        requestingState = false
-        requestState()
-      }
+    applyEffects(hydration.send({ type: 'tick', dt }))
+    if (!dump) return
+    // one silent frame before deciding what the dump left out, so a dump split
+    // over several chunks is judged whole instead of chunk by chunk.
+    // ponytail: a quiet frame, not a terminator — a chunk delayed by more than a
+    // frame reconciles early and its entities are dropped and re-created (churn,
+    // not divergence). Upgrade path: mark the last chunk of a dump on the wire.
+    if (!dump.quiet) {
+      dump.quiet = true
+      return
     }
+    if (dump.reconcile) reconcileWithDump(dump.entities)
+    dump = null
+  })
+
+  void isServerAtom.pipe((isServer) => {
+    applyEffects(hydration.send({ type: 'roleResolved', isServer }))
+    for (const replay of bufferedComms.splice(0)) replay()
   })
 
   players.onLeaveScene((userId) => {
     DEBUG_NETWORK_MESSAGES() && console.log('[onLeaveScene]', userId)
   })
 
-  function isStateSyncronized() {
-    return stateIsSyncronized
-  }
-
   return {
     ...entityDefinitions,
     myProfile,
-    isStateSyncronized,
+    isStateSyncronized: hydration.isSynced,
     binaryMessageBus,
     eventBus,
     isServerAtom,

--- a/packages/@dcl/sdk/src/network/server/index.ts
+++ b/packages/@dcl/sdk/src/network/server/index.ts
@@ -213,7 +213,15 @@ export function createServerValidator(config: ServerValidationConfig) {
   return {
     findExistingNetworkEntity,
     // transform Network messages to CRDT Common Messages.
-    processClientMessages: function processClientMessages(value: Uint8Array, sender: string, forceCorrections = false) {
+    // `seen` collects the local entities the payload named, so a caller applying a
+    // full state dump can tell which of its network entities the dump left out
+    // without parsing the payload a second time.
+    processClientMessages: function processClientMessages(
+      value: Uint8Array,
+      sender: string,
+      forceCorrections = false,
+      seen?: Set<Entity>
+    ) {
       // console.log(`[CLIENT] Processing message from ${sender}, ${value.length} bytes`)
 
       // Collect all regular messages in a single buffer for batched application
@@ -227,6 +235,7 @@ export function createServerValidator(config: ServerValidationConfig) {
 
           // Find or create network entity mapping
           const localEntityId = findOrCreateNetworkEntity(networkMessage, sender, false)
+          seen?.add(localEntityId)
 
           // Convert network message to regular message or correction message
           const regularMessage = convertNetworkToRegularMessage(networkMessage, localEntityId, forceCorrections)

--- a/test/sdk/network/characterization-flow.spec.ts
+++ b/test/sdk/network/characterization-flow.spec.ts
@@ -51,9 +51,6 @@ describe('network flow characterization', () => {
 
     expect(clientA.sync.isStateSyncronized()).toBe(true)
     expect(clientB.sync.isStateSyncronized()).toBe(true)
-    // QUIRK(pinned): the server never receives a RES_CRDT_STATE, so its own
-    // isStateSyncronized() stays false forever — see defect #14.
-    expect(server.sync.isStateSyncronized()).toBe(false)
     expect(clientA.sync.isRoomReadyAtom.getOrNull()).toBe(true)
     expect(server.sync.isRoomReadyAtom.getOrNull()).toBe(true)
   })
@@ -165,14 +162,5 @@ describe('network flow characterization', () => {
     expect(queuedHarness.clientA.sync.eventBus.isReady()).toBe(true)
     expect(queuedHarness.sentBy(CLIENT_A, CommsMessage.CUSTOM_EVENT)).toHaveLength(1)
     expect(inbox).toEqual(['queued'])
-  })
-
-  it('QUIRK(pinned): a non-server peer answers REQ_CRDT_STATE — see defect #1', async () => {
-    // will move to the red suite when the responder gets an isServer guard
-    harness.clear()
-    harness.inject(CLIENT_A, CLIENT_B, CommsMessage.REQ_CRDT_STATE, new Uint8Array())
-    await harness.tick()
-
-    expect(harness.sentBy(CLIENT_A, CommsMessage.RES_CRDT_STATE).map((response) => response.to)).toEqual([[CLIENT_B]])
   })
 })

--- a/test/sdk/network/defects-red.spec.ts
+++ b/test/sdk/network/defects-red.spec.ts
@@ -1,18 +1,17 @@
 /**
  * Red suite: one test per known defect, each asserting the CORRECT behavior.
  *
- * Every test is declared with `it.failing`, so jest expects it to throw today.
- * When a phase fixes a defect its test starts passing and `it.failing` turns
+ * An unfixed defect is declared with `it.failing`, so jest expects it to throw
+ * today. When a phase fixes one its test starts passing and `it.failing` turns
  * red — that is the signal to flip it to a plain `it` (and to drop the matching
  * `QUIRK(pinned)` assertion from the characterization specs).
  *
- * Source locations verified against the tree at the time of writing:
- *   #1  message-bus-sync.ts:117-129   REQ_CRDT_STATE responder, no isServer guard
- *   #2  message-bus-sync.ts:130-133   RES_CRDT_STATE clears the retry state before checking the sender
+ * Fixed in phase 1 (hydration FSM), now plain `it`: #1, #2, #6, #7, #9, #14.
+ *
+ * Source locations of what is still red, verified at the time of writing:
  *   #3  server/index.ts:108-141       validateMessagePermissions: DELETE_ENTITY TODO + default `return true`
  *   #4  server/index.ts:169-211       sendCorrectionToSender
  *   #8  state.ts:106-111 (already names the component) + chunking.ts:29-32 (does not)
- *   #9  message-bus-sync.ts:150-163   CRDT handler reads a possibly-null role
  *   #10 message-bus-sync.ts:89-91     client emits CRDT with no address
  *   #11 server/index.ts:143-167       broadcastBatchedMessages ignores excludeSender
  *   #12 events/implementation.ts:245-253  registerMessages Object.assign over a flat global registry
@@ -60,7 +59,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     jest.restoreAllMocks()
   })
 
-  it.failing('#1 only the authoritative server answers REQ_CRDT_STATE', async () => {
+  it('#1 only the authoritative server answers REQ_CRDT_STATE', async () => {
     const harness = createHarness()
     await flush()
     harness.clear()
@@ -71,7 +70,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.sentBy(CLIENT_A, CommsMessage.RES_CRDT_STATE)).toHaveLength(0)
   })
 
-  it.failing('#2 a stray RES_CRDT_STATE from a non-server peer must not halt the retry loop', async () => {
+  it('#2 a stray RES_CRDT_STATE from a non-server peer must not halt the retry loop', async () => {
     const harness = createHarness()
     await flush()
     setRealmConnected(true)
@@ -137,7 +136,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.clientA.components.Transform.get(entity).position.x).not.toBe(600)
   })
 
-  it.failing('#6 re-hydration removes network entities missing from the new full state', async () => {
+  it('#6 re-hydration removes network entities missing from the new full state', async () => {
     const harness = createHarness()
     await harness.connect()
 
@@ -162,7 +161,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.entities(harness.clientA)).toHaveLength(1)
   })
 
-  it.failing('#7 a restarted server makes its clients re-hydrate', async () => {
+  it('#7 a restarted server makes its clients re-hydrate', async () => {
     const harness = createHarness()
     await harness.connect()
 
@@ -206,7 +205,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(error).toHaveBeenCalledWith(expect.stringContaining(`component ${GlobalTransform.componentId}`))
   })
 
-  it.failing('#9 CRDT that arrives before the role resolves is buffered, not dropped', async () => {
+  it('#9 CRDT that arrives before the role resolves is buffered, not dropped', async () => {
     const harness = createHarness()
     let resolveRole!: (isServer: boolean) => void
     const role = new Promise<boolean>((resolve) => (resolveRole = resolve))
@@ -287,7 +286,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(left).toEqual(['0xplayer'])
   })
 
-  it.failing('#14 the server reports a synchronized state once it is ready', async () => {
+  it('#14 the server reports a synchronized state once it is ready', async () => {
     const harness = createHarness()
     await harness.connect()
 

--- a/test/sdk/network/hydration-fsm.spec.ts
+++ b/test/sdk/network/hydration-fsm.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for the hydration state machine. No engines, no comms, no clock:
+ * the machine only sees events and only answers with effects, which is the whole
+ * point of extracting it out of `message-bus-sync`.
+ */
+import { AUTH_SERVER_PEER_ID } from '../../../packages/@dcl/sdk/src/network/constants'
+import {
+  Hydration,
+  STATE_REQUEST_RETRY_INTERVAL,
+  createHydration,
+  decodeGeneration,
+  encodeGeneration,
+  newGeneration,
+  stateResponse
+} from '../../../packages/@dcl/sdk/src/network/hydration'
+
+const dump = () => stateResponse(AUTH_SERVER_PEER_ID)
+
+/** a client that asked for the state and is waiting for it */
+function requestingClient(): Hydration {
+  const hydration = createHydration()
+  hydration.send({ type: 'roleResolved', isServer: false })
+  expect(hydration.send({ type: 'realmConnected' })).toEqual(['requestState'])
+  return hydration
+}
+
+function syncedClient(generation = 7): Hydration {
+  const hydration = requestingClient()
+  hydration.send({ type: 'serverAnnounced', generation })
+  expect(hydration.send(dump())).toEqual(['markSynced'])
+  return hydration
+}
+
+describe('hydration state machine', () => {
+  it('starts disconnected, unsynchronized, and ignores everything that is not a connection', () => {
+    const hydration = createHydration()
+
+    expect(hydration.state()).toBe('DISCONNECTED')
+    expect(hydration.isSynced()).toBe(false)
+    expect(hydration.send({ type: 'tick', dt: 60 })).toEqual([])
+    expect(hydration.send({ type: 'ownPlayerEntered' })).toEqual([])
+    expect(hydration.send({ type: 'realmDisconnected' })).toEqual([])
+    expect(hydration.state()).toBe('DISCONNECTED')
+  })
+
+  describe('reaching the first hydration', () => {
+    it('waits in CONNECTED while the role is unknown, then requests the state as a client', () => {
+      const hydration = createHydration()
+
+      expect(hydration.send({ type: 'realmConnected' })).toEqual([])
+      expect(hydration.state()).toBe('CONNECTED')
+
+      expect(hydration.send({ type: 'roleResolved', isServer: false })).toEqual(['requestState'])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+    })
+
+    it('requests the state when the realm comes up after the role', () => {
+      const hydration = createHydration()
+
+      expect(hydration.send({ type: 'roleResolved', isServer: false })).toEqual([])
+      expect(hydration.state()).toBe('DISCONNECTED')
+      expect(hydration.send({ type: 'realmConnected' })).toEqual(['requestState'])
+    })
+
+    it('lets the own player entering the scene drive the request out of CONNECTED', () => {
+      const hydration = createHydration()
+      hydration.send({ type: 'realmConnected' })
+
+      // still no role: nothing to do yet
+      expect(hydration.send({ type: 'ownPlayerEntered' })).toEqual([])
+
+      hydration.send({ type: 'roleResolved', isServer: false })
+      // and once requesting, entering the scene again changes nothing
+      expect(hydration.send({ type: 'ownPlayerEntered' })).toEqual([])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+    })
+
+    it('applies a state dump without reconciling anything on a first join', () => {
+      const hydration = requestingClient()
+
+      expect(hydration.send(dump())).toEqual(['markSynced'])
+      expect(hydration.state()).toBe('SYNCED')
+      expect(hydration.isSynced()).toBe(true)
+    })
+
+    it('reconciles every dump after the first one', () => {
+      const hydration = syncedClient()
+
+      expect(hydration.send(dump())).toEqual(['reconcile', 'markSynced'])
+    })
+  })
+
+  describe('the server short-circuit', () => {
+    it('is synchronized and announces itself as soon as its role is known', () => {
+      const hydration = createHydration()
+
+      expect(hydration.send({ type: 'roleResolved', isServer: true })).toEqual(['markSynced', 'announce'])
+      expect(hydration.state()).toBe('SYNCED')
+      expect(hydration.isSynced()).toBe(true)
+    })
+
+    it('does not announce twice when the realm comes up afterwards', () => {
+      const hydration = createHydration()
+      hydration.send({ type: 'roleResolved', isServer: true })
+
+      expect(hydration.send({ type: 'realmConnected' })).toEqual([])
+    })
+
+    it('announces once when the role lands after the realm', () => {
+      const hydration = createHydration()
+      hydration.send({ type: 'realmConnected' })
+
+      expect(hydration.send({ type: 'roleResolved', isServer: true })).toEqual(['markSynced', 'announce'])
+    })
+
+    it('stays synchronized across a disconnect, and never hydrates from anyone', () => {
+      const hydration = createHydration()
+      hydration.send({ type: 'roleResolved', isServer: true })
+
+      expect(hydration.send({ type: 'realmDisconnected' })).toEqual([])
+      expect(hydration.state()).toBe('SYNCED')
+      expect(hydration.send(dump())).toEqual([])
+      expect(hydration.send({ type: 'serverAnnounced', generation: 99 })).toEqual([])
+      expect(hydration.state()).toBe('SYNCED')
+    })
+  })
+
+  describe('the retry timer', () => {
+    it('re-requests once the accumulated dt reaches the interval, then starts over', () => {
+      const hydration = requestingClient()
+      const step = STATE_REQUEST_RETRY_INTERVAL / 4
+
+      expect(hydration.send({ type: 'tick', dt: step })).toEqual([])
+      expect(hydration.send({ type: 'tick', dt: step })).toEqual([])
+      expect(hydration.send({ type: 'tick', dt: step })).toEqual([])
+      expect(hydration.send({ type: 'tick', dt: step })).toEqual(['requestState'])
+
+      expect(hydration.send({ type: 'tick', dt: step })).toEqual([])
+      expect(hydration.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL })).toEqual(['requestState'])
+    })
+
+    it('does not run outside REQUESTING_STATE', () => {
+      const disconnected = createHydration()
+      expect(disconnected.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 3 })).toEqual([])
+
+      const connected = createHydration()
+      connected.send({ type: 'realmConnected' })
+      expect(connected.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 3 })).toEqual([])
+
+      const synced = syncedClient()
+      expect(synced.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 3 })).toEqual([])
+    })
+
+    it('restarts from zero once the dump lands', () => {
+      const hydration = requestingClient()
+      hydration.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 0.9 })
+      hydration.send(dump())
+
+      // back to requesting: the leftover 0.9 must not carry over into the new wait
+      hydration.send({ type: 'realmDisconnected' })
+      hydration.send({ type: 'realmConnected' })
+      expect(hydration.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 0.9 })).toEqual([])
+    })
+  })
+
+  describe('a reply from anyone but the authoritative server', () => {
+    it('cannot be turned into an event at all', () => {
+      expect(stateResponse('clientB')).toBeNull()
+      expect(stateResponse('')).toBeNull()
+      expect(stateResponse(AUTH_SERVER_PEER_ID)?.type).toBe('stateReceived')
+    })
+
+    it('is not representable as one either', () => {
+      const hydration = requestingClient()
+
+      // @ts-expect-error only stateResponse() can mint a stateReceived event
+      hydration.send({ type: 'stateReceived' })
+    })
+
+    it('leaves the retry timer exactly where it was', () => {
+      const hydration = requestingClient()
+      hydration.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 0.75 })
+
+      expect(hydration.send(stateResponse('clientB'))).toEqual([])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+      expect(hydration.isSynced()).toBe(false)
+
+      // the timer kept counting from 0.75, so a quarter of the interval is enough
+      expect(hydration.send({ type: 'tick', dt: STATE_REQUEST_RETRY_INTERVAL * 0.25 })).toEqual(['requestState'])
+    })
+  })
+
+  describe('reconnecting', () => {
+    it('drops back to DISCONNECTED and re-requests on the way back', () => {
+      const hydration = syncedClient()
+
+      expect(hydration.send({ type: 'realmDisconnected' })).toEqual([])
+      expect(hydration.state()).toBe('DISCONNECTED')
+      expect(hydration.isSynced()).toBe(false)
+
+      expect(hydration.send({ type: 'realmConnected' })).toEqual(['requestState'])
+    })
+
+    it('remembers it has hydrated before, so the dump it comes back to is reconciled', () => {
+      const hydration = syncedClient()
+      hydration.send({ type: 'realmDisconnected' })
+      hydration.send({ type: 'realmConnected' })
+
+      expect(hydration.send(dump())).toEqual(['reconcile', 'markSynced'])
+    })
+
+    it('ignores a disconnect it is already in, and a connect it is already out of', () => {
+      const hydration = requestingClient()
+
+      expect(hydration.send({ type: 'realmConnected' })).toEqual([])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+
+      hydration.send({ type: 'realmDisconnected' })
+      expect(hydration.send({ type: 'realmDisconnected' })).toEqual([])
+      expect(hydration.state()).toBe('DISCONNECTED')
+    })
+  })
+
+  describe('server generations', () => {
+    it('records the first announcement without re-hydrating', () => {
+      const hydration = requestingClient()
+
+      expect(hydration.send({ type: 'serverAnnounced', generation: 1 })).toEqual([])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+    })
+
+    it('ignores an announcement repeating the generation it hydrated from', () => {
+      const hydration = syncedClient(3)
+
+      expect(hydration.send({ type: 'serverAnnounced', generation: 3 })).toEqual([])
+      expect(hydration.state()).toBe('SYNCED')
+    })
+
+    it('re-enters REQUESTING_STATE when a synced client sees a new generation', () => {
+      const hydration = syncedClient(3)
+
+      expect(hydration.send({ type: 'serverAnnounced', generation: 4 })).toEqual(['requestState'])
+      expect(hydration.state()).toBe('REQUESTING_STATE')
+      expect(hydration.isSynced()).toBe(false)
+    })
+
+    it('takes the new generation quietly when it is still hydrating or offline', () => {
+      const midHydration = requestingClient()
+      midHydration.send({ type: 'serverAnnounced', generation: 3 })
+      expect(midHydration.send({ type: 'serverAnnounced', generation: 4 })).toEqual([])
+      expect(midHydration.state()).toBe('REQUESTING_STATE')
+      // and the dump it was already waiting for still counts
+      expect(midHydration.send(dump())).toEqual(['markSynced'])
+
+      const offline = syncedClient(3)
+      offline.send({ type: 'realmDisconnected' })
+      expect(offline.send({ type: 'serverAnnounced', generation: 4 })).toEqual([])
+      expect(offline.state()).toBe('DISCONNECTED')
+    })
+  })
+
+  describe('the generation payload', () => {
+    it('round-trips through 4 bytes', () => {
+      for (const generation of [0, 1, 0xdeadbeef, 0xffffffff]) {
+        const encoded = encodeGeneration(generation)
+        expect(encoded.byteLength).toBe(4)
+        expect(decodeGeneration(encoded)).toBe(generation)
+      }
+    })
+
+    it('survives a payload that is not one, and mints values inside the encodable range', () => {
+      expect(decodeGeneration(new Uint8Array())).toBe(0)
+      expect(decodeGeneration(new Uint8Array([1, 2]))).toBe(0)
+
+      for (let i = 0; i < 50; i++) {
+        const generation = newGeneration()
+        expect(decodeGeneration(encodeGeneration(generation))).toBe(generation)
+      }
+    })
+  })
+})

--- a/test/sdk/network/late-join-hydration.spec.ts
+++ b/test/sdk/network/late-join-hydration.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * A peer that joins a world already in progress must end up holding exactly that
+ * world, and must keep asking for it until somebody answers. Every scenario ends
+ * on the convergence oracle.
+ */
+import { Entity } from '../../../packages/@dcl/ecs'
+import { CommsMessage } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { expectConvergence } from './utils/convergence'
+import { CLIENT_A, Harness, Peer, createHarness, flush, setRealmConnected } from './utils/harness'
+
+const LATE = 'clientLate'
+
+/** `count` synced entities authored by clientA, one unit apart on x */
+async function populate(harness: Harness, count: number): Promise<Entity[]> {
+  const entities: Entity[] = []
+  for (let i = 0; i < count; i++) {
+    const entity = harness.clientA.engine.addEntity()
+    harness.clientA.components.Transform.create(entity, { position: { x: i, y: 0, z: 0 } })
+    harness.clientA.sync.syncEntity(entity, [harness.clientA.components.Transform.componentId])
+    entities.push(entity)
+  }
+  await harness.tick()
+  return entities
+}
+
+/** attaches a peer that was not around when the world was built */
+async function joinLate(harness: Harness): Promise<Peer> {
+  const late = harness.attach(LATE, false)
+  await flush()
+  setRealmConnected(true)
+  return late
+}
+
+describe('late join hydration', () => {
+  it('hands a fresh peer the whole world', async () => {
+    const harness = createHarness()
+    await harness.connect()
+    await populate(harness, 3)
+    expect(harness.entities(harness.server)).toHaveLength(3)
+
+    const late = await joinLate(harness)
+    await harness.tick(6)
+
+    expect(late.sync.isStateSyncronized()).toBe(true)
+    expect(harness.entities(late)).toHaveLength(3)
+    expectConvergence({
+      server: harness.server.engine,
+      clientA: harness.clientA.engine,
+      clientLate: late.engine
+    })
+  })
+
+  it('asks the authoritative server, and nobody else answers', async () => {
+    const harness = createHarness()
+    await harness.connect()
+    await populate(harness, 1)
+
+    const late = await joinLate(harness)
+    harness.clear()
+    await harness.tick(6)
+
+    expect(harness.sentBy(LATE, CommsMessage.REQ_CRDT_STATE).length).toBeGreaterThanOrEqual(1)
+    // the other clients hear nothing of it: only the server is reachable, and only
+    // the server answers
+    expect(harness.sentBy(CLIENT_A, CommsMessage.RES_CRDT_STATE)).toHaveLength(0)
+    expect(
+      harness.deliveredTo(LATE, CommsMessage.RES_CRDT_STATE).every((record) => record.from === 'authoritative-server')
+    ).toBe(true)
+    expectConvergence({ server: harness.server.engine, clientLate: late.engine })
+  })
+
+  it('keeps asking while the answer never comes, and hydrates on the one that does', async () => {
+    const harness = createHarness()
+    await harness.connect()
+    await populate(harness, 2)
+
+    const late = await joinLate(harness)
+    harness.clear()
+
+    // three seconds of frames the server sleeps through
+    for (let i = 0; i < 30; i++) await late.engine.update(0.1)
+
+    expect(late.sync.isStateSyncronized()).toBe(false)
+    expect(harness.entities(late)).toHaveLength(0)
+    // the first request plus at least one retry across the 2s interval
+    expect(harness.sentBy(LATE, CommsMessage.REQ_CRDT_STATE).length).toBeGreaterThanOrEqual(2)
+
+    await harness.tick(6)
+
+    expect(late.sync.isStateSyncronized()).toBe(true)
+    expect(harness.entities(late)).toHaveLength(2)
+    expectConvergence({
+      server: harness.server.engine,
+      clientA: harness.clientA.engine,
+      clientLate: late.engine
+    })
+  })
+
+  it('does not reconcile away what the joining peer created before the dump landed', async () => {
+    const harness = createHarness()
+    await harness.connect()
+    await populate(harness, 1)
+
+    const late = await joinLate(harness)
+    const own = late.engine.addEntity()
+    late.components.Transform.create(own, { position: { x: 9, y: 9, z: 9 } })
+    late.sync.syncEntity(own, [late.components.Transform.componentId])
+    await harness.tick(6)
+
+    // a first join has nothing to reconcile against, so the local entity survives
+    // and reaches the rest of the world the normal way
+    expect(harness.entities(late)).toHaveLength(2)
+    expectConvergence({
+      server: harness.server.engine,
+      clientA: harness.clientA.engine,
+      clientLate: late.engine
+    })
+  })
+})

--- a/test/sdk/network/reconnect-convergence.spec.ts
+++ b/test/sdk/network/reconnect-convergence.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * What happens to a client that comes back to a world that moved on without it,
+ * and to a whole room whose authoritative server was replaced underneath it.
+ * Every scenario ends on the convergence oracle.
+ */
+import { Entity } from '../../../packages/@dcl/ecs'
+import { CommsMessage } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import { expectConvergence } from './utils/convergence'
+import { CLIENT_A, Harness, Peer, SERVER, createHarness, flush, setRealmConnected } from './utils/harness'
+
+function spawn(peer: Peer, position: { x: number; y: number; z: number }): Entity {
+  const entity = peer.engine.addEntity()
+  peer.components.Transform.create(entity, { position })
+  peer.sync.syncEntity(entity, [peer.components.Transform.componentId])
+  return entity
+}
+
+/** ticks everyone except the peer that is meant to be offline */
+async function tickWithout(harness: Harness, offline: string, rounds = 4) {
+  const online = Object.values(harness.peers).filter((peer) => peer.id !== offline)
+  for (let i = 0; i < rounds; i++) await Promise.all(online.map((peer) => peer.engine.update(1)))
+}
+
+describe('reconnect convergence', () => {
+  it('drops the ghost of an entity deleted while the client was away', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    const kept = spawn(harness.clientA, { x: 1, y: 1, z: 1 })
+    const doomed = spawn(harness.clientB, { x: 2, y: 2, z: 2 })
+    await harness.tick()
+    expect(harness.entities(harness.clientA)).toHaveLength(2)
+
+    setRealmConnected(false)
+    harness.clientB.engine.removeEntity(doomed)
+    await tickWithout(harness, CLIENT_A)
+    // nothing was held for the peer that was not there
+    harness.drop(CLIENT_A)
+    expect(harness.entities(harness.server)).toHaveLength(1)
+
+    setRealmConnected(true)
+    await harness.tick(6)
+
+    expect(harness.clientA.sync.isStateSyncronized()).toBe(true)
+    expect(harness.entities(harness.clientA)).toEqual([kept])
+    expectConvergence({
+      server: harness.server.engine,
+      clientA: harness.clientA.engine,
+      clientB: harness.clientB.engine
+    })
+  })
+
+  it('keeps the entities the world still has when the client reconnects', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    spawn(harness.clientA, { x: 1, y: 1, z: 1 })
+    spawn(harness.clientB, { x: 2, y: 2, z: 2 })
+    await harness.tick()
+
+    setRealmConnected(false)
+    await harness.clientA.engine.update(1)
+    harness.drop(CLIENT_A)
+    setRealmConnected(true)
+    await harness.tick(6)
+
+    // the dump named both, so reconciliation has nothing to take away
+    expect(harness.entities(harness.clientA)).toHaveLength(2)
+    expectConvergence({
+      server: harness.server.engine,
+      clientA: harness.clientA.engine,
+      clientB: harness.clientB.engine
+    })
+  })
+
+  it('re-hydrates every client onto a restarted server', async () => {
+    const harness = createHarness()
+    await harness.connect()
+
+    spawn(harness.clientA, { x: 1, y: 1, z: 1 })
+    spawn(harness.clientB, { x: 2, y: 2, z: 2 })
+    await harness.tick()
+    expect(harness.entities(harness.clientA)).toHaveLength(2)
+
+    // same comms identity, brand new engine holding a world of its own
+    const restarted = harness.attach(SERVER, true)
+    await flush()
+    harness.clear()
+    spawn(restarted, { x: 9, y: 9, z: 9 })
+    await harness.tick(8)
+
+    expect(harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE).length).toBeGreaterThanOrEqual(1)
+    // the two entities of the world that died are gone, the new one arrived
+    expect(harness.entities(harness.clientA)).toHaveLength(1)
+    expect(harness.entities(harness.clientB)).toHaveLength(1)
+    expectConvergence({
+      restartedServer: restarted.engine,
+      clientA: harness.clientA.engine,
+      clientB: harness.clientB.engine
+    })
+  })
+
+  it('does not make a client re-hydrate while the same server keeps announcing itself', async () => {
+    const harness = createHarness()
+    await harness.connect()
+    spawn(harness.clientA, { x: 1, y: 1, z: 1 })
+    await harness.tick()
+    harness.clear()
+
+    // reconnecting the realm re-announces the very same generation
+    setRealmConnected(true)
+    await harness.tick(4)
+
+    expect(harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE)).toHaveLength(0)
+    expect(harness.clientA.sync.isStateSyncronized()).toBe(true)
+    expectConvergence({ server: harness.server.engine, clientA: harness.clientA.engine })
+  })
+})

--- a/test/sdk/network/utils/harness.ts
+++ b/test/sdk/network/utils/harness.ts
@@ -10,7 +10,7 @@
  *   - the server reaches the addresses it asks for, or every client when the
  *     address list is empty (broadcast)
  */
-import { Engine, Entity, IEngine, RealmInfo, engine as globalEngine } from '../../../../packages/@dcl/ecs'
+import { Engine, Entity, IEngine } from '../../../../packages/@dcl/ecs'
 import * as components from '../../../../packages/@dcl/ecs/dist/components'
 import { addSyncTransport } from '../../../../packages/@dcl/sdk/src/network/message-bus-sync'
 import {
@@ -67,12 +67,13 @@ export function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+/** every engine `attach` ever built, so a realm write reaches all of them at once */
+const attachedEngines: IEngine[] = []
+
 /**
- * `message-bus-sync` reads/observes `RealmInfo` through the singleton component
- * bound to the module-level global engine (not the engine passed to
- * `addSyncTransport`), so a single write here is observed by every peer.
- * `onChange` callbacks only fire from the CRDT receive path, hence the explicit
- * `__onChangeCallbacks` call.
+ * Writes `RealmInfo` on every attached peer, which is what comms coming up looks
+ * like from inside a scene. `onChange` callbacks only fire from the CRDT receive
+ * path, hence the explicit `__onChangeCallbacks` call.
  */
 export function setRealmConnected(isConnectedSceneRoom: boolean): void {
   const value = {
@@ -84,10 +85,13 @@ export function setRealmConnected(isConnectedSceneRoom: boolean): void {
     room: 'scene-room',
     isConnectedSceneRoom
   }
-  RealmInfo.createOrReplace(globalEngine.RootEntity, value)
-  // `__onChangeCallbacks` is @internal, so it is trimmed from the published types
-  const internal = RealmInfo as unknown as { __onChangeCallbacks(entity: Entity, value: unknown): void }
-  internal.__onChangeCallbacks(globalEngine.RootEntity, value)
+  for (const engine of attachedEngines) {
+    const RealmInfo = components.RealmInfo(engine)
+    RealmInfo.createOrReplace(engine.RootEntity, value)
+    // `__onChangeCallbacks` is @internal, so it is trimmed from the published types
+    const internal = RealmInfo as unknown as { __onChangeCallbacks(entity: Entity, value: unknown): void }
+    internal.__onChangeCallbacks(engine.RootEntity, value)
+  }
 }
 
 export function createHarness() {
@@ -127,6 +131,7 @@ export function createHarness() {
   function attach(id: string, isServer: boolean | Promise<boolean>): Peer {
     queues[id] = queues[id] ?? []
     const engine = Engine()
+    attachedEngines.push(engine)
     const peerComponents = defineComponents(engine)
     const sendBinary = async (msg: SendBinaryRequest): Promise<SendBinaryResponse> => {
       for (const peerData of msg.peerData) {
@@ -169,6 +174,10 @@ export function createHarness() {
     tick,
     /** also usable to replace a peer with a fresh engine keeping its comms identity */
     attach,
+    /** throw away what piled up for a peer, the way a real disconnect does */
+    drop(peerId: string) {
+      queues[peerId].length = 0
+    },
     /** push a comms message into a peer's inbox as if `sender` had emitted it */
     inject(target: string, sender: string, type: CommsMessage, payload: Uint8Array) {
       deliver(target, sender, craftCommsMessage(type, payload))


### PR DESCRIPTION
Phase 1 of the authoritative-server network refactor. Fixes the core
divergence class ('some players see it, some don't'):

- network/hydration.ts: pure state machine (DISCONNECTED → CONNECTED →
  REQUESTING_STATE → SYNCED) replacing the loose booleans in
  message-bus-sync; a stray RES_CRDT_STATE from a non-server peer is
  unrepresentable as an FSM event (unique-symbol constructor), so the
  retry-halt bug is structurally impossible
- REQ_CRDT_STATE responder is server-gated: clients no longer hand out
  their partial world view to late joiners
- re-hydration reconciliation: a full state dump now removes local
  NetworkEntity-tagged entities it omits (ghost cleanup after
  reconnect); multi-chunk dumps accumulate before reconciling; tag is
  dropped before removal so cleanup never broadcasts deletions
- SERVER_ANNOUNCE (additive CommsMessage 10): the server names its run
  generation on ready and per state request; clients seeing a new
  generation re-hydrate, so a server restart converges automatically
- comms arriving before the isServer role resolves is buffered and
  replayed in order (capped, loud on overflow) instead of being
  misrouted down the client path
- isStateSyncronized() is now true on a ready server
- RealmInfo observed on the injected engine, not the global singleton

Red defect tests #1, #2, #6, #7, #9, #14 flip to passing; #3, #4, #8,
#10, #11, #12, #13 verified still red. Two QUIRK pins migrated from the
characterization suite to the red suite per the TDD discipline. New
specs: hydration-fsm (25 unit tests, no engine), late-join-hydration,
reconnect-convergence — all ending in the cross-engine convergence
oracle.

Claude-Session: https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


---
## 📚 Stack (splits #1505 — merge top-down within each stack)

**Network layer** (each PR is one self-contained, independently-green commit):
1. #1518 test harness — characterization baseline + red defect suite *(this stack's root)*
2. #1519 foundations — cycle break, single isServer, logging discipline
3. #1520 hydration FSM — late-join/reconnect correctness
4. #1521 validator — default-deny, correction path, entity index
5. #1522 codec — parse-once pipeline (wire goldens byte-identical)
6. #1523 topology — targeted sends, registry collisions, players dedupe
7. #1524 boot + host-conformance doc
8. #1525 simplification sweep (−95 lines)

**sdk-commands** (independent of the stack above):
- #1526 world-storage namespacing (pre-existing WIP, carried from the working tree)
- #1527 local dev-server reliability (depends on #1526)

After a parent squash-merges, the child needs `git rebase --onto origin/auth-server <old-parent> <child>` — ping the session and it gets restacked.
