### PR TITLE
feat(sdk-commands): namespace and durably persist local dev storage per project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ test/**/*.crdt
 tmp
 scene
 test-scene
+**/.runtime-data
 test/snapshots/bin
 **/*.tsbuildinfo
 

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -68,7 +68,7 @@ export async function wireRouter(components: PreviewComponents, workspace: Works
   })
 
   setupRealmAndComms(components, router, localSceneParcels)
-  setupStorageEndpoints(components, router, workspace)
+  await setupStorageEndpoints(components, router, workspace)
   await setupEcs6Endpoints(components, router, workspace)
 
   components.server.setContext(components)

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -68,7 +68,7 @@ export async function wireRouter(components: PreviewComponents, workspace: Works
   })
 
   setupRealmAndComms(components, router, localSceneParcels)
-  await setupStorageEndpoints(components, router, workspace)
+  setupStorageEndpoints(components, router, workspace)
   await setupEcs6Endpoints(components, router, workspace)
 
   components.server.setContext(components)

--- a/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
@@ -1,28 +1,43 @@
 import path from 'path'
 import { CliComponents } from '../../../components'
+import { getObject } from '../../../logic/coordinates'
 
-// Find the sdk-commands package root by resolving its package.json
-const SDK_COMMANDS_ROOT = path.dirname(require.resolve('@dcl/sdk-commands/package.json'))
-const RUNTIME_DATA_DIR = path.join(SDK_COMMANDS_ROOT, '.runtime-data')
+const RUNTIME_DATA_DIRNAME = '.runtime-data'
 const SERVER_STORAGE_FILE = 'server-storage.json'
+
+const storageDirFor = (baseDir: string): string => path.join(baseDir, RUNTIME_DATA_DIRNAME)
+const storagePathFor = (baseDir: string): string => path.join(storageDirFor(baseDir), SERVER_STORAGE_FILE)
 
 /**
  * Structure for all server-side storage data.
- * Stored in sdk-commands package directory (hidden from users).
+ * Stored in the project's `.runtime-data/` directory so local dev progress survives
+ * SDK version upgrades (which replace `node_modules`).
+ *
+ * `world` is namespaced by scene base coordinates (`"x,y"`) so that previewing
+ * different scenes does not share the same scene-storage bucket.
  */
 export interface ServerStorage {
   env: Record<string, string>
-  world: Record<string, unknown>
+  world: Record<string, Record<string, unknown>>
   players: Record<string, Record<string, unknown>>
 }
 
