### PR TITLE
feat: --asset-bundles forwards local-ab=true into the Explorer deep link

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/explorer-alpha.ts
@@ -72,6 +72,7 @@ async function runApp(
   const landscapeTerrainEnabled = !!args['--landscape-terrain-enabled']
   const openDeeplinkInNewInstance = !!args['-n']
   const multiInstance = !!args['--multi-instance']
+  const assetBundles = !!args['--asset-bundles']
   const mcp = !!args['--mcp']
   const mcpPort = args['--mcp-port']
 
@@ -104,6 +105,11 @@ async function runApp(
     }
     if (multiInstance) {
       params.set('multi-instance', 'true')
+    }
+    if (assetBundles) {
+      // The explorer owns asset-bundle conversion: local-ab makes it spawn its own
+      // JIT converter against this preview's content server. No sidecar runs here.
+      params.set('local-ab', 'true')
     }
     if (mcp) {
       params.set('mcp', 'true')

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -68,6 +68,7 @@ export const args = declareArgs({
   '--bevy-web': Boolean,
   '--web': '--bevy-web',
   '--multi-instance': Boolean,
+  '--asset-bundles': Boolean,
   '--no-client': Boolean,
   '--mcp': Boolean,
   '--mcp-port': Number
@@ -98,6 +99,7 @@ export async function help(options: Options) {
       --web, --bevy-web                 Opens preview using the Bevy Web browser window.
       --mobile                          Show QR code for mobile preview on the same network.
       --multi-instance                  Allow running multiple Explorer instances simultaneously.
+      --asset-bundles                   Preview with optimized asset bundles (forwarded as local-ab=true in the deep link; the Desktop Explorer converts the scene's assets itself).
       --no-client                       Suppress every auto-launch (desktop Explorer deeplink, browser open, mobile QR). The file watcher still notifies a desktop Explorer if it connects on its own — useful when an external tool owns the Explorer process.
       --mcp                             Enable the MCP server in the Explorer (forwarded as a deep link parameter).
       --mcp-port                        Port for the MCP server in the Explorer (forwarded as a deep link parameter).

--- a/test/sdk-commands/commands/start/explorer-alpha.spec.ts
+++ b/test/sdk-commands/commands/start/explorer-alpha.spec.ts
@@ -185,6 +185,48 @@ describe('explorer-alpha', () => {
     })
   })
 
+  describe('assetBundles parameter', () => {
+    it('should include local-ab parameter when --asset-bundles flag is provided', async () => {
+      const args: any = {
+        '--asset-bundles': true
+      }
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args
+      })
+
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.arrayContaining([expect.stringContaining('local-ab=true')]),
+        { silent: true }
+      )
+    })
+
+    it('should not include local-ab parameter when --asset-bundles flag is not provided', async () => {
+      const args: any = {}
+
+      await runExplorerAlpha(mockComponents, {
+        cwd: '/test',
+        realm: 'test-realm',
+        baseCoords: { x: 0, y: 0 },
+        isHub: false,
+        args
+      })
+
+      expect(mockExec).toHaveBeenCalledWith(
+        '/test',
+        'open',
+        expect.arrayContaining([expect.not.stringContaining('local-ab')]),
+        { silent: true }
+      )
+    })
+  })
+
   describe('mcp parameter', () => {
     it('should include mcp parameter when --mcp flag is provided', async () => {
       const args: any = {


### PR DESCRIPTION
## What

`sdk-commands start --asset-bundles` now just adds `local-ab=true` to the Desktop Explorer deep link. Nothing else: no sidecar process, no binary download, no proxy endpoints.

## Why

The Desktop Explorer now owns asset-bundle conversion for local scene development (decentraland/unity-explorer#9704): when it receives `local-ab`, it spawns and supervises its own [abgen](https://github.com/decentraland/abgen) JIT converter pointed at the preview's content server (which the realm already in the deep link carries). Conversion progress, caching, and failure reporting all live in the client's scene dev console.

That makes the sdk-commands side of #1498 unnecessary — this PR is the minimal replacement: declare the flag, forward it.

## Creator Hub compatibility (no Hub changes needed)

The merged decentraland/creator-hub#1396 flow works unchanged against this:

- The Hub feature-detects support by grepping the installed sdk-commands `dist/commands/start/index.js` for the quoted literal `--asset-bundles` — declaring the flag in `args` satisfies that.
- With the *Optimize Assets* checkbox on, the Hub spawns `sdk-commands start --explorer-alpha --hub --asset-bundles ...` — accepted here.
- The Hub keys its sidecar-aware behavior (restart-on-toggle-mismatch, option flips on a running preview, stripping `local-ab` when the toggle goes off) on `local-ab` being present in the captured deep link — emitted here.
- The Hub's "Optimizing…" button state clears as soon as the deep link is captured; since there is no sidecar to wait for, the client opens immediately and conversion progress is shown inside the Explorer instead.

## Test plan

- `explorer-alpha.spec.ts`: `--asset-bundles` → deep link contains `local-ab=true`; flag absent → no `local-ab` param.
- Manual: Creator Hub with *Optimize Assets* checked launches the Explorer with `local-ab=true` in the deep link and the Explorer's AB console shows the conversion; unchecked launches carry no `local-ab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
