### PR TITLE
[DO NOT MERGE] feat(sdk): clients target the authoritative server; registry collisions; players dedupe

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -23,6 +23,7 @@ Curated map of every doc in this repo. Use this as the entry point when looking 
 | [on-demand-composite-loading.md](on-demand-composite-loading.md) | Runtime composite instantiation via `engine.addEntityFromComposite(src, options)`. The provider abstraction and pre-registration flow. |
 | [material-getflat-api.md](material-getflat-api.md) | Material `getFlat` API: reading a fully-resolved material descriptor instead of the discriminated union. |
 | [network-timestamp-trust.md](network-timestamp-trust.md) | Why the authoritative server trusts client-supplied CRDT timestamps, the griefing that enables, and what server-side re-stamping would cost. |
+| [network-peer-visibility.md](network-peer-visibility.md) | Why the server can't exclude a sender from its broadcast and why a same-frame player join and leave goes unreported. Two defects that need a layer below the network code. |
 
 ## Guides (how-to)
 

--- a/docs/network-peer-visibility.md
+++ b/docs/network-peer-visibility.md
@@ -1,0 +1,183 @@
+# Peer visibility limits in the network layer
+
+Two known defects in the authoritative network layer cannot be fixed inside
+that layer. Both come down to something the network code is never in a position
+to observe: who is connected to the room, and which components changed between
+two frames. This note records what was measured, why the obvious fixes are worse
+than the defects, and what a real fix would need.
+
+Both have a red test pinned as `it.failing` in
+`test/sdk/network/defects-red.spec.ts` (#11 and #13). Leave them failing until
+the underlying layer changes.
+
+## The server does not know who is connected
+
+`broadcastBatchedMessages` in `packages/@dcl/sdk/src/network/server/index.ts`
+takes an `excludeSender` argument and does nothing with it beyond logging. Every
+accepted client write is re-broadcast to the whole room, including back to the
+client that sent it. That client already applied the change locally, so the echo
+is a wasted round trip for every write in the scene.
+
+Removing the echo means addressing the broadcast to everyone except the sender.
+The comms API has no primitive for that: `PeerMessageData.address` in
+`packages/@dcl/js-runtime/apis.d.ts` is a list of recipients, and an empty list
+means broadcast. To exclude one peer, you must name all the others — which
+requires a roster the server does not have.
+
+### What the server actually holds
+
+Instrumenting the red #11 scenario (an authoritative server and two clients,
+where only the first client writes) shows everything available server-side after
+the write propagates:
+
+```
+players= []  avatars= 0  createdBy= ["clientA"]
+clientB-sent-ever= []
+```
+
+Three candidate rosters, and why each one fails:
+
+- **The players helper is empty.** `definePlayerHelper` reads
+  `PlayerIdentityData` and `AvatarBase`, which the renderer writes into a
+  scene's CRDT stream. An authoritative server has no renderer, and nothing in
+  this repository writes those components server-side. The query returns
+  nothing.
+- **Observed senders are incomplete by construction.** The server knows
+  `clientA` because `clientA` wrote something, recorded in `CreatedBy`. A peer
+  that only listens never appears. Excluding the sender from a roster built this
+  way would leave the room with nobody to address.
+- **`~system/Players.getConnectedPlayers` is unproven here.** The runtime API
+  exists in `packages/@dcl/js-runtime/apis.d.ts`, but nothing in the SDK calls
+  it, it's marked for deprecation, and the only headless host in this repository
+  (`packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts`)
+  doesn't mock `~system/Players` at all. There's no evidence the server host
+  implements it.
+
+### Why a partial roster is worse than the echo
+
+The failure modes aren't symmetric. If a roster comes back empty, the code falls
+back to broadcasting and the fix does nothing in production while passing in
+tests. If a roster comes back *partial*, the server stops addressing the peers
+it omits, and a client that never writes silently stops receiving world updates.
+
+Trading a measurable bandwidth cost for possible silent divergence is the wrong
+direction. Delivery-level exclusion is only safe on a roster known to be
+complete.
+
+### What a real fix needs
+
+Either of these makes the exclusion sound:
+
+- **A wire-level exclude.** A "broadcast except these addresses" option on
+  `sendBinary` is the correct primitive. It costs nothing per peer, needs no
+  roster in the scene, and can't go stale.
+- **A roster the server host commits to.** If the host guarantees
+  `getConnectedPlayers` reflects the comms room on a server runtime, pass it into
+  `addSyncTransport` and target the roster minus the sender, falling back to
+  broadcast whenever the roster is empty.
+
+## A player that joins and leaves in one frame is invisible
+
+The per-frame diff in `packages/@dcl/sdk/src/players/index.ts` compares the
+current `PlayerIdentityData` and `AvatarBase` entities against a cached map. A
+player whose entity is created and destroyed between two system runs never
+appears in either snapshot, so neither `onEnterScene` nor `onLeaveScene` fires.
+
+This isn't a matter of polling more carefully. Instrumenting the red #13
+scenario shows what survives to the next system run:
+
+```
+system-saw= ["rows=0 dirty=[512] has(512)=false val=null"]
+onChange-fired-on-local-writes= ["null"]
+```
+
+The entity id is still in the dirty set. The value is gone: `has()` is false and
+the component reads as null, so the player's address is unrecoverable.
+
+The second line rules out the event-driven alternative for local writes. That
+probe subscribed `onChange` up front on the exact entity id — something the real
+helper can never do, since the entity doesn't exist when the helper starts — and
+the callback still fired once, with `undefined`. `create`, `createOrReplace`,
+and `deleteFrom` in
+`packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts` never
+invoke `__onChangeCallbacks`. Those callbacks run from the flush in
+`packages/@dcl/ecs/src/engine/index.ts`, which reports the settled state, and a
+create and a delete in the same frame collapse to a single notification. The
+outgoing wire collapses the same way: `getCrdtUpdates` emits only a
+`DELETE_COMPONENT`, so the value never reaches another peer either.
+
+### The wire path is different, and it defines the requirement
+
+A player never arrives through local writes in production. The renderer delivers
+`PlayerIdentityData` over CRDT, so the case that matters is a `PUT_COMPONENT`
+and a `DELETE_COMPONENT` for the same entity arriving in one batch. Feeding
+exactly that through a transport, with `onChange` again pre-subscribed on the
+entity id, gives a different result:
+
+```
+onChange-fired= ["{\"address\":\"0xplayer\",\"isGuest\":false}", "null"]
+system-saw= ["rows=0"]
+```
+
+The receive path applies each message in turn and notifies for each, so the
+callback fires twice and **the first one carries the address**. The value is
+genuinely observable on the wire path; it's the poll that misses it, because by
+the time a system runs the entity is gone again.
+
+That difference is the whole follow-up. Nothing prevents the players helper from
+seeing a renderer-delivered join and leave in the same frame except the shape of
+the subscription: `onChange` is registered per entity, and an entity that
+doesn't exist yet can't be subscribed to. The requirement on `@dcl/ecs` is
+therefore a **component-wide change subscription** — "call me for every change to
+`PlayerIdentityData`, whatever the entity" — not a change to when notifications
+fire. With that in place, every player that arrives the way real players arrive
+is reported correctly, and only the purely local same-frame case remains
+unreachable.
+
+Note that red #13's fixture uses local writes, so it exercises the one variant
+that stays unfixable even after the subscription lands. Rewrite the fixture to
+drive the component over a transport when picking this up.
+
+### What was fixed, and what wasn't
+
+The diff loop is now a mark-and-sweep poll over both directions, which fixes two
+real bugs the old shortcut hid:
+
+- A frame in which one player joins and another leaves keeps the entity count
+  equal, and the old `players.length === playerEntities.size` check skipped the
+  whole frame, missing the join.
+- Departures used to be reported by a per-entity `AvatarBase.onChange`
+  registered when the player was first seen, which never fired for a player
+  whose entity was removed whole. The sweep uses the cached address instead.
+
+Every player visible for at least one frame is now reported correctly. A player
+who comes and goes inside a single frame is still missed, and stays missed until
+the component-wide subscription described above exists.
+
+## What not to do now
+
+Do not make either test pass by narrowing the fix to the test:
+
+- **Do not build the roster from observed senders.** It reaches only peers that
+  have already written, which is precisely the set that doesn't need the echo.
+- **Do not patch `PlayerIdentityData.create` from inside the players helper.**
+  Local writes are the only calls it would intercept, and renderer-driven
+  players arrive through `updateFromCrdt`. The test goes green and production is
+  unchanged.
+- **Do not fire `onChange` synchronously on local writes** as a targeted fix. It
+  redefines `onChange` for every scene, in a package held to 100% coverage, and
+  it addresses the wrong half of the problem: on the path players actually
+  arrive by, the notification already carries the value. Add the component-wide
+  subscription instead.
+
+## Related
+
+- `packages/@dcl/sdk/src/network/server/index.ts` — `broadcastBatchedMessages`
+  and the validator.
+- `packages/@dcl/sdk/src/players/index.ts` — the player-diff system.
+- `packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts` —
+  component writes, dirty tracking, and change callbacks.
+- `packages/@dcl/ecs/src/engine/index.ts` — where `__onChangeCallbacks` runs, and
+  why the receive path notifies per message while the flush reports net state.
+- [network-timestamp-trust.md](network-timestamp-trust.md) — a second trust
+  boundary in the same layer.

