### PR TITLE
feat: expose openItemPurchase types to scenes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -711,7 +711,7 @@
     "node_modules/@dcl/protocol": {
       "version": "1.0.0-31699450756.commit-f68310e",
       "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31699450756.commit-f68310e.tgz",
-      "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
+      "integrity": "sha512-8QNsEOf8wz1l20zs+Yv0gq36uVQc11xbq8O7FaEQlTxwmXbnhaJF0Yxd0QCiZ+gfiTw1JIi3icfr9pzUeeDrdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+        "@dcl/protocol": "1.0.0-31699450756.commit-f68310e",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,8 +709,8 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-31508413180.commit-2faaa7a",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+      "version": "1.0.0-31699450756.commit-f68310e",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31699450756.commit-f68310e.tgz",
       "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-31617402096.commit-86c4613",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-31617402096.commit-86c4613",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-31617402096.commit-86c4613.tgz",
-      "integrity": "sha512-vVwwWnvECHhIwBolmOz7rcyBZwjRPyckL+07SA/xDbSIjlBzbE/iFyKn9VhAZyNaivqo5ej8IjQ+n1/eublEew==",
+      "version": "1.0.0-31508413180.commit-2faaa7a",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+      "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+    "@dcl/protocol": "1.0.0-31699450756.commit-f68310e",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-31617402096.commit-86c4613",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -202,6 +202,14 @@ export const AvatarBase: LastWriteWinElementSetComponentDefinition<PBAvatarBase>
 export const AvatarEmoteCommand: GrowOnlyValueSetComponentDefinition<PBAvatarEmoteCommand>;
 
 // @public (undocumented)
+export const enum AvatarEmoteMask {
+    // (undocumented)
+    AEM_FULL_BODY = 0,
+    // (undocumented)
+    AEM_UPPER_BODY = 1
+}
+
+// @public (undocumented)
 export const AvatarEquippedData: LastWriteWinElementSetComponentDefinition<PBAvatarEquippedData>;
 
 // @public (undocumented)

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -367,7 +367,7 @@
     "node_modules/@dcl/protocol": {
       "version": "1.0.0-31699450756.commit-f68310e",
       "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31699450756.commit-f68310e.tgz",
-      "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
+      "integrity": "sha512-8QNsEOf8wz1l20zs+Yv0gq36uVQc11xbq8O7FaEQlTxwmXbnhaJF0Yxd0QCiZ+gfiTw1JIi3icfr9pzUeeDrdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+        "@dcl/protocol": "1.0.0-31699450756.commit-f68310e",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,8 +365,8 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-31508413180.commit-2faaa7a",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+      "version": "1.0.0-31699450756.commit-f68310e",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31699450756.commit-f68310e.tgz",
       "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-31617402096.commit-86c4613",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-31617402096.commit-86c4613",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-31617402096.commit-86c4613.tgz",
-      "integrity": "sha512-vVwwWnvECHhIwBolmOz7rcyBZwjRPyckL+07SA/xDbSIjlBzbE/iFyKn9VhAZyNaivqo5ej8IjQ+n1/eublEew==",
+      "version": "1.0.0-31508413180.commit-2faaa7a",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+      "integrity": "sha512-4oi+/gCZFclF0d05kQPn3A+KrziFo8PJQZCe5xsonQClC2o9M8A3aFTB6d0l4RoA/sn1VZYG0P7EbI0owQ53lw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
+    "@dcl/protocol": "1.0.0-31699450756.commit-f68310e",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-31617402096.commit-86c4613",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-31508413180.commit-2faaa7a.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=619.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=620.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16866
+  MALLOC_COUNT = 16872
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1546.52k bytes
+  MEMORY_USAGE_COUNT ~= 1546.79k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=620.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=620.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17418
+  MALLOC_COUNT = 17424
   ALIVE_OBJS_DELTA ~= 3.46k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1552.21k bytes
+  MEMORY_USAGE_COUNT ~= 1552.48k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=620.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=620.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17418
+  MALLOC_COUNT = 17424
   ALIVE_OBJS_DELTA ~= 3.46k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1552.22k bytes
+  MEMORY_USAGE_COUNT ~= 1552.49k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-31617402096.commit-86c4613",
+        "@dcl/protocol": "1.0.0-31699450756.commit-f68310e",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=269.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=269.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15745
+  MALLOC_COUNT = 15751
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1138.00k bytes
+  MEMORY_USAGE_COUNT ~= 1138.26k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=310.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=310.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18254
+  MALLOC_COUNT = 18260
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1323.91k bytes
+  MEMORY_USAGE_COUNT ~= 1324.17k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14865
+  MALLOC_COUNT = 14871
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1100.15k bytes
+  MEMORY_USAGE_COUNT ~= 1100.40k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=265.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14838
+  MALLOC_COUNT = 14844
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1089.90k bytes
+  MEMORY_USAGE_COUNT ~= 1090.16k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21591
+  MALLOC_COUNT = 21597
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1548.38k bytes
+  MEMORY_USAGE_COUNT ~= 1548.64k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15131
+  MALLOC_COUNT = 15137
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1109.60k bytes
+  MEMORY_USAGE_COUNT ~= 1109.86k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14970
+  OPCODES ~= 82k
+  MALLOC_COUNT = 14976
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1092.35k bytes
+  MEMORY_USAGE_COUNT ~= 1092.61k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=430.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23132
+  MALLOC_COUNT = 23139
   ALIVE_OBJS_DELTA ~= 4.69k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 80k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1977.34k bytes
+  MEMORY_USAGE_COUNT ~= 1977.61k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15074
-  ALIVE_OBJS_DELTA ~= 3.34k
+  MALLOC_COUNT = 15080
+  ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1109.38k bytes
+  MEMORY_USAGE_COUNT ~= 1109.64k bytes


### PR DESCRIPTION
Draft: pinned to a branch build of the protocol PR this depends on. See "Before this can merge".

Depends on decentraland/protocol#462. Client implementation: decentraland/unity-explorer#9725.

## Changes

Bumps `@dcl/protocol` so scene authors get types for the new `openItemPurchase` restricted action:

```ts
import { openItemPurchase, OpenItemPurchaseResult } from '~system/RestrictedActions'

const { result } = await openItemPurchase({ urn: ITEM_URN })
if (result === OpenItemPurchaseResult.OIP_PURCHASED) dispense()
```

That is the whole change — four lines across two `package.json` files and their lockfiles. Nothing else is needed here because `~system/*` types are generated from the pinned protocol at build time and are not committed, and no hand-written TypeScript wraps these calls: the entire `~system/RestrictedActions` surface is generated.

Verified locally with node 24.16.0 that the generated
`scripts/rpc-api-generation/src/proto/decentraland/kernel/apis/restricted_actions.gen.ts` now contains
`openItemPurchase` and the `OpenItemPurchaseResult` enum, and that the enum's member names match the runtime
values the client exposes — that pairing matters, because the scene imports the *type* from here and the
*value* from the client, so a name mismatch would typecheck and then read `undefined` at runtime.

## Two things a reviewer should know

**The API report was left out on purpose.** `make build` regenerates
`packages/@dcl/playground-assets/etc/playground-assets.api.md` with 68 deletions — it drops `ExplorerUi`,
`ExplorerUiEventsResult` and `core::ExplorerUiEventsResult`. That is **not** caused by this bump: no proto in
the currently pinned protocol build (`commit-2c475cb`) mentions `ExplorerUiEventsResult` at all, so the
committed report cannot have been produced from it — it was committed from a build made against the
`feat/explorer-ui-events-result` protocol branch. Regenerating it here would make this PR look like it
deletes public API, so the file is untouched and the drift is left for whoever owns that feature. Happy to
split it into its own PR if you would rather have it reconciled.

**The lockfile diff is only the protocol entries.** `npm ci` fails on `main` with npm 10 (`Missing: glob@10.5.0
from lock file`), but that is an artifact of the older npm — with npm 11 (node 24.16.0, what CI uses) the
install is clean and the lockfile change is 8 lines, all `@dcl/protocol`.

## Before this can merge

The pin points at a branch build of the protocol PR (`dcl-protocol-1.0.0-31508413180.commit-2faaa7a`). Once
decentraland/protocol#462 merges and publishes from `main`, this needs a re-pin to that release. That is the
only reason it is a draft.

## Test plan

- [x] `make install` and `make build` with node 24.16.0 — type checking clean, 38 tests passing
- [x] The generated `restricted_actions.gen.ts` exposes `openItemPurchase` and `OpenItemPurchaseResult`
- [x] Generated enum member names match the values the client's `RestrictedActions.js` exposes at runtime, one to one
- [x] Lockfile diff limited to `@dcl/protocol`
- [x] A scene calling `openItemPurchase` compiles and runs end to end against the client in decentraland/unity-explorer#9725 (purchase completed on Amoy, verdict returned, scene reacted)