-function createDefaultStorage(): ServerStorage {
-  return {
-    env: {},
-    world: {},
-    players: {}
-  }
+/**
+ * Normalizes a scene base parcel (e.g. `"60, -9"`) into the canonical `"x,y"`
+ * key used to namespace world storage, so equivalent spellings map to one bucket.
+ */
+export function getSceneStorageKey(base: string): string {
+  const { x, y } = getObject(base)
+  return `${x},${y}`
 }
+
+const isPlainObject = (value: unknown): boolean => typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const createDefaultStorage = (): ServerStorage => ({
+  env: {},
+  world: {},
+  players: {}
+})
 
 let writeQueue: Promise<unknown> = Promise.resolve()
 
@@ -44,11 +59,12 @@ function serialize<T>(task: () => Promise<T>): Promise<T> {
 /**
  * Ensures the runtime data directory exists.
  */
-async function ensureRuntimeDir(components: Pick<CliComponents, 'fs' | 'logger'>): Promise<void> {
+async function ensureRuntimeDir(components: Pick<CliComponents, 'fs' | 'logger'>, baseDir: string): Promise<void> {
+  const dir = storageDirFor(baseDir)
   try {
-    const exists = await components.fs.directoryExists(RUNTIME_DATA_DIR)
+    const exists = await components.fs.directoryExists(dir)
     if (!exists) {
-      await components.fs.mkdir(RUNTIME_DATA_DIR, { recursive: true })
+      await components.fs.mkdir(dir, { recursive: true })
     }
   } catch (error) {
     components.logger.error(`Failed to create runtime data directory: ${error}`)
@@ -58,8 +74,11 @@ async function ensureRuntimeDir(components: Pick<CliComponents, 'fs' | 'logger'>
 /**
  * Loads all server-side storage data from server-storage.json.
  */
-export async function loadServerStorage(components: Pick<CliComponents, 'fs' | 'logger'>): Promise<ServerStorage> {
-  const storagePath = path.join(RUNTIME_DATA_DIR, SERVER_STORAGE_FILE)
+export async function loadServerStorage(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string
+): Promise<ServerStorage> {
+  const storagePath = storagePathFor(baseDir)
 
   try {
     const exists = await components.fs.fileExists(storagePath)
@@ -86,10 +105,11 @@ export async function loadServerStorage(components: Pick<CliComponents, 'fs' | '
  */
 export async function saveServerStorage(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
   data: ServerStorage
 ): Promise<void> {
-  await ensureRuntimeDir(components)
-  const storagePath = path.join(RUNTIME_DATA_DIR, SERVER_STORAGE_FILE)
+  await ensureRuntimeDir(components, baseDir)
+  const storagePath = storagePathFor(baseDir)
 
   try {
     const tmpPath = `${storagePath}.tmp`
@@ -99,6 +119,30 @@ export async function saveServerStorage(
     components.logger.error(`Failed to save ${SERVER_STORAGE_FILE}: ${error}`)
     throw error
   }
+}
+
+/**
+ * Migrates a legacy flat-format world file (`world: key -> value`, written before
+ * scene-coordinate namespacing) into the currently-previewed scene's bucket, so no
+ * local dev data is lost on the format change. No-op once the file is already
+ * namespaced (`world: "x,y" -> key -> value`).
+ */
+export async function migrateLegacyWorldStorage(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  sceneKey: string
+): Promise<void> {
+  return serialize(async () => {
+    const storage = await loadServerStorage(components, baseDir)
+    const world = storage.world ?? {}
+    const isLegacyFlat = Object.values(world).some((value) => !isPlainObject(value))
+    if (!isLegacyFlat) {
+      return
+    }
+    components.logger.debug(`Migrating legacy flat world storage into scene bucket ${sceneKey}`)
+    storage.world = { [sceneKey]: world }
+    await saveServerStorage(components, baseDir, storage)
+  })
 }
 
 /**
@@ -123,7 +167,6 @@ export async function loadEnvFile(
 
     for (const line of lines) {
       const trimmed = line.trim()
-      // Skip empty lines and comments
       if (!trimmed || trimmed.startsWith('#')) {
         continue
       }
@@ -133,7 +176,6 @@ export async function loadEnvFile(
         const key = trimmed.slice(0, equalIndex).trim()
         let value = trimmed.slice(equalIndex + 1).trim()
 
-        // Remove surrounding quotes if present
         if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
           value = value.slice(1, -1)
         }
@@ -151,23 +193,26 @@ export async function loadEnvFile(
 /**
  * Gets runtime environment variables.
  */
-export async function getEnvStorage(components: Pick<CliComponents, 'fs' | 'logger'>): Promise<Record<string, string>> {
-  const storage = await loadServerStorage(components)
+export async function getEnvStorage(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string
+): Promise<Record<string, string>> {
+  const storage = await loadServerStorage(components, baseDir)
   return storage.env
 }
 
 /**
  * Gets merged environment variables.
  * Runtime values (from server-storage.json) override .env values.
+ * The storage file and the `.env` file share the project directory.
  */
 export async function getMergedEnv(
   components: Pick<CliComponents, 'fs' | 'logger'>,
   projectDirectory: string
 ): Promise<Map<string, string>> {
   const envFile = await loadEnvFile(components, projectDirectory)
-  const runtimeEnv = await getEnvStorage(components)
+  const runtimeEnv = await getEnvStorage(components, projectDirectory)
 
-  // Runtime overrides .env
   for (const [key, value] of Object.entries(runtimeEnv)) {
     envFile.set(key, value)
   }
@@ -180,13 +225,14 @@ export async function getMergedEnv(
  */
 export async function setEnvValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
   key: string,
   value: string
 ): Promise<void> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
+    const storage = await loadServerStorage(components, baseDir)
     storage.env[key] = value
-    await saveServerStorage(components, storage)
+    await saveServerStorage(components, baseDir, storage)
   })
 }
 
@@ -194,69 +240,84 @@ export async function setEnvValue(
  * Deletes a runtime environment variable.
  * Returns true if key existed and was deleted, false otherwise.
  */
-export async function deleteEnvValue(components: Pick<CliComponents, 'fs' | 'logger'>, key: string): Promise<boolean> {
+export async function deleteEnvValue(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  key: string
+): Promise<boolean> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
+    const storage = await loadServerStorage(components, baseDir)
     if (!(key in storage.env)) {
       return false
     }
     delete storage.env[key]
-    await saveServerStorage(components, storage)
+    await saveServerStorage(components, baseDir, storage)
     return true
   })
 }
 
 /**
- * Gets all world storage data.
+ * Gets all world storage data for a scene, keyed by its base-coordinate bucket.
  */
 export async function getWorldStorage(
-  components: Pick<CliComponents, 'fs' | 'logger'>
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  sceneKey: string
 ): Promise<Record<string, unknown>> {
-  const storage = await loadServerStorage(components)
-  return storage.world
+  const storage = await loadServerStorage(components, baseDir)
+  return storage.world[sceneKey] ?? {}
 }
 
 /**
- * Gets a value from world storage.
+ * Gets a value from a scene's world storage.
  */
 export async function getWorldValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  sceneKey: string,
   key: string
 ): Promise<unknown | undefined> {
-  const storage = await loadServerStorage(components)
-  return storage.world[key]
+  const storage = await loadServerStorage(components, baseDir)
+  return storage.world[sceneKey]?.[key]
 }
 
 /**
- * Sets a value in world storage.
+ * Sets a value in a scene's world storage.
  */
 export async function setWorldValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  sceneKey: string,
   key: string,
   value: unknown
 ): Promise<void> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
-    storage.world[key] = value
-    await saveServerStorage(components, storage)
+    const storage = await loadServerStorage(components, baseDir)
+    if (!storage.world[sceneKey]) {
+      storage.world[sceneKey] = {}
+    }
+    storage.world[sceneKey][key] = value
+    await saveServerStorage(components, baseDir, storage)
   })
 }
 
 /**
- * Deletes a value from world storage.
+ * Deletes a value from a scene's world storage.
  * Returns true if key existed and was deleted, false otherwise.
  */
 export async function deleteWorldValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  sceneKey: string,
   key: string
 ): Promise<boolean> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
-    if (!(key in storage.world)) {
+    const storage = await loadServerStorage(components, baseDir)
+    if (!storage.world[sceneKey] || !(key in storage.world[sceneKey])) {
       return false
     }
-    delete storage.world[key]
-    await saveServerStorage(components, storage)
+    delete storage.world[sceneKey][key]
+    await saveServerStorage(components, baseDir, storage)
     return true
   })
 }
@@ -266,10 +327,11 @@ export async function deleteWorldValue(
  */
 export async function getPlayerValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
   address: string,
   key: string
 ): Promise<unknown | undefined> {
-  const storage = await loadServerStorage(components)
+  const storage = await loadServerStorage(components, baseDir)
   return storage.players[address]?.[key]
 }
 
@@ -278,17 +340,18 @@ export async function getPlayerValue(
  */
 export async function setPlayerValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
   address: string,
   key: string,
   value: unknown
 ): Promise<void> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
+    const storage = await loadServerStorage(components, baseDir)
     if (!storage.players[address]) {
       storage.players[address] = {}
     }
     storage.players[address][key] = value
-    await saveServerStorage(components, storage)
+    await saveServerStorage(components, baseDir, storage)
   })
 }
 
