### PR TITLE
fix: probe 0.0.0.0 in getPort so busy IPv4 ports are detected

### DIFF
--- a/packages/@dcl/sdk-commands/src/logic/get-free-port.ts
+++ b/packages/@dcl/sdk-commands/src/logic/get-free-port.ts
@@ -9,7 +9,10 @@ function tryListen(port: number): Promise<number> {
     const server = net.createServer()
     server.unref()
     server.once('error', reject)
-    server.listen(port, () => {
+    // probe the same address the servers bind (HTTP_SERVER_HOST=0.0.0.0): a hostless
+    // listen binds the IPv6 wildcard, which on macOS coexists with an IPv4 listener
+    // and reports ports as free that the real server then fails to bind (EADDRINUSE)
+    server.listen(port, '0.0.0.0', () => {
       const address = server.address()
       server.close(() => resolve(typeof address === 'object' && address ? address.port : port))
     })

--- a/test/sdk-commands/utils/get-free-port.spec.ts
+++ b/test/sdk-commands/utils/get-free-port.spec.ts
@@ -20,6 +20,31 @@ describe('utils/get-free-port', () => {
     expect(result).toBeLessThan(65536)
   })
 
+  it('never returns a port that is taken on 0.0.0.0, the address the preview server binds', async () => {
+    // occupy the base port (8000) with an IPv4-only listener, like a leftover preview server;
+    // a hostless probe binds the IPv6 wildcard and, on macOS, misses this listener entirely
+    const blocker = net.createServer()
+    blocker.unref()
+    const blocked = await new Promise<boolean>((resolve) => {
+      blocker.once('error', () => resolve(false))
+      blocker.listen(8000, '0.0.0.0', () => resolve(true))
+    })
+    try {
+      const result = await getPort(NaN, 123)
+      if (blocked) expect(result).not.toBe(8000)
+      // the returned port must be bindable on 0.0.0.0, exactly like the real server binds it
+      const server = net.createServer()
+      server.unref()
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(result, '0.0.0.0', () => resolve())
+      })
+      await new Promise((resolve) => server.close(resolve))
+    } finally {
+      if (blocked) await new Promise((resolve) => blocker.close(resolve))
+    }
+  })
+
   it('should return the fail-over port when probing fails', async () => {
     jest.spyOn(net, 'createServer').mockImplementation(() => {
       throw new Error('probe failed')


### PR DESCRIPTION
## Problem

Updating any scene to `@dcl/sdk` 7.26.0 and running `npm run start` on macOS crashes when something is already listening on IPv4 port 8000 (a leftover preview, `python -m http.server`, etc.):

```
Error [ERR_SERVER_NOT_RUNNING]: Server is not running.
Error: listen EADDRINUSE: address already in use 0.0.0.0:8000
  errno: -48, syscall: 'listen', address: '0.0.0.0', port: 8000
```

## Root cause

#1534 replaced portfinder with a hand-rolled scan whose probe calls `server.listen(port)` **without a host**, binding the IPv6 wildcard `::`. On Darwin an IPv6 wildcard socket coexists with an existing IPv4 `0.0.0.0` listener, so the scan reports busy ports as free. The preview/linker servers then bind `HTTP_SERVER_HOST=0.0.0.0` for real and die with `EADDRINUSE`; the `ERR_SERVER_NOT_RUNNING` on top is the Lifecycle tearing down the server that never got to listen. 7.25.0's portfinder probed real interface addresses and quietly fell through to 8001.

## Fix

Probe `0.0.0.0` explicitly — the same address the servers bind. One line, plus a regression test (the test only bites on Darwin; Linux dual-stack bind conflicts mask the bug there).

## Verification

On a macOS machine with a fresh 7.26.0 scene:
- stock CLI + a process holding `0.0.0.0:8000` → reproduces the exact crash above
- patched CLI + `0.0.0.0:8000` **and** `:8001` busy → logs `Listening 0.0.0.0:8002`, preview healthy
- patched CLI with 8000 free → still binds 8000 (stable preview URL preserved)

`make build`, `make lint`, and the full `test/sdk-commands` suite (178 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)