### PR TITLE
fix(sdk): keep state sync retrying until the authoritative server answers

### DIFF
--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -128,9 +128,9 @@ export function addSyncTransport(
     }
   })
   binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, async (data, sender) => {
+    if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
     requestingState = false
     elapsedTimeSinceRequest = 0
-    if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
     if (data.byteLength > 0) {
       transport.onmessage!(serverValidator.processClientMessages(data, sender))

--- a/test/sdk/network/state-sync-retry.spec.ts
+++ b/test/sdk/network/state-sync-retry.spec.ts
@@ -1,0 +1,62 @@
+import { engine, RealmInfo } from '../../../packages/@dcl/ecs/dist'
+import * as components from '../../../packages/@dcl/ecs/dist/components'
+import { addSyncTransport } from '../../../packages/@dcl/sdk/src/network/message-bus-sync'
+import { CommsMessage, encodeString } from '../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import type { SendBinaryRequest, SendBinaryResponse } from '~system/CommunicationsController'
+
+function craftResCrdtState(sender: string): Uint8Array {
+  const senderBytes = encodeString(sender)
+  const buf = new Uint8Array(1 + senderBytes.byteLength + 1)
+  buf[0] = senderBytes.byteLength
+  buf.set(senderBytes, 1)
+  buf[1 + senderBytes.byteLength] = CommsMessage.RES_CRDT_STATE
+  return buf
+}
+
+describe('state-sync request retry', () => {
+  it('keeps retrying REQ_CRDT_STATE after a non-authoritative RES_CRDT_STATE', async () => {
+    components.NetworkEntity(engine as any)
+    components.NetworkParent(engine as any)
+    components.Transform(engine as any)
+    components.SyncComponents(engine as any)
+
+    let reqCount = 0
+    const sendBinary = async (msg: SendBinaryRequest): Promise<SendBinaryResponse> => {
+      for (const peerData of msg.peerData) {
+        for (const data of peerData.data) {
+          if (data[0] === CommsMessage.REQ_CRDT_STATE) reqCount++
+        }
+      }
+      return { data: [] }
+    }
+    const getUserData = async () => ({
+      data: { userId: 'clientA', version: 1, displayName: 'A', hasConnectedWeb3: true, avatar: undefined }
+    })
+    const isServerFn = async () => ({ isServer: false })
+
+    const sync = addSyncTransport(engine as any, sendBinary, getUserData as any, isServerFn as any, 'clientA')
+
+    RealmInfo.createOrReplace(engine.RootEntity, {
+      baseUrl: 'http://localhost:8000',
+      realmName: 'LocalPreview',
+      networkId: 0,
+      commsAdapter: 'ws-room',
+      isPreview: true,
+      room: 'room-1',
+      isConnectedSceneRoom: true
+    } as any)
+    await engine.update(1)
+    await engine.update(1)
+
+    expect(reqCount).toBeGreaterThanOrEqual(1)
+    const reqsBeforeNonAuthResponse = reqCount
+
+    sync.binaryMessageBus.__processMessages([craftResCrdtState('some-other-peer')])
+    expect(sync.isStateSyncronized()).toBe(false)
+
+    await engine.update(3)
+    await engine.update(1)
+
+    expect(reqCount).toBeGreaterThan(reqsBeforeNonAuthResponse)
+  })
+})


### PR DESCRIPTION
## Summary

Client-side state sync in `@dcl/sdk` could wedge or waste bandwidth in an authoritative-multiplayer scene. Three fixes, one per commit. The `sdk-commands` server-spawn work that used to live here moved to #1620 so each PR can be reviewed by the people who know that layer.

1. **Keep the state-request retry armed.** The `RES_CRDT_STATE` handler cleared `requestingState` before checking the sender, so a reply from any non-authoritative peer disarmed the 2 s retry without ever marking the client synchronized. Only a reply from `authoritative-server` clears it now; a stray reply is ignored and the retry keeps firing until the real server answers.
2. **Clients no longer answer `REQ_CRDT_STATE`.** Every peer used to reply with a full state dump that the requester then discarded. Only the server owns the state.
3. **Treat an unresolved `isServer` as client.** The guard in 2 checked for `false`, but the atom is `null` until the runtime answers, so a client still answered during that window. Any non-true value is now client, matching every other handler; a server that drops a request in its own pending window is covered by the retry in 1.

## How to test

```bash
node_modules/.bin/jest --forceExit --testPathPatterns='test/sdk/network'
```

`test/sdk/network/state-sync-retry.spec.ts` covers each fix and was red before it: a non-authoritative reply leaves the client unsynchronized and retrying; a foreign request gets no answer from a client; a server answers; a peer whose `isServer` is still pending does not.

Manual, in a scene with `authoritativeMultiplayer` enabled and a second client in the room: `isStateSyncronized()` turns true on the first launch, and the second client's console shows no `[Emiting:]` lines when `DEBUG_NETWORK_MESSAGES` is on.

## Notes

- `packages/@dcl/sdk` fails `tsc --noEmit` at HEAD in an unrelated file; the changes are covered by the Jest suite.
- The `no-unused-expressions` lint findings in `message-bus-sync.ts` predate this branch and are unchanged.