--- a/packages/@dcl/sdk/src/network/events/implementation.ts
+++ b/packages/@dcl/sdk/src/network/events/implementation.ts
@@ -122,7 +122,7 @@ export class Room<T extends EventSchemaRegistry = EventSchemaRegistry> {
         this.binaryMessageBus.emit(CommsMessage.CUSTOM_EVENT, buffer, options?.to)
       } else {
         // Client always sends to authoritative server
-        this.binaryMessageBus.emit(CommsMessage.CUSTOM_EVENT, buffer)
+        this.binaryMessageBus.emit(CommsMessage.CUSTOM_EVENT, buffer, [AUTH_SERVER_PEER_ID])
       }
     } catch (error) {
       console.error(`[EventBus] Failed to send event '${String(eventType)}':`, error)
@@ -234,14 +234,34 @@ export function setGlobalRoom(roomInstance: Room): void {
   globalRoom = roomInstance
 }
 
+/** message keys the SDK keeps for itself, so its own traffic can never clash with a scene's */
+export const RESERVED_MESSAGE_PREFIX = '~sdk/'
+
 /**
  * Register message schemas for use with the room
  * Call this before main() to define your custom messages
+ *
+ * The registry is flat and global: a key names the same message for every peer in
+ * the room. Registering one twice is therefore reported — the last schema wins,
+ * and any peer still holding the earlier one decodes the payload as garbage.
+ * Keys under `~sdk/` are reserved for SDK-internal messages and are not registered.
+ *
  * @param messages - Object containing your message schemas
  * @returns Typed room instance for your registered messages
  */
 export function registerMessages<T extends EventSchemaRegistry>(messages: T): Room<T> {
-  Object.assign(globalEventRegistry, messages)
+  for (const [key, schema] of Object.entries(messages)) {
+    // reported through `error` and not `warn`: the scene runtime's console has
+    // only `log` and `error`
+    if (key.startsWith(RESERVED_MESSAGE_PREFIX)) {
+      console.error(`[Room] ignoring '${key}': the '${RESERVED_MESSAGE_PREFIX}' prefix is reserved for the SDK`)
+      continue
+    }
+    if (key in globalEventRegistry) {
+      console.error(`[Room] message '${key}' is already registered; the schema registered last is the one that decodes`)
+    }
+    globalEventRegistry[key] = schema
+  }
   if (!globalRoom) {
     throw new Error('Room not initialized. Make sure the SDK network transport is initialized.')
   }

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -8,7 +8,7 @@ import { fetchProfile } from './utils'
 import { entityUtils } from './entities'
 import { createServerValidator } from './server'
 import { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdentity'
-import { definePlayerHelper } from '../players'
+import { getPlayerHelper } from '../players'
 import { serializeCrdtMessages } from '../internal/transports/logger'
 import { IsServerRequest, IsServerResponse } from '~system/EngineApi'
 import { AUTH_SERVER_PEER_ID, DEBUG_NETWORK_MESSAGES, IProfile } from './constants'
@@ -69,7 +69,7 @@ export function addSyncTransport(
     pendingMessageBusMessagesToSend.length = 0
     return messages
   }
-  const players = definePlayerHelper(engine)
+  const players = getPlayerHelper(engine)
 
   const RealmInfo = components.RealmInfo(engine)
   const NetworkEntity = components.NetworkEntity(engine)
@@ -85,6 +85,20 @@ export function addSyncTransport(
    */
   let tick = 0
   const TRANSPORT_INITIALIZED_NUMBER = isTestEnvironment() ? 0 : 2
+
+  /**
+   * Who this peer's own CRDT is addressed to. A client only ever talks to the
+   * authoritative server; the server's fan-out to the room is legitimate, so it
+   * keeps broadcasting (`undefined` — an empty address list means broadcast).
+   *
+   * Comms is buffered until the role resolves, so nothing *received* is handled
+   * before it is known. `transport.send` is not: it runs on the engine clock and
+   * can reach here first. Broadcasting in that window is the pre-role fallback,
+   * not a leftover of the peer-to-peer topology.
+   */
+  function crdtAudience(): string[] | undefined {
+    return isServerAtom.getOrNull() === false ? [AUTH_SERVER_PEER_ID] : undefined
+  }
   // Add Sync Transport
   const transport: Transport = {
     filter: syncFilter(engine),
@@ -97,7 +111,7 @@ export function addSyncTransport(
 
           // Convert regular messages to network messages for broadcasting with chunking
           for (const chunk of serverValidator.convertRegularToNetworkMessage(message)) {
-            binaryMessageBus.emit(CommsMessage.CRDT, chunk)
+            binaryMessageBus.emit(CommsMessage.CRDT, chunk, crdtAudience())
           }
         }
       }
@@ -159,7 +173,8 @@ export function addSyncTransport(
     for (const effect of effects) {
       if (effect === 'requestState') {
         DEBUG_NETWORK_MESSAGES() && console.log('Requesting state...')
-        binaryMessageBus.emit(CommsMessage.REQ_CRDT_STATE, new Uint8Array())
+        // unconditionally addressed: the FSM only ever asks for state as a client
+        binaryMessageBus.emit(CommsMessage.REQ_CRDT_STATE, new Uint8Array(), [AUTH_SERVER_PEER_ID])
       } else if (effect === 'markSynced') {
         // the room only counts as ready once comms has answered at least once
         if (RealmInfo.getOrNull(engine.RootEntity)) {

--- a/packages/@dcl/sdk/src/players/index.ts
+++ b/packages/@dcl/sdk/src/players/index.ts
@@ -32,27 +32,22 @@ export function definePlayerHelper(engine: IEngine) {
   const onEnterSceneCb: ((player: GetPlayerDataRes) => void)[] = []
   const onLeaveSceneCb: ((userId: string) => void)[] = []
 
+  // Both directions are polled. The `players.length === playerEntities.size`
+  // shortcut this replaces went blind on a frame where one player joined and
+  // another left, and the per-entity `AvatarBase.onChange` that used to report a
+  // departure never fired for a player whose entity was removed whole.
   engine.addSystem(() => {
-    const players = Array.from(engine.getEntitiesWith(PlayerIdentityData, AvatarBase))
-    if (players.length === playerEntities.size) return
-
-    for (const [entity, identity] of players) {
-      if (!playerEntities.has(entity)) {
-        playerEntities.set(entity, identity.address)
-
-        // Call onEnter callback
-        if (onEnterSceneCb.length) {
-          onEnterSceneCb.forEach((cb) => cb(getPlayer({ userId: identity.address })!))
-        }
-
-        // Check for changes/remove callbacks
-        AvatarBase.onChange(entity, (value) => {
-          if (!value && playerEntities.get(entity)) {
-            onLeaveSceneCb.forEach((cb) => cb(playerEntities.get(entity)!))
-            playerEntities.delete(entity)
-          }
-        })
-      }
+    const present = new Set<Entity>()
+    for (const [entity, identity] of engine.getEntitiesWith(PlayerIdentityData, AvatarBase)) {
+      present.add(entity)
+      if (playerEntities.has(entity)) continue
+      playerEntities.set(entity, identity.address)
+      for (const cb of onEnterSceneCb) cb(getPlayer({ userId: identity.address })!)
+    }
+    for (const [entity, address] of playerEntities) {
+      if (present.has(entity)) continue
+      playerEntities.delete(entity)
+      for (const cb of onLeaveSceneCb) cb(address)
     }
   })
 
@@ -100,7 +95,23 @@ export function definePlayerHelper(engine: IEngine) {
   }
 }
 
-const players = definePlayerHelper(engine)
+type PlayerHelper = ReturnType<typeof definePlayerHelper>
+const helpers = new WeakMap<IEngine, PlayerHelper>()
+
+/**
+ * One helper per engine. Both the public API below and `addSyncTransport` need
+ * one, and two of them on the same engine means two identical per-frame diffs
+ * and every `onEnterScene` callback firing twice.
+ */
+export function getPlayerHelper(engine: IEngine): PlayerHelper {
+  const existing = helpers.get(engine)
+  if (existing) return existing
+  const helper = definePlayerHelper(engine)
+  helpers.set(engine, helper)
+  return helper
+}
+
+const players = getPlayerHelper(engine)
 const { getPlayer, onEnterScene, onLeaveScene } = players
 
 export { getPlayer, onEnterScene, onLeaveScene }

--- a/test/sdk/network/characterization-flow.spec.ts
+++ b/test/sdk/network/characterization-flow.spec.ts
@@ -40,9 +40,7 @@ describe('network flow characterization', () => {
 
     const requests = harness.sentBy(CLIENT_A, CommsMessage.REQ_CRDT_STATE)
     expect(requests.length).toBeGreaterThanOrEqual(1)
-    // QUIRK(pinned): the state request is broadcast to every peer instead of
-    // being addressed to the authoritative server — see defect #1/#10.
-    expect(requests[0].to).toEqual([])
+    expect(requests[0].to).toEqual([SERVER])
 
     const responses = harness.sentBy(SERVER, CommsMessage.RES_CRDT_STATE)
     expect(responses.map((response) => response.to)).toEqual(expect.arrayContaining([[CLIENT_A], [CLIENT_B]]))
@@ -76,9 +74,6 @@ describe('network flow characterization', () => {
     )[0]
     expect(clientB.components.Transform.get(clientBEntity).position).toMatchObject({ x: 1, y: 2, z: 3 })
 
-    // QUIRK(pinned): a client emits CRDT with an empty address list (broadcast)
-    // rather than addressing the server — see defect #10.
-    expect(harness.sentBy(CLIENT_A, CommsMessage.CRDT)[0].to).toEqual([])
     // QUIRK(pinned): the server re-broadcasts to everybody, so the originating
     // client receives an echo of its own write — see defect #11.
     expect(harness.sentBy(SERVER, CommsMessage.CRDT)[0].to).toEqual([])

--- a/test/sdk/network/defects-red.spec.ts
+++ b/test/sdk/network/defects-red.spec.ts
@@ -9,13 +9,11 @@
  * Fixed in phase 1 (hydration FSM), now plain `it`: #1, #2, #6, #7, #9, #14.
  * Fixed in phase 2 (validator hardening), now plain `it`: #3, #4.
  * Fixed in phase 3 (codec unification), now plain `it`: #8.
+ * Fixed in phase 4 (topology), now plain `it`: #10, #12.
  *
- * Source locations of what is still red, verified at the time of writing:
- *   #8  fixed in phase 3: codec.ts `packChunks` is the one place that reports it
- *   #10 message-bus-sync.ts:89-91     client emits CRDT with no address
- *   #11 server/index.ts:143-167       broadcastBatchedMessages ignores excludeSender
- *   #12 events/implementation.ts:245-253  registerMessages Object.assign over a flat global registry
- *   #13 players/index.ts:35-57        per-frame diff keyed on `players.length === playerEntities.size`
+ * Fixed: 11. Deferred pending lower layers: 2 (#11, #13). Neither is fixable in
+ * the network layer; the measurements and the upgrade paths are in
+ * `docs/network-peer-visibility.md`.
  */
 import { Engine, Entity, Schemas, Transform as GlobalTransform } from '../../../packages/@dcl/ecs'
 import * as components from '../../../packages/@dcl/ecs/dist/components'
@@ -225,7 +223,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(Array.from(late.engine.getEntitiesWith(late.components.NetworkEntity))).toHaveLength(1)
   })
 
-  it.failing('#10 a client addresses its CRDT to the authoritative server', async () => {
+  it('#10 a client addresses its CRDT to the authoritative server', async () => {
     const harness = createHarness()
     await flush()
 
@@ -240,6 +238,9 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(crdt.map((message) => message.to)).toEqual(crdt.map(() => [SERVER]))
   })
 
+  // deferred: needs a host roster or a wire-level broadcast-except-X primitive.
+  // Excluding one peer means naming all the others, and the server has no roster
+  // to name them from — see `docs/network-peer-visibility.md`
   it.failing('#11 the server broadcast excludes the peer that sent the message', async () => {
     const harness = createHarness()
     await flush()
@@ -254,7 +255,7 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(harness.deliveredTo(CLIENT_B, CommsMessage.CRDT).length).toBeGreaterThanOrEqual(1)
   })
 
-  it.failing('#12 registering the same message key twice reports the collision', async () => {
+  it('#12 registering the same message key twice reports the collision', async () => {
     createHarness()
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
     const error = jest.spyOn(console, 'error').mockImplementation(() => {})
@@ -265,6 +266,11 @@ describe('known defects (red: asserting the correct behavior)', () => {
     expect(warn.mock.calls.length + error.mock.calls.length).toBeGreaterThanOrEqual(1)
   })
 
+  // deferred: needs a component-wide change subscription in @dcl/ecs — per-entity
+  // `onChange` cannot be registered for an entity that does not exist yet. This
+  // fixture writes locally, which collapses to a delete and loses the address
+  // outright; over the wire the value does survive — see
+  // `docs/network-peer-visibility.md`
   it.failing('#13 a player joining and leaving within one frame fires both callbacks', async () => {
     const engine = Engine()
     const players = definePlayerHelper(engine)

--- a/test/sdk/network/network-transport.spec.ts
+++ b/test/sdk/network/network-transport.spec.ts
@@ -10,7 +10,8 @@ import {
   CrdtMessage
 } from '../../../packages/@dcl/ecs'
 import * as components from '../../../packages/@dcl/ecs/src/components'
-import { addSyncTransport } from '../../../packages/@dcl/sdk/network/message-bus-sync'
+import { addSyncTransport } from '../../../packages/@dcl/sdk/src/network/message-bus-sync'
+import { getPlayerHelper } from '../../../packages/@dcl/sdk/src/players'
 import { CommsMessage, encodeString } from '../../../packages/@dcl/sdk/network/binary-message-bus'
 import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { readMessage } from '../../../packages/@dcl/ecs/src/serialization/crdt/message'
@@ -106,5 +107,29 @@ describe('Network Parenting', () => {
     expect(Math.round(networkmessages[0].byteLength / 1024)).toBe(12)
     expect(interceptedMessages.length).toBe(CUBES_LENGTH)
     expect(networkmessages.length).toBe(2)
+  })
+})
+
+describe('players helper wiring', () => {
+  it('runs one player-diff system per engine, however many consumers ask for the helper', () => {
+    const engine = Engine()
+    defineComponents(engine)
+    const helper = getPlayerHelper(engine)
+
+    const addSystem = jest.spyOn(engine, 'addSystem')
+    addSyncTransport(
+      engine,
+      async () => ({ data: [] }),
+      async () => ({
+        data: { userId: 'A', version: 1, displayName: '1', hasConnectedWeb3: true, avatar: undefined }
+      }),
+      async () => ({ isServer: false }),
+      'A'
+    )
+
+    expect(getPlayerHelper(engine)).toBe(helper)
+    // the hydration tick, and nothing else: the transport shares the existing
+    // helper rather than registering a second identical per-frame diff
+    expect(addSystem).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=564.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=564.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 66k
-  MALLOC_COUNT = 16523
-  ALIVE_OBJS_DELTA ~= 3.26k
+  MALLOC_COUNT = 16533
+  ALIVE_OBJS_DELTA ~= 3.27k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -57,4 +57,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1414.57k bytes
+  MEMORY_USAGE_COUNT ~= 1414.51k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 66k
-  MALLOC_COUNT = 16759
-  ALIVE_OBJS_DELTA ~= 3.33k
+  MALLOC_COUNT = 16769
+  ALIVE_OBJS_DELTA ~= 3.34k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -61
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1415.63k bytes
+  MEMORY_USAGE_COUNT ~= 1415.57k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=565.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=565.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -12,8 +12,8 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 66k
-  MALLOC_COUNT = 16759
-  ALIVE_OBJS_DELTA ~= 3.33k
+  MALLOC_COUNT = 16769
+  ALIVE_OBJS_DELTA ~= 3.34k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -63,4 +63,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -61
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1415.63k bytes
+  MEMORY_USAGE_COUNT ~= 1415.58k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=248.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=248.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 69k
-  MALLOC_COUNT = 15085
-  ALIVE_OBJS_DELTA ~= 3.33k
+  MALLOC_COUNT = 15095
+  ALIVE_OBJS_DELTA ~= 3.34k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -56,4 +56,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 14k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1054.16k bytes
+  MEMORY_USAGE_COUNT ~= 1054.29k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=289.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=289.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 18020
-  ALIVE_OBJS_DELTA ~= 3.91k
+  MALLOC_COUNT = 18030
+  ALIVE_OBJS_DELTA ~= 3.92k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -78,4 +78,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 11k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1248.89k bytes
+  MEMORY_USAGE_COUNT ~= 1249.02k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 68k
-  MALLOC_COUNT = 14472
+  MALLOC_COUNT = 14482
   ALIVE_OBJS_DELTA ~= 3.18k
 CALL onStart()
   OPCODES ~= 0k
@@ -43,4 +43,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1022.92k bytes
+  MEMORY_USAGE_COUNT ~= 1023.05k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 67k
-  MALLOC_COUNT = 14445
+  MALLOC_COUNT = 14455
   ALIVE_OBJS_DELTA ~= 3.17k
 CALL onStart()
   OPCODES ~= 0k
@@ -33,4 +33,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1012.50k bytes
+  MEMORY_USAGE_COUNT ~= 1012.63k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 119k
-  MALLOC_COUNT = 21327
-  ALIVE_OBJS_DELTA ~= 5.19k
+  MALLOC_COUNT = 21337
+  ALIVE_OBJS_DELTA ~= 5.20k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -1653,4 +1653,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 690k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1472.97k bytes
+  MEMORY_USAGE_COUNT ~= 1473.10k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=245.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=245.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 69k
-  MALLOC_COUNT = 14768
-  ALIVE_OBJS_DELTA ~= 3.26k
+  MALLOC_COUNT = 14778
+  ALIVE_OBJS_DELTA ~= 3.27k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -44,4 +44,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1032.82k bytes
+  MEMORY_USAGE_COUNT ~= 1032.95k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=244.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=244.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 71k
-  MALLOC_COUNT = 14607
-  ALIVE_OBJS_DELTA ~= 3.21k
+  MALLOC_COUNT = 14617
+  ALIVE_OBJS_DELTA ~= 3.22k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -32,4 +32,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 2k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1015.34k bytes
+  MEMORY_USAGE_COUNT ~= 1015.48k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=406.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=406.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 80k
-  MALLOC_COUNT = 22699
-  ALIVE_OBJS_DELTA ~= 4.55k
+  MALLOC_COUNT = 22709
+  ALIVE_OBJS_DELTA ~= 4.56k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 73k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1885.17k bytes
+  MEMORY_USAGE_COUNT ~= 1885.30k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=292k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -10,8 +10,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 94k
-  MALLOC_COUNT = 21348
-  ALIVE_OBJS_DELTA ~= 4.96k
+  MALLOC_COUNT = 21358
+  ALIVE_OBJS_DELTA ~= 4.97k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -38,4 +38,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 4k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1291.59k bytes
+  MEMORY_USAGE_COUNT ~= 1291.72k bytes


### PR DESCRIPTION
Phase 4 of the authoritative-server network refactor — retiring the
P2P-era wire topology:

- clients emit CRDT, REQ_CRDT_STATE, and room CUSTOM_EVENTs targeted
  [authoritative-server] instead of broadcasting to every peer (the
  O(N²)→O(N) client-traffic fix, #10); the server's room fan-out stays
  broadcast until AOI; pre-role sends fall back to broadcast, by
  design and documented
- registerMessages reports re-registration of an existing key and
  enforces the reserved '~sdk/' prefix (skipped, reported) — via
  console.error because the scene runtime console has no warn (#12)
- players helper: one instance per engine via a WeakMap memo shared by
  the public API and addSyncTransport (removes the duplicate per-frame
  diff system and double-fired callbacks); the diff loop itself is now
  mark-and-sweep in both directions, fixing a real join-miss when one
  player joined and another left in the same frame
- docs/network-peer-visibility.md: measured evidence for the two
  deferred defects — #11 needs a host roster or a wire-level
  broadcast-except-X primitive (the headless server provably cannot
  know its silent peers); #13 needs a component-wide change
  subscription in @dcl/ecs (local same-frame create+delete collapses
  at flush; the wire path notifies per message, so only the
  subscription shape blocks it)

Red suite final state: 11 of 13 defects fixed and green; #11 and #13
stay pinned it.failing with deferral notes. Wire goldens byte-identical.

Claude-Session: https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


---
## 📚 Stack (splits #1505 — merge top-down within each stack)

**Network layer** (each PR is one self-contained, independently-green commit):
1. #1518 test harness — characterization baseline + red defect suite *(this stack's root)*
2. #1519 foundations — cycle break, single isServer, logging discipline
3. #1520 hydration FSM — late-join/reconnect correctness
4. #1521 validator — default-deny, correction path, entity index
5. #1522 codec — parse-once pipeline (wire goldens byte-identical)
6. #1523 topology — targeted sends, registry collisions, players dedupe
7. #1524 boot + host-conformance doc
8. #1525 simplification sweep (−95 lines)

**sdk-commands** (independent of the stack above):
- #1526 world-storage namespacing (pre-existing WIP, carried from the working tree)
- #1527 local dev-server reliability (depends on #1526)

After a parent squash-merges, the child needs `git rebase --onto origin/auth-server <old-parent> <child>` — ping the session and it gets restacked.
