### PR TITLE
fix: address CLI regressions from dependency slimming (#1532)

### DIFF
--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -47,6 +47,9 @@
         "@types/archiver": "^5.3.2",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "../ecs": {
@@ -224,6 +227,100 @@
       "integrity": "sha512-qOT+Wovc6m4b2Qz2JaAmIR3I2Cf/pEM1hmPicEn2Au5KtRd8MauAV9orMRl//ir0oWH2WJjw/fpNmlcGQcJOLQ==",
       "license": "Apache-2.0",
       "peer": true
+    },
+    "node_modules/@dcl/inspector/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@dcl/inspector/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@dcl/js-runtime": {
       "version": "7.25.0",
@@ -409,80 +506,6 @@
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",
         "protobufjs": "7.2.4"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/minimatch": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
-      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/sdk-commands/node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/undici": {
@@ -883,99 +906,12 @@
       }
     },
     "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=18"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -1049,37 +985,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1201,12 +1130,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -2048,12 +1971,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2392,24 +2309,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2662,38 +2574,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipfs-unixfs/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/ipfs-unixfs/node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/ipld-dag-pb": {
       "version": "0.22.3",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
@@ -2712,38 +2592,6 @@
       "engines": {
         "node": ">=6.0.0",
         "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/ipld-dag-pb/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/ipld-dag-pb/node_modules/protobufjs": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/is-binary-path": {
@@ -2873,12 +2721,12 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -3025,13 +2873,10 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -3076,39 +2921,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.8"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -3121,12 +2945,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=8"
       }
     },
     "node_modules/mitt": {
@@ -3393,19 +3217,28 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3487,24 +3320,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3778,35 +3610,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4071,24 +3875,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -42,6 +42,12 @@
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.5.4"
   },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "overrides": {
+    "protobufjs": "^7.6.3"
+  },
   "files": [
     "dist",
     ".dclrc",

--- a/packages/@dcl/sdk-commands/src/components/log.ts
+++ b/packages/@dcl/sdk-commands/src/components/log.ts
@@ -19,10 +19,9 @@ export const writeToStderr = (...parameters: readonly unknown[]) => {
 // @see https://no-color.org
 // @see https://www.npmjs.com/package/chalk
 const useColor = process.env.FORCE_COLOR !== '0' && !process.env.NO_COLOR
-const paint =
-  (format: Parameters<typeof styleText>[0]) =>
-  (text: string | number) =>
-    useColor ? styleText(format, String(text)) : String(text)
+// skip styleText's stream validation: it checks stdout, but the logger writes to stderr
+const paint = (format: Parameters<typeof styleText>[0]) => (text: string | number) =>
+  useColor ? styleText(format, String(text), { validateStream: false }) : String(text)
 
 export const colors = {
   bgBlack: paint('bgBlack'),

--- a/packages/@dcl/sdk-commands/src/logic/get-free-port.ts
+++ b/packages/@dcl/sdk-commands/src/logic/get-free-port.ts
@@ -1,5 +1,9 @@
 import * as net from 'net'
 
+// search upward from 8000 (portfinder's contract) so the preview URL stays stable across runs
+const BASE_PORT = 8000
+const HIGHEST_PORT = 65535
+
 function tryListen(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = net.createServer()
@@ -16,11 +20,14 @@ export async function getPort(port: number, failoverPort = 2044) {
   const resolvedPort = port && Number.isInteger(port) ? +port : 0
 
   if (!resolvedPort) {
-    try {
-      return await tryListen(0)
-    } catch (e) {
-      return failoverPort
+    for (let candidate = BASE_PORT; candidate <= HIGHEST_PORT; candidate++) {
+      try {
+        return await tryListen(candidate)
+      } catch {
+        // busy, try the next one
+      }
     }
+    return failoverPort
   }
 
   return resolvedPort

--- a/packages/@dcl/sdk-commands/src/logic/open.ts
+++ b/packages/@dcl/sdk-commands/src/logic/open.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, SpawnOptions } from 'child_process'
 import { release } from 'os'
 
 function isWsl(): boolean {
@@ -10,14 +10,25 @@ export default async function open(target: string): Promise<void> {
   if (protocol !== 'http:' && protocol !== 'https:') {
     throw new Error(`Refusing to open non-http(s) URL: ${target}`)
   }
-  const [command, args] =
-    process.platform === 'darwin'
-      ? ['open', [target]]
-      : process.platform === 'win32' || isWsl()
-        ? // `start` treats the first quoted arg as a window title; `&` must be escaped for cmd
-          [isWsl() ? 'cmd.exe' : 'cmd', ['/c', 'start', '""', target.replace(/&/g, '^&')]]
-        : ['xdg-open', [target]]
-  const child = spawn(command, args, { stdio: 'ignore', detached: true })
+  const spawnOptions: SpawnOptions = { stdio: 'ignore', detached: true }
+  let command: string
+  let args: string[]
+  if (process.platform === 'darwin') {
+    command = 'open'
+    args = [target]
+  } else if (process.platform === 'win32') {
+    // libuv's CRT-style quoting mangles the '""' title arg, so hand cmd the exact line
+    command = 'cmd'
+    args = ['/c', `start "" "${target}"`]
+    spawnOptions.windowsVerbatimArguments = true
+  } else if (isWsl()) {
+    command = 'cmd.exe'
+    args = ['/c', 'start', '""', target.replace(/&/g, '^&')]
+  } else {
+    command = 'xdg-open'
+    args = [target]
+  }
+  const child = spawn(command, args, spawnOptions)
   // opening the browser is best-effort: without this handler a missing
   // xdg-open/open/cmd (headless, containers) crashes the CLI
   child.on('error', () => {})

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -1,7 +1,7 @@
 import { ContentMapping } from '@dcl/schemas/dist/misc/content-mapping'
 import { CliComponents } from '../components'
 import { getDCLIgnorePatterns } from './dcl-ignore'
-import { sync as globSync } from 'glob'
+import { globSync, statSync, Dirent } from 'fs'
 import ignore from 'ignore'
 import i18next from 'i18next'
 import os from 'os'
@@ -27,13 +27,15 @@ export async function getPublishableFiles(
   const ig = ignore().add(ignorePatterns)
   const allFiles = globSync('**/*', {
     cwd: projectRoot,
-    absolute: false,
-    dot: false,
-    ignore: ignorePatterns,
-    nodir: true
+    // prune walking into trees ig.filter below always excludes anyway (perf only;
+    // exclude receives a string on some Node versions and a Dirent on others)
+    exclude: (entry: string | Dirent) => {
+      const name = typeof entry === 'string' ? path.basename(entry) : entry.name
+      return name.startsWith('.') || name === 'node_modules'
+    }
   })
 
-  return ig.filter(allFiles)
+  return ig.filter(allFiles).filter((file) => statSync(resolve(projectRoot, file)).isFile())
 }
 
 /**

--- a/packages/@dcl/sdk-commands/src/logic/prompts.ts
+++ b/packages/@dcl/sdk-commands/src/logic/prompts.ts
@@ -22,10 +22,13 @@ export default async function prompts(
   options: Options = {}
 ): Promise<Record<string, string | number | boolean>> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  // on Node <24 Ctrl+C only pauses stdin instead of rejecting rl.question; abort so onCancel runs
+  const canceled = new AbortController()
+  rl.on('SIGINT', () => canceled.abort())
   try {
     for (;;) {
       const suffix = question.type === 'confirm' ? (question.initial ? ' [Y/n] ' : ' [y/N] ') : ' '
-      const answer = await rl.question(`${question.message}${suffix}`)
+      const answer = await rl.question(`${question.message}${suffix}`, { signal: canceled.signal })
       if (question.type === 'confirm') {
         const value = answer === '' ? !!question.initial : /^y(es)?$/i.test(answer)
         return { [question.name]: value }

--- a/scripts/helpers.ts
+++ b/scripts/helpers.ts
@@ -1,8 +1,7 @@
 import { exec } from 'child_process'
-import { sync as globSync } from 'glob'
 import { resolve, relative } from 'path'
 import { existsSync, readFileSync, writeFileSync, lstatSync, removeSync, copySync } from 'fs-extra'
-import { rmSync } from 'fs'
+import { rmSync, globSync } from 'fs'
 
 /**
  * @returns the resolved absolute path
@@ -51,10 +50,12 @@ export function itDeletesFolder(folder: string, cwd: string) {
 }
 export function itDeletesGlob(pattern: string, cwd: string) {
   it(`deletes ${pattern} in ${cwd}`, () => {
-    globSync(pattern, { absolute: true, cwd }).forEach((file) => {
-      console.log(`> deleting ${file}`)
-      rmSync(file, { recursive: true, force: true })
-    })
+    globSync(pattern, { cwd })
+      .map((file) => resolve(cwd, file))
+      .forEach((file) => {
+        console.log(`> deleting ${file}`)
+        rmSync(file, { recursive: true, force: true })
+      })
   })
 }
 

--- a/test/ecs/add-entity-from-composite.spec.ts
+++ b/test/ecs/add-entity-from-composite.spec.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from 'fs'
-import { glob } from 'glob'
+import { readFileSync, globSync } from 'fs'
 import path from 'path'
 import { Composite, Engine, Entity, IEngine } from '../../packages/@dcl/ecs/src'
 import { components } from '../../packages/@dcl/ecs/src'
@@ -7,7 +6,7 @@ import { components } from '../../packages/@dcl/ecs/src'
 const COMPOSITE_BASE_PATH = 'test/ecs/composites'
 
 function getJsonCompositeFrom(globPath: string, cwd: string): Composite.Resource[] {
-  const compositeFileContent = glob.sync(globPath, { cwd }).map((item) => ({
+  const compositeFileContent = globSync(globPath, { cwd }).map((item) => ({
     src: item,
     content: readFileSync(path.resolve(cwd, item)).toString()
   }))

--- a/test/ecs/composite.spec.ts
+++ b/test/ecs/composite.spec.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs'
-import { glob } from 'glob'
+import { existsSync, readFileSync, writeFileSync, globSync } from 'fs'
 import path from 'path'
 import {
   Composite,
@@ -23,7 +22,7 @@ const nonBinaryCompositeJsonPath = 'non-binary.composite'
 // ########
 
 function getJsonCompositeFrom(globPath: string, cwd: string): Composite.Resource[] {
-  const compositeFileContent = glob.sync(globPath, { cwd }).map((item) => ({
+  const compositeFileContent = globSync(globPath, { cwd }).map((item) => ({
     src: item,
     content: readFileSync(path.resolve(cwd, item)).toString()
   }))
@@ -34,7 +33,7 @@ function getJsonCompositeFrom(globPath: string, cwd: string): Composite.Resource
 }
 
 function getBinaryCompositeFrom(globPath: string, cwd: string) {
-  const compositeFileContent = glob.sync(globPath, { cwd }).map((item) => ({
+  const compositeFileContent = globSync(globPath, { cwd }).map((item) => ({
     src: item,
     content: readFileSync(path.resolve(cwd, item))
   }))
@@ -149,7 +148,7 @@ describe('composite instantiation system', () => {
       // actually instances nested child composites. Leaf composites (whose
       // definition carries no `composite::root` component) emit none.
       const hasNestedComposites = composite.composite.components.some(
-        component => component.name === CompositeRootComponent.componentName
+        (component) => component.name === CompositeRootComponent.componentName
       )
       if (hasNestedComposites) {
         expect(composites.length).toBeGreaterThan(0)

--- a/test/snapshots.spec.ts
+++ b/test/snapshots.spec.ts
@@ -1,7 +1,7 @@
 import { version as vmVersion } from '@dcl/quickjs-emscripten/package.json'
 import { exec } from 'child_process'
 import { existsSync, readFileSync, writeFileSync } from 'fs-extra'
-import { glob } from 'glob'
+import { globSync } from 'fs'
 import path from 'path'
 import { CrdtMessageType, engine } from '../packages/@dcl/ecs/src'
 import { ReadWriteByteBuffer } from '../packages/@dcl/ecs/src/serialization/ByteBuffer'
@@ -40,13 +40,9 @@ describe('Runs the snapshots', () => {
     ENV
   )
 
-  glob
-    .sync('test/snapshots/production-bundles/*.ts', { absolute: false })
-    .forEach((file) => testFileSnapshot(file, true))
+  globSync('test/snapshots/production-bundles/*.ts').forEach((file) => testFileSnapshot(file, true))
 
-  glob
-    .sync('test/snapshots/development-bundles/*.ts', { absolute: false })
-    .forEach((file) => testFileSnapshot(file, false))
+  globSync('test/snapshots/development-bundles/*.ts').forEach((file) => testFileSnapshot(file, false))
 })
 
 function testFileSnapshot(fileName: string, _productionBuild: boolean) {

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -79,6 +79,9 @@
         "@types/archiver": "^5.3.2",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.5.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@dcl/ecs": {


### PR DESCRIPTION
## Summary

Post-merge review of #1532 (dependency slimming) surfaced several regressions in the published CLI. This PR fixes them:

- **Node runtime floor was raised silently.** `fs.globSync` (used in `bundle.ts`, `composite.ts`, `code-commenter.ts`) requires Node ≥22, but the package declared no `engines` field, so Node 20 users got a hard runtime crash on every build with no install-time warning. Now declared: `"engines": { "node": ">=22.0.0" }`.
- **Phantom `glob` imports.** `glob` was removed from dependencies but `src/logic/project-files.ts` still imported it at runtime — `deploy`/`export-static` only worked because a transitive copy (via archiver) happened to hoist, which breaks under pnpm/strict resolution. `getPublishableFiles` is now migrated to `fs.globSync`, finishing the removal #1532 started. The old `dot: false` / `ignore` glob options were belt-and-braces: the `ignore`-package filter right after it is the authoritative `.dclignore` gate (gitignore semantics, applies `.*`/`node_modules`/etc. at any depth), so the glob call only needs to enumerate files — directories are filtered with a stat check (the old `nodir: true`), and dot-dirs/node_modules are pruned during the walk for performance. Old and new implementations produce byte-identical file lists on a fixture covering dotfiles, nested dot-dirs, node_modules, empty dirs, and every default-ignored extension. The repo-root scripts/tests (`scripts/helpers.ts`, `test/snapshots.spec.ts`, `test/ecs/composite.spec.ts`, `test/ecs/add-entity-from-composite.spec.ts`) had the same phantom import and were migrated the same way (root already pins Node ≥24.16).
- **Preview server lost its stable port.** `tryListen(0)` hands out a random OS ephemeral port on every run; portfinder used to search upward from 8000, so `sdk-commands start` without `--port` always served on a predictable URL. Restored the 8000-based upward scan.
- **Colors decided by the wrong stream.** All logger output goes to stderr, but `util.styleText`'s default validation consults `process.stdout` — piping stdout (`sdk-commands start | tee log`) or CI silently stripped all styling despite `FORCE_COLOR`. Now passes `validateStream: false`; the env-var contract (`FORCE_COLOR`/`NO_COLOR`) is the single source of truth again, as it was with colorette.
- **Ctrl+C during prompts hung on Node <24.** The readline-based `prompts` shim registered no `SIGINT` handling, and on Node 20–23 readline just pauses stdin — the prompt hung forever and `onCancel` never ran. Now aborts the pending question via `AbortController` on `SIGINT`.
- **Windows never opened the browser.** `spawn('cmd', ['/c', 'start', '""', url])` gets mangled by libuv's CRT-style quoting (the `'""'` title arg becomes `\"\"`, which cmd doesn't unescape). Now passes the command line verbatim (`windowsVerbatimArguments: true`) with the URL quoted.
- **The protobufjs security fix never reached sdk-commands' own install.** The root `overrides` block doesn't apply to sdk-commands' standalone install (this monorepo is not npm workspaces), so its lockfile still resolved protobufjs 7.2.4 — the exact critical advisory #1532 set out to eliminate. The override is now declared in sdk-commands' own `package.json`, so `make build`, CI, and development installs in the package dir resolve 7.6.x (the nested 6.11.6 copies collapse too). Caveat: npm only honors `overrides` at the install root, so scene creators installing the published CLI still resolve @dcl/protocol's exact `protobufjs@7.2.4` pin — fully fixing the consumer side needs a @dcl/protocol release that stops exact-pinning 7.2.4 (follow-up, tracked below).

Known issues from the same review that this PR does **not** address:

- Scene bundles grew ~38KB (+6.7%) because protobufjs 7.6.x inlines the `buffer`/`long` shims into every compiled scene (the `REQUIRE: buffer`/`REQUIRE: long` lines vanished from the snapshots). Recovering the old size likely needs esbuild `alias`/`external` configuration — worth its own PR.
- The ts-jest → babel-jest swap means the test suite is no longer type-checked (babel strips annotations without checking). A `tsc --noEmit` pass over `test/` would need the test tsconfig cleaned up first.
- End users installing the published CLI still get protobufjs 7.2.4 via @dcl/protocol's exact pin (see caveat above) — needs a @dcl/protocol bump.

## What could break

- The port scan starts at 8000 again: anyone who started relying on the random-port behavior from #1532 (unlikely in the ~1 day it was on main) gets 8000 back.
- `engines` produces an npm `EBADENGINE` warning for consumers on Node <22 (npm default is warn, not fail). That's the intent — today those installs crash at runtime instead.
- sdk-commands' `package-lock.json` was regenerated to pick up the restored `glob` dep and the protobufjs override, so the lockfile diff is large but mechanical.
- Colored output now appears in logs captured from stderr in CI (that was colorette's behavior before #1532; `NO_COLOR=1` opts out).

## How to test

1. `make install && make build && make test`
2. Preview port: `cd <any scene> && npx sdk-commands start` → serves on `http://127.0.0.1:8000` again (run twice; port is stable).
3. Deploy globbing: `npx sdk-commands deploy --skip-validations` in a scene with a `.dclignore` → file list matches pre-#1532 (the export-static blackbox test exercises the same path).
4. Prompts cancel (Node 20/22): run `npx sdk-commands init` in a non-empty directory and hit Ctrl+C at the confirm prompt → exits via onCancel instead of hanging.
5. protobufjs: `cd packages/@dcl/sdk-commands && npm ls protobufjs` → 7.6.x, and `npm audit` no longer reports the critical advisory.
6. Windows: `npx sdk-commands start` opens the default browser.
