### PR TITLE
[DO NOT MERGE] refactor(sdk): parameterize network boot, document the host contract

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -24,6 +24,7 @@ Curated map of every doc in this repo. Use this as the entry point when looking 
 | [material-getflat-api.md](material-getflat-api.md) | Material `getFlat` API: reading a fully-resolved material descriptor instead of the discriminated union. |
 | [network-timestamp-trust.md](network-timestamp-trust.md) | Why the authoritative server trusts client-supplied CRDT timestamps, the griefing that enables, and what server-side re-stamping would cost. |
 | [network-peer-visibility.md](network-peer-visibility.md) | Why the server can't exclude a sender from its broadcast and why a same-frame player join and leave goes unreported. Two defects that need a layer below the network code. |
+| [host-conformance.md](host-conformance.md) | The `~system` contract the network layer actually depends on, as a checklist a new host (Bevy client, headless server) validates against — required behaviors, known gaps, and how to run the 3-engine harness as a conformance smoke test. |
 
 ## Guides (how-to)
 

--- a/docs/host-conformance.md
+++ b/docs/host-conformance.md
@@ -1,0 +1,167 @@
+# Host conformance: what the network layer requires of a runtime
+
+The authoritative-multiplayer network layer (`packages/@dcl/sdk/src/network/`) is
+written against the `~system` APIs declared in
+[`packages/@dcl/js-runtime/apis.d.ts`](../packages/@dcl/js-runtime/apis.d.ts). It
+assumes more of them than the type signatures say. This is the checklist a new
+host — the Bevy client, a headless server, a test harness — validates against
+before a multiplayer scene can be trusted on it.
+
+Scope is Layer A only: the scene-side network layer. Rendering, comms transport,
+and the CRDT protocol itself are out of scope.
+
+## REQUIRED
+
+### 1. `EngineApi.isServer()` answers truthfully, exactly once, and resolves
+
+- Declared at `apis.d.ts:943-947` (`IsServerResponse.isServer`) and `apis.d.ts:968`.
+- Called once per transport at boot: `network/runtime-context.ts:20`. The answer
+  populates an atom that never re-resolves; a host cannot change a peer's role
+  mid-session.
+- **A promise that never settles wedges the peer.** Received comms is buffered
+  until the role is known (`network/message-bus-sync.ts:155-166`, cap 256
+  messages) and then dropped with a loud error. Outgoing CRDT is *not* buffered:
+  before the role resolves it is broadcast (`message-bus-sync.ts:85-96`), which
+  is safe but wasteful. Resolve promptly.
+- Exactly one peer per room may answer `true`. Two authoritative servers means
+  two worlds, and nothing in the layer detects it.
+
+### 2. `CommunicationsController.sendBinary` honours per-peer addressing
+
+- `PeerMessageData.address` — `apis.d.ts:74-77`. **An empty array means
+  broadcast**; a non-empty array must be delivered to exactly those addresses.
+- Addresses are the peer identities `getUserData` reports, plus the reserved
+  `'authoritative-server'` (`network/constants.ts:7`). The host must route that
+  identity to the authoritative peer.
+- Targeted delivery is load-bearing, not an optimization:
+  - a client sends **all** its CRDT to `['authoritative-server']` only
+    (`message-bus-sync.ts:95-96`, `:110`) — if the host ignores the address list
+    and broadcasts, every client sees every other client's unvalidated writes;
+  - state hydration answers one requester: `SERVER_ANNOUNCE` and each
+    `RES_CRDT_STATE` chunk go to `[sender]` (`message-bus-sync.ts:216`, `:220`,
+    `:224`) — if these are broadcast, every already-synced client re-hydrates
+    from another client's dump.
+- The server's own fan-out uses the empty-array broadcast
+  (`network/server/index.ts:169-177`).
+- `sendBinary` doubles as the receive poll: its response drains the peer's inbox
+  (`message-bus-sync.ts:115-116`). A host that never returns queued messages
+  from `sendBinary` delivers nothing, however well it accepts sends.
+
+### 3. Avatar components are populated for connected players
+
+- The players helper queries `PlayerIdentityData` + `AvatarBase`
+  (`packages/@dcl/sdk/src/players/index.ts:41`). Both must arrive as CRDT on the
+  scene's stream, one entity per connected player.
+- The network layer depends on this for hydration, not just for scene code: one
+  of the events that drives a client to request world state is its **own** player
+  entity appearing (`message-bus-sync.ts:288-291`). Other triggers remain — the
+  realm connecting, and a tick-driven retry — so a host that never writes these
+  components degrades hydration rather than breaking it outright.
+- On the current runtime these arrive in the `crdtSendToRenderer` **response**
+  (`apis.d.ts:956-960`, "the CRDT changes back from the renderer ... like the
+  player's position"), which is why a host without a renderer has none — see
+  the gap below.
+
+### 4. `EngineApi` CRDT round-trip, including on a headless host
+
+- `crdtSendToRenderer` (`apis.d.ts:956-960`) and `crdtGetState`
+  (`apis.d.ts:961-965`).
+- `@dcl/sdk` attaches the renderer transport and a per-frame `pollEvents` at
+  **import time**, before any role is known (`packages/@dcl/sdk/src/index.ts:10-11`,
+  `:19`). A host cannot opt out of this: the scene entrypoint contract has no
+  initializer hook, so importing `@dcl/sdk` is what boots the engine.
+- Therefore **a headless host must still implement `crdtSendToRenderer`,
+  `crdtGetState` and `sendBatch`**. Two shapes are known to work:
+  - *Consume the stream.* The headless host in this repo feeds
+    `crdtSendToRenderer` straight back into its own engine:
+    `packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts:109-112`.
+    Here the "renderer" transport is the host's primary CRDT ingestion path.
+  - *Stub it.* `crdtSendToRenderer: async () => ({ data: [] })`,
+    `crdtGetState: async () => ({ hasEntities: false, data: [] })`,
+    `sendBatch: async () => ({ events: [] })` (the shape used for the other
+    stubs at `scene-executor.ts:113-121`). `pollEvents` tolerates an empty event
+    list (`packages/@dcl/sdk/src/observables.ts:208-209`).
+- A *missing* or throwing `crdtSendToRenderer` is survivable but noisy: the
+  transport swallows the rejection and logs it every frame
+  (`packages/@dcl/sdk/src/internal/transports/rendererTransport.ts:26-31`).
+  Prefer an explicit stub.
+
+**Why the renderer path is not gated off on the server.** It would be a natural
+saving — the authoritative server has no renderer — and it was considered and
+rejected in the Phase 5 boot cleanup. Three reasons: the role is only known
+asynchronously, so the import-time attach cannot be skipped on it at all; the
+one headless host that can be inspected here treats `crdtSendToRenderer` as the
+channel it *receives* the world on (`scene-executor.ts:109-112`), so gating it
+would blind that class of host entirely; and `@dcl/hammurabi-server` is an
+external package resolved by `npx` at run time
+(`packages/@dcl/sdk-commands/src/commands/start/hammurabi-server.ts:8`, `:13`),
+not vendored here, so its `EngineApi` implementation cannot be read. Absent
+evidence that the round trip is a no-op there, a gate risks silently breaking
+the server. The cost of leaving it attached is bounded and visible. Revisit if
+and when a host documents `crdtSendToRenderer` as a no-op under `isServer`.
+
+## GAPS TODAY
+
+Known-missing capabilities. Each one is a defect the network layer cannot fix
+from inside; the first two are pinned as `it.failing` in
+`test/sdk/network/defects-red.spec.ts` (#11, #13). Full measurements in
+[network-peer-visibility.md](network-peer-visibility.md).
+
+- **No peer roster.** Nothing tells a scene who is in the room. On a server
+  there are no avatar components to infer one from (no renderer, and nothing
+  writes them server-side), and `~system/Players.getConnectedPlayers` is
+  unproven on a server runtime and marked deprecated.
+- **No "broadcast except X" primitive.** `PeerMessageData.address` can only
+  name recipients (`apis.d.ts:76-77`), so excluding one peer requires naming all
+  the others — i.e. a roster. Consequence: every accepted client write is echoed
+  back to its own sender (`network/server/index.ts:169-177`, red #11). A host
+  that adds a wire-level exclude removes the echo outright.
+- **No component-wide change subscription in `@dcl/ecs`.** `onChange` is
+  registered per entity, so a player whose entity is created and destroyed
+  inside one frame is never observed (red #13). This one is an SDK gap that only
+  shows up as host behavior — it is visible precisely because players arrive over
+  the wire rather than through local writes.
+- **Client CRDT timestamps are trusted.** The server validates ownership and
+  permissions but not the clock. See
+  [network-timestamp-trust.md](network-timestamp-trust.md).
+
+## VERIFICATION
+
+The 3-engine harness (`test/sdk/network/utils/harness.ts`) simulates one
+authoritative server and two clients with the routing rules above, and the
+convergence oracle (`test/sdk/network/utils/convergence.ts`) compares engines by
+network identity rather than local entity id. Together they are the conformance
+smoke test for a routing implementation.
+
+```bash
+# prerequisite: server-client-connectivity.spec.ts imports the compiled package
+make build
+
+# full network suite
+node_modules/.bin/jest --forceExit --testPathPattern='test/sdk/network'
+
+# 3-engine harness + convergence oracle only
+node_modules/.bin/jest --forceExit \
+  --testPathPattern='test/sdk/network/(characterization-flow|late-join-hydration|reconnect-convergence|server-client-connectivity)'
+```
+
+Expected: green, with `defects-red.spec.ts` reporting #11 and #13 as the only
+`it.failing` pins. Two failures there is the pass condition, not a regression.
+
+To port the harness against a real host, replace the `sendBinary` passed to
+`addSyncTransport` (`test/sdk/network/utils/harness.ts:136-143`) with one that
+crosses the host's comms. Every runtime dependency of the layer — engine,
+`sendBinary`, `getUserData`, `isServer`, transport name, and the number of
+startup ticks whose CRDT is suppressed — is a parameter of that one function
+(`packages/@dcl/sdk/src/network/message-bus-sync.ts:46-52`); nothing else needs
+stubbing.
+
+## Related
+
+- [network-peer-visibility.md](network-peer-visibility.md) — the measurements
+  behind the roster and same-frame-player gaps.
+- [network-timestamp-trust.md](network-timestamp-trust.md) — the timestamp trust
+  boundary.
+- [wire-message.md](wire-message.md) — the CRDT wire format underneath all of
+  this.
+</content>

--- a/packages/@dcl/sdk/src/network/events/index.ts
+++ b/packages/@dcl/sdk/src/network/events/index.ts
@@ -5,7 +5,8 @@
  *
  * @example Basic usage:
  * ```typescript
- * import { registerMessages, getRoom, isServer } from '@dcl/sdk/network/events'
+ * import { registerMessages, getRoom } from '@dcl/sdk/network/events'
+ * import { isServer } from '@dcl/sdk/network'
  *
  * const MyMessages = {
  *   playerJump: Schemas.Map({ playerId: Schemas.String, position: Schemas.Vector3 }),

--- a/packages/@dcl/sdk/src/network/index.ts
+++ b/packages/@dcl/sdk/src/network/index.ts
@@ -1,10 +1,19 @@
+/**
+ * Public facade of `@dcl/sdk/network`.
+ *
+ * Boot lives in `addSyncTransport`, which takes every runtime dependency as a
+ * parameter; this module is the one place that binds them to the real `~system`
+ * APIs and the global engine. The call stays at module scope because a scene
+ * only ever imports this module — the generated entrypoint calls `onStart` /
+ * `onUpdate` and never an initializer, so importing has to be what boots the
+ * layer. Tests call `addSyncTransport` directly instead of importing here.
+ */
 import { sendBinary } from '~system/CommunicationsController'
 import { engine } from '@dcl/ecs'
 import { addSyncTransport } from './message-bus-sync'
 import { getUserData } from '~system/UserIdentity'
 import { isServer as isServerApi } from '~system/EngineApi'
 
-// initialize sync transport for sdk engine
 const {
   getChildren,
   syncEntity,

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -30,23 +30,26 @@ export type { IProfile } from './constants'
 /** how much comms may pile up while the peer does not know its own role yet */
 const MAX_BUFFERED_COMMS = 256
 
-// Test environment detection without 'as any'
-const isTestEnvironment = (): boolean => {
-  try {
-    if (typeof globalThis === 'undefined') return false
-    const globalWithProcess = globalThis as unknown as { process?: { env?: { NODE_ENV?: string } } }
-    return globalWithProcess.process?.env?.NODE_ENV === 'test'
-  } catch {
-    return false
-  }
-}
+/**
+ * We need to wait till 2 ticks that is when the engine is ready to send new messages.
+ * The first tick is for the client engine processing the CRDT messages,
+ * and the second one are the messages created by the main() function.
+ * So to avoid sending those messages, that all the clients have, through the network we put this validation here.
+ */
+const TRANSPORT_INITIALIZED_TICKS = 2
 
+/**
+ * Boots the network layer on `engine`. Everything the layer talks to is a
+ * parameter, so a test drives it exactly the way `network/index.ts` does at
+ * import time — with the runtime's `~system` functions swapped for fakes.
+ */
 export function addSyncTransport(
   engine: IEngine,
   sendBinary: (msg: SendBinaryRequest) => Promise<SendBinaryResponse>,
   getUserData: (value: GetUserDataRequest) => Promise<GetUserDataResponse>,
   isServerFn: (request: IsServerRequest) => Promise<IsServerResponse>,
-  name: string
+  name: string,
+  { transportInitializedTicks = TRANSPORT_INITIALIZED_TICKS }: { transportInitializedTicks?: number } = {}
 ) {
   // Profile Info
   const myProfile: IProfile = {} as IProfile
@@ -77,14 +80,7 @@ export function addSyncTransport(
   /** names this run of the peer; only an authoritative server ever announces it */
   const generation = newGeneration()
 
-  /**
-   * We need to wait till 2 ticks that is when the engine is ready to send new messages.
-   * The first tick is for the client engine processing the CRDT messages,
-   * and the second one are the messages created by the main() function.
-   * So to avoid sending those messages, that all the clients have, through the network we put this validation here.
-   */
   let tick = 0
-  const TRANSPORT_INITIALIZED_NUMBER = isTestEnvironment() ? 0 : 2
 
   /**
    * Who this peer's own CRDT is addressed to. A client only ever talks to the
@@ -103,8 +99,8 @@ export function addSyncTransport(
   const transport: Transport = {
     filter: syncFilter(engine),
     send: async (messages) => {
-      if (tick <= TRANSPORT_INITIALIZED_NUMBER) tick++
-      for (const message of tick > TRANSPORT_INITIALIZED_NUMBER ? [messages].flat() : []) {
+      if (tick <= transportInitializedTicks) tick++
+      for (const message of tick > transportInitializedTicks ? [messages].flat() : []) {
         if (message.byteLength) {
           DEBUG_NETWORK_MESSAGES() &&
             console.log(...Array.from(serializeCrdtMessages('[NetworkMessage sent]:', message, engine)))

--- a/test/sdk/network/crdt-chunking.spec.ts
+++ b/test/sdk/network/crdt-chunking.spec.ts
@@ -58,7 +58,8 @@ function setupEngineWithSyncTransport(name: string, isServer: boolean = false) {
   const isServerFn = async () => ({ isServer })
 
   // Initialize sync transport AFTER defining components
-  addSyncTransport(engine, sendBinary, getUserData, isServerFn, name)
+  // this spec asserts on the first frames, so nothing is suppressed
+  addSyncTransport(engine, sendBinary, getUserData, isServerFn, name, { transportInitializedTicks: 0 })
 
   return {
     engine,

--- a/test/sdk/network/network-transport.spec.ts
+++ b/test/sdk/network/network-transport.spec.ts
@@ -79,7 +79,9 @@ describe('Network Parenting', () => {
       data: { userId: 'A', version: 1, displayName: '1', hasConnectedWeb3: true, avatar: undefined }
     }),
     async () => ({ isServer: false }),
-    'A'
+    'A',
+    // this spec asserts on the first frames, so nothing is suppressed
+    { transportInitializedTicks: 0 }
   )
 
   const Cube = engineA.defineComponent('cube', {})

--- a/test/sdk/network/server-client-connectivity.spec.ts
+++ b/test/sdk/network/server-client-connectivity.spec.ts
@@ -188,7 +188,9 @@ describe('Server-Client Connectivity', () => {
       data: { userId: 'clientA', version: 1, displayName: 'Client A', hasConnectedWeb3: true, avatar: undefined }
     }),
     mockIsServerClient,
-    'clientA'
+    'clientA',
+    // this spec asserts on the first frames, so nothing is suppressed
+    { transportInitializedTicks: 0 }
   ) // clientA is not a server
 
   const syncB = addSyncTransport(
@@ -198,7 +200,8 @@ describe('Server-Client Connectivity', () => {
       data: { userId: 'clientB', version: 1, displayName: 'Client B', hasConnectedWeb3: true, avatar: undefined }
     }),
     mockIsServerClient,
-    'clientB'
+    'clientB',
+    { transportInitializedTicks: 0 }
   ) // clientB is not a server
 
   // Server sync transport - configured to run in server mode
@@ -215,7 +218,8 @@ describe('Server-Client Connectivity', () => {
       }
     }),
     mockIsServerServer,
-    'server'
+    'server',
+    { transportInitializedTicks: 0 }
   ) // server is a server
 
   let testEntity: Entity

--- a/test/sdk/network/utils/harness.ts
+++ b/test/sdk/network/utils/harness.ts
@@ -148,7 +148,9 @@ export function createHarness() {
         data: { userId: id, version: 1, displayName: id, hasConnectedWeb3: true, avatar: undefined }
       }),
       async () => ({ isServer: await isServer }),
-      id
+      id,
+      // the harness asserts on the very first frames, so nothing is suppressed
+      { transportInitializedTicks: 0 }
     )
     peers[id] = { id, engine, components: peerComponents, sync }
     return peers[id]


### PR DESCRIPTION
Phase 5 (final) of the authoritative-server network refactor:

- addSyncTransport gains an optional transportInitializedTicks param
  (default 2) replacing the NODE_ENV sniffing that made tick-gating
  behave differently in tests than in production; tests now opt into 0
  explicitly, and no environment detection remains in the sdk package.
  No separate init wrapper: with every dependency already a parameter,
  addSyncTransport IS the init function and network/index.ts the
  composition root binding production ~system APIs at module scope
  (kept deliberately — the entrypoint contract has no initializer hook,
  so importing is what boots; documented in the facade header)
- renderer transport deliberately NOT gated on the server role: the
  readable headless host ingests scene CRDT through crdtSendToRenderer
  (scene-executor.ts), so gating would silently blind that host class;
  rendererTransport already tolerates an absent renderer. Recorded
  with evidence and a revisit condition in the conformance doc
- docs/host-conformance.md: the ~system checklist a new host (Bevy,
  headless, harness) validates against — truthful isServer, per-peer
  sendBinary addressing (targeted delivery is load-bearing, not an
  optimization), avatar-component population, CRDT round-trip shapes;
  plus today's gaps (roster/broadcast-except-X, component-wide change
  subscription, trusted timestamps) and the exact verification commands
- events/index.ts doc example fixed (isServer import path)

Wire goldens, export-list pin, and QuickJS snapshots all byte-identical.

Claude-Session: https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzo6zwrn1CA79S4RN1dgsU


---
## 📚 Stack (splits #1505 — merge top-down within each stack)

**Network layer** (each PR is one self-contained, independently-green commit):
1. #1518 test harness — characterization baseline + red defect suite *(this stack's root)*
2. #1519 foundations — cycle break, single isServer, logging discipline
3. #1520 hydration FSM — late-join/reconnect correctness
4. #1521 validator — default-deny, correction path, entity index
5. #1522 codec — parse-once pipeline (wire goldens byte-identical)
6. #1523 topology — targeted sends, registry collisions, players dedupe
7. #1524 boot + host-conformance doc
8. #1525 simplification sweep (−95 lines)

**sdk-commands** (independent of the stack above):
- #1526 world-storage namespacing (pre-existing WIP, carried from the working tree)
- #1527 local dev-server reliability (depends on #1526)

After a parent squash-merges, the child needs `git rebase --onto origin/auth-server <old-parent> <child>` — ping the session and it gets restacked.
