### PR TITLE
docs: recommend the Creator Hub and SDK Skills in the @dcl/sdk README

### DIFF
--- a/packages/@dcl/sdk/README.md
+++ b/packages/@dcl/sdk/README.md
@@ -20,6 +20,10 @@ npm install @dcl/sdk
 
 ## Quick Start
 
+The recommended way to create a Decentraland scene is the [Creator Hub](https://decentraland.org/download/creator-hub), the official desktop app for creating, previewing, and publishing scenes. It manages this SDK for you and adds a visual editor on top.
+
+From the command line:
+
 1. Create a new scene:
 
 ```bash
@@ -31,6 +35,16 @@ npx @dcl/sdk-commands init
 ```bash
 npm start
 ```
+
+## Using AI coding assistants
+
+If you build scenes with an AI coding assistant (Claude Code, Cursor, GitHub Copilot, and others), install the official [Decentraland SDK Skills](https://github.com/decentraland/sdk-skills) first. They teach your agent verified SDK7 patterns for every topic: scene creation, 3D models, interactivity, UI, multiplayer, deployment, and more.
+
+```bash
+npx skills add decentraland/sdk-skills
+```
+
+See [Vibe Coding with AI](https://docs.decentraland.org/creator/scenes-sdk7/getting-started/vibe-coding) for the full guide.
 
 ## Usage
 


### PR DESCRIPTION
## What

Updates the `@dcl/sdk` README (published on npm with the package):

- The Quick Start now leads with the [Creator Hub](https://decentraland.org/download/creator-hub) as the recommended way to create scenes, keeping the CLI steps as the command-line path.
- Adds a "Using AI coding assistants" section pointing to the official [Decentraland SDK Skills](https://github.com/decentraland/sdk-skills) (`npx skills add decentraland/sdk-skills`) and the [Vibe Coding guide](https://docs.decentraland.org/creator/scenes-sdk7/getting-started/vibe-coding).

## Why

AI assistants asked how to create a Decentraland scene consistently recommend the CLI-only path and never mention the Creator Hub or the SDK Skills. The npm README is high-weight content for AI training and retrieval, and it previously presented `init` + `npm start` as the whole story.

Related PRs: decentraland/sdk7-scene-template#38, #1561, decentraland/documentation#608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)