### PR TITLE
feat: pointerEventsSystem maxCameraDistance; deprecate maxPlayerDistance (bump protocol)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-32863591307.commit-0b3d285",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32863591307.commit-0b3d285.tgz",
-      "integrity": "sha512-Bg6xVXQLEUGtsr2LA7hGHNnDe/xQj4RXH3hANCS9b6B7O4LNuf6VHudyt06nfzwogEonxtz1Mcrs17JNpCwuOQ==",
+      "version": "1.0.0-33189663741.commit-641dbdf",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+      "integrity": "sha512-A7gq8pDG7OGHUv86nMViOunyXkR2MZ0O5Vny5vCJ1RtV/b0z1zngxc/bu949a9ZJXjGKMoY+zgMLCH4E5wphgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33189663741.commit-641dbdf",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
-      "integrity": "sha512-A7gq8pDG7OGHUv86nMViOunyXkR2MZ0O5Vny5vCJ1RtV/b0z1zngxc/bu949a9ZJXjGKMoY+zgMLCH4E5wphgA==",
+      "version": "1.0.0-33421599964.commit-0e82dcd",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33421599964.commit-0e82dcd.tgz",
+      "integrity": "sha512-iN5zs1UzZ/gdE/K/xxLMBt9RhBDD8NNmZdTNKIedSQCr6L/nsVb/Q5Xeh/NoobHTmA+v40d6e6V6z+SJvt/IaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+    "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -22,8 +22,10 @@ export type EventSystemOptions = {
   maxDistance?: number
   showFeedback?: boolean
   showHighlight?: boolean
+  /** @deprecated use `maxDistance` instead (same semantics: distance from the player) */
   maxPlayerDistance?: number
   priority?: number
+  maxCameraDistance?: number
 }
 
 export const getDefaultOpts = (opts: Partial<EventSystemOptions> = {}): EventSystemOptions => ({
@@ -229,7 +231,8 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
         hoverText: opts.hoverText,
         maxDistance: opts.maxDistance,
         maxPlayerDistance: opts.maxPlayerDistance,
-        priority: opts.priority
+        priority: opts.priority,
+        maxCameraDistance: opts.maxCameraDistance
       },
       interactionType: interactionType ?? InteractionType.CURSOR
     })

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1269,6 +1269,7 @@ export type EventSystemOptions = {
     showHighlight?: boolean;
     maxPlayerDistance?: number;
     priority?: number;
+    maxCameraDistance?: number;
 };
 
 // @public
@@ -3485,7 +3486,9 @@ export namespace PBPointerEvents_Entry {
 export interface PBPointerEvents_Info {
     button?: InputAction | undefined;
     hoverText?: string | undefined;
+    maxCameraDistance?: number | undefined;
     maxDistance?: number | undefined;
+    // @deprecated (undocumented)
     maxPlayerDistance?: number | undefined;
     priority?: number | undefined;
     showFeedback?: boolean | undefined;

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-32863591307.commit-0b3d285",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32863591307.commit-0b3d285.tgz",
-      "integrity": "sha512-Bg6xVXQLEUGtsr2LA7hGHNnDe/xQj4RXH3hANCS9b6B7O4LNuf6VHudyt06nfzwogEonxtz1Mcrs17JNpCwuOQ==",
+      "version": "1.0.0-33189663741.commit-641dbdf",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+      "integrity": "sha512-A7gq8pDG7OGHUv86nMViOunyXkR2MZ0O5Vny5vCJ1RtV/b0z1zngxc/bu949a9ZJXjGKMoY+zgMLCH4E5wphgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33189663741.commit-641dbdf",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
-      "integrity": "sha512-A7gq8pDG7OGHUv86nMViOunyXkR2MZ0O5Vny5vCJ1RtV/b0z1zngxc/bu949a9ZJXjGKMoY+zgMLCH4E5wphgA==",
+      "version": "1.0.0-33421599964.commit-0e82dcd",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33421599964.commit-0e82dcd.tgz",
+      "integrity": "sha512-iN5zs1UzZ/gdE/K/xxLMBt9RhBDD8NNmZdTNKIedSQCr6L/nsVb/Q5Xeh/NoobHTmA+v40d6e6V6z+SJvt/IaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+    "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/test/ecs/components/PointerEvents.spec.ts
+++ b/test/ecs/components/PointerEvents.spec.ts
@@ -18,6 +18,7 @@ describe('Generated OnPointerDown ProtoBuf', () => {
             showHighlight: true,
             maxPlayerDistance: 10,
             priority: 1,
+            maxCameraDistance: 12
           },
           interactionType: InteractionType.CURSOR
         }
@@ -35,7 +36,8 @@ describe('Generated OnPointerDown ProtoBuf', () => {
             showFeedback: false,
             showHighlight: false,
             maxPlayerDistance: 7,
-            priority: 2
+            priority: 2,
+            maxCameraDistance: 3
           },
           interactionType: InteractionType.CURSOR
         }

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=621.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16880
+  MALLOC_COUNT = 16881
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.59k bytes
+  MEMORY_USAGE_COUNT ~= 1550.00k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
+  MALLOC_COUNT = 17436
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1555.76k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17435
+  MALLOC_COUNT = 17436
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1555.77k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15760
+  MALLOC_COUNT = 15761
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.45k bytes
+  MEMORY_USAGE_COUNT ~= 1139.72k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18266
+  MALLOC_COUNT = 18267
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.29k bytes
+  MEMORY_USAGE_COUNT ~= 1325.56k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14877
+  MALLOC_COUNT = 14878
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.53k bytes
+  MEMORY_USAGE_COUNT ~= 1101.80k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14850
+  MALLOC_COUNT = 14851
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.28k bytes
+  MEMORY_USAGE_COUNT ~= 1091.55k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21603
+  MALLOC_COUNT = 21604
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.76k bytes
+  MEMORY_USAGE_COUNT ~= 1550.04k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15143
+  MALLOC_COUNT = 15144
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.98k bytes
+  MEMORY_USAGE_COUNT ~= 1111.26k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 81k
-  MALLOC_COUNT = 14982
+  MALLOC_COUNT = 14983
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1093.73k bytes
+  MEMORY_USAGE_COUNT ~= 1094.00k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=430.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23146
+  MALLOC_COUNT = 23147
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1978.82k bytes
+  MEMORY_USAGE_COUNT ~= 1979.19k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15086
+  MALLOC_COUNT = 15087
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.76k bytes
+  MEMORY_USAGE_COUNT ~= 1111.04k bytes


### PR DESCRIPTION
## What

- `EventSystemOptions.maxCameraDistance` — new option, plumbed into `PointerEvents.Info.maxCameraDistance`.
- `maxPlayerDistance` marked `@deprecated`: per decentraland/protocol#470, `maxDistance` is the player-distance threshold (what unity/godot always measured), so `maxPlayerDistance` is a same-meaning alias. Still sent as before.
- `@dcl/protocol` bumped to the #470 branch artifact (`1.0.0-33189663741.commit-641dbdf`); switch to the npm release once that PR merges.
- Regenerated `playground-assets.api.md` and the snapshot metric lines.

Client side: bevy decentraland/bevy-explorer#1158; unity to follow.
