### PR TITLE
[DO NOT MERGE] feat(sdk): default-deny server validation, fixed correction path, O(1) entity lookup

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -22,6 +22,7 @@ Curated map of every doc in this repo. Use this as the entry point when looking 
 | [world-transform-no-caching.md](world-transform-no-caching.md) | Why world-space transforms are computed lazily (not cached) and what that means for system authors. |
 | [on-demand-composite-loading.md](on-demand-composite-loading.md) | Runtime composite instantiation via `engine.addEntityFromComposite(src, options)`. The provider abstraction and pre-registration flow. |
 | [material-getflat-api.md](material-getflat-api.md) | Material `getFlat` API: reading a fully-resolved material descriptor instead of the discriminated union. |
+| [network-timestamp-trust.md](network-timestamp-trust.md) | Why the authoritative server trusts client-supplied CRDT timestamps, the griefing that enables, and what server-side re-stamping would cost. |
 
 ## Guides (how-to)
 

--- a/docs/network-timestamp-trust.md
+++ b/docs/network-timestamp-trust.md
@@ -1,0 +1,103 @@
+# Timestamp trust in the authoritative network layer
+
+The authoritative server decides which client writes survive, but it does not
+decide *when* they happened. Clients stamp their own CRDT timestamps and the
+server takes them at face value. This note records why that is a problem, what
+fixing it costs, and what not to build in the meantime.
+
+## Current behavior
+
+Every component write carries a Lamport timestamp the writer picks. On a client
+that timestamp comes from `incrementTimestamp` in
+`packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts`, which
+bumps the writer's own per-entity counter. The value travels unmodified inside
+`PUT_COMPONENT_NETWORK`.
+
+When the server receives that message, `validateMessagePermissions` in
+`packages/@dcl/sdk/src/network/server/index.ts` runs a dry run
+(`__dry_run_updateFromCrdt`) against the server's copy of the component. The dry
+run is pure last-write-wins conflict resolution: a message whose timestamp beats
+the server's stored one is accepted, a message that loses is rejected. The
+server then broadcasts the accepted message **with the client's timestamp
+intact**, so every other peer resolves the same conflict the same way.
+
+Rejection is the only lever the server has, and it is exercised through
+`sendCorrectionToSender`, which replies to the offender alone with a
+`CRDT_AUTHORITATIVE` message.
+
+## The risk
+
+Because the number is chosen by the writer and never rewritten, it is a trust
+boundary the server does not police:
+
+- **Clock skew.** Two clients that disagree about how far their counters have
+  advanced resolve conflicts in favor of whoever counted higher, not whoever
+  acted later. A client that reconnects and re-hydrates can come back with a
+  counter well ahead of its peers for no reason a player would recognize.
+- **Crafted timestamps.** A modified client can send `timestamp: 0xFFFFFFFF` and
+  win every subsequent conflict on that entity and component. Nothing in the
+  validator caps the value or compares it against the server's own clock. The
+  write still has to pass `validateBeforeChange`, so a scene with per-component
+  rules is not defenseless — but a scene without them has no protection at all.
+- **Corrections inherit the problem.** A correction built from
+  `getCrdtState(entity)` carries the server's stored timestamp, which is itself
+  a number some client picked earlier.
+
+The scene-visible symptom is a griefer who can pin a component to a value
+nobody else can overwrite.
+
+## Why server re-stamping is the fix
+
+The durable answer is for the server to own the clock: on an accepted write it
+replaces the client's timestamp with its own monotonic per-entity counter before
+broadcasting. Clients then never compete on a number they control, and a crafted
+timestamp buys nothing because it is discarded on arrival.
+
+That change is larger than it looks, and the reasons are worth writing down
+before someone attempts it:
+
+- **The sender must be corrected, not just the room.** Today the writer applies
+  its change locally and the server echoes the same timestamp back, so the echo
+  is a no-op. Re-stamping makes the echo differ from what the sender applied, so
+  the sender needs the rewritten message too — and it has to override the
+  sender's local state, which is what `AUTHORITATIVE_PUT_COMPONENT` and
+  `__forceUpdateFromCrdt` already do.
+- **Echo suppression interacts.** `lastSentData` in the LWW component definition
+  exists so a peer doesn't rebroadcast state it just sent. A rewritten timestamp
+  coming back has to update the sender's clock without being mistaken for a new
+  local edit that needs sending again.
+- **State dumps have to agree.** `engineToCrdt` ships the server's timestamps to
+  a hydrating client. Once the server owns the clock those dumps become the
+  authoritative baseline, so a client must adopt them wholesale rather than
+  merging them against its own counters.
+- **`DELETE_COMPONENT` has no force-apply opcode.** The wire has exactly one
+  authoritative operation, `AUTHORITATIVE_PUT_COMPONENT`. A re-stamped delete
+  has to win on merit, which is why the current correction path picks
+  `rejected timestamp + 1`. Server-owned clocks make that arithmetic principled
+  instead of a workaround, but only if the delete path gets the same treatment.
+
+## What not to do now
+
+Do not add partial mitigations. In particular:
+
+- **Do not clamp or sanity-check incoming timestamps.** A ceiling ("reject
+  anything more than N ahead of the server") is guesswork that breaks legitimate
+  reconnects and still lets an attacker advance N at a time.
+- **Do not swap Lamport counters for wall-clock time.** It replaces one
+  untrusted client number with another, and adds real clock skew to the failure
+  modes.
+- **Do not re-stamp on the server without also fixing the sender echo path.**
+  Rewriting the timestamp on broadcast while leaving the sender on its own value
+  produces a permanent split between the writer and everyone else — a worse
+  failure than the one being fixed.
+
+Treat timestamp ownership as one change that lands whole, alongside the tests
+that pin sender-echo behavior.
+
+## Related
+
+- `packages/@dcl/sdk/src/network/server/index.ts` — validator and correction
+  path.
+- `packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts` —
+  timestamp allocation, conflict resolution, and force-apply.
+- [wire-message.md](wire-message.md) — CRDT wire message format.

--- a/packages/@dcl/sdk/src/network/entities.ts
+++ b/packages/@dcl/sdk/src/network/entities.ts
@@ -11,6 +11,7 @@ import {
   ISyncComponents
 } from '@dcl/ecs'
 import { IProfile } from './constants'
+import { createNetworkEntityIndex } from './entity-index'
 import { getDesyncedComponents } from './state'
 
 export type SyncEntity = (entityId: Entity, componentIds: number[], entityEnumId?: number) => void
@@ -20,6 +21,7 @@ export function entityUtils(engine: IEngine, profile: IProfile) {
   const NetworkParent = engine.getComponent(_NetworkParent.componentId) as INetowrkParent
   const Transform = engine.getComponent(_Transform.componentId) as TransformComponent
   const SyncComponents = engine.getComponent(_SyncComponents.componentId) as ISyncComponents
+  const findNetworkEntity = createNetworkEntityIndex(engine, NetworkEntity)
 
   /**
    * Create a network entity (sync) through comms, and sync the received components
@@ -42,10 +44,8 @@ export function entityUtils(engine: IEngine, profile: IProfile) {
       networkValue.entityId = entityEnumId as Entity
 
       // Check if this enum is already used
-      for (const [_, network] of engine.getEntitiesWith(NetworkEntity)) {
-        if (network.networkId === networkValue.networkId && network.entityId === networkValue.entityId) {
-          throw new Error('syncEntity failed because the id provided is already in use')
-        }
+      if (findNetworkEntity(networkValue.networkId, networkValue.entityId)) {
+        throw new Error('syncEntity failed because the id provided is already in use')
       }
     }
 
@@ -65,6 +65,11 @@ export function entityUtils(engine: IEngine, profile: IProfile) {
    * Returns an iterable of all the childrens of the given entity.
    * for (const children of getChildren(parent)) { console.log(children) }
    * or just => const childrens: Entity[] = Array.from(getChildren(parent))
+   *
+   * ponytail: still a scan, and over NetworkParent rather than NetworkEntity —
+   * a one-to-many reverse index is a different structure, and nothing on the
+   * per-message hot path calls this. Upgrade path: a second index keyed by parent
+   * identity, once a caller makes it worth maintaining.
    */
   function* getChildren(parent: Entity): Iterable<Entity> {
     const network = NetworkEntity.getOrNull(parent)
@@ -87,12 +92,7 @@ export function entityUtils(engine: IEngine, profile: IProfile) {
   function getParent(child: Entity): Entity | undefined {
     const parent = NetworkParent.getOrNull(child)
     if (!parent) return undefined
-    for (const [entity, network] of engine.getEntitiesWith(NetworkEntity)) {
-      if (parent.networkId === network.networkId && parent.entityId === network.entityId) {
-        return entity
-      }
-    }
-    return undefined
+    return findNetworkEntity(parent.networkId, parent.entityId) ?? undefined
   }
 
   /**

--- a/packages/@dcl/sdk/src/network/entity-index.ts
+++ b/packages/@dcl/sdk/src/network/entity-index.ts
@@ -1,0 +1,35 @@
+import { Entity, IEngine, INetowrkEntity } from '@dcl/ecs'
+
+/**
+ * Resolves the local entity that carries a network identity (`networkId:entityId`),
+ * replacing the `getEntitiesWith(NetworkEntity)` scan the network layer used to run
+ * once per inbound message.
+ *
+ * The map is a cache, not a registry: a hit counts only while the entity still
+ * carries the identity it was filed under, and a miss falls back to the scan. That
+ * is what keeps it honest without a single invalidation hook — NetworkEntity is
+ * written from several places (`syncEntity`, the validator, an applied state dump)
+ * and dropped by the engine (`reconcileWithDump`, DELETE_ENTITY), so a registry
+ * would have to hook all of them and would go stale the day one is added.
+ */
+export function createNetworkEntityIndex(engine: IEngine, NetworkEntity: INetowrkEntity) {
+  const index = new Map<string, Entity>()
+
+  return function findNetworkEntity(networkId: number, entityId: Entity): Entity | null {
+    const key = `${networkId}:${entityId}`
+    const cached = index.get(key)
+    if (cached !== undefined) {
+      const network = NetworkEntity.getOrNull(cached)
+      if (network && network.networkId === networkId && network.entityId === entityId) return cached
+      index.delete(key)
+    }
+
+    for (const [entity, network] of engine.getEntitiesWith(NetworkEntity)) {
+      if (network.networkId === networkId && network.entityId === entityId) {
+        index.set(key, entity)
+        return entity
+      }
+    }
+    return null
+  }
+}

--- a/packages/@dcl/sdk/src/network/server/index.ts
+++ b/packages/@dcl/sdk/src/network/server/index.ts
@@ -15,11 +15,13 @@ import { type BinaryMessageBus } from '../binary-message-bus'
 import {
   components,
   ReadWriteByteBuffer,
+  DeleteComponentNetwork,
   LastWriteWinElementSetComponentDefinition,
   GrowOnlyValueSetComponentDefinition,
   ComponentDefinition,
   InternalBaseComponent
 } from '../ecs-adapter'
+import { createNetworkEntityIndex } from '../entity-index'
 
 export { LIVEKIT_MAX_SIZE } from '../constants'
 
@@ -47,15 +49,10 @@ export function createServerValidator(config: ServerValidationConfig) {
     )
   }
 
+  const findNetworkEntity = createNetworkEntityIndex(engine, NetworkEntity)
+
   function findExistingNetworkEntity(message: utils.NetworkMessage): Entity | null {
-    // Look for existing network entity mapping (don't create new ones)
-    for (const [entityId, networkData] of engine.getEntitiesWith(NetworkEntity)) {
-      if (networkData.networkId === message.networkId && networkData.entityId === message.entityId) {
-        return entityId
-      }
-    }
-    // Return null if not found
-    return null
+    return findNetworkEntity(message.networkId, message.entityId)
   }
 
   function findOrCreateNetworkEntity(message: utils.NetworkMessage, sender: string, isServer: boolean): Entity {
@@ -105,39 +102,71 @@ export function createServerValidator(config: ServerValidationConfig) {
     }
   }
 
-  function validateMessagePermissions(message: utils.RegularMessage, sender: string, _localEntityId: Entity): boolean {
-    // Basic checks
+  /**
+   * Everything a peer asks the authoritative world to change goes through here.
+   * A type this function does not name is refused: a permissive fallthrough turns
+   * every message the protocol grows into an unaudited write.
+   *
+   * ponytail: authority is per-component (`validateBeforeChange`) plus CreatedBy
+   * ownership on entity deletion. The sync mode the old TODO promised
+   * ('all' | 'owner' | 'server') does not exist on this branch — `SyncComponents`
+   * carries a bare `componentIds: number[]` and nothing anywhere reads a mode — so
+   * there is nothing to enforce. Upgrade path: add the mode to the SyncComponents
+   * schema, then gate the PUT/DELETE_COMPONENT arm on it before the dry run.
+   */
+  function validateMessagePermissions(message: CrdtMessageBody, sender: string, localEntityId: Entity): boolean {
     if (!sender || sender === AUTH_SERVER_PEER_ID) {
       return false // Server shouldn't send messages to itself
     }
 
-    if (message.type === CrdtMessageType.DELETE_ENTITY) {
-      // TODO: how to handle this case ?
+    switch (message.type) {
+      case CrdtMessageType.PUT_COMPONENT:
+      case CrdtMessageType.DELETE_COMPONENT: {
+        const component = engine.getComponent(message.componentId) as InternalBaseComponent<unknown>
+        const buf = 'data' in message ? new ReadWriteByteBuffer(message.data) : null
+        const value = buf ? component.schema.deserialize(buf) : null
+        const dryRunCRDT = component.__dry_run_updateFromCrdt(message)
+        const validCRDT = [
+          ProcessMessageResultType.StateUpdatedData,
+          ProcessMessageResultType.StateUpdatedTimestamp,
+          ProcessMessageResultType.EntityDeleted
+        ].includes(dryRunCRDT)
+        const createdBy = CreatedBy.getOrNull(localEntityId)
+
+        return !!(
+          validCRDT &&
+          component.__run_validateBeforeChange(
+            message.entityId,
+            value,
+            sender,
+            createdBy?.address ?? AUTH_SERVER_PEER_ID
+          )
+        )
+      }
+
+      case CrdtMessageType.DELETE_ENTITY:
+      case CrdtMessageType.DELETE_ENTITY_NETWORK:
+        // Destroying an entity is only the creator's call. The server may do it too,
+        // which it cannot reach today: a message from itself is refused above.
+        // `localEntityId` and not `message.entityId`, because the network variant
+        // still names the sender's entity id rather than the local one.
+        //
+        // ponytail: a delete naming an entity the server has never seen still passes,
+        // because `findOrCreateNetworkEntity` created it a few lines earlier and
+        // stamped the sender as its creator. No existing state is reachable that way,
+        // but it does let a peer make the server broadcast a create and a delete for
+        // a phantom entity. Upgrade path: skip the create for DELETE_ENTITY_NETWORK
+        // and reject the message when the lookup misses.
+        return sender === AUTH_SERVER_PEER_ID || CreatedBy.getOrNull(localEntityId)?.address === sender
+
+      default:
+        console.error(
+          `[network] rejected an unhandled message type ${
+            CrdtMessageType[message.type] ?? message.type
+          } from ${sender}: the authoritative server only accepts component writes and entity deletions`
+        )
+        return false
     }
-
-    if (message.type === CrdtMessageType.PUT_COMPONENT || message.type === CrdtMessageType.DELETE_COMPONENT) {
-      const component = engine.getComponent(message.componentId) as InternalBaseComponent<unknown>
-      const buf = 'data' in message ? new ReadWriteByteBuffer(message.data) : null
-      const value = buf ? component.schema.deserialize(buf) : null
-      const dryRunCRDT = component.__dry_run_updateFromCrdt(message)
-      const validCRDT = [
-        ProcessMessageResultType.StateUpdatedData,
-        ProcessMessageResultType.StateUpdatedTimestamp,
-        ProcessMessageResultType.EntityDeleted
-      ].includes(dryRunCRDT)
-      const createdBy = CreatedBy.getOrNull(message.entityId)
-      const validMessage =
-        validCRDT &&
-        component.__run_validateBeforeChange(message.entityId, value, sender, createdBy?.address ?? AUTH_SERVER_PEER_ID)
-
-      return !!validMessage
-    }
-
-    // For now, basic validation - in the future this will check component sync permissions
-    // TODO: Check if sender owns the entity
-    // TODO: Check component sync mode ('all' | 'owner' | 'server')
-    // TODO: Run component custom validation
-    return true
   }
 
   function broadcastBatchedMessages(messages: utils.NetworkMessage[], excludeSender: string) {
@@ -184,11 +213,11 @@ export function createServerValidator(config: ServerValidationConfig) {
       }
 
       const serverCRDTState = component.getCrdtState(localEntityId)
+      const correctionBuffer = new ReadWriteByteBuffer()
 
       if (serverCRDTState) {
         // Create authoritative message using PUT_COMPONENT_NETWORK
         // Each client will convert this to AUTHORITATIVE_PUT_COMPONENT with proper entity mapping
-        const correctionBuffer = new ReadWriteByteBuffer()
         PutNetworkComponentOperation.write(
           networkMessage.entityId, // Use original network entity ID
           serverCRDTState.timestamp,
@@ -197,14 +226,32 @@ export function createServerValidator(config: ServerValidationConfig) {
           serverCRDTState.data,
           correctionBuffer
         )
-        // Send authoritative message directly to the sender
-        binaryMessageBus.emit(CommsMessage.CRDT_AUTHORITATIVE, correctionBuffer.toBinary(), [sender])
-
-        DEBUG_NETWORK_MESSAGES() &&
-          console.log(
-            `[AUTHORITATIVE] Sent authoritative message to ${sender} for entity ${localEntityId} component ${networkMessage.componentId} with timestamp ${networkMessage.timestamp}`
-          )
+      } else {
+        // A rejected *first* write leaves the server holding nothing, and "revert to
+        // the server state" then means "you do not have this component". There is no
+        // authoritative delete on the wire — AUTHORITATIVE_PUT_COMPONENT is the only
+        // force-applied opcode — so the delete has to win the LWW on merit, and the
+        // one clock we know beats the offender's is the timestamp it just sent.
+        DeleteComponentNetwork.write(
+          networkMessage.entityId,
+          networkMessage.componentId,
+          networkMessage.timestamp + 1,
+          networkMessage.networkId,
+          correctionBuffer
+        )
       }
+
+      // Send authoritative message directly to the sender
+      binaryMessageBus.emit(CommsMessage.CRDT_AUTHORITATIVE, correctionBuffer.toBinary(), [sender])
+
+      DEBUG_NETWORK_MESSAGES() &&
+        console.log(
+          `[AUTHORITATIVE] Sent authoritative ${
+            serverCRDTState ? 'state' : 'delete'
+          } to ${sender} for entity ${localEntityId} component ${networkMessage.componentId} with timestamp ${
+            networkMessage.timestamp
+          }`
+        )
     } catch (error) {
       DEBUG_NETWORK_MESSAGES() && console.error('Error sending correction:', error)
     }
@@ -266,8 +313,10 @@ export function createServerValidator(config: ServerValidationConfig) {
             // 2. Convert network message to regular message and collect for local application
             const regularMessage = convertNetworkToRegularMessage(networkMessage, localEntityId)
 
-            // 3. Basic permission validation
-            if (!validateMessagePermissions(regularMessage as any, sender, localEntityId)) {
+            // 3. Basic permission validation. A payload that did not decode is
+            //    unvalidatable and therefore unbroadcastable, so it is treated as a
+            //    rejection rather than waved through as an untyped message.
+            if (!regularMessage || !validateMessagePermissions(regularMessage, sender, localEntityId)) {
               // Send correction back to sender with server's authoritative state
               sendCorrectionToSender(networkMessage, sender, localEntityId)
               continue
@@ -276,7 +325,7 @@ export function createServerValidator(config: ServerValidationConfig) {
             // 4. Collect valid message for batched broadcasting
             messagesToBroadcast.push(networkMessage)
 
-            if (regularMessage?.messageBuffer.byteLength) {
+            if (regularMessage.messageBuffer.byteLength) {
               regularMessagesBuffer.writeBuffer(regularMessage.messageBuffer, false)
             }
           }

--- a/test/sdk/network/defects-red.spec.ts
+++ b/test/sdk/network/defects-red.spec.ts
@@ -7,10 +7,9 @@
  * `QUIRK(pinned)` assertion from the characterization specs).
  *
  * Fixed in phase 1 (hydration FSM), now plain `it`: #1, #2, #6, #7, #9, #14.
+ * Fixed in phase 2 (validator hardening), now plain `it`: #3, #4.
  *
  * Source locations of what is still red, verified at the time of writing:
- *   #3  server/index.ts:108-141       validateMessagePermissions: DELETE_ENTITY TODO + default `return true`
- *   #4  server/index.ts:169-211       sendCorrectionToSender
  *   #8  state.ts:106-111 (already names the component) + chunking.ts:29-32 (does not)
  *   #10 message-bus-sync.ts:89-91     client emits CRDT with no address
  *   #11 server/index.ts:143-167       broadcastBatchedMessages ignores excludeSender
@@ -93,7 +92,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.clientA.sync.isStateSyncronized()).toBe(true)
   })
 
-  it.failing('#3 the server rejects a DELETE_ENTITY for an entity the sender did not create', async () => {
+  it('#3 the server rejects a DELETE_ENTITY for an entity the sender did not create', async () => {
     const harness = createHarness()
     await flush()
 
@@ -116,7 +115,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.sentBy(SERVER, CommsMessage.CRDT)).toHaveLength(0)
   })
 
-  it.failing('#4 a rejected first write is corrected with CRDT_AUTHORITATIVE to the offender', async () => {
+  it('#4 a rejected first write is corrected with CRDT_AUTHORITATIVE to the offender', async () => {
     const harness = createHarness()
     await flush()
     harness.server.components.Transform.validateBeforeChange(
@@ -129,11 +128,13 @@ describe('known defects (red: asserting the correct behavior)', () => {
     harness.clear()
     await harness.tick()
 
-    // the server holds no state for the component yet, so getCrdtState() returns
-    // null and the correction is silently skipped
+    // the server holds no state for the component, so the only correction it can
+    // state is "you do not have this component" — hence getOrNull, the offender is
+    // left with no Transform at all rather than with a different one
     const corrections = harness.sentBy(SERVER, CommsMessage.CRDT_AUTHORITATIVE)
     expect(corrections.map((correction) => correction.to)).toEqual([[CLIENT_A]])
-    expect(harness.clientA.components.Transform.get(entity).position.x).not.toBe(600)
+    expect(harness.clientA.components.Transform.getOrNull(entity)?.position.x).not.toBe(600)
+    expectConvergence({ server: harness.server.engine, clientA: harness.clientA.engine })
   })
 
   it('#6 re-hydration removes network entities missing from the new full state', async () => {

--- a/test/sdk/network/entity-index.spec.ts
+++ b/test/sdk/network/entity-index.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * The index is a cache with no invalidation hook, so what it owes is that a
+ * cached hit is never returned once it stopped being true. These are the three
+ * ways the network layer makes that happen.
+ */
+import { Engine, Entity } from '../../../packages/@dcl/ecs'
+import { createNetworkEntityIndex } from '../../../packages/@dcl/sdk/src/network/entity-index'
+import { defineComponents } from './utils/harness'
+
+function setup() {
+  const engine = Engine()
+  const { NetworkEntity } = defineComponents(engine)
+  return { engine, NetworkEntity, find: createNetworkEntityIndex(engine, NetworkEntity) }
+}
+
+describe('network entity index', () => {
+  it('resolves an entity by its network identity, and misses on an unknown one', () => {
+    const { engine, NetworkEntity, find } = setup()
+    const entity = engine.addEntity()
+    NetworkEntity.create(entity, { networkId: 7, entityId: 512 as Entity })
+
+    expect(find(7, 512 as Entity)).toBe(entity)
+    // repeated, so the second lookup is served by the cache
+    expect(find(7, 512 as Entity)).toBe(entity)
+    expect(find(7, 513 as Entity)).toBeNull()
+    expect(find(8, 512 as Entity)).toBeNull()
+  })
+
+  it('does not return an entity the engine has removed', () => {
+    const { engine, NetworkEntity, find } = setup()
+    const entity = engine.addEntity()
+    NetworkEntity.create(entity, { networkId: 7, entityId: 512 as Entity })
+    expect(find(7, 512 as Entity)).toBe(entity)
+
+    // what reconcileWithDump does to an entity the state dump left out
+    NetworkEntity.deleteFrom(entity)
+    engine.removeEntity(entity)
+
+    expect(find(7, 512 as Entity)).toBeNull()
+  })
+
+  it('follows an identity that moved to a different local entity', () => {
+    const { engine, NetworkEntity, find } = setup()
+    const first = engine.addEntity()
+    NetworkEntity.create(first, { networkId: 7, entityId: 512 as Entity })
+    expect(find(7, 512 as Entity)).toBe(first)
+
+    NetworkEntity.deleteFrom(first)
+    const second = engine.addEntity()
+    NetworkEntity.create(second, { networkId: 7, entityId: 512 as Entity })
+
+    expect(find(7, 512 as Entity)).toBe(second)
+  })
+})

--- a/test/sdk/network/server-client-connectivity.spec.ts
+++ b/test/sdk/network/server-client-connectivity.spec.ts
@@ -16,6 +16,7 @@ import { createRendererTransport } from '../../../packages/@dcl/sdk/internal/tra
 import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { readMessage } from '../../../packages/@dcl/ecs/src/serialization/crdt/message'
 import { SendBinaryRequest, SendBinaryResponse } from '~system/CommunicationsController'
+import { expectConvergence } from './utils/convergence'
 
 function defineComponents(engine: IEngine) {
   return {
@@ -82,9 +83,13 @@ describe('Server-Client Connectivity', () => {
     'authoritative-server': [] as Uint8Array[]
   }
 
+  /** one entry per comms payload that crossed the wire, with the addresses it asked for */
+  const sentComms: { from: string; to: string[]; type: CommsMessage }[] = []
+
   // Common routing function - routes message and tags with sender info
   function routeMessage(data: Uint8Array, addresses: string[], sender: string) {
     console.log(`Routing message from ${sender} to addresses: [${addresses.join(', ')}]`)
+    sentComms.push({ from: sender, to: [...addresses], type: data[0] as CommsMessage })
 
     // Create message with sender information
     const senderBytes = encodeString(sender)
@@ -511,65 +516,49 @@ describe('Server-Client Connectivity', () => {
     expect(serverValidationCalled).toBe(true)
   })
 
-  it('should handle CRDT authoritative messages when server rejects invalid client message', async () => {
-    console.log('=== Testing CRDT Authoritative Mechanism ===')
+  it('corrects only the offender when the server rejects an invalid change', async () => {
     interceptedMessages.length = 0
 
-    let serverValidationCalled = false
     let serverRejectedChange = false
 
-    // Add server validation that rejects position.x > 100
+    // Reject any position past x = 100
     serverComponents.Transform.validateBeforeChange((value) => {
-      serverValidationCalled = true
-      console.log('Server validation checking:', value)
       if (value.newValue && value.newValue.position.x > 100) {
-        console.log('Server rejecting change due to x > 100, will send authoritative message')
         serverRejectedChange = true
-        return false // This should trigger authoritative message mechanism
+        return false
       }
       return true
     })
 
-    // Create entity on client A with valid initial position
+    // A valid state the server accepts and keeps, so it has something to correct with
     const correctionEntity = clientEngineA.addEntity()
     componentsA.Transform.create(correctionEntity, { position: { x: 50, y: 60, z: 70 } })
     syncA.syncEntity(correctionEntity, [componentsA.Transform.componentId])
-
-    // Let initial sync happen successfully
     await tick()
 
-    // Store the initial valid state
-    const initialTransform = componentsA.Transform.get(correctionEntity)
-    console.log('Initial client A position:', initialTransform.position)
+    let serverEntity: Entity | undefined
+    for (const [local, network] of serverEngine.getEntitiesWith(serverComponents.NetworkEntity)) {
+      if (network.networkId === syncA.myProfile.networkId && network.entityId === correctionEntity) serverEntity = local
+    }
+    expect(serverComponents.Transform.get(serverEntity!).position).toMatchObject({ x: 50, y: 60, z: 70 })
 
-    // Client A tries to make an invalid change (x > 100)
-    const mutableTransform = componentsA.Transform.getMutable(correctionEntity)
-    mutableTransform.position = { x: 150, y: 60, z: 70 } // This should be rejected
-
-    console.log('Client A attempting invalid position update to x=150')
-    console.log('Client A local state after change:', componentsA.Transform.get(correctionEntity).position)
-
-    // Process the invalid update
+    sentComms.length = 0
+    componentsA.Transform.getMutable(correctionEntity).position = { x: 150, y: 60, z: 70 }
     await tick()
     await tick()
 
-    console.log('Validation called:', serverValidationCalled)
-    console.log('Server rejected change:', serverRejectedChange)
-
-    expect(serverValidationCalled).toBe(true)
     expect(serverRejectedChange).toBe(true)
 
-    // The client retains its local invalid state since no authoritative message was sent
-    const finalTransform = componentsA.Transform.get(correctionEntity)
-    console.log('Final client A position after authoritative update:', finalTransform.position)
+    // the correction is a CRDT_AUTHORITATIVE addressed to the offender and nobody else
+    const corrections = sentComms.filter((message) => message.type === CommsMessage.CRDT_AUTHORITATIVE)
+    expect(corrections.length).toBeGreaterThanOrEqual(1)
+    expect(corrections.map((correction) => [correction.from, ...correction.to])).toEqual(
+      corrections.map(() => ['authoritative-server', 'clientA'])
+    )
 
-    // Interesting: The client's state was corrected from x=150 back to x=50
-    // This suggests CRDT sync is already providing some authoritative mechanism
-    expect(finalTransform.position.x).toBe(50) // Client state was corrected back to server state
-
-    // TODO: Fix CRDT transmission so server receives client's invalid changes
-    // Once fixed, the test should verify:
-    // expect(serverRejectedChange).toBe(true) // Server should reject invalid change
-    // expect(finalTransform.position).toMatchObject({ x: 50, y: 60, z: 70 }) // Client corrected to server state
+    // the offender is back on the state the server kept, and the world agrees
+    expect(componentsA.Transform.get(correctionEntity).position).toMatchObject({ x: 50, y: 60, z: 70 })
+    expect(serverComponents.Transform.get(serverEntity!).position).toMatchObject({ x: 50, y: 60, z: 70 })
+    expectConvergence({ server: serverEngine, clientA: clientEngineA, clientB: clientEngineB })
   })
 })


### PR DESCRIPTION
Phase 2 of the authoritative-server network refactor:

- validateMessagePermissions is a discriminated switch with default-
  deny: unknown message types (incl. client-sent AUTHORITATIVE_PUT,
  previously accepted by the return-true fallthrough) are rejected with
  an always-on error; DELETE_ENTITY/DELETE_ENTITY_NETWORK require the
  sender to be the entity's creator (CreatedBy)
- a payload that fails conversion is now an explicit rejection with a
  correction, replacing the as-any cast over a possibly-null message
- sendCorrectionToSender always corrects: when the server holds no
  state for the rejected component (the rejected-first-write case) it
  emits a DELETE_COMPONENT_NETWORK stamped rejectedTimestamp+1, which
  wins LWW on the offender — the only force-applied opcode on the wire
  is AUTHORITATIVE_PUT, so the delete must win on merit
- entity-index.ts: validated-hit cache over networkId:entityId with
  scan fallback — O(1) on the per-message hot path, provably never
  stale, no invalidation hooks; adopted by the validator,
  getParent, and syncEntity's duplicate-enum check
- the stale connectivity correction test now genuinely exercises the
  loop: rejection → targeted CRDT_AUTHORITATIVE to the offender only →
  local revert → cross-engine convergence
- docs/network-timestamp-trust.md: why client-stamped LWW timestamps
  are a trust gap and what server re-stamping requires (evaluation
  only, no code change)

Red defect tests #3 and #4 flip to passing (#4's assertion corrected to
getOrNull — a no-state correction removes the component, so the old
get() was unsatisfiable by any correct implementation); #8, #10, #11,
#12, #13 verified still red. Sync-mode enforcement found to be vapor
(SyncComponents carries no mode field) — documented in place.

Claude-Session: https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


---
## 📚 Stack (splits #1505 — merge top-down within each stack)

**Network layer** (each PR is one self-contained, independently-green commit):
1. #1518 test harness — characterization baseline + red defect suite *(this stack's root)*
2. #1519 foundations — cycle break, single isServer, logging discipline
3. #1520 hydration FSM — late-join/reconnect correctness
4. #1521 validator — default-deny, correction path, entity index
5. #1522 codec — parse-once pipeline (wire goldens byte-identical)
6. #1523 topology — targeted sends, registry collisions, players dedupe
7. #1524 boot + host-conformance doc
8. #1525 simplification sweep (−95 lines)

**sdk-commands** (independent of the stack above):
- #1526 world-storage namespacing (pre-existing WIP, carried from the working tree)
- #1527 local dev-server reliability (depends on #1526)

After a parent squash-merges, the child needs `git rebase --onto origin/auth-server <old-parent> <child>` — ping the session and it gets restacked.
