### PR TITLE
fix(sdk-commands): forward real headers through the linker-dapp auth proxy

### DIFF
--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -8,12 +8,7 @@ import { AuthChain } from '@dcl/crypto'
 
 import { CliComponents } from '../components'
 
-/**
- * Headers that describe THIS connection rather than the proxied request. Passing them along
- * makes undici reject the request outright or leaves the upstream framing a body that is no
- * longer the one being sent.
- */
-const HOP_BY_HOP_HEADERS = new Set([
+const CONNECTION_HEADERS = new Set([
   'connection',
   'content-length',
   'keep-alive',
@@ -25,29 +20,20 @@ const HOP_BY_HOP_HEADERS = new Set([
   'upgrade'
 ])
 
-/**
- * Builds the header set to forward upstream, with `overrides` winning over whatever the
- * client sent.
- *
- * Header names are case-insensitive on the wire but not as object keys, so an incoming
- * `host` and an override `Host` would both survive into the request and be sent as two
- * conflicting headers. Names are lowercased and the overridden ones dropped first, so each
- * one is written exactly once.
- */
-function forwardedHeaders(
+export function forwardedHeaders(
   request: IHttpServerComponent.IRequest,
   overrides: Record<string, string>
 ): Record<string, string> {
-  const overridden = new Set(Object.keys(overrides).map((name) => name.toLowerCase()))
-  const headers: Record<string, string> = {}
+  const overriddenNames = new Set(Object.keys(overrides).map((name) => name.toLowerCase()))
+  const forwarded: Record<string, string> = {}
 
   for (const [key, value] of request.headers) {
     const name = key.toLowerCase()
-    if (HOP_BY_HOP_HEADERS.has(name) || overridden.has(name)) continue
-    headers[name] = value
+    if (CONNECTION_HEADERS.has(name) || overriddenNames.has(name)) continue
+    forwarded[name] = value
   }
 
-  return { ...headers, ...overrides }
+  return { ...forwarded, ...overrides }
 }
 
 /**
@@ -65,8 +51,6 @@ export function setRoutes<T extends { [key: string]: any }>(
   const router = new Router()
   const linkerDapp = dirname(require.resolve('@dcl/linker-dapp/package.json'))
 
-  // Dispatcher used by the /auth proxy below to skip TLS verification, mirroring the
-  // previous `new https.Agent({ rejectUnauthorized: false })` behavior with native fetch.
   const insecureDispatcher = new Agent({ connect: { rejectUnauthorized: false } })
 
   router.get(mainRoute, async () => ({
@@ -90,50 +74,34 @@ export function setRoutes<T extends { [key: string]: any }>(
     }
   })
 
-  /* This route acts as a proxy to handle the auth flow with the Decentraland auth dApp,
-   * because this latest one validates the communication be on the same domain.
-   */
   router.get('/auth/(.*)', async (ctx): Promise<IHttpServerComponent.IResponse> => {
     try {
       const domain = 'decentraland.org'
       const url = `https://${domain}${ctx.url.pathname}${ctx.url.search}`
 
-      // Forward the incoming request to the Decentraland auth endpoint.
-      //
-      // The client's headers have to be ITERATED, never spread: they live behind a
-      // symbol-keyed slot, so a spread copies that symbol and none of the headers — and
-      // undici rejects a symbol key outright ("cannot be converted to a ByteString"),
-      // taking the whole proxied request down with it.
-      const resp = await components.fetch.fetch(url, {
-        method: ctx.request.method, // Ensure the correct method (GET in this case).
+      const response = await components.fetch.fetch(url, {
+        method: ctx.request.method,
         headers: forwardedHeaders(ctx.request, {
           host: domain,
           referer: url,
           origin: url
         }),
-        body: ctx.request.body as any, // Forward request body if necessary.
-        duplex: 'half', // Required by native fetch when streaming a request body.
-        dispatcher: insecureDispatcher // Skip TLS verification.
+        body: ctx.request.body as any,
+        duplex: 'half',
+        dispatcher: insecureDispatcher
       })
 
-      // undici decompresses the body but leaves content-encoding / content-length in
-      // place; forwarding them would make the client re-decode or truncate the body.
-      // The headers on a fetch() Response are immutable (mutating them throws
-      // `TypeError: immutable`), so build a filtered copy instead of deleting in place.
-      const headers: Record<string, string> = {}
-      for (const [key, value] of resp.headers) {
+      const responseHeaders: Record<string, string> = {}
+      for (const [key, value] of response.headers) {
         const name = key.toLowerCase()
         if (name === 'content-encoding' || name === 'content-length') continue
-        headers[key] = value
+        responseHeaders[key] = value
       }
 
-      // Return the proxied response, including body, status, and headers.
-      // `resp.body` is a web ReadableStream; convert it to a Node stream so the
-      // http-server can pipe it (it only handles Node streams / Buffers / strings).
       return {
-        body: resp.body ? Readable.fromWeb(resp.body as any) : undefined,
-        status: resp.status,
-        headers
+        body: response.body ? Readable.fromWeb(response.body as any) : undefined,
+        status: response.status,
+        headers: responseHeaders
       }
     } catch (error) {
       return {

--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -8,7 +8,7 @@ import { AuthChain } from '@dcl/crypto'
 
 import { CliComponents } from '../components'
 
-const CONNECTION_HEADERS = new Set([
+const STRIPPED_REQUEST_HEADERS = new Set([
   'connection',
   'content-length',
   'keep-alive',
@@ -29,7 +29,7 @@ export function forwardedHeaders(
 
   for (const [key, value] of request.headers) {
     const name = key.toLowerCase()
-    if (CONNECTION_HEADERS.has(name) || overriddenNames.has(name)) continue
+    if (STRIPPED_REQUEST_HEADERS.has(name) || overriddenNames.has(name)) continue
     forwarded[name] = value
   }
 
@@ -94,8 +94,8 @@ export function setRoutes<T extends { [key: string]: any }>(
       const responseHeaders: Record<string, string> = {}
       for (const [key, value] of response.headers) {
         const name = key.toLowerCase()
-        if (name === 'content-encoding' || name === 'content-length') continue
-        responseHeaders[key] = value
+        if (['content-encoding', 'content-length'].includes(name)) continue
+        responseHeaders[name] = value
       }
 
       return {

--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -9,6 +9,48 @@ import { AuthChain } from '@dcl/crypto'
 import { CliComponents } from '../components'
 
 /**
+ * Headers that describe THIS connection rather than the proxied request. Passing them along
+ * makes undici reject the request outright or leaves the upstream framing a body that is no
+ * longer the one being sent.
+ */
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade'
+])
+
+/**
+ * Builds the header set to forward upstream, with `overrides` winning over whatever the
+ * client sent.
+ *
+ * Header names are case-insensitive on the wire but not as object keys, so an incoming
+ * `host` and an override `Host` would both survive into the request and be sent as two
+ * conflicting headers. Names are lowercased and the overridden ones dropped first, so each
+ * one is written exactly once.
+ */
+function forwardedHeaders(
+  request: IHttpServerComponent.IRequest,
+  overrides: Record<string, string>
+): Record<string, string> {
+  const overridden = new Set(Object.keys(overrides).map((name) => name.toLowerCase()))
+  const headers: Record<string, string> = {}
+
+  for (const [key, value] of request.headers) {
+    const name = key.toLowerCase()
+    if (HOP_BY_HOP_HEADERS.has(name) || overridden.has(name)) continue
+    headers[name] = value
+  }
+
+  return { ...headers, ...overrides }
+}
+
+/**
  * Set common routes to use on Linker dApp
  * @param components Server components
  * @param info Info to be sent within /api/info body response
@@ -57,14 +99,18 @@ export function setRoutes<T extends { [key: string]: any }>(
       const url = `https://${domain}${ctx.url.pathname}${ctx.url.search}`
 
       // Forward the incoming request to the Decentraland auth endpoint.
+      //
+      // The client's headers have to be ITERATED, never spread: they live behind a
+      // symbol-keyed slot, so a spread copies that symbol and none of the headers — and
+      // undici rejects a symbol key outright ("cannot be converted to a ByteString"),
+      // taking the whole proxied request down with it.
       const resp = await components.fetch.fetch(url, {
         method: ctx.request.method, // Ensure the correct method (GET in this case).
-        headers: {
-          ...ctx.request.headers,
-          Host: domain,
-          Referer: url,
-          Origin: url
-        }, // Forward headers for proper proxy behavior.
+        headers: forwardedHeaders(ctx.request, {
+          host: domain,
+          referer: url,
+          origin: url
+        }),
         body: ctx.request.body as any, // Forward request body if necessary.
         duplex: 'half', // Required by native fetch when streaming a request body.
         dispatcher: insecureDispatcher // Skip TLS verification.

--- a/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
+++ b/packages/@dcl/sdk-commands/src/linker-dapp/routes.ts
@@ -37,6 +37,26 @@ export function forwardedHeaders(
 }
 
 /**
+ * Builds the headers returned to the linker-dapp client from a proxied fetch response.
+ *
+ * undici transparently decompresses the body but leaves the upstream `content-encoding` and
+ * `content-length` in place; forwarding them would make the client re-decode an already-decoded
+ * body or truncate it at the wrong length, so both are dropped and the framing is recomputed
+ * downstream.
+ */
+export function proxiedResponseHeaders(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {}
+
+  for (const [key, value] of headers) {
+    const name = key.toLowerCase()
+    if (['content-encoding', 'content-length'].includes(name)) continue
+    result[name] = value
+  }
+
+  return result
+}
+
+/**
  * Set common routes to use on Linker dApp
  * @param components Server components
  * @param info Info to be sent within /api/info body response
@@ -91,12 +111,7 @@ export function setRoutes<T extends { [key: string]: any }>(
         dispatcher: insecureDispatcher
       })
 
-      const responseHeaders: Record<string, string> = {}
-      for (const [key, value] of response.headers) {
-        const name = key.toLowerCase()
-        if (['content-encoding', 'content-length'].includes(name)) continue
-        responseHeaders[name] = value
-      }
+      const responseHeaders = proxiedResponseHeaders(response.headers)
 
       return {
         body: response.body ? Readable.fromWeb(response.body as any) : undefined,

--- a/test/sdk-commands/linker-dapp/routes.spec.ts
+++ b/test/sdk-commands/linker-dapp/routes.spec.ts
@@ -1,0 +1,73 @@
+import { createRequire } from 'module'
+import type { IHttpServerComponent } from '@well-known-components/interfaces'
+import { forwardedHeaders } from '../../../packages/@dcl/sdk-commands/src/linker-dapp/routes'
+
+const sdkRequire = createRequire(require.resolve('../../../packages/@dcl/sdk-commands/package.json'))
+const { Headers } = sdkRequire('node-fetch')
+
+function requestWithHeaders(headers: Record<string, string>): IHttpServerComponent.IRequest {
+  return { headers: new Headers(headers) } as unknown as IHttpServerComponent.IRequest
+}
+
+describe('forwardedHeaders', () => {
+  let overrides: Record<string, string>
+  let request: IHttpServerComponent.IRequest
+  let result: Record<string, string>
+
+  beforeEach(() => {
+    overrides = {
+      host: 'decentraland.org',
+      referer: 'https://decentraland.org/auth/requests/abc',
+      origin: 'https://decentraland.org/auth/requests/abc'
+    }
+  })
+
+  describe('when the request headers come from node-fetch', () => {
+    beforeEach(() => {
+      request = requestWithHeaders({ Authorization: 'Bearer token' })
+      result = forwardedHeaders(request, overrides)
+    })
+
+    it('should return a plain object without the node-fetch symbol slot that undici rejects', () => {
+      expect(Object.getOwnPropertySymbols(result)).toHaveLength(0)
+    })
+
+    it('should forward the client header with a lowercased name', () => {
+      expect(result.authorization).toBe('Bearer token')
+    })
+  })
+
+  describe('when the client sends headers that collide with the overrides', () => {
+    beforeEach(() => {
+      request = requestWithHeaders({ host: 'localhost:3000', origin: 'http://localhost:3000' })
+      result = forwardedHeaders(request, overrides)
+    })
+
+    it('should use the override host instead of the incoming one', () => {
+      expect(result.host).toBe('decentraland.org')
+    })
+
+    it('should use the override origin instead of the incoming one', () => {
+      expect(result.origin).toBe('https://decentraland.org/auth/requests/abc')
+    })
+  })
+
+  describe('when the client sends connection-scoped headers', () => {
+    beforeEach(() => {
+      request = requestWithHeaders({ connection: 'keep-alive', 'content-length': '42', authorization: 'Bearer token' })
+      result = forwardedHeaders(request, overrides)
+    })
+
+    it('should drop the connection header', () => {
+      expect(result.connection).toBeUndefined()
+    })
+
+    it('should drop the content-length header', () => {
+      expect(result['content-length']).toBeUndefined()
+    })
+
+    it('should still forward the end-to-end headers', () => {
+      expect(result.authorization).toBe('Bearer token')
+    })
+  })
+})

--- a/test/sdk-commands/linker-dapp/routes.spec.ts
+++ b/test/sdk-commands/linker-dapp/routes.spec.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'module'
 import type { IHttpServerComponent } from '@well-known-components/interfaces'
-import { forwardedHeaders } from '../../../packages/@dcl/sdk-commands/src/linker-dapp/routes'
+import { forwardedHeaders, proxiedResponseHeaders } from '../../../packages/@dcl/sdk-commands/src/linker-dapp/routes'
 
 const sdkRequire = createRequire(require.resolve('../../../packages/@dcl/sdk-commands/package.json'))
 const { Headers } = sdkRequire('node-fetch')
@@ -68,6 +68,34 @@ describe('forwardedHeaders', () => {
 
     it('should still forward the end-to-end headers', () => {
       expect(result.authorization).toBe('Bearer token')
+    })
+  })
+})
+
+describe('proxiedResponseHeaders', () => {
+  let responseHeaders: Headers
+  let result: Record<string, string>
+
+  describe('when the upstream response includes body-framing headers', () => {
+    beforeEach(() => {
+      responseHeaders = new Headers({
+        'content-encoding': 'gzip',
+        'content-length': '10',
+        'cache-control': 'no-cache'
+      })
+      result = proxiedResponseHeaders(responseHeaders)
+    })
+
+    it('should drop the content-encoding header that no longer matches the decompressed body', () => {
+      expect(result['content-encoding']).toBeUndefined()
+    })
+
+    it('should drop the content-length header that no longer matches the decompressed body', () => {
+      expect(result['content-length']).toBeUndefined()
+    })
+
+    it('should forward the remaining headers', () => {
+      expect(result['cache-control']).toBe('no-cache')
     })
   })
 })


### PR DESCRIPTION
The incoming request's headers were spread into the fetch init. They live behind a symbol-keyed slot, so the spread copied that symbol and none of the headers - and undici rejects a symbol key outright ("cannot be converted to a ByteString"), so every /auth request returned a 500 instead of proxying. Sign in navigates straight there, which renders the error body as raw text; the "No identity found" toast that follows is downstream of the same failure.

Iterates the headers instead. Names are lowercased and the ones we override dropped first, so an incoming `host` and our `Host` cannot both go on the wire as conflicting headers, and hop-by-hop headers that describe the inbound connection are left behind rather than confusing the upstream framing.