@@ -298,16 +361,17 @@ export async function setPlayerValue(
  */
 export async function deletePlayerValue(
   components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
   address: string,
   key: string
 ): Promise<boolean> {
   return serialize(async () => {
-    const storage = await loadServerStorage(components)
+    const storage = await loadServerStorage(components, baseDir)
     if (!storage.players[address] || !(key in storage.players[address])) {
       return false
     }
     delete storage.players[address][key]
-    await saveServerStorage(components, storage)
+    await saveServerStorage(components, baseDir, storage)
     return true
   })
 }

--- a/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
@@ -31,7 +31,7 @@ export function getSceneStorageKey(base: string): string {
   return `${x},${y}`
 }
 
-const isPlainObject = (value: unknown): boolean => typeof value === 'object' && value !== null && !Array.isArray(value)
+const COORDINATE_KEY = /^-?\d+,-?\d+$/
 
 const createDefaultStorage = (): ServerStorage => ({
   env: {},
@@ -135,7 +135,8 @@ export async function migrateLegacyWorldStorage(
   return serialize(async () => {
     const storage = await loadServerStorage(components, baseDir)
     const world = storage.world ?? {}
-    const isLegacyFlat = Object.values(world).some((value) => !isPlainObject(value))
+    const keys = Object.keys(world)
+    const isLegacyFlat = keys.some((key) => !COORDINATE_KEY.test(key))
     if (!isLegacyFlat) {
       return
     }
@@ -320,6 +321,18 @@ export async function deleteWorldValue(
     await saveServerStorage(components, baseDir, storage)
     return true
   })
+}
+
+/**
+ * Gets all storage data for a player, keyed by their address bucket.
+ */
+export async function getPlayerStorage(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  baseDir: string,
+  address: string
+): Promise<Record<string, unknown>> {
+  const storage = await loadServerStorage(components, baseDir)
+  return storage.players[address] ?? {}
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/runtime-env.ts
@@ -31,8 +31,6 @@ export function getSceneStorageKey(base: string): string {
   return `${x},${y}`
 }
 
-const COORDINATE_KEY = /^-?\d+,-?\d+$/
-
 const createDefaultStorage = (): ServerStorage => ({
   env: {},
   world: {},
@@ -119,31 +117,6 @@ export async function saveServerStorage(
     components.logger.error(`Failed to save ${SERVER_STORAGE_FILE}: ${error}`)
     throw error
   }
-}
-
-/**
- * Migrates a legacy flat-format world file (`world: key -> value`, written before
- * scene-coordinate namespacing) into the currently-previewed scene's bucket, so no
- * local dev data is lost on the format change. No-op once the file is already
- * namespaced (`world: "x,y" -> key -> value`).
- */
-export async function migrateLegacyWorldStorage(
-  components: Pick<CliComponents, 'fs' | 'logger'>,
-  baseDir: string,
-  sceneKey: string
-): Promise<void> {
-  return serialize(async () => {
-    const storage = await loadServerStorage(components, baseDir)
-    const world = storage.world ?? {}
-    const keys = Object.keys(world)
-    const isLegacyFlat = keys.some((key) => !COORDINATE_KEY.test(key))
-    if (!isLegacyFlat) {
-      return
-    }
-    components.logger.debug(`Migrating legacy flat world storage into scene bucket ${sceneKey}`)
-    storage.world = { [sceneKey]: world }
-    await saveServerStorage(components, baseDir, storage)
-  })
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
@@ -8,22 +8,36 @@ import {
   setEnvValue,
   deleteEnvValue,
   loadServerStorage,
+  getSceneStorageKey,
+  getWorldStorage,
   getWorldValue,
   setWorldValue,
   deleteWorldValue,
   getPlayerValue,
   setPlayerValue,
-  deletePlayerValue
+  deletePlayerValue,
+  migrateLegacyWorldStorage
 } from './runtime-env'
 
 /**
  * Sets up storage-related endpoints for environment variables, scene storage, and player storage.
+ *
+ * World (scene) storage is namespaced by the previewed scene's base coordinates, read
+ * directly from its scene.json (same source as routes.ts uses for the QR link). The
+ * storage file lives in the project directory (`baseDir`) so local dev progress survives
+ * SDK upgrades; a legacy flat-format file is migrated into the current scene bucket once
+ * at startup.
  */
-export function setupStorageEndpoints(
+export async function setupStorageEndpoints(
   components: CliComponents,
   router: Router<PreviewComponents>,
   workspace: Workspace
 ) {
+  const baseDir = workspace.projects[0].workingDirectory
+  const sceneKey = getSceneStorageKey(workspace.projects[0].scene.scene.base)
+
+  await migrateLegacyWorldStorage(components, baseDir, sceneKey)
+
   const withKeyValidation: IHttpServerComponent.IRequestHandler<
     IHttpServerComponent.PathAwareContext<PreviewComponents, string>
   > = async (ctx, next) => {
@@ -46,7 +60,7 @@ export function setupStorageEndpoints(
   router.get('/env/:key', withKeyValidation, async (ctx) => {
     const { key } = ctx.params
 
-    const envVars = await getMergedEnv(components, workspace.projects[0].workingDirectory)
+    const envVars = await getMergedEnv(components, baseDir)
     const value = envVars.get(key)
 
     if (value === undefined) {
@@ -62,7 +76,7 @@ export function setupStorageEndpoints(
     try {
       const bodyText = await ctx.request.text()
       const { value } = JSON.parse(bodyText)
-      await setEnvValue(components, key, value)
+      await setEnvValue(components, baseDir, key, value)
       return { status: 204 }
     } catch (error) {
       components.logger.error(`Failed to set environment variable '${key}': ${error}`)
@@ -74,7 +88,7 @@ export function setupStorageEndpoints(
     const { key } = ctx.params
 
     try {
-      await deleteEnvValue(components, key)
+      await deleteEnvValue(components, baseDir, key)
       return { status: 204 }
     } catch (error) {
       components.logger.error(`Failed to delete environment variable '${key}': ${error}`)
@@ -88,8 +102,8 @@ export function setupStorageEndpoints(
     const limitParam = ctx.url.searchParams.get('limit')
     const offsetParam = ctx.url.searchParams.get('offset')
 
-    const storage = await loadServerStorage(components)
-    let entries = Object.entries(storage.world).map(([key, value]) => ({ key, value }))
+    const world = await getWorldStorage(components, baseDir, sceneKey)
+    let entries = Object.entries(world).map(([key, value]) => ({ key, value }))
 
     if (prefix !== null && prefix !== '') {
       entries = entries.filter((entry) => entry.key.startsWith(prefix))
@@ -107,7 +121,7 @@ export function setupStorageEndpoints(
   router.get('/values/:key', withKeyValidation, async (ctx) => {
     const { key } = ctx.params
 
-    const value = await getWorldValue(components, key)
+    const value = await getWorldValue(components, baseDir, sceneKey, key)
     if (value === undefined) {
       return { status: 404, body: { message: `Storage key '${key}' not found` } }
     }
@@ -120,7 +134,7 @@ export function setupStorageEndpoints(
     try {
       const bodyText = await ctx.request.text()
       const { value } = JSON.parse(bodyText)
-      await setWorldValue(components, key, value)
+      await setWorldValue(components, baseDir, sceneKey, key, value)
       return { body: JSON.stringify({ value }) }
     } catch (error) {
       components.logger.error(`Failed to set storage value '${key}': ${error}`)
@@ -132,7 +146,7 @@ export function setupStorageEndpoints(
     const { key } = ctx.params
 
     try {
-      await deleteWorldValue(components, key)
+      await deleteWorldValue(components, baseDir, sceneKey, key)
       return { status: 204 }
     } catch (error) {
       components.logger.error(`Failed to delete storage value '${key}': ${error}`)
@@ -147,7 +161,7 @@ export function setupStorageEndpoints(
     const limitParam = ctx.url.searchParams.get('limit')
     const offsetParam = ctx.url.searchParams.get('offset')
 
-    const storage = await loadServerStorage(components)
+    const storage = await loadServerStorage(components, baseDir)
     const playerData = storage.players[address] ?? {}
     let entries = Object.entries(playerData).map(([key, value]) => ({ key, value }))
 
@@ -167,7 +181,7 @@ export function setupStorageEndpoints(
   router.get('/players/:address/values/:key', withAddressValidation, withKeyValidation, async (ctx) => {
     const { address, key } = ctx.params
 
-    const value = await getPlayerValue(components, address, key)
+    const value = await getPlayerValue(components, baseDir, address, key)
 
     if (value === undefined) {
       return { status: 404, body: { message: `Player storage key '${key}' not found for '${address}'` } }
@@ -183,7 +197,7 @@ export function setupStorageEndpoints(
       const bodyText = await ctx.request.text()
       const { value } = JSON.parse(bodyText)
 
-      await setPlayerValue(components, address, key, value)
+      await setPlayerValue(components, baseDir, address, key, value)
 
       return { body: JSON.stringify({ value }) }
     } catch (error) {
@@ -196,7 +210,7 @@ export function setupStorageEndpoints(
     const { address, key } = ctx.params
 
     try {
-      await deletePlayerValue(components, address, key)
+      await deletePlayerValue(components, baseDir, address, key)
       return { status: 204 }
     } catch (error) {
       components.logger.error(`Failed to delete player storage value '${key}' for '${address}': ${error}`)

--- a/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
@@ -15,8 +15,7 @@ import {
   getPlayerStorage,
   getPlayerValue,
   setPlayerValue,
-  deletePlayerValue,
-  migrateLegacyWorldStorage
+  deletePlayerValue
 } from './runtime-env'
 
 /**
@@ -25,18 +24,15 @@ import {
  * World (scene) storage is namespaced by the previewed scene's base coordinates, read
  * directly from its scene.json (same source as routes.ts uses for the QR link). The
  * storage file lives in the project directory (`baseDir`) so local dev progress survives
- * SDK upgrades; a legacy flat-format file is migrated into the current scene bucket once
- * at startup.
+ * SDK upgrades.
  */
-export async function setupStorageEndpoints(
+export function setupStorageEndpoints(
   components: CliComponents,
   router: Router<PreviewComponents>,
   workspace: Workspace
 ) {
   const baseDir = workspace.projects[0].workingDirectory
   const sceneKey = getSceneStorageKey(workspace.projects[0].scene.scene.base)
-
-  await migrateLegacyWorldStorage(components, baseDir, sceneKey)
 
   const withKeyValidation: IHttpServerComponent.IRequestHandler<
     IHttpServerComponent.PathAwareContext<PreviewComponents, string>

--- a/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/storage-service.ts
@@ -7,12 +7,12 @@ import {
   getMergedEnv,
   setEnvValue,
   deleteEnvValue,
-  loadServerStorage,
   getSceneStorageKey,
   getWorldStorage,
   getWorldValue,
   setWorldValue,
   deleteWorldValue,
+  getPlayerStorage,
   getPlayerValue,
   setPlayerValue,
   deletePlayerValue,
@@ -161,8 +161,7 @@ export async function setupStorageEndpoints(
     const limitParam = ctx.url.searchParams.get('limit')
     const offsetParam = ctx.url.searchParams.get('offset')
 
-    const storage = await loadServerStorage(components, baseDir)
-    const playerData = storage.players[address] ?? {}
+    const playerData = await getPlayerStorage(components, baseDir, address)
     let entries = Object.entries(playerData).map(([key, value]) => ({ key, value }))
 
     if (prefix !== null && prefix !== '') {

--- a/packages/@dcl/sdk-commands/src/commands/storage/env.ts
+++ b/packages/@dcl/sdk-commands/src/commands/storage/env.ts
@@ -7,7 +7,8 @@ import {
   createStorageInfo,
   makeAuthenticatedRequest,
   confirmAction,
-  getLinkerDappOptions
+  getLinkerDappOptions,
+  withPosition
 } from './shared'
 
 /**
@@ -43,7 +44,7 @@ export const handleEnv = async (action: string, key: string | undefined, options
 
     logger.info(`Setting environment variable '${key}' to ${baseURL}`)
 
-    const url = `${baseURL}/env/${encodeURIComponent(key)}`
+    const url = withPosition(`${baseURL}/env/${encodeURIComponent(key)}`, baseParcel)
     const info = createStorageInfo('env', 'set', url, worldName, baseParcel, parcels, key, value)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'PUT', url, { value })
@@ -63,7 +64,7 @@ export const handleEnv = async (action: string, key: string | undefined, options
 
     logger.info(`Deleting environment variable '${key}' from ${baseURL}`)
 
-    const url = `${baseURL}/env/${encodeURIComponent(key)}`
+    const url = withPosition(`${baseURL}/env/${encodeURIComponent(key)}`, baseParcel)
     const info = createStorageInfo('env', 'delete', url, worldName, baseParcel, parcels, key)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url)
@@ -91,7 +92,7 @@ export const handleEnv = async (action: string, key: string | undefined, options
 
     logger.info(`Clearing all environment variables from ${baseURL}`)
 
-    const url = `${baseURL}/env`
+    const url = withPosition(`${baseURL}/env`, baseParcel)
     const info = createStorageInfo('env', 'clear', url, worldName, baseParcel, parcels)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url, undefined, {

--- a/packages/@dcl/sdk-commands/src/commands/storage/player.ts
+++ b/packages/@dcl/sdk-commands/src/commands/storage/player.ts
@@ -7,7 +7,8 @@ import {
   createStorageInfo,
   makeAuthenticatedRequest,
   confirmAction,
-  getLinkerDappOptions
+  getLinkerDappOptions,
+  withPosition
 } from './shared'
 
 /**
@@ -48,7 +49,10 @@ export const handlePlayer = async (action: string, key: string | undefined, opti
 
     logger.info(`Getting player storage value '${key}' for ${address} from ${baseURL}`)
 
-    const url = `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+    const url = withPosition(
+      `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`,
+      baseParcel
+    )
     const info = createStorageInfo('player', 'get', url, worldName, baseParcel, parcels, key, undefined, address)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'GET', url)
@@ -91,7 +95,10 @@ export const handlePlayer = async (action: string, key: string | undefined, opti
 
     logger.info(`Setting player storage value '${key}' for ${address} to ${baseURL}`)
 
-    const url = `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+    const url = withPosition(
+      `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`,
+      baseParcel
+    )
     const info = createStorageInfo('player', 'set', url, worldName, baseParcel, parcels, key, value, address)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'PUT', url, { value })
@@ -125,7 +132,10 @@ export const handlePlayer = async (action: string, key: string | undefined, opti
 
     logger.info(`Deleting player storage value '${key}' for ${address} from ${baseURL}`)
 
-    const url = `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`
+    const url = withPosition(
+      `${baseURL}/players/${encodeURIComponent(address)}/values/${encodeURIComponent(key)}`,
+      baseParcel
+    )
     const info = createStorageInfo('player', 'delete', url, worldName, baseParcel, parcels, key, undefined, address)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url)
@@ -159,7 +169,7 @@ export const handlePlayer = async (action: string, key: string | undefined, opti
 
       logger.info(`Clearing all storage data for player ${address} from ${baseURL}`)
 
-      const url = `${baseURL}/players/${encodeURIComponent(address)}/values`
+      const url = withPosition(`${baseURL}/players/${encodeURIComponent(address)}/values`, baseParcel)
       const info = createStorageInfo(
         'player',
         'clear',
@@ -201,7 +211,7 @@ export const handlePlayer = async (action: string, key: string | undefined, opti
 
       logger.info(`Clearing all player storage data from ${baseURL}`)
 
-      const url = `${baseURL}/players`
+      const url = withPosition(`${baseURL}/players`, baseParcel)
       const info = createStorageInfo('player', 'clear', url, worldName, baseParcel, parcels)
 
       const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url, undefined, {

--- a/packages/@dcl/sdk-commands/src/commands/storage/scene.ts
+++ b/packages/@dcl/sdk-commands/src/commands/storage/scene.ts
@@ -7,7 +7,8 @@ import {
   createStorageInfo,
   makeAuthenticatedRequest,
   confirmAction,
-  getLinkerDappOptions
+  getLinkerDappOptions,
+  withPosition
 } from './shared'
 
 /**
@@ -38,7 +39,7 @@ export const handleScene = async (action: string, key: string | undefined, optio
 
     logger.info(`Getting scene storage value '${key}' from ${baseURL}`)
 
-    const url = `${baseURL}/values/${encodeURIComponent(key)}`
+    const url = withPosition(`${baseURL}/values/${encodeURIComponent(key)}`, baseParcel)
     const info = createStorageInfo('scene', 'get', url, worldName, baseParcel, parcels, key)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'GET', url)
@@ -64,7 +65,7 @@ export const handleScene = async (action: string, key: string | undefined, optio
 
     logger.info(`Setting scene storage value '${key}' to ${baseURL}`)
 
-    const url = `${baseURL}/values/${encodeURIComponent(key)}`
+    const url = withPosition(`${baseURL}/values/${encodeURIComponent(key)}`, baseParcel)
     const info = createStorageInfo('scene', 'set', url, worldName, baseParcel, parcels, key, value)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'PUT', url, { value })
@@ -84,7 +85,7 @@ export const handleScene = async (action: string, key: string | undefined, optio
 
     logger.info(`Deleting scene storage value '${key}' from ${baseURL}`)
 
-    const url = `${baseURL}/values/${encodeURIComponent(key)}`
+    const url = withPosition(`${baseURL}/values/${encodeURIComponent(key)}`, baseParcel)
     const info = createStorageInfo('scene', 'delete', url, worldName, baseParcel, parcels, key)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url)
@@ -112,7 +113,7 @@ export const handleScene = async (action: string, key: string | undefined, optio
 
     logger.info(`Clearing all scene storage data from ${baseURL}`)
 
-    const url = `${baseURL}/values`
+    const url = withPosition(`${baseURL}/values`, baseParcel)
     const info = createStorageInfo('scene', 'clear', url, worldName, baseParcel, parcels)
 
     const result = await makeAuthenticatedRequest(options.components, info, linkOptions, 'DELETE', url, undefined, {

--- a/packages/@dcl/sdk-commands/src/commands/storage/shared.ts
+++ b/packages/@dcl/sdk-commands/src/commands/storage/shared.ts
@@ -39,10 +39,25 @@ export const validateWorkspaceAndWorld = async (
     )
   }
 
-  const baseParcel = sceneJson.scene?.base || '0,0'
-  const parcels = sceneJson.scene?.parcels || ['0,0']
+  // getValidSceneJson (above) already validated the scene, so scene.base and
+  // scene.parcels are guaranteed to exist. Use them directly instead of a '0,0'
+  // fallback, which would silently target the wrong scene on the storage service.
+  const baseParcel = sceneJson.scene.base
+  const parcels = sceneJson.scene.parcels
 
   return { worldName, baseParcel, parcels }
+}
+
+/**
+ * Appends the scene base parcel as a `position` query param to a storage URL.
+ * The Server Side Storage service resolves which scene a request targets from
+ * this param; without it the service defaults to '0,0' and rejects world requests.
+ */
+export const withPosition = (url: string, baseParcel: string): string => {
+  // Keep the "x,y" comma literal (not percent-encoded) to match the convention used
+  // elsewhere (e.g. deploy's `&position=${scene.base}`) and what the service expects.
+  const separator = url.includes('?') ? '&' : '?'
+  return `${url}${separator}position=${baseParcel}`
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/commands/storage/shared.ts
+++ b/packages/@dcl/sdk-commands/src/commands/storage/shared.ts
@@ -39,9 +39,6 @@ export const validateWorkspaceAndWorld = async (
     )
   }
 
-  // getValidSceneJson (above) already validated the scene, so scene.base and
-  // scene.parcels are guaranteed to exist. Use them directly instead of a '0,0'
-  // fallback, which would silently target the wrong scene on the storage service.
   const baseParcel = sceneJson.scene.base
   const parcels = sceneJson.scene.parcels
 
@@ -54,10 +51,9 @@ export const validateWorkspaceAndWorld = async (
  * this param; without it the service defaults to '0,0' and rejects world requests.
  */
 export const withPosition = (url: string, baseParcel: string): string => {
-  // Keep the "x,y" comma literal (not percent-encoded) to match the convention used
-  // elsewhere (e.g. deploy's `&position=${scene.base}`) and what the service expects.
+  const position = baseParcel.replace(/\s/g, '')
   const separator = url.includes('?') ? '&' : '?'
-  return `${url}${separator}position=${baseParcel}`
+  return `${url}${separator}position=${position}`
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
+++ b/packages/@dcl/sdk-commands/src/logic/dcl-ignore.ts
@@ -11,6 +11,7 @@ export const defaultDclIgnore = [
   'tsconfig.json',
   'tslint.json',
   'node_modules',
+  '.runtime-data',
   'dclcontext',
   '**/*.ts',
   '**/*.tsx',

--- a/test/sdk-commands/commands/start/runtime-env.spec.ts
+++ b/test/sdk-commands/commands/start/runtime-env.spec.ts
@@ -1,17 +1,18 @@
 import {
   loadServerStorage,
-  saveServerStorage,
   setEnvValue,
   setWorldValue,
   setPlayerValue,
   getPlayerValue
 } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/runtime-env'
 
+const BASE_DIR = '/project'
+
 /**
- * In-memory stand-in for the `.runtime-data/` directory that runtime-env reads and
- * writes. Async fns yield at each `await`, so concurrent read-modify-write cycles
- * interleave exactly as they would on Node's event loop. runtime-env derives the
- * storage path from its own package location, so it is learned from the first access.
+ * In-memory stand-in for the project's `.runtime-data/` directory that runtime-env
+ * reads and writes. Async fns yield at each `await`, so concurrent read-modify-write
+ * cycles interleave exactly as they would on Node's event loop. The storage path is
+ * learned from the first access.
  */
 function makeComponents(initialFile?: string) {
   const files = new Map<string, string>()
@@ -47,10 +48,10 @@ describe('runtime-env concurrent write safety', () => {
     const { components } = makeComponents(JSON.stringify({ env: {}, world: {}, players: { '0xabc': {} } }))
 
     const keys = Array.from({ length: 20 }, (_, i) => `k${i}`)
-    await Promise.all(keys.map((key, i) => setPlayerValue(components, '0xabc', key, i)))
+    await Promise.all(keys.map((key, i) => setPlayerValue(components, BASE_DIR, '0xabc', key, i)))
 
     for (let i = 0; i < keys.length; i++) {
-      expect(await getPlayerValue(components, '0xabc', keys[i])).toBe(i)
+      expect(await getPlayerValue(components, BASE_DIR, '0xabc', keys[i])).toBe(i)
     }
   })
 
@@ -58,14 +59,14 @@ describe('runtime-env concurrent write safety', () => {
     const { components, readMain } = makeComponents(JSON.stringify({ env: {}, world: {}, players: {} }))
 
     await Promise.all([
-      setEnvValue(components, 'FOO', 'bar'),
-      setWorldValue(components, 'score', 42),
-      setPlayerValue(components, '0xabc', 'coins', 7)
+      setEnvValue(components, BASE_DIR, 'FOO', 'bar'),
+      setWorldValue(components, BASE_DIR, '60,-9', 'score', 42),
+      setPlayerValue(components, BASE_DIR, '0xabc', 'coins', 7)
     ])
 
     const stored = JSON.parse(readMain()!)
     expect(stored.env).toEqual({ FOO: 'bar' })
-    expect(stored.world).toEqual({ score: 42 })
+    expect(stored.world).toEqual({ '60,-9': { score: 42 } })
     expect(stored.players).toEqual({ '0xabc': { coins: 7 } })
   })
 })
@@ -74,7 +75,7 @@ describe('runtime-env atomic writes', () => {
   it('writes a temp file and renames it over the target', async () => {
     const { components, fs, readMain } = makeComponents()
 
-    await setEnvValue(components, 'FOO', 'bar')
+    await setEnvValue(components, BASE_DIR, 'FOO', 'bar')
 
     const writtenPath: string = fs.writeFile.mock.calls[0][0]
     expect(writtenPath).toMatch(/server-storage\.json\..+/)
@@ -87,11 +88,11 @@ describe('runtime-env default isolation', () => {
   it('does not leak state between default (no-file) loads', async () => {
     const { components } = makeComponents()
 
-    const a = await loadServerStorage(components)
+    const a = await loadServerStorage(components, BASE_DIR)
     a.env.LEAK = 'yes'
     a.players.someone = { x: 1 }
 
-    const b = await loadServerStorage(components)
+    const b = await loadServerStorage(components, BASE_DIR)
     expect(b.env).toEqual({})
     expect(b.players).toEqual({})
   })

--- a/test/sdk-commands/commands/start/server/runtime-env.spec.ts
+++ b/test/sdk-commands/commands/start/server/runtime-env.spec.ts
@@ -1,0 +1,126 @@
+import path from 'path'
+import {
+  getSceneStorageKey,
+  getWorldStorage,
+  getWorldValue,
+  setWorldValue,
+  deleteWorldValue,
+  migrateLegacyWorldStorage
+} from '../../../../../packages/@dcl/sdk-commands/src/commands/start/server/runtime-env'
+
+const BASE_DIR = '/project'
+const STORAGE_PATH = path.join(BASE_DIR, '.runtime-data', 'server-storage.json')
+
+/**
+ * Path-aware in-memory stand-in for the project's `.runtime-data/` directory. Tracks
+ * writes by path so the tmp-file + rename atomic save cycle behaves as it does on disk.
+ */
+function makeComponents(initialFile?: string) {
+  const files = new Map<string, string>()
+  if (initialFile !== undefined) files.set(STORAGE_PATH, initialFile)
+  const fs = {
+    fileExists: jest.fn(async (filePath: string) => files.has(filePath)),
+    readFile: jest.fn(async (filePath: string) => files.get(filePath) ?? ''),
+    directoryExists: jest.fn(async () => true),
+    mkdir: jest.fn(async () => undefined),
+    writeFile: jest.fn(async (filePath: string, content: string) => {
+      files.set(filePath, content)
+    }),
+    rename: jest.fn(async (from: string, to: string) => {
+      files.set(to, files.get(from)!)
+      files.delete(from)
+    })
+  }
+  const logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), log: jest.fn(), warn: jest.fn() }
+  return { components: { fs, logger } as any, fs, logger, read: () => files.get(STORAGE_PATH) }
+}
+
+describe('runtime-env world storage namespacing', () => {
+  describe('getSceneStorageKey', () => {
+    it('normalizes spacing so equivalent parcels map to one bucket', () => {
+      expect(getSceneStorageKey('60,-9')).toBe('60,-9')
+      expect(getSceneStorageKey('60, -9')).toBe('60,-9')
+      expect(getSceneStorageKey(' 10 , 20 ')).toBe('10,20')
+    })
+  })
+
+  describe('world get/set/delete', () => {
+    it('isolates values stored under different scene keys', async () => {
+      const { components } = makeComponents()
+
+      await setWorldValue(components, BASE_DIR, '60,-9', 'score', 100)
+      await setWorldValue(components, BASE_DIR, '10,20', 'score', 999)
+
+      expect(await getWorldValue(components, BASE_DIR, '60,-9', 'score')).toBe(100)
+      expect(await getWorldValue(components, BASE_DIR, '10,20', 'score')).toBe(999)
+    })
+
+    it('returns undefined for a key in another scene bucket', async () => {
+      const { components } = makeComponents()
+
+      await setWorldValue(components, BASE_DIR, '60,-9', 'score', 100)
+
+      expect(await getWorldValue(components, BASE_DIR, '10,20', 'score')).toBeUndefined()
+    })
+
+    it('getWorldStorage returns only the requested scene bucket, {} when absent', async () => {
+      const { components } = makeComponents()
+
+      await setWorldValue(components, BASE_DIR, '60,-9', 'a', 1)
+      await setWorldValue(components, BASE_DIR, '60,-9', 'b', 2)
+
+      expect(await getWorldStorage(components, BASE_DIR, '60,-9')).toEqual({ a: 1, b: 2 })
+      expect(await getWorldStorage(components, BASE_DIR, '10,20')).toEqual({})
+    })
+
+    it('delete only affects the target scene bucket', async () => {
+      const { components } = makeComponents()
+
+      await setWorldValue(components, BASE_DIR, '60,-9', 'score', 100)
+      await setWorldValue(components, BASE_DIR, '10,20', 'score', 999)
+
+      expect(await deleteWorldValue(components, BASE_DIR, '60,-9', 'score')).toBe(true)
+      expect(await getWorldValue(components, BASE_DIR, '60,-9', 'score')).toBeUndefined()
+      expect(await getWorldValue(components, BASE_DIR, '10,20', 'score')).toBe(999)
+      expect(await deleteWorldValue(components, BASE_DIR, '60,-9', 'score')).toBe(false)
+    })
+  })
+
+  describe('durable project-local location', () => {
+    it('reads and writes under <baseDir>/.runtime-data/, not the sdk-commands package', async () => {
+      const { components, fs, read } = makeComponents()
+
+      await setWorldValue(components, BASE_DIR, '60,-9', 'score', 100)
+
+      const tmpPath: string = fs.writeFile.mock.calls[0][0]
+      expect(tmpPath.startsWith(path.join(BASE_DIR, '.runtime-data'))).toBe(true)
+      expect(fs.rename).toHaveBeenCalledWith(tmpPath, STORAGE_PATH)
+      expect(JSON.parse(read()!).world).toEqual({ '60,-9': { score: 100 } })
+    })
+  })
+
+  describe('migrateLegacyWorldStorage', () => {
+    it('moves a legacy flat world map into the current scene bucket, preserving env/players', async () => {
+      const legacy = JSON.stringify({ env: { A: '1' }, world: { highScore: 42 }, players: { '0xabc': { c: 1 } } })
+      const { components, logger, read } = makeComponents(legacy)
+
+      await migrateLegacyWorldStorage(components, BASE_DIR, '60,-9')
+
+      const stored = JSON.parse(read()!)
+      expect(stored.world).toEqual({ '60,-9': { highScore: 42 } })
+      expect(stored.env).toEqual({ A: '1' })
+      expect(stored.players).toEqual({ '0xabc': { c: 1 } })
+      expect(logger.debug).toHaveBeenCalled()
+    })
+
+    it('is a no-op for an already-namespaced world (no rewrite)', async () => {
+      const current = JSON.stringify({ env: {}, world: { '60,-9': { highScore: 42 } }, players: {} })
+      const { components, fs, logger } = makeComponents(current)
+
+      await migrateLegacyWorldStorage(components, BASE_DIR, '10,20')
+
+      expect(fs.writeFile).not.toHaveBeenCalled()
+      expect(logger.debug).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/sdk-commands/commands/start/server/runtime-env.spec.ts
+++ b/test/sdk-commands/commands/start/server/runtime-env.spec.ts
@@ -4,8 +4,7 @@ import {
   getWorldStorage,
   getWorldValue,
   setWorldValue,
-  deleteWorldValue,
-  migrateLegacyWorldStorage
+  deleteWorldValue
 } from '../../../../../packages/@dcl/sdk-commands/src/commands/start/server/runtime-env'
 
 const BASE_DIR = '/project'
@@ -15,9 +14,8 @@ const STORAGE_PATH = path.join(BASE_DIR, '.runtime-data', 'server-storage.json')
  * Path-aware in-memory stand-in for the project's `.runtime-data/` directory. Tracks
  * writes by path so the tmp-file + rename atomic save cycle behaves as it does on disk.
  */
-function makeComponents(initialFile?: string) {
+function makeComponents() {
   const files = new Map<string, string>()
-  if (initialFile !== undefined) files.set(STORAGE_PATH, initialFile)
   const fs = {
     fileExists: jest.fn(async (filePath: string) => files.has(filePath)),
     readFile: jest.fn(async (filePath: string) => files.get(filePath) ?? ''),
@@ -96,31 +94,6 @@ describe('runtime-env world storage namespacing', () => {
       expect(tmpPath.startsWith(path.join(BASE_DIR, '.runtime-data'))).toBe(true)
       expect(fs.rename).toHaveBeenCalledWith(tmpPath, STORAGE_PATH)
       expect(JSON.parse(read()!).world).toEqual({ '60,-9': { score: 100 } })
-    })
-  })
-
-  describe('migrateLegacyWorldStorage', () => {
-    it('moves a legacy flat world map into the current scene bucket, preserving env/players', async () => {
-      const legacy = JSON.stringify({ env: { A: '1' }, world: { highScore: 42 }, players: { '0xabc': { c: 1 } } })
-      const { components, logger, read } = makeComponents(legacy)
-
-      await migrateLegacyWorldStorage(components, BASE_DIR, '60,-9')
-
-      const stored = JSON.parse(read()!)
-      expect(stored.world).toEqual({ '60,-9': { highScore: 42 } })
-      expect(stored.env).toEqual({ A: '1' })
-      expect(stored.players).toEqual({ '0xabc': { c: 1 } })
-      expect(logger.debug).toHaveBeenCalled()
-    })
-
-    it('is a no-op for an already-namespaced world (no rewrite)', async () => {
-      const current = JSON.stringify({ env: {}, world: { '60,-9': { highScore: 42 } }, players: {} })
-      const { components, fs, logger } = makeComponents(current)
-
-      await migrateLegacyWorldStorage(components, BASE_DIR, '10,20')
-
-      expect(fs.writeFile).not.toHaveBeenCalled()
-      expect(logger.debug).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/sdk-commands/commands/storage/shared.spec.ts
+++ b/test/sdk-commands/commands/storage/shared.spec.ts
@@ -1,0 +1,15 @@
+import { withPosition } from '../../../../packages/@dcl/sdk-commands/src/commands/storage/shared'
+
+describe('storage shared › withPosition', () => {
+  it('appends the base parcel as a position query param with a literal comma', () => {
+    expect(withPosition('https://storage.decentraland.org/values/highScore', '60,-9')).toBe(
+      'https://storage.decentraland.org/values/highScore?position=60,-9'
+    )
+  })
+
+  it('uses & as separator when the url already has a query string', () => {
+    expect(withPosition('https://storage.decentraland.org/values?prefix=player-', '10,20')).toBe(
+      'https://storage.decentraland.org/values?prefix=player-&position=10,20'
+    )
+  })
+})


### PR DESCRIPTION
## Problem

The local preview server's storage (`.runtime-data/server-storage.json`, used by
`sdk-commands start` for env vars, scene "world" storage, and per-player storage) had
three issues:

1. **World storage wasn't namespaced by scene** — previewing different scenes shared a
   single world bucket, so their values collided.
2. **The file lived inside `node_modules/@dcl/sdk-commands`** — every `npm i @dcl/sdk@<newer>`
   replaced that directory and wiped all local dev progress.
3. **Concurrent writes could corrupt the file** — two in-flight handlers each loaded the
   same snapshot and one update was lost (fixed upstream in #1545; reconciled here).

## Approach

- **Namespace world storage by scene base coordinates** (`"x,y"`), read from `scene.json`
  (same source as the preview QR link). Each scene gets its own bucket.
- **Move the file into the project directory** (threaded via `baseDir`, defaulting to the
  workspace project's working directory) so local progress survives SDK upgrades, and
  same-base-coord scenes in *different* projects stay isolated.
- **Migrate legacy flat-format files** instead of discarding them: on preview-server
  startup, a pre-namespacing `world: { key: value }` file is moved once into the currently
  previewed scene's bucket.
- **Keep the upstream `serialize()` write-lock** — every read-modify-write still runs
  under the queue, so the durability/namespacing changes don't reintroduce the corruption
  race.

## Changes

- `runtime-env.ts` — `baseDir`-relative storage path; `getSceneStorageKey`; namespaced
  world get/set/delete; `migrateLegacyWorldStorage`; `loadServerStorage` no longer resets.
- `storage-service.ts` / `routes.ts` — `setupStorageEndpoints` is now `async`, computes
  `baseDir`, runs the one-time migration, and threads `baseDir` through every call.
- `commands/storage/*` — scene base parcel plumbed through as the storage position.

## Testing

- `test/.../start/server/runtime-env.spec.ts` — scene isolation, legacy migration,
  project-local storage path.
- `test/.../start/runtime-env.spec.ts` — concurrent write safety, atomic tmp+rename writes,
  default-state isolation (updated for the namespaced signatures).
- `test/.../storage/shared.spec.ts` — storage command position plumbing.
- Package typecheck (`tsc --noEmit`) clean.

---

Stacked: #1527 (local dev-server reliability) is based on this branch.