### PR TITLE
feat(sdk-commands): derive the LSD Pulse realm key for the preview engine

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -23,6 +23,7 @@ Curated map of every doc in this repo. Use this as the entry point when looking 
 | [world-transform-no-caching.md](world-transform-no-caching.md) | Why world-space transforms are computed lazily (not cached) and what that means for system authors. |
 | [on-demand-composite-loading.md](on-demand-composite-loading.md) | Runtime composite instantiation via `engine.addEntityFromComposite(src, options)`. The provider abstraction and pre-registration flow. |
 | [material-getflat-api.md](material-getflat-api.md) | Material `getFlat` API: reading a fully-resolved material descriptor instead of the discriminated union. |
+| [lsd-identity-and-pulse-realm.md](lsd-identity-and-pulse-realm.md) | Local Scene Development identity: the preview scene id and the Pulse realm key derived from it. Cross-repo contract — unity-explorer and bevy-explorer derive the same strings independently. |
 
 ## Guides (how-to)
 

--- a/docs/lsd-identity-and-pulse-realm.md
+++ b/docs/lsd-identity-and-pulse-realm.md
@@ -63,15 +63,25 @@ same function the preview server already uses for scene and file entity ids:
 
 ## Invariants
 
-- **The project root's id is path-only.** Per-file preview hashes are mtime-versioned
-  (`b64-<base64(path\0mtimeMs-machineId)>`), but the project directory's own entity id
-  deliberately is not, so scene identity survives edits and reloads. Deriving the realm key from a
-  content entry instead of from `b64HashingFunction(projectRoot)` would re-partition comms on
-  every file save.
-- **The path is absolute.** `workspaceFromFolders` resolves each project's `workingDirectory`
-  before it reaches any caller.
+- **The project root's id is path-only.** Today every preview id — the project's and each file's —
+  is path-only. [PR #1529](https://github.com/decentraland/js-sdk-toolchain/pull/1529) (open at
+  time of writing) would version *per-file* hashes by mtime as
+  `b64-<base64(path\0mtimeMs-machineId)>` while deliberately leaving the project directory's own
+  entity id path-only. The realm key must keep deriving from `b64HashingFunction(projectRoot)`: a
+  content- or mtime-shaped input would re-partition comms on every file save.
+- **The path is absolute, and byte-exact.** `workspaceFromFolders` resolves each project's
+  `workingDirectory` before it reaches any caller, but `path.resolve` normalizes the separator
+  style — **not** drive-letter case on Windows. `e:\dev\scene` and `E:\dev\scene` are the same
+  project and yield two different realm keys. An explorer deriving the key independently must use
+  the byte-identical path string the CLI used, casing included; when in doubt, read the scene
+  entity id off the preview server instead of re-deriving it.
 - **`machineId` is part of the input.** Two developers who check the same project out to the same
   path still get different realms.
+
+The non-overflow key is reversible base64 of an absolute path and a hostname, so it can carry a
+developer's directory layout and machine name. That is unchanged from the entity ids the preview
+server already serves locally, but once the gate below opens the same string travels as a comms
+realm — worth knowing before it leaves the machine.
 
 ## The `--pulse-realm` gate
 

