### PR TITLE
chore: deprecate get-context-files in favor of the SDK Skills

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/get-context-files/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/get-context-files/index.ts
@@ -1,24 +1,11 @@
-import path from 'path'
 import { CliComponents } from '../../components'
 import { declareArgs } from '../../logic/args'
-import { assertValidProjectFolder } from '../../logic/project-validations'
-import { CliError } from '../../logic/error'
-import { drainResponse } from '../../logic/fetch'
-import i18next from 'i18next'
 
 import { Result } from 'arg'
-const GITHUB_API_BASE = 'https://api.github.com/repos/decentraland/documentation/contents/ai-sdk-context'
-interface GitHubFile {
-  name: string
-  path: string
-  type: 'file' | 'dir'
-  download_url?: string
-  url: string
-}
 
 export interface Options {
   args: Result<typeof args>
-  components: Pick<CliComponents, 'logger' | 'fs' | 'fetch'>
+  components: Pick<CliComponents, 'logger'>
 }
 
 export const args = declareArgs({
@@ -26,119 +13,26 @@ export const args = declareArgs({
   '-h': '--help'
 })
 
+const DEPRECATION_MESSAGE = `
+  'sdk-commands get-context-files' is deprecated and no longer downloads anything.
+
+  The AI context files it used to download are superseded by the official
+  Decentraland SDK Skills, which are actively maintained and far more complete.
+
+  If you are using an AI coding assistant (or you are one), install the skills instead:
+
+    npx skills add decentraland/sdk-skills --all
+
+  Skills source: https://github.com/decentraland/sdk-skills
+  AI-assisted creation guide: https://docs.decentraland.org/creator/scenes-sdk7/getting-started/vibe-coding
+
+  If your project contains a 'dclcontext' folder from a previous run, you can safely delete it.
+`
+
 export function help(options: Options) {
-  options.components.logger.log(`
-  Usage: 'sdk-commands get-context-files [options]'
-    Options:
-      -h, --help                Gets & updates context files from https://github.com/decentraland/documentation/tree/main/ai-sdk-context only on valid scenes
-
-    Example:
-    - Get context files:
-      $ sdk-commands get-context-files
-  `)
-}
-
-async function listFilesFromPath(components: Pick<CliComponents, 'fetch'>, url: string): Promise<GitHubFile[]> {
-  const response = await components.fetch.fetch(url)
-
-  if (!response.ok) {
-    await drainResponse(response)
-    throw new CliError('GET_CONTEXT_FILES_LIST_FAILED', i18next.t('errors.get_context_files.list_failed'))
-  }
-
-  return (await response.json()) as GitHubFile[]
-}
-
-async function downloadFile(components: Pick<CliComponents, 'fetch'>, url: string): Promise<string> {
-  const response = await components.fetch.fetch(url)
-  if (!response.ok) {
-    await drainResponse(response)
-    throw new CliError('GET_CONTEXT_FILES_DOWNLOAD_FAILED', i18next.t('errors.get_context_files.download_failed'))
-  }
-  return await response.text()
-}
-
-async function getAllFiles(
-  components: Pick<CliComponents, 'fetch'>,
-  initialUrl: string = GITHUB_API_BASE
-): Promise<Array<{ url: string; filename: string; path: string }>> {
-  const files: Array<{ url: string; filename: string; path: string }> = []
-  const rootFiles = await listFilesFromPath(components, initialUrl)
-  for (const file of rootFiles) {
-    if (file.type === 'file') {
-      if (file.download_url) {
-        const filename = file.name
-        const fileInfo = {
-          url: file.download_url,
-          filename: filename,
-          path: file.path
-        }
-        files.push(fileInfo)
-      }
-    } else if (file.type === 'dir') {
-      const subFiles = await getAllFiles(components, file.url)
-      files.push(...subFiles)
-    }
-  }
-
-  return files
+  options.components.logger.log(DEPRECATION_MESSAGE)
 }
 
 export async function main(options: Options) {
-  const targetDir = process.cwd()
-  try {
-    await assertValidProjectFolder(options.components, targetDir)
-    options.components.logger.log('✓ Valid Scene project')
-  } catch (error) {
-    options.components.logger.log('Not a valid Scene...')
-    return
-  }
-
-  const contextDir = path.join(targetDir, 'dclcontext')
-  const contextExists = await options.components.fs.directoryExists(contextDir)
-
-  if (contextExists) {
-    options.components.logger.log('Context directory exists. Removing old files...')
-    await options.components.fs.rm(contextDir, { recursive: true })
-  }
-
-  options.components.logger.log('Creating context directory...')
-  await options.components.fs.mkdir(contextDir)
-
-  const filesToDownload = await getAllFiles(options.components, GITHUB_API_BASE)
-  const successfulDownloads: string[] = []
-  const failedDownloads: Array<{ filePath: string; error: string }> = []
-
-  const downloadPromises = filesToDownload.map(async ({ url, filename, path: filePath }) => {
-    try {
-      const content = await downloadFile(options.components, url)
-      const localFilePath = path.join(contextDir, filename)
-      await options.components.fs.writeFile(localFilePath, content)
-      options.components.logger.log(`✓ Saved ${filePath}`)
-      successfulDownloads.push(filePath)
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      options.components.logger.log(`✗ Failed to download ${filePath}: ${errorMessage}`)
-      failedDownloads.push({ filePath, error: errorMessage })
-    }
-  })
-
-  await Promise.all(downloadPromises)
-
-  options.components.logger.log(
-    `\nDownload complete: ${successfulDownloads.length} successful, ${failedDownloads.length} failed`
-  )
-  if (successfulDownloads.length > 0) {
-    options.components.logger.log(`Successfully downloaded:`)
-    successfulDownloads.forEach((filePath) => {
-      options.components.logger.log(`  ✓ ${filePath}`)
-    })
-  }
-
-  if (failedDownloads.length > 0) {
-    options.components.logger.log(`Failed downloads:`)
-    failedDownloads.forEach(({ filePath, error }) => {
-      options.components.logger.log(`  ✗ ${filePath}: ${error}`)
-    })
-  }
+  options.components.logger.log(DEPRECATION_MESSAGE)
 }

--- a/packages/@dcl/sdk-commands/src/locales/en.json
+++ b/packages/@dcl/sdk-commands/src/locales/en.json
@@ -48,10 +48,6 @@
       "invalid_realm_name": "--realmName has invalid characters",
       "invalid_output_directory": "The destination path {{outputDirectory}} is not a directory"
     },
-    "get_context_files": {
-      "list_failed": "Failed to list context files",
-      "download_failed": "Failed to download context file"
-    },
     "init": {
       "dir_not_empty": "The target directory specified is not empty. Run this command with --yes to override.",
       "invalid_arguments": "Specifying --template and --project at the same time is not allowed. Please specify only one of them.",

--- a/packages/@dcl/sdk-commands/src/locales/es.json
+++ b/packages/@dcl/sdk-commands/src/locales/es.json
@@ -48,10 +48,6 @@
       "invalid_realm_name": "--realmName tiene caracteres inválidos",
       "invalid_output_directory": "La ruta de destino {{outputDirectory}} no es un directorio"
     },
-    "get_context_files": {
-      "list_failed": "Error al listar archivos de contexto",
-      "download_failed": "Error al descargar archivo de contexto"
-    },
     "init": {
       "dir_not_empty": "El directorio de destino especificado no está vacío. Ejecuta este comando con --yes para sobrescribir.",
       "invalid_arguments": "No se permite especificar --template y --project al mismo tiempo. Por favor especifica solo uno de ellos.",

--- a/packages/@dcl/sdk-commands/src/locales/zh.json
+++ b/packages/@dcl/sdk-commands/src/locales/zh.json
@@ -48,10 +48,6 @@
       "invalid_realm_name": "--realmName 包含无效字符",
       "invalid_output_directory": "目标路径 {{outputDirectory}} 不是一个目录"
     },
-    "get_context_files": {
-      "list_failed": "列出上下文文件失败",
-      "download_failed": "下载上下文文件失败"
-    },
     "init": {
       "dir_not_empty": "指定的目标目录不为空。使用 --yes 运行此命令以覆盖。",
       "invalid_arguments": "不允许同时指定 --template 和 --project。请只指定其中一个。",


### PR DESCRIPTION
## What

Retires `sdk-commands get-context-files`. The command no longer downloads anything; it now prints a deprecation notice pointing to the official [Decentraland SDK Skills](https://github.com/decentraland/sdk-skills):

```
npx skills add decentraland/sdk-skills --all
```

The unused `get_context_files` error strings were removed from the en/es/zh locale files.

## Why

The command downloaded the `ai-sdk-context` folder from the old `decentraland/documentation` repo into a `dclcontext/` folder inside scene projects, where AI assistants were told to look for SDK context. That reference is no longer maintained and has drifted out of date, so it actively teaches AI agents outdated patterns. The SDK Skills are now the canonical, maintained machine-readable reference.

The command is kept as a stub rather than deleted so that old tutorials, scripts, and AI agents that memorized it don't hit an unknown-command error: anything that runs it now reads the redirect to the skills in stdout, which is exactly the audience we want to reach.

A companion PR to `decentraland/documentation` replaces the downloaded reference file itself with a pointer to the skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)