--- a/docs/lsd-identity-and-pulse-realm.md
+++ b/docs/lsd-identity-and-pulse-realm.md
@@ -1,0 +1,110 @@
+# LSD identity and the Pulse realm key
+
+Canonical contract for **Local Scene Development (LSD)** identity: the preview scene id and the
+Pulse realm key derived from it. `sdk-commands`, unity-explorer and bevy-explorer all implement
+this; it is documented once here so the implementations can reference a single source instead of
+each other.
+
+## Why this needs a canonical definition
+
+Pulse partitions visibility by **exact realm-string match**, and no realm key is ever exchanged —
+every party derives it independently from the project path. That is what makes local previews
+isolated without any handshake, and it is also the failure mode: if two implementations derive
+even slightly different strings, nothing errors. The peers just never see each other.
+
+This is the same class of bug as the LiveKit `preview-${sceneId}` vs `LocalPreview:{sceneId}`
+room-name mismatch, and the reason this contract is written down rather than reimplemented.
+
+## The derivation
+
+```
+machineId      = os.hostname() || os.userInfo().username
+previewSceneId = "b64-" + base64(`${absoluteProjectRoot}-${machineId}`)
+realmKey       = "lsd:" + previewSceneId
+```
+
+If `realmKey` exceeds Pulse's `MaxRealmLength` of **255**, it collapses deterministically:
+
+```
+realmKey = "lsd:sha256:" + SHA256Hex(previewSceneId)
+```
+
+The hash is taken over `previewSceneId` (including its `b64-` prefix), hex-encoded lowercase. The
+overflow form is always 75 characters, so it always fits. Truncation is deliberately *not* used —
+every party must land on the identical string without coordinating.
+
+### Worked examples
+
+With `machineId = "dev-box"`:
+
+| `absoluteProjectRoot` | `realmKey` |
+| --- | --- |
+| `/home/dev/my-scene` | `lsd:b64-L2hvbWUvZGV2L215LXNjZW5lLWRldi1ib3g=` |
+| `/home/dev/` + `a`×200 | `lsd:sha256:783635fb50eadaed0300d80104920bfc55894d5ad2ab69ab6b48c6ff1ddb9da5` |
+
+The second row's raw key would have been 300 characters.
+
+## Source of truth
+
+[`packages/@dcl/sdk-commands/src/logic/lsd-realm.ts`](../packages/@dcl/sdk-commands/src/logic/lsd-realm.ts)
+implements the realm key. It composes — rather than re-derives — `machineId` and
+`b64HashingFunction` from
+[`logic/project-files.ts`](../packages/@dcl/sdk-commands/src/logic/project-files.ts), which is the
+same function the preview server already uses for scene and file entity ids:
+
+| Caller | Uses it for |
+| --- | --- |
+| `commands/start/index.ts` | `projectHash` on the `Preview started` analytics event |
+| `commands/start/server/endpoints.ts` | the scene entity id served to clients, and decoding it back to a path |
+| `commands/start/server/file-watch-notifier.ts` | `sceneId` on every hot-reload message, plus per-file hashes |
+| `commands/build/index.ts`, `commands/deploy/index.ts`, `commands/export-static/index.ts`, `commands/pack-smart-wearable/index.ts` | `projectHash` on their analytics events |
+
+**Do not add a second derivation.** A new one that agrees today will drift.
+
+## Invariants
+
+- **The project root's id is path-only.** Per-file preview hashes are mtime-versioned
+  (`b64-<base64(path\0mtimeMs-machineId)>`), but the project directory's own entity id
+  deliberately is not, so scene identity survives edits and reloads. Deriving the realm key from a
+  content entry instead of from `b64HashingFunction(projectRoot)` would re-partition comms on
+  every file save.
+- **The path is absolute.** `workspaceFromFolders` resolves each project's `workingDirectory`
+  before it reaches any caller.
+- **`machineId` is part of the input.** Two developers who check the same project out to the same
+  path still get different realms.
+
+## The `--pulse-realm` gate
+
+`sdk-commands start` passes the realm to the spawned preview engine as `--pulse-realm=<key>`,
+identically for bevy and the hammurabi opt-out. It is **off by default**:
+
+```bash
+DCL_SERVER_PULSE_REALM=1 npm start
+```
+
+Two upstream reasons:
+
+- bevy-headless has no Pulse transport in server mode. `src/bin/headless.rs` never mentions Pulse,
+  and `crates/comms/src/pulse/plugin.rs` notes that a multi-tenant server "stays on LiveKit for
+  now". Tracked at
+  [decentraland/sdk-multiplayer-server#132](https://github.com/decentraland/sdk-multiplayer-server/issues/132).
+- Today the headless binary silently ignores unknown arguments, but
+  [bevy-explorer#1030](https://github.com/decentraland/bevy-explorer/pull/1030) makes it exit 2 on
+  them. Passing the flag unconditionally would break every preview on the default engine the day
+  that ships.
+
+**To flip the default on** once a bevy-headless release declares support: set
+`PULSE_REALM_DEFAULT = true` in `logic/lsd-realm.ts`. `DCL_SERVER_PULSE_REALM=0` remains the
+opt-out.
+
+## Parcel bounds
+
+Pulse's `FieldValidator` disconnects peers that report invalid parcel indices, so a scene outside
+Genesis City bounds would join a realm and then silently fail to get comms.
+
+`sdk-commands` cannot produce such a scene: `assertValidScene`
+([`logic/scene-validations.ts`](../packages/@dcl/sdk-commands/src/logic/scene-validations.ts))
+already rejects any parcel failing `isInsideWorldLimits` from `@dcl/schemas` with
+`SCENE_VALIDATIONS_COORDINATES_OUTSIDE_LIMITS`, and `start` reaches it through
+`getValidWorkspace` → `assertValidProjectFolder` → `getValidSceneJson`. The preview fails to start
+rather than starting without comms.

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -6,6 +6,7 @@ import { colors } from '../../components/log'
 import { PreviewComponents } from './types'
 import { ProjectUnion } from '../../logic/project-validations'
 import { isElectronEnvironment, getSpawnEnv, findNpxCliJs, getNpxBin } from './utils'
+import { pulseRealmArgs } from '../../logic/lsd-realm'
 
 const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
@@ -150,7 +151,7 @@ export function startMultiplayerServer(
     `Starting ${colors.bold('Multiplayer Server')} (${engine}) with realm: ${colors.bold(realm)}`
   )
 
-  const npxArgs = ['--yes', pkg, `--realm=${realm}`]
+  const npxArgs = ['--yes', pkg, `--realm=${realm}`, ...pulseRealmArgs(workingDir)]
   const npxCliJs = findNpxCliJs()
 
   // In Electron, override npm_config_prefix because npm derives its prefix from process.execPath,

--- a/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
+++ b/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
@@ -1,0 +1,68 @@
+/**
+ * Local Scene Development (LSD) identity and the Pulse realm key.
+ *
+ * Pulse partitions visibility by exact realm-string match and nothing is
+ * exchanged: the CLI, unity-explorer and bevy-explorer each derive the string
+ * independently. Drift between two derivations is therefore invisible — peers
+ * simply never see each other — which is why this contract lives in one place.
+ * See docs/lsd-identity-and-pulse-realm.md.
+ */
+import { createHash } from 'crypto'
+import { b64HashingFunction } from './project-files'
+
+/** Pulse's `MaxRealmLength`. Longer realm strings are rejected. */
+export const PULSE_MAX_REALM_LENGTH = 255
+
+const LSD_REALM_PREFIX = 'lsd:'
+const LSD_REALM_HASHED_PREFIX = 'lsd:sha256:'
+
+/**
+ * `b64-` + base64(`${absoluteProjectRoot}-${machineId}`).
+ *
+ * Deliberately the same {@link b64HashingFunction} the preview server already
+ * hands clients as the scene's entity id, not a parallel derivation. It is a
+ * function of the project root alone: per-file preview hashes are mtime-versioned
+ * but the project directory's own id stays path-only, so deriving the realm from
+ * a content entry would re-partition comms on every file save.
+ */
+export function lsdPreviewSceneId(projectRoot: string): string {
+  return b64HashingFunction(projectRoot)
+}
+
+/**
+ * The Pulse realm key for a local preview.
+ *
+ * Long project paths can push the raw key past Pulse's limit, so it collapses to
+ * a hash of the same input rather than being truncated — every party has to land
+ * on the identical string without coordinating.
+ */
+export function lsdRealmKey(projectRoot: string): string {
+  const previewSceneId = lsdPreviewSceneId(projectRoot)
+  const realmKey = LSD_REALM_PREFIX + previewSceneId
+
+  if (realmKey.length <= PULSE_MAX_REALM_LENGTH) return realmKey
+
+  return LSD_REALM_HASHED_PREFIX + createHash('sha256').update(previewSceneId).digest('hex')
+}
+
+// Flip to `true` once a bevy-headless release declares `--pulse-realm` support;
+// `DCL_SERVER_PULSE_REALM=0` stays the opt-out afterwards.
+const PULSE_REALM_DEFAULT = false
+
+/**
+ * bevy-headless has no Pulse transport in server mode yet
+ * (decentraland/sdk-multiplayer-server#132), and once bevy-explorer#1030 lands the
+ * headless binary exits 2 on arguments it used to ignore — so passing the realm
+ * unconditionally today would break every preview on the default engine.
+ */
+export function pulseRealmEnabled(): boolean {
+  const requested = process.env.DCL_SERVER_PULSE_REALM
+  if (!requested) return PULSE_REALM_DEFAULT
+  return requested === '1' || requested.toLowerCase() === 'true'
+}
+
+/** The realm arguments for the spawned engine — identical for bevy and hammurabi. */
+export function pulseRealmArgs(projectRoot: string): string[] {
+  if (!pulseRealmEnabled()) return []
+  return [`--pulse-realm=${lsdRealmKey(projectRoot)}`]
+}

--- a/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
+++ b/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
@@ -1,67 +1,41 @@
-/**
- * Local Scene Development (LSD) identity and the Pulse realm key.
- *
- * Pulse partitions visibility by exact realm-string match and nothing is
- * exchanged: the CLI, unity-explorer and bevy-explorer each derive the string
- * independently. Drift between two derivations is therefore invisible — peers
- * simply never see each other — which is why this contract lives in one place.
- * See docs/lsd-identity-and-pulse-realm.md.
- */
+// Local Scene Development identity and the Pulse realm key.
+// Pulse matches realms by exact string and nothing is exchanged, so a derivation
+// that drifts is invisible: peers just never see each other.
+// Contract and caveats: docs/lsd-identity-and-pulse-realm.md
 import { createHash } from 'crypto'
 import { b64HashingFunction } from './project-files'
 
-/** Pulse's `MaxRealmLength`. Longer realm strings are rejected. */
+/** Pulse's `MaxRealmLength`. */
 export const PULSE_MAX_REALM_LENGTH = 255
 
 const LSD_REALM_PREFIX = 'lsd:'
 const LSD_REALM_HASHED_PREFIX = 'lsd:sha256:'
 
-/**
- * `b64-` + base64(`${absoluteProjectRoot}-${machineId}`).
- *
- * Deliberately the same {@link b64HashingFunction} the preview server already
- * hands clients as the scene's entity id, not a parallel derivation. It is a
- * function of the project root alone: per-file preview hashes are mtime-versioned
- * but the project directory's own id stays path-only, so deriving the realm from
- * a content entry would re-partition comms on every file save.
- */
+/** The scene entity id the preview server already serves, reused verbatim. */
 export function lsdPreviewSceneId(projectRoot: string): string {
   return b64HashingFunction(projectRoot)
 }
 
-/**
- * The Pulse realm key for a local preview.
- *
- * Long project paths can push the raw key past Pulse's limit, so it collapses to
- * a hash of the same input rather than being truncated — every party has to land
- * on the identical string without coordinating.
- */
 export function lsdRealmKey(projectRoot: string): string {
   const previewSceneId = lsdPreviewSceneId(projectRoot)
   const realmKey = LSD_REALM_PREFIX + previewSceneId
 
+  // hashed, not truncated: every party must land on the same string unprompted
   if (realmKey.length <= PULSE_MAX_REALM_LENGTH) return realmKey
 
   return LSD_REALM_HASHED_PREFIX + createHash('sha256').update(previewSceneId).digest('hex')
 }
 
-// Flip to `true` once a bevy-headless release declares `--pulse-realm` support;
-// `DCL_SERVER_PULSE_REALM=0` stays the opt-out afterwards.
+// Off until bevy-headless declares `--pulse-realm` support; flip to `true` then,
+// leaving `DCL_SERVER_PULSE_REALM=0` as the opt-out.
 const PULSE_REALM_DEFAULT = false
 
-/**
- * bevy-headless has no Pulse transport in server mode yet
- * (decentraland/sdk-multiplayer-server#132), and once bevy-explorer#1030 lands the
- * headless binary exits 2 on arguments it used to ignore — so passing the realm
- * unconditionally today would break every preview on the default engine.
- */
 export function pulseRealmEnabled(): boolean {
   const requested = process.env.DCL_SERVER_PULSE_REALM
   if (!requested) return PULSE_REALM_DEFAULT
   return requested === '1' || requested.toLowerCase() === 'true'
 }
 
-/** The realm arguments for the spawned engine — identical for bevy and hammurabi. */
 export function pulseRealmArgs(projectRoot: string): string[] {
   if (!pulseRealmEnabled()) return []
   return [`--pulse-realm=${lsdRealmKey(projectRoot)}`]

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -105,6 +105,12 @@ export async function getProjectPublishableFilesWithHashes(
   return ret
 }
 export const machineId = os.hostname() || os.userInfo().username
+
+/**
+ * Preview entity ids. Also the base of the LSD Pulse realm key, which explorers
+ * derive independently — see docs/lsd-identity-and-pulse-realm.md before changing
+ * the encoding.
+ */
 export const b64HashingFunction = (str: string) => {
   const unique = `${str}-${machineId}`
   return 'b64-' + Buffer.from(unique).toString('base64')

--- a/packages/@dcl/sdk-commands/src/logic/project-files.ts
+++ b/packages/@dcl/sdk-commands/src/logic/project-files.ts
@@ -106,11 +106,8 @@ export async function getProjectPublishableFilesWithHashes(
 }
 export const machineId = os.hostname() || os.userInfo().username
 
-/**
- * Preview entity ids. Also the base of the LSD Pulse realm key, which explorers
- * derive independently — see docs/lsd-identity-and-pulse-realm.md before changing
- * the encoding.
- */
+// Preview entity ids, and the base of the LSD Pulse realm key that explorers
+// derive independently. See docs/lsd-identity-and-pulse-realm.md before changing.
 export const b64HashingFunction = (str: string) => {
   const unique = `${str}-${machineId}`
   return 'b64-' + Buffer.from(unique).toString('base64')

--- a/test/sdk-commands/commands/start/multiplayer-server.spec.ts
+++ b/test/sdk-commands/commands/start/multiplayer-server.spec.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from 'events'
+import * as childProcess from 'child_process'
+import { startMultiplayerServer } from '../../../../packages/@dcl/sdk-commands/src/commands/start/multiplayer-server'
+import { lsdRealmKey } from '../../../../packages/@dcl/sdk-commands/src/logic/lsd-realm'
+
+jest.mock('child_process', () => ({ spawn: jest.fn() }))
+
+const spawnMock = childProcess.spawn as unknown as jest.Mock
+
+function fakeChild() {
+  const child = new EventEmitter() as any
+  child.stdout = null
+  child.stderr = null
+  child.killed = false
+  child.kill = jest.fn()
+  return child
+}
+
+const components = {
+  logger: { log: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  analytics: { track: jest.fn(), stop: jest.fn() }
+} as any
+
+/** The argv handed to npx, whichever way npx was located. */
+function spawnedArgs(): string[] {
+  const [, args] = spawnMock.mock.calls[0]
+  return args as string[]
+}
+
+describe('multiplayer server Pulse realm flag', () => {
+  const original = process.env.DCL_SERVER_PULSE_REALM
+  const workingDir = '/home/dev/my-scene'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    spawnMock.mockImplementation(() => fakeChild())
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.DCL_SERVER_PULSE_REALM
+    else process.env.DCL_SERVER_PULSE_REALM = original
+  })
+
+  // Until bevy-explorer#1030 lands the headless binary ignores unknown flags;
+  // afterwards it exits 2. Passing --pulse-realm unconditionally would therefore
+  // break every preview on the default engine the day that ships.
+  it('passes no --pulse-realm while the gate is closed', () => {
+    delete process.env.DCL_SERVER_PULSE_REALM
+
+    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
+
+    expect(spawnedArgs().some((arg) => arg.startsWith('--pulse-realm'))).toBe(false)
+  })
+
+  it('passes the realm key derived from the project root when opted in', () => {
+    process.env.DCL_SERVER_PULSE_REALM = '1'
+
+    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
+
+    expect(spawnedArgs()).toContain(`--pulse-realm=${lsdRealmKey(workingDir)}`)
+  })
+
+  it('passes the identical flag to the hammurabi opt-out', () => {
+    process.env.DCL_SERVER_PULSE_REALM = '1'
+
+    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'hammurabi')
+
+    expect(spawnedArgs()).toContain(`--pulse-realm=${lsdRealmKey(workingDir)}`)
+  })
+
+  it('keeps the existing --realm argument alongside it', () => {
+    process.env.DCL_SERVER_PULSE_REALM = '1'
+
+    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
+
+    expect(spawnedArgs()).toContain('--realm=http://localhost:8000')
+  })
+})

--- a/test/sdk-commands/commands/start/multiplayer-server.spec.ts
+++ b/test/sdk-commands/commands/start/multiplayer-server.spec.ts
@@ -6,6 +6,12 @@ import { lsdRealmKey } from '../../../../packages/@dcl/sdk-commands/src/logic/ls
 jest.mock('child_process', () => ({ spawn: jest.fn() }))
 
 const spawnMock = childProcess.spawn as unknown as jest.Mock
+const WORKING_DIR = '/home/dev/my-scene'
+
+const components = {
+  logger: { log: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  analytics: { track: jest.fn(), stop: jest.fn() }
+} as any
 
 function fakeChild() {
   const child = new EventEmitter() as any
@@ -16,20 +22,16 @@ function fakeChild() {
   return child
 }
 
-const components = {
-  logger: { log: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
-  analytics: { track: jest.fn(), stop: jest.fn() }
-} as any
-
-/** The argv handed to npx, whichever way npx was located. */
-function spawnedArgs(): string[] {
+/** Spawns, then closes so the process-level cleanup handlers are released. */
+function spawnedArgs(engine: 'bevy' | 'hammurabi'): string[] {
+  const child = startMultiplayerServer(components, WORKING_DIR, 'http://localhost:8000', engine)
+  child.emit('close', 0, null)
   const [, args] = spawnMock.mock.calls[0]
   return args as string[]
 }
 
 describe('multiplayer server Pulse realm flag', () => {
   const original = process.env.DCL_SERVER_PULSE_REALM
-  const workingDir = '/home/dev/my-scene'
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -41,38 +43,29 @@ describe('multiplayer server Pulse realm flag', () => {
     else process.env.DCL_SERVER_PULSE_REALM = original
   })
 
-  // Until bevy-explorer#1030 lands the headless binary ignores unknown flags;
-  // afterwards it exits 2. Passing --pulse-realm unconditionally would therefore
-  // break every preview on the default engine the day that ships.
+  // the engine currently ignores unknown flags but is due to start rejecting
+  // them, so passing this ungated would break every preview on the default engine
   it('passes no --pulse-realm while the gate is closed', () => {
     delete process.env.DCL_SERVER_PULSE_REALM
 
-    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
+    const args = spawnedArgs('bevy')
 
-    expect(spawnedArgs().some((arg) => arg.startsWith('--pulse-realm'))).toBe(false)
+    expect(args.some((arg) => arg.startsWith('--pulse-realm'))).toBe(false)
+    expect(args).toContain('--realm=http://localhost:8000')
   })
 
   it('passes the realm key derived from the project root when opted in', () => {
     process.env.DCL_SERVER_PULSE_REALM = '1'
 
-    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
+    const args = spawnedArgs('bevy')
 
-    expect(spawnedArgs()).toContain(`--pulse-realm=${lsdRealmKey(workingDir)}`)
+    expect(args).toContain(`--pulse-realm=${lsdRealmKey(WORKING_DIR)}`)
+    expect(args).toContain('--realm=http://localhost:8000')
   })
 
   it('passes the identical flag to the hammurabi opt-out', () => {
     process.env.DCL_SERVER_PULSE_REALM = '1'
 
-    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'hammurabi')
-
-    expect(spawnedArgs()).toContain(`--pulse-realm=${lsdRealmKey(workingDir)}`)
-  })
-
-  it('keeps the existing --realm argument alongside it', () => {
-    process.env.DCL_SERVER_PULSE_REALM = '1'
-
-    startMultiplayerServer(components, workingDir, 'http://localhost:8000', 'bevy')
-
-    expect(spawnedArgs()).toContain('--realm=http://localhost:8000')
+    expect(spawnedArgs('hammurabi')).toContain(`--pulse-realm=${lsdRealmKey(WORKING_DIR)}`)
   })
 })

--- a/test/sdk-commands/logic/lsd-realm.spec.ts
+++ b/test/sdk-commands/logic/lsd-realm.spec.ts
@@ -1,4 +1,7 @@
 import { createHash } from 'crypto'
+import { mkdtemp, writeFile } from 'fs/promises'
+import os from 'os'
+import path from 'path'
 import {
   PULSE_MAX_REALM_LENGTH,
   lsdPreviewSceneId,
@@ -8,53 +11,46 @@ import {
 } from '../../../packages/@dcl/sdk-commands/src/logic/lsd-realm'
 import { b64HashingFunction, machineId } from '../../../packages/@dcl/sdk-commands/src/logic/project-files'
 
-/**
- * The LSD identity contract (see docs/lsd-identity-and-pulse-realm.md).
- *
- * Pulse partitions visibility by exact realm-string match: every party derives
- * the string independently and there is no key exchange, so any drift between
- * the CLI and an explorer is an invisible "my friend can't see me" bug rather
- * than a connection error. These tests pin the derivation.
- */
+// Pulse matches realms by exact string, so a drifting derivation fails silently.
+// Contract: docs/lsd-identity-and-pulse-realm.md
+const PROJECT_ROOT = '/home/dev/my-scene'
+
 describe('LSD preview scene id', () => {
   it('is the shared b64HashingFunction, not a second derivation', () => {
-    const projectRoot = '/home/dev/my-scene'
-
-    expect(lsdPreviewSceneId(projectRoot)).toEqual(b64HashingFunction(projectRoot))
+    expect(lsdPreviewSceneId(PROJECT_ROOT)).toEqual(b64HashingFunction(PROJECT_ROOT))
   })
 
   it('encodes `${absoluteProjectRoot}-${machineId}` as documented', () => {
-    const projectRoot = '/home/dev/my-scene'
+    const expected = 'b64-' + Buffer.from(`${PROJECT_ROOT}-${machineId}`).toString('base64')
 
-    const expected = 'b64-' + Buffer.from(`${projectRoot}-${machineId}`).toString('base64')
-    expect(lsdPreviewSceneId(projectRoot)).toEqual(expected)
+    expect(lsdPreviewSceneId(PROJECT_ROOT)).toEqual(expected)
   })
 })
 
 describe('LSD Pulse realm key', () => {
   it('prefixes the preview scene id with `lsd:`', () => {
-    const projectRoot = '/home/dev/my-scene'
-
-    expect(lsdRealmKey(projectRoot)).toEqual(`lsd:${b64HashingFunction(projectRoot)}`)
-  })
-
-  it('derives from the project root alone, so it survives edits and reloads', () => {
-    // PR #1529 versions per-file preview hashes by mtime but keeps the project
-    // directory's own entity id path-only. Deriving the realm key from anything
-    // content- or mtime-shaped would re-partition comms on every file save.
-    const projectRoot = '/home/dev/my-scene'
-
-    expect(lsdRealmKey(projectRoot)).toEqual(lsdRealmKey(projectRoot))
+    expect(lsdRealmKey(PROJECT_ROOT)).toEqual(`lsd:${b64HashingFunction(PROJECT_ROOT)}`)
   })
 
   it('gives different projects different realms', () => {
     expect(lsdRealmKey('/home/dev/scene-a')).not.toEqual(lsdRealmKey('/home/dev/scene-b'))
   })
 
+  it('does not change when the project contents change', async () => {
+    // the realm must survive edits and reloads; a content- or mtime-shaped
+    // derivation would re-partition comms on every file save
+    const projectRoot = await mkdtemp(path.join(os.tmpdir(), 'lsd-realm-'))
+    const before = lsdRealmKey(projectRoot)
+
+    await writeFile(path.join(projectRoot, 'game.ts'), 'export const a = 1')
+    await writeFile(path.join(projectRoot, 'game.ts'), 'export const a = 2')
+
+    expect(lsdRealmKey(projectRoot)).toEqual(before)
+  })
+
   describe('when the raw key would exceed Pulse MaxRealmLength', () => {
-    // base64 output length is always a multiple of 4, so no project root yields a
-    // raw key of exactly 255 chars. Grow the root until the rule trips and assert
-    // on the two keys straddling the boundary.
+    // base64 lengths are multiples of 4, so no root yields exactly 255; grow the
+    // root until the rule trips and assert on the keys straddling the boundary
     const boundary = (() => {
       for (let length = 1; length < 1024; length++) {
         const root = '/home/dev/' + 'x'.repeat(length)
@@ -77,10 +73,9 @@ describe('LSD Pulse realm key', () => {
       expect(boundary.firstHashed).toEqual(expected)
     })
 
-    it('produces a key that fits, deterministically', () => {
+    it('produces a key that fits', () => {
       expect(boundary.firstHashed).toMatch(/^lsd:sha256:[0-9a-f]{64}$/)
       expect(boundary.firstHashed.length).toBeLessThanOrEqual(PULSE_MAX_REALM_LENGTH)
-      expect(lsdRealmKey(boundary.root)).toEqual(boundary.firstHashed)
     })
   })
 })
@@ -93,8 +88,6 @@ describe('the --pulse-realm gate', () => {
     else process.env.DCL_SERVER_PULSE_REALM = original
   })
 
-  // bevy-explorer#1030 makes the headless binary exit 2 on arguments it used to
-  // ignore, so the flag stays opt-in until bevy-headless declares support.
   it('is off unless opted into', () => {
     delete process.env.DCL_SERVER_PULSE_REALM
     expect(pulseRealmEnabled()).toBe(false)
@@ -120,12 +113,12 @@ describe('the --pulse-realm gate', () => {
   it('contributes no arguments while gated off', () => {
     delete process.env.DCL_SERVER_PULSE_REALM
 
-    expect(pulseRealmArgs('/home/dev/my-scene')).toEqual([])
+    expect(pulseRealmArgs(PROJECT_ROOT)).toEqual([])
   })
 
-  it('contributes one engine-agnostic flag when enabled', () => {
+  it('contributes one flag when enabled', () => {
     process.env.DCL_SERVER_PULSE_REALM = '1'
 
-    expect(pulseRealmArgs('/home/dev/my-scene')).toEqual([`--pulse-realm=${lsdRealmKey('/home/dev/my-scene')}`])
+    expect(pulseRealmArgs(PROJECT_ROOT)).toEqual([`--pulse-realm=${lsdRealmKey(PROJECT_ROOT)}`])
   })
 })

--- a/test/sdk-commands/logic/lsd-realm.spec.ts
+++ b/test/sdk-commands/logic/lsd-realm.spec.ts
@@ -1,0 +1,131 @@
+import { createHash } from 'crypto'
+import {
+  PULSE_MAX_REALM_LENGTH,
+  lsdPreviewSceneId,
+  lsdRealmKey,
+  pulseRealmArgs,
+  pulseRealmEnabled
+} from '../../../packages/@dcl/sdk-commands/src/logic/lsd-realm'
+import { b64HashingFunction, machineId } from '../../../packages/@dcl/sdk-commands/src/logic/project-files'
+
+/**
+ * The LSD identity contract (see docs/lsd-identity-and-pulse-realm.md).
+ *
+ * Pulse partitions visibility by exact realm-string match: every party derives
+ * the string independently and there is no key exchange, so any drift between
+ * the CLI and an explorer is an invisible "my friend can't see me" bug rather
+ * than a connection error. These tests pin the derivation.
+ */
+describe('LSD preview scene id', () => {
+  it('is the shared b64HashingFunction, not a second derivation', () => {
+    const projectRoot = '/home/dev/my-scene'
+
+    expect(lsdPreviewSceneId(projectRoot)).toEqual(b64HashingFunction(projectRoot))
+  })
+
+  it('encodes `${absoluteProjectRoot}-${machineId}` as documented', () => {
+    const projectRoot = '/home/dev/my-scene'
+
+    const expected = 'b64-' + Buffer.from(`${projectRoot}-${machineId}`).toString('base64')
+    expect(lsdPreviewSceneId(projectRoot)).toEqual(expected)
+  })
+})
+
+describe('LSD Pulse realm key', () => {
+  it('prefixes the preview scene id with `lsd:`', () => {
+    const projectRoot = '/home/dev/my-scene'
+
+    expect(lsdRealmKey(projectRoot)).toEqual(`lsd:${b64HashingFunction(projectRoot)}`)
+  })
+
+  it('derives from the project root alone, so it survives edits and reloads', () => {
+    // PR #1529 versions per-file preview hashes by mtime but keeps the project
+    // directory's own entity id path-only. Deriving the realm key from anything
+    // content- or mtime-shaped would re-partition comms on every file save.
+    const projectRoot = '/home/dev/my-scene'
+
+    expect(lsdRealmKey(projectRoot)).toEqual(lsdRealmKey(projectRoot))
+  })
+
+  it('gives different projects different realms', () => {
+    expect(lsdRealmKey('/home/dev/scene-a')).not.toEqual(lsdRealmKey('/home/dev/scene-b'))
+  })
+
+  describe('when the raw key would exceed Pulse MaxRealmLength', () => {
+    // base64 output length is always a multiple of 4, so no project root yields a
+    // raw key of exactly 255 chars. Grow the root until the rule trips and assert
+    // on the two keys straddling the boundary.
+    const boundary = (() => {
+      for (let length = 1; length < 1024; length++) {
+        const root = '/home/dev/' + 'x'.repeat(length)
+        const key = lsdRealmKey(root)
+        if (key.startsWith('lsd:sha256:')) {
+          return { lastRaw: lsdRealmKey('/home/dev/' + 'x'.repeat(length - 1)), firstHashed: key, root }
+        }
+      }
+      throw new Error('the overflow rule never tripped')
+    })()
+
+    it('keeps the raw form while it fits', () => {
+      expect(boundary.lastRaw).toMatch(/^lsd:b64-/)
+      expect(boundary.lastRaw.length).toBeLessThanOrEqual(PULSE_MAX_REALM_LENGTH)
+    })
+
+    it('falls back to `lsd:sha256:` + SHA256Hex(previewSceneId)', () => {
+      const expected = 'lsd:sha256:' + createHash('sha256').update(lsdPreviewSceneId(boundary.root)).digest('hex')
+
+      expect(boundary.firstHashed).toEqual(expected)
+    })
+
+    it('produces a key that fits, deterministically', () => {
+      expect(boundary.firstHashed).toMatch(/^lsd:sha256:[0-9a-f]{64}$/)
+      expect(boundary.firstHashed.length).toBeLessThanOrEqual(PULSE_MAX_REALM_LENGTH)
+      expect(lsdRealmKey(boundary.root)).toEqual(boundary.firstHashed)
+    })
+  })
+})
+
+describe('the --pulse-realm gate', () => {
+  const original = process.env.DCL_SERVER_PULSE_REALM
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.DCL_SERVER_PULSE_REALM
+    else process.env.DCL_SERVER_PULSE_REALM = original
+  })
+
+  // bevy-explorer#1030 makes the headless binary exit 2 on arguments it used to
+  // ignore, so the flag stays opt-in until bevy-headless declares support.
+  it('is off unless opted into', () => {
+    delete process.env.DCL_SERVER_PULSE_REALM
+    expect(pulseRealmEnabled()).toBe(false)
+
+    process.env.DCL_SERVER_PULSE_REALM = ''
+    expect(pulseRealmEnabled()).toBe(false)
+  })
+
+  it('accepts 1/true, case-insensitively', () => {
+    for (const value of ['1', 'true', 'TRUE', 'True']) {
+      process.env.DCL_SERVER_PULSE_REALM = value
+      expect(pulseRealmEnabled()).toBe(true)
+    }
+  })
+
+  it('treats any other value as off', () => {
+    for (const value of ['0', 'false', 'yes', 'no']) {
+      process.env.DCL_SERVER_PULSE_REALM = value
+      expect(pulseRealmEnabled()).toBe(false)
+    }
+  })
+
+  it('contributes no arguments while gated off', () => {
+    delete process.env.DCL_SERVER_PULSE_REALM
+
+    expect(pulseRealmArgs('/home/dev/my-scene')).toEqual([])
+  })
+
+  it('contributes one engine-agnostic flag when enabled', () => {
+    process.env.DCL_SERVER_PULSE_REALM = '1'
+
+    expect(pulseRealmArgs('/home/dev/my-scene')).toEqual([`--pulse-realm=${lsdRealmKey('/home/dev/my-scene')}`])
+  })
+})


### PR DESCRIPTION
## What / why

`sdk-commands start` derives the Local Scene Development realm key from the project root and passes
it to the spawned preview engine as `--pulse-realm=<key>`, the same flag for bevy and the hammurabi
opt-out. Pulse matches realms by exact string with no key exchange, so the derivation *is* the
contract — it composes the existing `machineId` + `b64HashingFunction` rather than adding a second
one, keeping the realm byte-identical to the scene entity id the preview server already serves.
[`docs/lsd-identity-and-pulse-realm.md`](docs/lsd-identity-and-pulse-realm.md) writes that contract
down once so unity-explorer and bevy-explorer can point at one place.

**The flag is gated off by default** behind `DCL_SERVER_PULSE_REALM=1`, pending
decentraland/sdk-multiplayer-server#132 (bevy-headless has no Pulse transport in server mode) and
decentraland/bevy-explorer#1030 (makes the binary exit 2 on arguments it currently ignores — passing
this ungated would break every preview on the default engine). Flip `PULSE_REALM_DEFAULT` in
`logic/lsd-realm.ts` when a bevy-headless release declares support. Inert plumbing until then;
there is no live Pulse session to demo yet.

## How to test

```bash
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/sdk-commands/(logic/lsd-realm|commands/start/multiplayer-server)'
```

Then in a scene folder run `npm start` and confirm the server spawns with **no** `--pulse-realm`
argument, and `DCL_SERVER_PULSE_REALM=1 npm start` spawns it with `--pulse-realm=lsd:b64-…`. The
gated-off case is the one that must hold until bevy-explorer#1030 lands.

## Proof

16 tests, all new. `logic/lsd-realm.spec.ts` pins the derivation — that it is the shared
`b64HashingFunction` and not a copy, the documented encoding, the `lsd:` prefix, and both sides of
the `MaxRealmLength = 255` boundary (last raw key that fits, first `lsd:sha256:<64 hex>` that
replaces it). The path-only invariant is pinned against real file writes under a temp project root:
swapping in an mtime-versioned derivation locally failed that test and only that test.
`commands/start/multiplayer-server.spec.ts` pins the gate — absent when closed, correct key when
open, identical for both engines.

## Notes

- #1514 has landed in `auth-server` (squash-merged as `dae48fba`), so this now sits directly on
  `auth-server` and carries only its own two commits.
- Touches the two lines above `b64HashingFunction` in `logic/project-files.ts`, which #1529 also
  edits — expect a small textual conflict with whichever lands second.
- The brief also suggested warning when parcels fall outside Genesis bounds, since Pulse's
  `FieldValidator` drops peers reporting invalid parcel indices. No code was needed: `assertValidScene`
  already *rejects* those scenes via `isInsideWorldLimits`, and `start` reaches it through
  `getValidWorkspace` → `assertValidProjectFolder` → `getValidSceneJson`. A warning would be
  unreachable; noted in the doc instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

