### PR TITLE
[do not merge] experimental-bevy: protocol-squad features rebuilt on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,14 @@ on:
     branches:
       - main
       - experimental
+      - experimental-bevy
   pull_request:
   release:
     types:
       - created
 
 env:
-  BRANCH_TAG: ${{ github.ref_name == 'experimental' && 'experimental' || '' }}
+  BRANCH_TAG: ${{ github.ref_name == 'experimental' && 'experimental' || github.ref_name == 'experimental-bevy' && 'experimental-bevy' || '' }}
 
 name: CI
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-32863591307.commit-0b3d285",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32863591307.commit-0b3d285.tgz",
-      "integrity": "sha512-Bg6xVXQLEUGtsr2LA7hGHNnDe/xQj4RXH3hANCS9b6B7O4LNuf6VHudyt06nfzwogEonxtz1Mcrs17JNpCwuOQ==",
+      "version": "1.0.0-33219725173.commit-dc40022",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33668585153.commit-4a844e9",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
-      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
+      "version": "1.0.0-33674022401.commit-882d4ee",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33674022401.commit-882d4ee.tgz",
+      "integrity": "sha512-+gFspUQ/HSt4oqjjWuoSuftp3u6ab3VbCB+nhA8QMlmgabqNNT5XfX87q1u/NCQLHhg61my7y9We656TYl/4cw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33219725173.commit-dc40022",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
-      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
+      "version": "1.0.0-33247403125.commit-6e4ee4a",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
+      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33247403125.commit-6e4ee4a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
-      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
+      "version": "1.0.0-33668585153.commit-4a844e9",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
+      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33421599964.commit-0e82dcd",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33421599964.commit-0e82dcd.tgz",
-      "integrity": "sha512-iN5zs1UzZ/gdE/K/xxLMBt9RhBDD8NNmZdTNKIedSQCr6L/nsVb/Q5Xeh/NoobHTmA+v40d6e6V6z+SJvt/IaA==",
+      "version": "1.0.0-33219725173.commit-dc40022",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.28.5",
         "@babel/plugin-transform-react-jsx": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
+        "@dcl/protocol": "1.0.0-34100371654.commit-2ed0bdc",
         "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
         "@dcl/ts-proto": "1.153.0",
         "@types/fs-extra": "^9.0.12",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33674022401.commit-882d4ee",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33674022401.commit-882d4ee.tgz",
-      "integrity": "sha512-+gFspUQ/HSt4oqjjWuoSuftp3u6ab3VbCB+nhA8QMlmgabqNNT5XfX87q1u/NCQLHhg61my7y9We656TYl/4cw==",
+      "version": "1.0.0-34100371654.commit-2ed0bdc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-34100371654.commit-2ed0bdc.tgz",
+      "integrity": "sha512-AIcv8cV5HWIFB88JGUk8ZbrQR71VRJBH00GUwxhWybZiWVGgA8A/OftxiZYUYfj0IZAYXbv7tvbdSsJmGtJuxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+    "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+    "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+    "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
+    "@dcl/protocol": "1.0.0-34100371654.commit-2ed0bdc",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.28.5",
     "@babel/plugin-transform-react-jsx": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
     "@dcl/quickjs-emscripten": "^0.21.0-3680274614.commit-1808aa1",
     "@dcl/ts-proto": "1.153.0",
     "@types/fs-extra": "^9.0.12",

--- a/packages/@dcl/ecs/src/components/extended/AvatarEquippedData.ts
+++ b/packages/@dcl/ecs/src/components/extended/AvatarEquippedData.ts
@@ -1,0 +1,31 @@
+import { IEngine, LastWriteWinElementSetComponentDefinition } from '../../engine'
+import { AvatarEquippedDataSchema } from '../generated/AvatarEquippedData.gen'
+import { PBAvatarEquippedData } from '../generated/pb/decentraland/sdk/components/avatar_equipped_data.gen'
+
+/**
+ * @public
+ * AvatarEquippedData with `forceRender` optional: the wire type is a repeated field (always present, so the
+ * generated type requires it), but a scene rarely needs it and shouldn't have to pass `[]`.
+ */
+export type AvatarEquippedDataType = Omit<PBAvatarEquippedData, 'forceRender'> & {
+  forceRender?: string[] | undefined
+}
+
+/**
+ * @public
+ */
+export type AvatarEquippedDataComponentDefinitionExtended =
+  LastWriteWinElementSetComponentDefinition<AvatarEquippedDataType>
+
+export function defineAvatarEquippedDataComponent(
+  engine: Pick<IEngine, 'defineComponentFromSchema'>
+): AvatarEquippedDataComponentDefinitionExtended {
+  const patchedSchema = { ...AvatarEquippedDataSchema }
+  const origSerialize = patchedSchema.serialize
+  patchedSchema.serialize = (value: any, builder: any) => {
+    origSerialize(value.forceRender === undefined ? { ...value, forceRender: [] } : value, builder)
+  }
+
+  const theComponent = engine.defineComponentFromSchema('core::AvatarEquippedData', patchedSchema)
+  return theComponent as unknown as AvatarEquippedDataComponentDefinitionExtended
+}

--- a/packages/@dcl/ecs/src/components/extended/AvatarShape.ts
+++ b/packages/@dcl/ecs/src/components/extended/AvatarShape.ts
@@ -1,0 +1,30 @@
+import { IEngine, LastWriteWinElementSetComponentDefinition } from '../../engine'
+import { AvatarShapeSchema } from '../generated/AvatarShape.gen'
+import { PBAvatarShape } from '../generated/pb/decentraland/sdk/components/avatar_shape.gen'
+
+/**
+ * @public
+ * AvatarShape with `forceRender` optional: the wire type is a repeated field (always present, so the
+ * generated type requires it), but a scene rarely needs it and shouldn't have to pass `[]`.
+ */
+export type AvatarShapeType = Omit<PBAvatarShape, 'forceRender'> & {
+  forceRender?: string[] | undefined
+}
+
+/**
+ * @public
+ */
+export type AvatarShapeComponentDefinitionExtended = LastWriteWinElementSetComponentDefinition<AvatarShapeType>
+
+export function defineAvatarShapeComponent(
+  engine: Pick<IEngine, 'defineComponentFromSchema'>
+): AvatarShapeComponentDefinitionExtended {
+  const patchedSchema = { ...AvatarShapeSchema }
+  const origSerialize = patchedSchema.serialize
+  patchedSchema.serialize = (value: any, builder: any) => {
+    origSerialize(value.forceRender === undefined ? { ...value, forceRender: [] } : value, builder)
+  }
+
+  const theComponent = engine.defineComponentFromSchema('core::AvatarShape', patchedSchema)
+  return theComponent as unknown as AvatarShapeComponentDefinitionExtended
+}

--- a/packages/@dcl/ecs/src/components/extended/MeshCollider.ts
+++ b/packages/@dcl/ecs/src/components/extended/MeshCollider.ts
@@ -44,6 +44,16 @@ export interface MeshColliderComponentDefinitionExtended
    * @param colliderMask - the set of layer where the collider reacts, default: Physics and Pointer
    */
   setSphere(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void
+
+  /**
+   * @public
+   * Set a mesh from inside a gltf in the MeshCollider component
+   * @param entity - entity to create or replace the MeshCollider component
+   * @param source - the path to the gltf
+   * @param meshName - the name of the mesh in the gltf (see GltfContainerLoadingState.meshNames)
+   * @param colliderMask - the set of layer where the collider reacts, default: Physics and Pointer
+   */
+  setGltfMesh(entity: Entity, source: string, meshName: string, colliderLayers?: ColliderLayer | ColliderLayer[]): void
 }
 
 export function defineMeshColliderComponent(
@@ -87,6 +97,17 @@ export function defineMeshColliderComponent(
     setSphere(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void {
       theComponent.createOrReplace(entity, {
         mesh: { $case: 'sphere', sphere: {} },
+        collisionMask: getCollisionMask(colliderLayers)
+      })
+    },
+    setGltfMesh(
+      entity: Entity,
+      source: string,
+      meshName: string,
+      colliderLayers?: ColliderLayer | ColliderLayer[]
+    ): void {
+      theComponent.createOrReplace(entity, {
+        mesh: { $case: 'gltf', gltf: { gltfSrc: source, name: meshName } },
         collisionMask: getCollisionMask(colliderLayers)
       })
     }

--- a/packages/@dcl/ecs/src/components/extended/MeshRenderer.ts
+++ b/packages/@dcl/ecs/src/components/extended/MeshRenderer.ts
@@ -4,8 +4,7 @@ import { MeshRenderer, PBMeshRenderer } from '../generated/index.gen'
 /**
  * @public
  */
-export interface MeshRendererComponentDefinitionExtended
-  extends LastWriteWinElementSetComponentDefinition<PBMeshRenderer> {
+export interface MeshRendererComponentDefinitionExtended extends LastWriteWinElementSetComponentDefinition<PBMeshRenderer> {
   /**
    * @public
    * Set a box in the MeshRenderer component
@@ -37,6 +36,15 @@ export interface MeshRendererComponentDefinitionExtended
    * @param entity - entity to create or replace the MeshRenderer component
    */
   setSphere(entity: Entity): void
+
+  /**
+   * @public
+   * Set a mesh from inside a gltf in the MeshRenderer component
+   * @param entity - entity to create or replace the MeshRenderer component
+   * @param source - the path to the gltf
+   * @param meshName - the name of the mesh in the gltf (see GltfContainerLoadingState.meshNames)
+   */
+  setGltfMesh(entity: Entity, source: string, meshName: string): void
 }
 
 export function defineMeshRendererComponent(
@@ -64,6 +72,11 @@ export function defineMeshRendererComponent(
     setSphere(entity: Entity): void {
       theComponent.createOrReplace(entity, {
         mesh: { $case: 'sphere', sphere: {} }
+      })
+    },
+    setGltfMesh(entity: Entity, source: string, meshName: string): void {
+      theComponent.createOrReplace(entity, {
+        mesh: { $case: 'gltf', gltf: { gltfSrc: source, name: meshName } }
       })
     }
   }

--- a/packages/@dcl/ecs/src/components/index.ts
+++ b/packages/@dcl/ecs/src/components/index.ts
@@ -5,6 +5,11 @@ import { AudioSourceComponentDefinitionExtended, defineAudioSourceComponent } fr
 import { AudioAnalysisComponentDefinitionExtended, defineAudioAnalysisComponent } from './extended/AudioAnalysis'
 import type { AudioAnalysisView } from './extended/AudioAnalysis'
 import { defineMaterialComponent, MaterialComponentDefinitionExtended } from './extended/Material'
+import {
+  AvatarEquippedDataComponentDefinitionExtended,
+  defineAvatarEquippedDataComponent
+} from './extended/AvatarEquippedData'
+import { AvatarShapeComponentDefinitionExtended, defineAvatarShapeComponent } from './extended/AvatarShape'
 import { defineMeshColliderComponent, MeshColliderComponentDefinitionExtended } from './extended/MeshCollider'
 import { defineMeshRendererComponent, MeshRendererComponentDefinitionExtended } from './extended/MeshRenderer'
 import { defineTweenComponent, TweenComponentDefinitionExtended } from './extended/Tween'
@@ -67,6 +72,14 @@ export const MeshRenderer: LwwComponentGetter<MeshRendererComponentDefinitionExt
 /* @__PURE__ */
 export const MeshCollider: LwwComponentGetter<MeshColliderComponentDefinitionExtended> = (engine) =>
   defineMeshColliderComponent(engine)
+
+/* @__PURE__ */
+export const AvatarShape: LwwComponentGetter<AvatarShapeComponentDefinitionExtended> = (engine) =>
+  defineAvatarShapeComponent(engine)
+
+/* @__PURE__ */
+export const AvatarEquippedData: LwwComponentGetter<AvatarEquippedDataComponentDefinitionExtended> = (engine) =>
+  defineAvatarEquippedDataComponent(engine)
 
 /* @__PURE__ */
 export const Tween: LwwComponentGetter<TweenComponentDefinitionExtended> = (engine) => defineTweenComponent(engine)

--- a/packages/@dcl/ecs/src/components/types.ts
+++ b/packages/@dcl/ecs/src/components/types.ts
@@ -4,6 +4,11 @@ export type { AudioAnalysisComponentDefinitionExtended, AudioAnalysisView } from
 export type { AudioStreamComponentDefinitionExtended } from './extended/AudioStream'
 export type { MeshRendererComponentDefinitionExtended } from './extended/MeshRenderer'
 export type { MeshColliderComponentDefinitionExtended } from './extended/MeshCollider'
+export type { AvatarShapeComponentDefinitionExtended, AvatarShapeType } from './extended/AvatarShape'
+export type {
+  AvatarEquippedDataComponentDefinitionExtended,
+  AvatarEquippedDataType
+} from './extended/AvatarEquippedData'
 export type {
   TextureHelper,
   MaterialComponentDefinitionExtended,

--- a/packages/@dcl/ecs/src/index.ts
+++ b/packages/@dcl/ecs/src/index.ts
@@ -29,6 +29,8 @@ import {
   MaterialComponentDefinitionExtended,
   MeshColliderComponentDefinitionExtended,
   MeshRendererComponentDefinitionExtended,
+  AvatarShapeComponentDefinitionExtended,
+  AvatarEquippedDataComponentDefinitionExtended,
   TransformComponentExtended,
   AnimatorComponentDefinitionExtended,
   AudioSourceComponentDefinitionExtended,
@@ -57,6 +59,9 @@ export const AudioStream: AudioStreamComponentDefinitionExtended = /* @__PURE__*
 export const Material: MaterialComponentDefinitionExtended = /* @__PURE__*/ components.Material(engine)
 export const MeshRenderer: MeshRendererComponentDefinitionExtended = /* @__PURE__*/ components.MeshRenderer(engine)
 export const MeshCollider: MeshColliderComponentDefinitionExtended = /* @__PURE__*/ components.MeshCollider(engine)
+export const AvatarShape: AvatarShapeComponentDefinitionExtended = /* @__PURE__*/ components.AvatarShape(engine)
+export const AvatarEquippedData: AvatarEquippedDataComponentDefinitionExtended =
+  /* @__PURE__*/ components.AvatarEquippedData(engine)
 export const Name: NameComponent = components.Name(engine)
 export const Tags: TagsComponentDefinitionExtended = components.Tags(engine)
 export const Tween: TweenComponentDefinitionExtended = /* @__PURE__*/ components.Tween(engine)

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -71,6 +71,27 @@ export interface PointerEventsSystem {
 
   /**
    * @public
+   * Remove the callback for onPointerDrag event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDrag(entity: Entity): void
+
+  /**
+   * @public
+   * Remove the callback for onPointerDragLocked event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDragLocked(entity: Entity): void
+
+  /**
+   * @public
+   * Remove the callback for onPointerDragEnd event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDragEnd(entity: Entity): void
+
+  /**
+   * @public
    * Remove the callback for onProximityDown event
    * @param entity - Entity where the callback was attached
    */
@@ -158,6 +179,33 @@ export interface PointerEventsSystem {
 
   /**
    * @public
+   * Execute callback while the user holds the button pressed and moves the pointer, having pressed it on the entity
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute on every drag update
+   */
+  onPointerDrag(pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> }, cb: EventSystemCallback): void
+
+  /**
+   * @public
+   * Same as onPointerDrag, but the cursor is locked in place for the duration of the drag
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute on every drag update
+   */
+  onPointerDragLocked(
+    pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> },
+    cb: EventSystemCallback
+  ): void
+
+  /**
+   * @public
+   * Execute callback when the user releases the button after a drag that started on the entity
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute when the drag ends
+   */
+  onPointerDragEnd(pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> }, cb: EventSystemCallback): void
+
+  /**
+   * @public
    * Execute callback when the user presses the proximity button on the entity
    * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
    * @param cb - Function to execute when click fires
@@ -203,7 +251,10 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     HoverEnter,
     HoverLeave,
     ProximityEnter,
-    ProximityLeave
+    ProximityLeave,
+    Drag,
+    DragLocked,
+    DragEnd
   }
   type EventMapType = Map<EventType, { cb: EventSystemCallback; opts: EventSystemOptions }>
 
@@ -264,6 +315,12 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
       return PointerEventType.PET_PROXIMITY_ENTER
     } else if (eventType === EventType.ProximityLeave) {
       return PointerEventType.PET_PROXIMITY_LEAVE
+    } else if (eventType === EventType.Drag) {
+      return PointerEventType.PET_DRAG
+    } else if (eventType === EventType.DragLocked) {
+      return PointerEventType.PET_DRAG_LOCKED
+    } else if (eventType === EventType.DragEnd) {
+      return PointerEventType.PET_DRAG_END
     }
     return PointerEventType.PET_DOWN
   }
@@ -299,7 +356,10 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
           eventType === EventType.HoverEnter ||
           eventType === EventType.HoverLeave ||
           eventType === EventType.ProximityEnter ||
-          eventType === EventType.ProximityLeave
+          eventType === EventType.ProximityLeave ||
+          eventType === EventType.Drag ||
+          eventType === EventType.DragLocked ||
+          eventType === EventType.DragEnd
         ) {
           const command = inputSystem.getInputCommand(opts.button, getPointerEvent(eventType), entity)
           if (command) {
@@ -350,6 +410,33 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     removeEvent(entity, EventType.HoverLeave)
     getEvent(entity).set(EventType.HoverLeave, { cb, opts: options })
     setPointerEvent(entity, PointerEventType.PET_HOVER_LEAVE, options)
+  }
+
+  const onPointerDrag: PointerEventsSystem['onPointerDrag'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.Drag)
+    getEvent(entity).set(EventType.Drag, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG, options)
+  }
+
+  const onPointerDragLocked: PointerEventsSystem['onPointerDragLocked'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.DragLocked)
+    getEvent(entity).set(EventType.DragLocked, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG_LOCKED, options)
+  }
+
+  const onPointerDragEnd: PointerEventsSystem['onPointerDragEnd'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.DragEnd)
+    getEvent(entity).set(EventType.DragEnd, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG_END, options)
   }
 
   const onProximityDown: PointerEventsSystem['onProximityDown'] = (...args) => {
@@ -409,6 +496,18 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
       removeEvent(entity, EventType.HoverLeave)
     },
 
+    removeOnPointerDrag(entity: Entity) {
+      removeEvent(entity, EventType.Drag)
+    },
+
+    removeOnPointerDragLocked(entity: Entity) {
+      removeEvent(entity, EventType.DragLocked)
+    },
+
+    removeOnPointerDragEnd(entity: Entity) {
+      removeEvent(entity, EventType.DragEnd)
+    },
+
     removeOnProximityDown(entity: Entity) {
       removeEvent(entity, EventType.Down, InteractionType.PROXIMITY)
     },
@@ -440,6 +539,9 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     onPointerUp,
     onPointerHoverEnter,
     onPointerHoverLeave,
+    onPointerDrag,
+    onPointerDragLocked,
+    onPointerDragEnd,
     onProximityDown,
     onProximityUp,
     onProximityEnter,

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -73,6 +73,27 @@ export interface PointerEventsSystem {
 
   /**
    * @public
+   * Remove the callback for onPointerDrag event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDrag(entity: Entity): void
+
+  /**
+   * @public
+   * Remove the callback for onPointerDragLocked event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDragLocked(entity: Entity): void
+
+  /**
+   * @public
+   * Remove the callback for onPointerDragEnd event
+   * @param entity - Entity where the callback was attached
+   */
+  removeOnPointerDragEnd(entity: Entity): void
+
+  /**
+   * @public
    * Remove the callback for onProximityDown event
    * @param entity - Entity where the callback was attached
    */
@@ -160,6 +181,33 @@ export interface PointerEventsSystem {
 
   /**
    * @public
+   * Execute callback while the user holds the button pressed and moves the pointer, having pressed it on the entity
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute on every drag update
+   */
+  onPointerDrag(pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> }, cb: EventSystemCallback): void
+
+  /**
+   * @public
+   * Same as onPointerDrag, but the cursor is locked in place for the duration of the drag
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute on every drag update
+   */
+  onPointerDragLocked(
+    pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> },
+    cb: EventSystemCallback
+  ): void
+
+  /**
+   * @public
+   * Execute callback when the user releases the button after a drag that started on the entity
+   * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
+   * @param cb - Function to execute when the drag ends
+   */
+  onPointerDragEnd(pointerData: { entity: Entity; opts?: Partial<EventSystemOptions> }, cb: EventSystemCallback): void
+
+  /**
+   * @public
    * Execute callback when the user presses the proximity button on the entity
    * @param pointerData - Entity to attach the callback - Opts to trigger Feedback and Button
    * @param cb - Function to execute when click fires
@@ -205,7 +253,10 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     HoverEnter,
     HoverLeave,
     ProximityEnter,
-    ProximityLeave
+    ProximityLeave,
+    Drag,
+    DragLocked,
+    DragEnd
   }
   type EventMapType = Map<EventType, { cb: EventSystemCallback; opts: EventSystemOptions }>
 
@@ -267,6 +318,12 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
       return PointerEventType.PET_PROXIMITY_ENTER
     } else if (eventType === EventType.ProximityLeave) {
       return PointerEventType.PET_PROXIMITY_LEAVE
+    } else if (eventType === EventType.Drag) {
+      return PointerEventType.PET_DRAG
+    } else if (eventType === EventType.DragLocked) {
+      return PointerEventType.PET_DRAG_LOCKED
+    } else if (eventType === EventType.DragEnd) {
+      return PointerEventType.PET_DRAG_END
     }
     return PointerEventType.PET_DOWN
   }
@@ -302,7 +359,10 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
           eventType === EventType.HoverEnter ||
           eventType === EventType.HoverLeave ||
           eventType === EventType.ProximityEnter ||
-          eventType === EventType.ProximityLeave
+          eventType === EventType.ProximityLeave ||
+          eventType === EventType.Drag ||
+          eventType === EventType.DragLocked ||
+          eventType === EventType.DragEnd
         ) {
           const command = inputSystem.getInputCommand(opts.button, getPointerEvent(eventType), entity)
           if (command) {
@@ -353,6 +413,33 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     removeEvent(entity, EventType.HoverLeave)
     getEvent(entity).set(EventType.HoverLeave, { cb, opts: options })
     setPointerEvent(entity, PointerEventType.PET_HOVER_LEAVE, options)
+  }
+
+  const onPointerDrag: PointerEventsSystem['onPointerDrag'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.Drag)
+    getEvent(entity).set(EventType.Drag, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG, options)
+  }
+
+  const onPointerDragLocked: PointerEventsSystem['onPointerDragLocked'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.DragLocked)
+    getEvent(entity).set(EventType.DragLocked, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG_LOCKED, options)
+  }
+
+  const onPointerDragEnd: PointerEventsSystem['onPointerDragEnd'] = (...args) => {
+    const [data, cb] = args
+    const { entity, opts } = data
+    const options = getDefaultOpts(opts)
+    removeEvent(entity, EventType.DragEnd)
+    getEvent(entity).set(EventType.DragEnd, { cb, opts: options })
+    setPointerEvent(entity, PointerEventType.PET_DRAG_END, options)
   }
 
   const onProximityDown: PointerEventsSystem['onProximityDown'] = (...args) => {
@@ -412,6 +499,18 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
       removeEvent(entity, EventType.HoverLeave)
     },
 
+    removeOnPointerDrag(entity: Entity) {
+      removeEvent(entity, EventType.Drag)
+    },
+
+    removeOnPointerDragLocked(entity: Entity) {
+      removeEvent(entity, EventType.DragLocked)
+    },
+
+    removeOnPointerDragEnd(entity: Entity) {
+      removeEvent(entity, EventType.DragEnd)
+    },
+
     removeOnProximityDown(entity: Entity) {
       removeEvent(entity, EventType.Down, InteractionType.PROXIMITY)
     },
@@ -443,6 +542,9 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     onPointerUp,
     onPointerHoverEnter,
     onPointerHoverLeave,
+    onPointerDrag,
+    onPointerDragLocked,
+    onPointerDragEnd,
     onProximityDown,
     onProximityUp,
     onProximityEnter,

--- a/packages/@dcl/ecs/src/systems/raycast.ts
+++ b/packages/@dcl/ecs/src/systems/raycast.ts
@@ -1,5 +1,5 @@
 import * as components from '../components'
-import { ColliderLayer, RaycastQueryType, PBRaycastResult } from '../components'
+import { ColliderLayer, RaycastQueryType, RaycastShape, PBRaycastResult } from '../components'
 import { DeepReadonlyObject, Entity, IEngine } from '../engine'
 import { Vector3 } from '../components/generated/pb/decentraland/common/vectors.gen'
 import { EntityState } from '../engine/entity'
@@ -26,6 +26,10 @@ export type RaycastSystemOptions = {
   queryType: RaycastQueryType
   continuous?: boolean | undefined
   collisionMask?: number | undefined
+  /** shape to sweep along the ray, default RS_RAY (a point) */
+  shape?: RaycastShape | undefined
+  /** include colliders from other scenes, default false */
+  includeWorld?: boolean | undefined
 }
 
 export type LocalDirectionRaycastSystemOptions = {
@@ -197,7 +201,9 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     queryType: RaycastQueryType.RQT_HIT_FIRST,
     continuous: false,
     originOffset: { x: 0, y: 0, z: 0 },
-    collisionMask: ColliderLayer.CL_PHYSICS
+    collisionMask: ColliderLayer.CL_PHYSICS,
+    shape: RaycastShape.RS_RAY,
+    includeWorld: false
   }
   const getLocalDirectionRaycastDefaultOptions = (
     options: Partial<LocalDirectionRaycastOptions> = {}
@@ -256,6 +262,8 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
       raycast.direction = raycastValue.directionRawValue
       raycast.continuous = raycastValue.continuous
       raycast.queryType = raycastValue.queryType
+      raycast.shape = raycastValue.shape
+      raycast.includeWorld = raycastValue.includeWorld
 
       entitiesCallbackResultMap.set(entity, { callback: callback })
     }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -193,6 +193,25 @@ export const enum AvatarAnchorPointType {
 }
 
 // @public (undocumented)
+export interface AvatarAnimationState {
+    duration: number;
+    idle: boolean;
+    loop: boolean;
+    loopCount: number;
+    playbackTime: number;
+    speed: number;
+    src: string;
+}
+
+// @public (undocumented)
+export namespace AvatarAnimationState {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): AvatarAnimationState;
+    // (undocumented)
+    export function encode(message: AvatarAnimationState, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export const AvatarAttach: LastWriteWinElementSetComponentDefinition<PBAvatarAttach>;
 
 // @public (undocumented)
@@ -222,6 +241,12 @@ export const enum AvatarModifierType {
     AMT_HIDE_AVATARS = 0,
     AMT_HIDE_NAMETAGS = 2
 }
+
+// @public (undocumented)
+export const AvatarMovement: LastWriteWinElementSetComponentDefinition<PBAvatarMovement>;
+
+// @public (undocumented)
+export const AvatarMovementInfo: LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>;
 
 // @public (undocumented)
 export const AvatarShape: LastWriteWinElementSetComponentDefinition<PBAvatarShape>;
@@ -430,6 +455,12 @@ export interface ByteBuffer {
 
 // @public
 export type Callback = () => void;
+
+// @public (undocumented)
+export const CameraLayer: LastWriteWinElementSetComponentDefinition<PBCameraLayer>;
+
+// @public (undocumented)
+export const CameraLayers: LastWriteWinElementSetComponentDefinition<PBCameraLayers>;
 
 // @public (undocumented)
 export const CameraMode: LastWriteWinElementSetComponentDefinition<PBCameraMode>;
@@ -721,15 +752,22 @@ export const componentDefinitionByName: {
     "core::AvatarEquippedData": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarEquippedData>>;
     "core::AvatarLocomotionSettings": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>>;
     "core::AvatarModifierArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>>;
+    "core::AvatarMovement": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovement>>;
+    "core::AvatarMovementInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>>;
     "core::AvatarShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarShape>>;
     "core::Billboard": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBBillboard>>;
+    "core::CameraLayer": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraLayer>>;
+    "core::CameraLayers": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraLayers>>;
     "core::CameraMode": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraMode>>;
     "core::CameraModeArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraModeArea>>;
     "core::EngineInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBEngineInfo>>;
     "core::ExplorerUiEventsResult": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBExplorerUiEventsResult>>;
+    "core::GlobalLight": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGlobalLight>>;
     "core::GltfContainer": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfContainer>>;
     "core::GltfContainerLoadingState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfContainerLoadingState>>;
+    "core::GltfNode": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNode>>;
     "core::GltfNodeModifiers": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNodeModifiers>>;
+    "core::GltfNodeState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNodeState>>;
     "core::InputModifier": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBInputModifier>>;
     "core::LightSource": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBLightSource>>;
     "core::MainCamera": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBMainCamera>>;
@@ -750,6 +788,7 @@ export const componentDefinitionByName: {
     "core::RealmInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBRealmInfo>>;
     "core::SkyboxTime": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBSkyboxTime>>;
     "core::TextShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTextShape>>;
+    "core::TextureCamera": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTextureCamera>>;
     "core::TouchScreenControls": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTouchScreenControls>>;
     "core::TriggerArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTriggerArea>>;
     "core::TriggerAreaResult": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBTriggerAreaResult>>;
@@ -757,12 +796,14 @@ export const componentDefinitionByName: {
     "core::TweenSequence": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTweenSequence>>;
     "core::TweenState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTweenState>>;
     "core::UiBackground": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiBackground>>;
+    "core::UiCanvas": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiCanvas>>;
     "core::UiCanvasInformation": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiCanvasInformation>>;
     "core::UiDropdown": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdown>>;
     "core::UiDropdownResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdownResult>>;
     "core::UiInput": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInput>>;
     "core::UiInputBinding": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputBinding>>;
     "core::UiInputResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputResult>>;
+    "core::UiScrollResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiScrollResult>>;
     "core::UiText": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiText>>;
     "core::UiTransform": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiTransform>>;
     "core::VideoEvent": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBVideoEvent>>;
@@ -1402,6 +1443,9 @@ export type GlobalDirectionRaycastSystemOptions = {
     direction?: PBVector3;
 };
 
+// @public (undocumented)
+export const GlobalLight: LastWriteWinElementSetComponentDefinition<PBGlobalLight>;
+
 // Warning: (ae-missing-release-tag) "GlobalTargetRaycastOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1421,7 +1465,23 @@ export const GltfContainer: LastWriteWinElementSetComponentDefinition<PBGltfCont
 export const GltfContainerLoadingState: LastWriteWinElementSetComponentDefinition<PBGltfContainerLoadingState>;
 
 // @public (undocumented)
+export const GltfNode: LastWriteWinElementSetComponentDefinition<PBGltfNode>;
+
+// @public (undocumented)
 export const GltfNodeModifiers: LastWriteWinElementSetComponentDefinition<PBGltfNodeModifiers>;
+
+// @public (undocumented)
+export const GltfNodeState: LastWriteWinElementSetComponentDefinition<PBGltfNodeState>;
+
+// @public (undocumented)
+export const enum GltfNodeStateValue {
+    // (undocumented)
+    GNSV_FAILED = 1,
+    // (undocumented)
+    GNSV_PENDING = 0,
+    // (undocumented)
+    GNSV_READY = 2
+}
 
 // @public (undocumented)
 export interface GrowOnlyValueSetComponentDefinition<T> extends BaseComponent<T> {
@@ -2125,6 +2185,25 @@ export namespace MoveContinuous {
 }
 
 // @public (undocumented)
+export interface MovementAnimation {
+    idle: boolean;
+    loop: boolean;
+    playbackTime?: number | undefined;
+    sounds: string[];
+    speed: number;
+    src: string;
+    transitionSeconds?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace MovementAnimation {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): MovementAnimation;
+    // (undocumented)
+    export function encode(message: MovementAnimation, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface MoveRotateScale {
     // (undocumented)
     positionEnd: PBVector3 | undefined;
@@ -2370,6 +2449,19 @@ export const onVideoEvent: Observable<{
     totalVideoLength: number;
 }>;
 
+// @public (undocumented)
+export interface Orthographic {
+    verticalRange?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace Orthographic {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): Orthographic;
+    // (undocumented)
+    export function encode(message: Orthographic, writer?: _m0.Writer): _m0.Writer;
+}
+
 // @public
 export type OverflowType = 'hidden' | 'scroll' | 'visible';
 
@@ -2603,6 +2695,7 @@ export namespace PBAvatarEmoteCommand {
 export interface PBAvatarEquippedData {
     // (undocumented)
     emoteUrns: string[];
+    forceRender: string[];
     // (undocumented)
     wearableUrns: string[];
 }
@@ -2641,6 +2734,7 @@ export interface PBAvatarModifierArea {
     area: PBVector3 | undefined;
     excludeIds: string[];
     modifiers: AvatarModifierType[];
+    useColliderRange?: boolean | undefined;
 }
 
 // @public (undocumented)
@@ -2652,12 +2746,58 @@ export namespace PBAvatarModifierArea {
 }
 
 // @public (undocumented)
+export interface PBAvatarMovement {
+    animation?: MovementAnimation | undefined;
+    // (undocumented)
+    groundDirection?: PBVector3 | undefined;
+    orientation: number;
+    tiltPitch?: number | undefined;
+    tiltRoll?: number | undefined;
+    // (undocumented)
+    velocity: PBVector3 | undefined;
+    walkSuccess?: boolean | undefined;
+}
+
+// @public (undocumented)
+export namespace PBAvatarMovement {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarMovement;
+    // (undocumented)
+    export function encode(message: PBAvatarMovement, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBAvatarMovementInfo {
+    activeAnimationState?: AvatarAnimationState | undefined;
+    // (undocumented)
+    activeAvatarLocomotionSettings: PBAvatarLocomotionSettings | undefined;
+    // (undocumented)
+    activeInputModifier: PBInputModifier | undefined;
+    actualVelocity: PBVector3 | undefined;
+    externalVelocity: PBVector3 | undefined;
+    previousStepTime: number;
+    requestedVelocity: PBVector3 | undefined;
+    stepTime: number;
+    walkTarget?: PBVector3 | undefined;
+    walkThreshold?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace PBAvatarMovementInfo {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarMovementInfo;
+    // (undocumented)
+    export function encode(message: PBAvatarMovementInfo, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBAvatarShape {
     bodyShape?: string | undefined;
     emotes: string[];
     expressionTriggerId?: string | undefined;
     expressionTriggerTimestamp?: number | undefined;
     eyeColor?: PBColor3 | undefined;
+    forceRender: string[];
     hairColor?: PBColor3 | undefined;
     id: string;
     name?: string | undefined;
@@ -2690,6 +2830,42 @@ export namespace PBBillboard {
 }
 
 // @public (undocumented)
+export interface PBCameraLayer {
+    // (undocumented)
+    ambientBrightnessOverride?: number | undefined;
+    // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+    ambientColorOverride?: PBColor3 | undefined;
+    directionalLight?: boolean | undefined;
+    // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+    layer: number;
+    showAvatars?: boolean | undefined;
+    showFog?: boolean | undefined;
+    showSkybox?: boolean | undefined;
+}
+
+// @public (undocumented)
+export namespace PBCameraLayer {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBCameraLayer;
+    // (undocumented)
+    export function encode(message: PBCameraLayer, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBCameraLayers {
+    // (undocumented)
+    layers: number[];
+}
+
+// @public (undocumented)
+export namespace PBCameraLayers {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBCameraLayers;
+    // (undocumented)
+    export function encode(message: PBCameraLayers, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBCameraMode {
     mode: CameraType;
 }
@@ -2706,6 +2882,7 @@ export namespace PBCameraMode {
 export interface PBCameraModeArea {
     area: PBVector3 | undefined;
     mode: CameraType;
+    useColliderRange?: boolean | undefined;
 }
 
 // @public (undocumented)
@@ -2817,6 +2994,21 @@ export namespace PBExplorerUiEventsResult_UiOpened {
 }
 
 // @public (undocumented)
+export interface PBGlobalLight {
+    ambientBrightness?: number | undefined;
+    ambientColor?: PBColor3 | undefined;
+    direction?: PBVector3 | undefined;
+}
+
+// @public (undocumented)
+export namespace PBGlobalLight {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGlobalLight;
+    // (undocumented)
+    export function encode(message: PBGlobalLight, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBGltfContainer {
     invisibleMeshesCollisionMask?: number | undefined;
     src: string;
@@ -2833,8 +3025,13 @@ export namespace PBGltfContainer {
 
 // @public (undocumented)
 export interface PBGltfContainerLoadingState {
+    animationNames: string[];
     // (undocumented)
     currentState: LoadingState;
+    materialNames: string[];
+    meshNames: string[];
+    nodePaths: string[];
+    skinNames: string[];
 }
 
 // @public (undocumented)
@@ -2843,6 +3040,19 @@ export namespace PBGltfContainerLoadingState {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfContainerLoadingState;
     // (undocumented)
     export function encode(message: PBGltfContainerLoadingState, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBGltfNode {
+    path: string;
+}
+
+// @public (undocumented)
+export namespace PBGltfNode {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNode;
+    // (undocumented)
+    export function encode(message: PBGltfNode, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -2872,6 +3082,22 @@ export namespace PBGltfNodeModifiers_GltfNodeModifier {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNodeModifiers_GltfNodeModifier;
     // (undocumented)
     export function encode(message: PBGltfNodeModifiers_GltfNodeModifier, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBGltfNodeState {
+    // (undocumented)
+    error?: string | undefined;
+    // (undocumented)
+    state: GltfNodeStateValue;
+}
+
+// @public (undocumented)
+export namespace PBGltfNodeState {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNodeState;
+    // (undocumented)
+    export function encode(message: PBGltfNodeState, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -2986,6 +3212,7 @@ export namespace PBMainCamera {
 
 // @public (undocumented)
 export interface PBMaterial {
+    gltf?: PBMaterial_GltfMaterial | undefined;
     // (undocumented)
     material?: {
         $case: "unlit";
@@ -3002,6 +3229,22 @@ export namespace PBMaterial {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMaterial;
     // (undocumented)
     export function encode(message: PBMaterial, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMaterial_GltfMaterial {
+    // (undocumented)
+    gltfSrc: string;
+    // (undocumented)
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMaterial_GltfMaterial {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMaterial_GltfMaterial;
+    // (undocumented)
+    export function encode(message: PBMaterial_GltfMaterial, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3065,6 +3308,9 @@ export interface PBMeshCollider {
     } | {
         $case: "plane";
         plane: PBMeshCollider_PlaneMesh;
+    } | {
+        $case: "gltf";
+        gltf: PBMeshCollider_GltfMesh;
     } | undefined;
 }
 
@@ -3100,6 +3346,20 @@ export namespace PBMeshCollider_CylinderMesh {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshCollider_CylinderMesh;
     // (undocumented)
     export function encode(message: PBMeshCollider_CylinderMesh, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMeshCollider_GltfMesh {
+    gltfSrc: string;
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMeshCollider_GltfMesh {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshCollider_GltfMesh;
+    // (undocumented)
+    export function encode(message: PBMeshCollider_GltfMesh, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3141,6 +3401,9 @@ export interface PBMeshRenderer {
     } | {
         $case: "plane";
         plane: PBMeshRenderer_PlaneMesh;
+    } | {
+        $case: "gltf";
+        gltf: PBMeshRenderer_GltfMesh;
     } | undefined;
 }
 
@@ -3177,6 +3440,20 @@ export namespace PBMeshRenderer_CylinderMesh {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshRenderer_CylinderMesh;
     // (undocumented)
     export function encode(message: PBMeshRenderer_CylinderMesh, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMeshRenderer_GltfMesh {
+    gltfSrc: string;
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMeshRenderer_GltfMesh {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshRenderer_GltfMesh;
+    // (undocumented)
+    export function encode(message: PBMeshRenderer_GltfMesh, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3605,9 +3882,11 @@ export interface PBRaycast {
         $case: "targetEntity";
         targetEntity: number;
     } | undefined;
+    includeWorld?: boolean | undefined;
     maxDistance: number;
     originOffset?: PBVector3 | undefined;
     queryType: RaycastQueryType;
+    shape?: RaycastShape | undefined;
     timestamp?: number | undefined;
 }
 
@@ -3700,6 +3979,32 @@ export namespace PBTextShape {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTextShape;
     // (undocumented)
     export function encode(message: PBTextShape, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBTextureCamera {
+    clearColor?: PBColor4 | undefined;
+    farPlane?: number | undefined;
+    height?: number | undefined;
+    layer?: number | undefined;
+    // (undocumented)
+    mode?: {
+        $case: "perspective";
+        perspective: Perspective;
+    } | {
+        $case: "orthographic";
+        orthographic: Orthographic;
+    } | undefined;
+    volume?: number | undefined;
+    width?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace PBTextureCamera {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTextureCamera;
+    // (undocumented)
+    export function encode(message: PBTextureCamera, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3878,6 +4183,23 @@ export namespace PBUiBackground {
 }
 
 // @public (undocumented)
+export interface PBUiCanvas {
+    color?: PBColor4 | undefined;
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    width: number;
+}
+
+// @public (undocumented)
+export namespace PBUiCanvas {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiCanvas;
+    // (undocumented)
+    export function encode(message: PBUiCanvas, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBUiCanvasInformation {
     devicePixelRatio: number;
     height: number;
@@ -3935,11 +4257,13 @@ export namespace PBUiDropdownResult {
 
 // @public (undocumented)
 export interface PBUiInput {
+    clearOnSubmit?: boolean | undefined;
     color?: PBColor4 | undefined;
     // (undocumented)
     disabled: boolean;
     font?: Font | undefined;
     fontSize?: number | undefined;
+    multiLine?: boolean | undefined;
     // (undocumented)
     placeholder: string;
     placeholderColor?: PBColor4 | undefined;
@@ -3982,6 +4306,20 @@ export namespace PBUiInputResult {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiInputResult;
     // (undocumented)
     export function encode(message: PBUiInputResult, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBUiScrollResult {
+    // (undocumented)
+    value: PBVector2 | undefined;
+}
+
+// @public (undocumented)
+export namespace PBUiScrollResult {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiScrollResult;
+    // (undocumented)
+    export function encode(message: PBUiScrollResult, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -4039,6 +4377,7 @@ export interface PBUiTransform {
     borderTopWidth?: number | undefined;
     borderTopWidthUnit?: YGUnit | undefined;
     display: YGDisplay;
+    elementId?: string | undefined;
     // (undocumented)
     flexBasis: number;
     flexBasisUnit: YGUnit;
@@ -4107,6 +4446,8 @@ export interface PBUiTransform {
     positionType: YGPositionType;
     // (undocumented)
     rightOf: number;
+    scrollPosition?: ScrollPositionValue | undefined;
+    scrollVisible?: ShowScrollBar | undefined;
     // (undocumented)
     width: number;
     widthUnit: YGUnit;
@@ -4225,6 +4566,19 @@ export namespace PBVisibilityComponent {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBVisibilityComponent;
     // (undocumented)
     export function encode(message: PBVisibilityComponent, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface Perspective {
+    fieldOfView?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace Perspective {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): Perspective;
+    // (undocumented)
+    export function encode(message: Perspective, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public
@@ -4351,6 +4705,12 @@ export const enum PointerEventType {
     // (undocumented)
     PET_DOWN = 1,
     // (undocumented)
+    PET_DRAG = 7,
+    // (undocumented)
+    PET_DRAG_END = 8,
+    // (undocumented)
+    PET_DRAG_LOCKED = 6,
+    // (undocumented)
     PET_HOVER_ENTER = 2,
     // (undocumented)
     PET_HOVER_LEAVE = 3,
@@ -4379,7 +4739,13 @@ export const PointerLock: LastWriteWinElementSetComponentDefinition<PBPointerLoc
 // @public (undocumented)
 export const enum PointerType {
     POT_MOUSE = 1,
-    POT_NONE = 0
+    POT_NONE = 0,
+    // (undocumented)
+    POT_PAD = 2,
+    // (undocumented)
+    POT_TOUCH = 3,
+    // (undocumented)
+    POT_WAND = 4
 }
 
 // @public
@@ -4569,6 +4935,12 @@ export const enum RaycastQueryType {
 
 // @public (undocumented)
 export const RaycastResult: LastWriteWinElementSetComponentDefinition<PBRaycastResult>;
+
+// @public (undocumented)
+export const enum RaycastShape {
+    RS_AVATAR = 1,
+    RS_RAY = 0
+}
 
 // @public (undocumented)
 export interface RaycastSystem {
@@ -4931,6 +5303,26 @@ export namespace Schemas {
 // @public
 export function ScreenInsetArea(props: UiScreenInsetAreaProps): ReactEcs.JSX.Element;
 
+// @public (undocumented)
+export interface ScrollPositionValue {
+    // (undocumented)
+    value?: {
+        $case: "position";
+        position: PBVector2;
+    } | {
+        $case: "reference";
+        reference: string;
+    } | undefined;
+}
+
+// @public (undocumented)
+export namespace ScrollPositionValue {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): ScrollPositionValue;
+    // (undocumented)
+    export function encode(message: ScrollPositionValue, writer?: _m0.Writer): _m0.Writer;
+}
+
 // @public
 export function setCompositeProvider(engine: IEngine, provider: CompositeProvider): void;
 
@@ -4941,6 +5333,18 @@ export function setGlobalPolyfill<T>(key: string, value: T): void;
 export interface SetMoveRotateScaleParams extends MoveRotateScaleModeParams {
     duration: number;
     easingFunction?: EasingFunction;
+}
+
+// @public (undocumented)
+export const enum ShowScrollBar {
+    // (undocumented)
+    SSB_BOTH = 0,
+    // (undocumented)
+    SSB_HIDDEN = 3,
+    // (undocumented)
+    SSB_ONLY_HORIZONTAL = 2,
+    // (undocumented)
+    SSB_ONLY_VERTICAL = 1
 }
 
 // @public (undocumented)
@@ -5057,6 +5461,9 @@ export namespace Texture {
 }
 
 // @public (undocumented)
+export const TextureCamera: LastWriteWinElementSetComponentDefinition<PBTextureCamera>;
+
+// @public (undocumented)
 export const enum TextureFilterMode {
     // (undocumented)
     TFM_BILINEAR = 1,
@@ -5135,6 +5542,9 @@ export interface TextureUnion {
     } | {
         $case: "videoTexture";
         videoTexture: VideoTexture;
+    } | {
+        $case: "uiTexture";
+        uiTexture: UiCanvasTexture;
     } | undefined;
 }
 
@@ -5425,7 +5835,26 @@ export interface UiButtonProps extends UiLabelProps, EntityPropTypes {
 }
 
 // @public (undocumented)
+export const UiCanvas: LastWriteWinElementSetComponentDefinition<PBUiCanvas>;
+
+// @public (undocumented)
 export const UiCanvasInformation: LastWriteWinElementSetComponentDefinition<PBUiCanvasInformation>;
+
+// @public (undocumented)
+export interface UiCanvasTexture {
+    filterMode?: TextureFilterMode | undefined;
+    // (undocumented)
+    uiCanvasEntity: number;
+    wrapMode?: TextureWrapMode | undefined;
+}
+
+// @public (undocumented)
+export namespace UiCanvasTexture {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): UiCanvasTexture;
+    // (undocumented)
+    export function encode(message: UiCanvasTexture, writer?: _m0.Writer): _m0.Writer;
+}
 
 // @public (undocumented)
 export type UiComponent = () => ReactEcs.JSX.ReactNode;
@@ -5511,6 +5940,9 @@ export type UiScreenInset = 'device' | 'interactable' | 'none';
 export type UiScreenInsetAreaProps = Omit<EntityPropTypes, 'uiTransform'> & {
     uiTransform?: Omit<NonNullable<EntityPropTypes['uiTransform']>, 'positionType' | 'position'>;
 };
+
+// @public (undocumented)
+export const UiScrollResult: LastWriteWinElementSetComponentDefinition<PBUiScrollResult>;
 
 // @public (undocumented)
 export const UiText: LastWriteWinElementSetComponentDefinition<PBUiText>;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5876,6 +5876,7 @@ export interface UiBackgroundProps {
     textureMode?: TextureMode;
     textureSlices?: BorderRect | undefined;
     uvs?: number[];
+    videoTexture?: UiVideoTexture;
 }
 
 // @public
@@ -6046,6 +6047,16 @@ export interface UiTransformProps {
     scrollVisible?: ScrollVisibleType;
     width?: PositionUnit | 'auto';
     zIndex?: number;
+}
+
+// @public
+export interface UiVideoTexture {
+    // (undocumented)
+    filterMode?: TextureFilterType;
+    // (undocumented)
+    videoPlayerEntity: Entity;
+    // (undocumented)
+    wrapMode?: TextureWrapType;
 }
 
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -2124,6 +2124,7 @@ export const MeshCollider: MeshColliderComponentDefinitionExtended;
 export interface MeshColliderComponentDefinitionExtended extends LastWriteWinElementSetComponentDefinition<PBMeshCollider> {
     setBox(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setCylinder(entity: Entity, radiusBottom?: number, radiusTop?: number, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
+    setGltfMesh(entity: Entity, source: string, meshName: string, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setPlane(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setSphere(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
 }
@@ -2137,6 +2138,7 @@ export const MeshRenderer: MeshRendererComponentDefinitionExtended;
 export interface MeshRendererComponentDefinitionExtended extends LastWriteWinElementSetComponentDefinition<PBMeshRenderer> {
     setBox(entity: Entity, uvs?: number[]): void;
     setCylinder(entity: Entity, radiusBottom?: number, radiusTop?: number): void;
+    setGltfMesh(entity: Entity, source: string, meshName: string): void;
     setPlane(entity: Entity, uvs?: number[]): void;
     setSphere(entity: Entity): void;
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5040,7 +5040,9 @@ export type RaycastSystemOptions = {
 export interface ReactBasedUiSystem {
     addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void;
     destroy(): void;
+    removeTextureRenderer(entity: Entity): void;
     removeUiRenderer(entity: Entity): void;
+    setTextureRenderer(entity: Entity, ui: UiComponent): void;
     setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void;
 }
 

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -474,7 +474,7 @@ export interface ByteBuffer {
 }
 
 // @public
-export type Callback = () => void;
+export type Callback = (event: PBPointerEventsResult) => void;
 
 // @public (undocumented)
 export const CameraLayer: LastWriteWinElementSetComponentDefinition<PBCameraLayer>;
@@ -1278,6 +1278,9 @@ export type EntityComponents = {
     onMouseUp: Callback;
     onMouseEnter: Callback;
     onMouseLeave: Callback;
+    onMouseDrag: Callback;
+    onMouseDragLocked: Callback;
+    onMouseDragEnd: Callback;
 };
 
 // @public (undocumented)
@@ -1901,6 +1904,9 @@ export type Listeners = {
     onMouseUp?: Callback;
     onMouseEnter?: Callback;
     onMouseLeave?: Callback;
+    onMouseDrag?: Callback;
+    onMouseDragLocked?: Callback;
+    onMouseDragEnd?: Callback;
 };
 
 // @public (undocumented)
@@ -4679,6 +4685,18 @@ export interface PointerEventsSystem {
     }, cb: EventSystemCallback): void;
     // @deprecated (undocumented)
     onPointerDown(entity: Entity, cb: EventSystemCallback, opts?: Partial<EventSystemOptions>): void;
+    onPointerDrag(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
+    onPointerDragEnd(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
+    onPointerDragLocked(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
     onPointerHoverEnter(pointerData: {
         entity: Entity;
         opts?: Partial<EventSystemOptions>;
@@ -4710,6 +4728,9 @@ export interface PointerEventsSystem {
         opts?: Partial<EventSystemOptions>;
     }, cb: EventSystemCallback): void;
     removeOnPointerDown(entity: Entity): void;
+    removeOnPointerDrag(entity: Entity): void;
+    removeOnPointerDragEnd(entity: Entity): void;
+    removeOnPointerDragLocked(entity: Entity): void;
     removeOnPointerHoverEnter(entity: Entity): void;
     removeOnPointerHoverLeave(entity: Entity): void;
     removeOnPointerUp(entity: Entity): void;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -220,8 +220,18 @@ export const AvatarBase: LastWriteWinElementSetComponentDefinition<PBAvatarBase>
 // @public (undocumented)
 export const AvatarEmoteCommand: GrowOnlyValueSetComponentDefinition<PBAvatarEmoteCommand>;
 
+// Warning: (ae-missing-release-tag) "AvatarEquippedData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
-export const AvatarEquippedData: LastWriteWinElementSetComponentDefinition<PBAvatarEquippedData>;
+export const AvatarEquippedData: AvatarEquippedDataComponentDefinitionExtended;
+
+// @public (undocumented)
+export type AvatarEquippedDataComponentDefinitionExtended = LastWriteWinElementSetComponentDefinition<AvatarEquippedDataType>;
+
+// @public
+export type AvatarEquippedDataType = Omit<PBAvatarEquippedData, 'forceRender'> & {
+    forceRender?: string[] | undefined;
+};
 
 // @public (undocumented)
 export const AvatarLocomotionSettings: LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>;
@@ -248,8 +258,18 @@ export const AvatarMovement: LastWriteWinElementSetComponentDefinition<PBAvatarM
 // @public (undocumented)
 export const AvatarMovementInfo: LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>;
 
+// Warning: (ae-missing-release-tag) "AvatarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
-export const AvatarShape: LastWriteWinElementSetComponentDefinition<PBAvatarShape>;
+export const AvatarShape: AvatarShapeComponentDefinitionExtended;
+
+// @public (undocumented)
+export type AvatarShapeComponentDefinitionExtended = LastWriteWinElementSetComponentDefinition<AvatarShapeType>;
+
+// @public
+export type AvatarShapeType = Omit<PBAvatarShape, 'forceRender'> & {
+    forceRender?: string[] | undefined;
+};
 
 // @public (undocumented)
 export interface AvatarTexture {

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5011,6 +5011,8 @@ export type RaycastSystemOptions = {
     queryType: RaycastQueryType;
     continuous?: boolean | undefined;
     collisionMask?: number | undefined;
+    shape?: RaycastShape | undefined;
+    includeWorld?: boolean | undefined;
 };
 
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5369,6 +5369,9 @@ export namespace ScrollPositionValue {
 }
 
 // @public
+export type ScrollVisibleType = 'horizontal' | 'vertical' | 'both' | 'hidden';
+
+// @public
 export function setCompositeProvider(engine: IEngine, provider: CompositeProvider): void;
 
 // @public
@@ -6017,6 +6020,7 @@ export interface UiTransformProps {
     // (undocumented)
     borderWidth?: Partial<Position> | PositionUnit;
     display?: DisplayType;
+    elementId?: string;
     flex?: number;
     flexBasis?: number;
     flexDirection?: FlexDirectionType;
@@ -6036,6 +6040,8 @@ export interface UiTransformProps {
     pointerFilter?: PointerFilterType;
     position?: Partial<Position> | PositionShorthand;
     positionType?: PositionType;
+    scrollPosition?: PBVector2 | string;
+    scrollVisible?: ScrollVisibleType;
     width?: PositionUnit | 'auto';
     zIndex?: number;
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -2125,6 +2125,7 @@ export const MeshCollider: MeshColliderComponentDefinitionExtended;
 export interface MeshColliderComponentDefinitionExtended extends LastWriteWinElementSetComponentDefinition<PBMeshCollider> {
     setBox(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setCylinder(entity: Entity, radiusBottom?: number, radiusTop?: number, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
+    setGltfMesh(entity: Entity, source: string, meshName: string, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setPlane(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
     setSphere(entity: Entity, colliderLayers?: ColliderLayer | ColliderLayer[]): void;
 }
@@ -2138,6 +2139,7 @@ export const MeshRenderer: MeshRendererComponentDefinitionExtended;
 export interface MeshRendererComponentDefinitionExtended extends LastWriteWinElementSetComponentDefinition<PBMeshRenderer> {
     setBox(entity: Entity, uvs?: number[]): void;
     setCylinder(entity: Entity, radiusBottom?: number, radiusTop?: number): void;
+    setGltfMesh(entity: Entity, source: string, meshName: string): void;
     setPlane(entity: Entity, uvs?: number[]): void;
     setSphere(entity: Entity): void;
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -193,6 +193,25 @@ export const enum AvatarAnchorPointType {
 }
 
 // @public (undocumented)
+export interface AvatarAnimationState {
+    duration: number;
+    idle: boolean;
+    loop: boolean;
+    loopCount: number;
+    playbackTime: number;
+    speed: number;
+    src: string;
+}
+
+// @public (undocumented)
+export namespace AvatarAnimationState {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): AvatarAnimationState;
+    // (undocumented)
+    export function encode(message: AvatarAnimationState, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export const AvatarAttach: LastWriteWinElementSetComponentDefinition<PBAvatarAttach>;
 
 // @public (undocumented)
@@ -222,6 +241,12 @@ export const enum AvatarModifierType {
     AMT_HIDE_AVATARS = 0,
     AMT_HIDE_NAMETAGS = 2
 }
+
+// @public (undocumented)
+export const AvatarMovement: LastWriteWinElementSetComponentDefinition<PBAvatarMovement>;
+
+// @public (undocumented)
+export const AvatarMovementInfo: LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>;
 
 // @public (undocumented)
 export const AvatarShape: LastWriteWinElementSetComponentDefinition<PBAvatarShape>;
@@ -430,6 +455,12 @@ export interface ByteBuffer {
 
 // @public
 export type Callback = () => void;
+
+// @public (undocumented)
+export const CameraLayer: LastWriteWinElementSetComponentDefinition<PBCameraLayer>;
+
+// @public (undocumented)
+export const CameraLayers: LastWriteWinElementSetComponentDefinition<PBCameraLayers>;
 
 // @public (undocumented)
 export const CameraMode: LastWriteWinElementSetComponentDefinition<PBCameraMode>;
@@ -721,15 +752,22 @@ export const componentDefinitionByName: {
     "core::AvatarEquippedData": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarEquippedData>>;
     "core::AvatarLocomotionSettings": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarLocomotionSettings>>;
     "core::AvatarModifierArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>>;
+    "core::AvatarMovement": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovement>>;
+    "core::AvatarMovementInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>>;
     "core::AvatarShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarShape>>;
     "core::Billboard": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBBillboard>>;
+    "core::CameraLayer": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraLayer>>;
+    "core::CameraLayers": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraLayers>>;
     "core::CameraMode": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraMode>>;
     "core::CameraModeArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraModeArea>>;
     "core::EngineInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBEngineInfo>>;
     "core::ExplorerUiEventsResult": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBExplorerUiEventsResult>>;
+    "core::GlobalLight": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGlobalLight>>;
     "core::GltfContainer": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfContainer>>;
     "core::GltfContainerLoadingState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfContainerLoadingState>>;
+    "core::GltfNode": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNode>>;
     "core::GltfNodeModifiers": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNodeModifiers>>;
+    "core::GltfNodeState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBGltfNodeState>>;
     "core::InputModifier": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBInputModifier>>;
     "core::LightSource": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBLightSource>>;
     "core::MainCamera": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBMainCamera>>;
@@ -750,6 +788,7 @@ export const componentDefinitionByName: {
     "core::RealmInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBRealmInfo>>;
     "core::SkyboxTime": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBSkyboxTime>>;
     "core::TextShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTextShape>>;
+    "core::TextureCamera": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTextureCamera>>;
     "core::TouchScreenControls": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTouchScreenControls>>;
     "core::TriggerArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTriggerArea>>;
     "core::TriggerAreaResult": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBTriggerAreaResult>>;
@@ -757,12 +796,14 @@ export const componentDefinitionByName: {
     "core::TweenSequence": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTweenSequence>>;
     "core::TweenState": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBTweenState>>;
     "core::UiBackground": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiBackground>>;
+    "core::UiCanvas": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiCanvas>>;
     "core::UiCanvasInformation": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiCanvasInformation>>;
     "core::UiDropdown": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdown>>;
     "core::UiDropdownResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiDropdownResult>>;
     "core::UiInput": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInput>>;
     "core::UiInputBinding": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputBinding>>;
     "core::UiInputResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiInputResult>>;
+    "core::UiScrollResult": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiScrollResult>>;
     "core::UiText": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiText>>;
     "core::UiTransform": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBUiTransform>>;
     "core::VideoEvent": GSetComponentGetter<GrowOnlyValueSetComponentDefinition<PBVideoEvent>>;
@@ -1403,6 +1444,9 @@ export type GlobalDirectionRaycastSystemOptions = {
     direction?: PBVector3;
 };
 
+// @public (undocumented)
+export const GlobalLight: LastWriteWinElementSetComponentDefinition<PBGlobalLight>;
+
 // Warning: (ae-missing-release-tag) "GlobalTargetRaycastOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1422,7 +1466,23 @@ export const GltfContainer: LastWriteWinElementSetComponentDefinition<PBGltfCont
 export const GltfContainerLoadingState: LastWriteWinElementSetComponentDefinition<PBGltfContainerLoadingState>;
 
 // @public (undocumented)
+export const GltfNode: LastWriteWinElementSetComponentDefinition<PBGltfNode>;
+
+// @public (undocumented)
 export const GltfNodeModifiers: LastWriteWinElementSetComponentDefinition<PBGltfNodeModifiers>;
+
+// @public (undocumented)
+export const GltfNodeState: LastWriteWinElementSetComponentDefinition<PBGltfNodeState>;
+
+// @public (undocumented)
+export const enum GltfNodeStateValue {
+    // (undocumented)
+    GNSV_FAILED = 1,
+    // (undocumented)
+    GNSV_PENDING = 0,
+    // (undocumented)
+    GNSV_READY = 2
+}
 
 // @public (undocumented)
 export interface GrowOnlyValueSetComponentDefinition<T> extends BaseComponent<T> {
@@ -2126,6 +2186,25 @@ export namespace MoveContinuous {
 }
 
 // @public (undocumented)
+export interface MovementAnimation {
+    idle: boolean;
+    loop: boolean;
+    playbackTime?: number | undefined;
+    sounds: string[];
+    speed: number;
+    src: string;
+    transitionSeconds?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace MovementAnimation {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): MovementAnimation;
+    // (undocumented)
+    export function encode(message: MovementAnimation, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface MoveRotateScale {
     // (undocumented)
     positionEnd: PBVector3 | undefined;
@@ -2371,6 +2450,19 @@ export const onVideoEvent: Observable<{
     totalVideoLength: number;
 }>;
 
+// @public (undocumented)
+export interface Orthographic {
+    verticalRange?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace Orthographic {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): Orthographic;
+    // (undocumented)
+    export function encode(message: Orthographic, writer?: _m0.Writer): _m0.Writer;
+}
+
 // @public
 export type OverflowType = 'hidden' | 'scroll' | 'visible';
 
@@ -2604,6 +2696,7 @@ export namespace PBAvatarEmoteCommand {
 export interface PBAvatarEquippedData {
     // (undocumented)
     emoteUrns: string[];
+    forceRender: string[];
     // (undocumented)
     wearableUrns: string[];
 }
@@ -2642,6 +2735,7 @@ export interface PBAvatarModifierArea {
     area: PBVector3 | undefined;
     excludeIds: string[];
     modifiers: AvatarModifierType[];
+    useColliderRange?: boolean | undefined;
 }
 
 // @public (undocumented)
@@ -2653,12 +2747,58 @@ export namespace PBAvatarModifierArea {
 }
 
 // @public (undocumented)
+export interface PBAvatarMovement {
+    animation?: MovementAnimation | undefined;
+    // (undocumented)
+    groundDirection?: PBVector3 | undefined;
+    orientation: number;
+    tiltPitch?: number | undefined;
+    tiltRoll?: number | undefined;
+    // (undocumented)
+    velocity: PBVector3 | undefined;
+    walkSuccess?: boolean | undefined;
+}
+
+// @public (undocumented)
+export namespace PBAvatarMovement {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarMovement;
+    // (undocumented)
+    export function encode(message: PBAvatarMovement, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBAvatarMovementInfo {
+    activeAnimationState?: AvatarAnimationState | undefined;
+    // (undocumented)
+    activeAvatarLocomotionSettings: PBAvatarLocomotionSettings | undefined;
+    // (undocumented)
+    activeInputModifier: PBInputModifier | undefined;
+    actualVelocity: PBVector3 | undefined;
+    externalVelocity: PBVector3 | undefined;
+    previousStepTime: number;
+    requestedVelocity: PBVector3 | undefined;
+    stepTime: number;
+    walkTarget?: PBVector3 | undefined;
+    walkThreshold?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace PBAvatarMovementInfo {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarMovementInfo;
+    // (undocumented)
+    export function encode(message: PBAvatarMovementInfo, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBAvatarShape {
     bodyShape?: string | undefined;
     emotes: string[];
     expressionTriggerId?: string | undefined;
     expressionTriggerTimestamp?: number | undefined;
     eyeColor?: PBColor3 | undefined;
+    forceRender: string[];
     hairColor?: PBColor3 | undefined;
     id: string;
     name?: string | undefined;
@@ -2691,6 +2831,42 @@ export namespace PBBillboard {
 }
 
 // @public (undocumented)
+export interface PBCameraLayer {
+    // (undocumented)
+    ambientBrightnessOverride?: number | undefined;
+    // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+    ambientColorOverride?: PBColor3 | undefined;
+    directionalLight?: boolean | undefined;
+    // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+    layer: number;
+    showAvatars?: boolean | undefined;
+    showFog?: boolean | undefined;
+    showSkybox?: boolean | undefined;
+}
+
+// @public (undocumented)
+export namespace PBCameraLayer {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBCameraLayer;
+    // (undocumented)
+    export function encode(message: PBCameraLayer, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBCameraLayers {
+    // (undocumented)
+    layers: number[];
+}
+
+// @public (undocumented)
+export namespace PBCameraLayers {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBCameraLayers;
+    // (undocumented)
+    export function encode(message: PBCameraLayers, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBCameraMode {
     mode: CameraType;
 }
@@ -2707,6 +2883,7 @@ export namespace PBCameraMode {
 export interface PBCameraModeArea {
     area: PBVector3 | undefined;
     mode: CameraType;
+    useColliderRange?: boolean | undefined;
 }
 
 // @public (undocumented)
@@ -2818,6 +2995,21 @@ export namespace PBExplorerUiEventsResult_UiOpened {
 }
 
 // @public (undocumented)
+export interface PBGlobalLight {
+    ambientBrightness?: number | undefined;
+    ambientColor?: PBColor3 | undefined;
+    direction?: PBVector3 | undefined;
+}
+
+// @public (undocumented)
+export namespace PBGlobalLight {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGlobalLight;
+    // (undocumented)
+    export function encode(message: PBGlobalLight, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBGltfContainer {
     invisibleMeshesCollisionMask?: number | undefined;
     src: string;
@@ -2834,8 +3026,13 @@ export namespace PBGltfContainer {
 
 // @public (undocumented)
 export interface PBGltfContainerLoadingState {
+    animationNames: string[];
     // (undocumented)
     currentState: LoadingState;
+    materialNames: string[];
+    meshNames: string[];
+    nodePaths: string[];
+    skinNames: string[];
 }
 
 // @public (undocumented)
@@ -2844,6 +3041,19 @@ export namespace PBGltfContainerLoadingState {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfContainerLoadingState;
     // (undocumented)
     export function encode(message: PBGltfContainerLoadingState, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBGltfNode {
+    path: string;
+}
+
+// @public (undocumented)
+export namespace PBGltfNode {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNode;
+    // (undocumented)
+    export function encode(message: PBGltfNode, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -2873,6 +3083,22 @@ export namespace PBGltfNodeModifiers_GltfNodeModifier {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNodeModifiers_GltfNodeModifier;
     // (undocumented)
     export function encode(message: PBGltfNodeModifiers_GltfNodeModifier, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBGltfNodeState {
+    // (undocumented)
+    error?: string | undefined;
+    // (undocumented)
+    state: GltfNodeStateValue;
+}
+
+// @public (undocumented)
+export namespace PBGltfNodeState {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBGltfNodeState;
+    // (undocumented)
+    export function encode(message: PBGltfNodeState, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -2987,6 +3213,7 @@ export namespace PBMainCamera {
 
 // @public (undocumented)
 export interface PBMaterial {
+    gltf?: PBMaterial_GltfMaterial | undefined;
     // (undocumented)
     material?: {
         $case: "unlit";
@@ -3003,6 +3230,22 @@ export namespace PBMaterial {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMaterial;
     // (undocumented)
     export function encode(message: PBMaterial, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMaterial_GltfMaterial {
+    // (undocumented)
+    gltfSrc: string;
+    // (undocumented)
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMaterial_GltfMaterial {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMaterial_GltfMaterial;
+    // (undocumented)
+    export function encode(message: PBMaterial_GltfMaterial, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3066,6 +3309,9 @@ export interface PBMeshCollider {
     } | {
         $case: "plane";
         plane: PBMeshCollider_PlaneMesh;
+    } | {
+        $case: "gltf";
+        gltf: PBMeshCollider_GltfMesh;
     } | undefined;
 }
 
@@ -3101,6 +3347,20 @@ export namespace PBMeshCollider_CylinderMesh {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshCollider_CylinderMesh;
     // (undocumented)
     export function encode(message: PBMeshCollider_CylinderMesh, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMeshCollider_GltfMesh {
+    gltfSrc: string;
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMeshCollider_GltfMesh {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshCollider_GltfMesh;
+    // (undocumented)
+    export function encode(message: PBMeshCollider_GltfMesh, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3142,6 +3402,9 @@ export interface PBMeshRenderer {
     } | {
         $case: "plane";
         plane: PBMeshRenderer_PlaneMesh;
+    } | {
+        $case: "gltf";
+        gltf: PBMeshRenderer_GltfMesh;
     } | undefined;
 }
 
@@ -3178,6 +3441,20 @@ export namespace PBMeshRenderer_CylinderMesh {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshRenderer_CylinderMesh;
     // (undocumented)
     export function encode(message: PBMeshRenderer_CylinderMesh, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBMeshRenderer_GltfMesh {
+    gltfSrc: string;
+    name: string;
+}
+
+// @public (undocumented)
+export namespace PBMeshRenderer_GltfMesh {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBMeshRenderer_GltfMesh;
+    // (undocumented)
+    export function encode(message: PBMeshRenderer_GltfMesh, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3608,9 +3885,11 @@ export interface PBRaycast {
         $case: "targetEntity";
         targetEntity: number;
     } | undefined;
+    includeWorld?: boolean | undefined;
     maxDistance: number;
     originOffset?: PBVector3 | undefined;
     queryType: RaycastQueryType;
+    shape?: RaycastShape | undefined;
     timestamp?: number | undefined;
 }
 
@@ -3703,6 +3982,32 @@ export namespace PBTextShape {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTextShape;
     // (undocumented)
     export function encode(message: PBTextShape, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBTextureCamera {
+    clearColor?: PBColor4 | undefined;
+    farPlane?: number | undefined;
+    height?: number | undefined;
+    layer?: number | undefined;
+    // (undocumented)
+    mode?: {
+        $case: "perspective";
+        perspective: Perspective;
+    } | {
+        $case: "orthographic";
+        orthographic: Orthographic;
+    } | undefined;
+    volume?: number | undefined;
+    width?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace PBTextureCamera {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBTextureCamera;
+    // (undocumented)
+    export function encode(message: PBTextureCamera, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -3881,6 +4186,23 @@ export namespace PBUiBackground {
 }
 
 // @public (undocumented)
+export interface PBUiCanvas {
+    color?: PBColor4 | undefined;
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    width: number;
+}
+
+// @public (undocumented)
+export namespace PBUiCanvas {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiCanvas;
+    // (undocumented)
+    export function encode(message: PBUiCanvas, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
 export interface PBUiCanvasInformation {
     devicePixelRatio: number;
     height: number;
@@ -3938,11 +4260,13 @@ export namespace PBUiDropdownResult {
 
 // @public (undocumented)
 export interface PBUiInput {
+    clearOnSubmit?: boolean | undefined;
     color?: PBColor4 | undefined;
     // (undocumented)
     disabled: boolean;
     font?: Font | undefined;
     fontSize?: number | undefined;
+    multiLine?: boolean | undefined;
     // (undocumented)
     placeholder: string;
     placeholderColor?: PBColor4 | undefined;
@@ -3985,6 +4309,20 @@ export namespace PBUiInputResult {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiInputResult;
     // (undocumented)
     export function encode(message: PBUiInputResult, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBUiScrollResult {
+    // (undocumented)
+    value: PBVector2 | undefined;
+}
+
+// @public (undocumented)
+export namespace PBUiScrollResult {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBUiScrollResult;
+    // (undocumented)
+    export function encode(message: PBUiScrollResult, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)
@@ -4042,6 +4380,7 @@ export interface PBUiTransform {
     borderTopWidth?: number | undefined;
     borderTopWidthUnit?: YGUnit | undefined;
     display: YGDisplay;
+    elementId?: string | undefined;
     // (undocumented)
     flexBasis: number;
     flexBasisUnit: YGUnit;
@@ -4110,6 +4449,8 @@ export interface PBUiTransform {
     positionType: YGPositionType;
     // (undocumented)
     rightOf: number;
+    scrollPosition?: ScrollPositionValue | undefined;
+    scrollVisible?: ShowScrollBar | undefined;
     // (undocumented)
     width: number;
     widthUnit: YGUnit;
@@ -4228,6 +4569,19 @@ export namespace PBVisibilityComponent {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBVisibilityComponent;
     // (undocumented)
     export function encode(message: PBVisibilityComponent, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface Perspective {
+    fieldOfView?: number | undefined;
+}
+
+// @public (undocumented)
+export namespace Perspective {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): Perspective;
+    // (undocumented)
+    export function encode(message: Perspective, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public
@@ -4354,6 +4708,12 @@ export const enum PointerEventType {
     // (undocumented)
     PET_DOWN = 1,
     // (undocumented)
+    PET_DRAG = 7,
+    // (undocumented)
+    PET_DRAG_END = 8,
+    // (undocumented)
+    PET_DRAG_LOCKED = 6,
+    // (undocumented)
     PET_HOVER_ENTER = 2,
     // (undocumented)
     PET_HOVER_LEAVE = 3,
@@ -4382,7 +4742,13 @@ export const PointerLock: LastWriteWinElementSetComponentDefinition<PBPointerLoc
 // @public (undocumented)
 export const enum PointerType {
     POT_MOUSE = 1,
-    POT_NONE = 0
+    POT_NONE = 0,
+    // (undocumented)
+    POT_PAD = 2,
+    // (undocumented)
+    POT_TOUCH = 3,
+    // (undocumented)
+    POT_WAND = 4
 }
 
 // @public
@@ -4572,6 +4938,12 @@ export const enum RaycastQueryType {
 
 // @public (undocumented)
 export const RaycastResult: LastWriteWinElementSetComponentDefinition<PBRaycastResult>;
+
+// @public (undocumented)
+export const enum RaycastShape {
+    RS_AVATAR = 1,
+    RS_RAY = 0
+}
 
 // @public (undocumented)
 export interface RaycastSystem {
@@ -4934,6 +5306,26 @@ export namespace Schemas {
 // @public
 export function ScreenInsetArea(props: UiScreenInsetAreaProps): ReactEcs.JSX.Element;
 
+// @public (undocumented)
+export interface ScrollPositionValue {
+    // (undocumented)
+    value?: {
+        $case: "position";
+        position: PBVector2;
+    } | {
+        $case: "reference";
+        reference: string;
+    } | undefined;
+}
+
+// @public (undocumented)
+export namespace ScrollPositionValue {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): ScrollPositionValue;
+    // (undocumented)
+    export function encode(message: ScrollPositionValue, writer?: _m0.Writer): _m0.Writer;
+}
+
 // @public
 export function setCompositeProvider(engine: IEngine, provider: CompositeProvider): void;
 
@@ -4944,6 +5336,18 @@ export function setGlobalPolyfill<T>(key: string, value: T): void;
 export interface SetMoveRotateScaleParams extends MoveRotateScaleModeParams {
     duration: number;
     easingFunction?: EasingFunction;
+}
+
+// @public (undocumented)
+export const enum ShowScrollBar {
+    // (undocumented)
+    SSB_BOTH = 0,
+    // (undocumented)
+    SSB_HIDDEN = 3,
+    // (undocumented)
+    SSB_ONLY_HORIZONTAL = 2,
+    // (undocumented)
+    SSB_ONLY_VERTICAL = 1
 }
 
 // @public (undocumented)
@@ -5060,6 +5464,9 @@ export namespace Texture {
 }
 
 // @public (undocumented)
+export const TextureCamera: LastWriteWinElementSetComponentDefinition<PBTextureCamera>;
+
+// @public (undocumented)
 export const enum TextureFilterMode {
     // (undocumented)
     TFM_BILINEAR = 1,
@@ -5138,6 +5545,9 @@ export interface TextureUnion {
     } | {
         $case: "videoTexture";
         videoTexture: VideoTexture;
+    } | {
+        $case: "uiTexture";
+        uiTexture: UiCanvasTexture;
     } | undefined;
 }
 
@@ -5428,7 +5838,26 @@ export interface UiButtonProps extends UiLabelProps, EntityPropTypes {
 }
 
 // @public (undocumented)
+export const UiCanvas: LastWriteWinElementSetComponentDefinition<PBUiCanvas>;
+
+// @public (undocumented)
 export const UiCanvasInformation: LastWriteWinElementSetComponentDefinition<PBUiCanvasInformation>;
+
+// @public (undocumented)
+export interface UiCanvasTexture {
+    filterMode?: TextureFilterMode | undefined;
+    // (undocumented)
+    uiCanvasEntity: number;
+    wrapMode?: TextureWrapMode | undefined;
+}
+
+// @public (undocumented)
+export namespace UiCanvasTexture {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): UiCanvasTexture;
+    // (undocumented)
+    export function encode(message: UiCanvasTexture, writer?: _m0.Writer): _m0.Writer;
+}
 
 // @public (undocumented)
 export type UiComponent = () => ReactEcs.JSX.ReactNode;
@@ -5514,6 +5943,9 @@ export type UiScreenInset = 'device' | 'interactable' | 'none';
 export type UiScreenInsetAreaProps = Omit<EntityPropTypes, 'uiTransform'> & {
     uiTransform?: Omit<NonNullable<EntityPropTypes['uiTransform']>, 'positionType' | 'position'>;
 };
+
+// @public (undocumented)
+export const UiScrollResult: LastWriteWinElementSetComponentDefinition<PBUiScrollResult>;
 
 // @public (undocumented)
 export const UiText: LastWriteWinElementSetComponentDefinition<PBUiText>;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5043,7 +5043,9 @@ export type RaycastSystemOptions = {
 export interface ReactBasedUiSystem {
     addUiRenderer(entity: Entity, ui: UiComponent, options?: UiRendererOptions): void;
     destroy(): void;
+    removeTextureRenderer(entity: Entity): void;
     removeUiRenderer(entity: Entity): void;
+    setTextureRenderer(entity: Entity, ui: UiComponent): void;
     setUiRenderer(ui: UiComponent, options?: UiRendererOptions): void;
 }
 

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5879,6 +5879,7 @@ export interface UiBackgroundProps {
     textureMode?: TextureMode;
     textureSlices?: BorderRect | undefined;
     uvs?: number[];
+    videoTexture?: UiVideoTexture;
 }
 
 // @public
@@ -6049,6 +6050,16 @@ export interface UiTransformProps {
     scrollVisible?: ScrollVisibleType;
     width?: PositionUnit | 'auto';
     zIndex?: number;
+}
+
+// @public
+export interface UiVideoTexture {
+    // (undocumented)
+    filterMode?: TextureFilterType;
+    // (undocumented)
+    videoPlayerEntity: Entity;
+    // (undocumented)
+    wrapMode?: TextureWrapType;
 }
 
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -474,7 +474,7 @@ export interface ByteBuffer {
 }
 
 // @public
-export type Callback = () => void;
+export type Callback = (event: PBPointerEventsResult) => void;
 
 // @public (undocumented)
 export const CameraLayer: LastWriteWinElementSetComponentDefinition<PBCameraLayer>;
@@ -1278,6 +1278,9 @@ export type EntityComponents = {
     onMouseUp: Callback;
     onMouseEnter: Callback;
     onMouseLeave: Callback;
+    onMouseDrag: Callback;
+    onMouseDragLocked: Callback;
+    onMouseDragEnd: Callback;
 };
 
 // @public (undocumented)
@@ -1902,6 +1905,9 @@ export type Listeners = {
     onMouseUp?: Callback;
     onMouseEnter?: Callback;
     onMouseLeave?: Callback;
+    onMouseDrag?: Callback;
+    onMouseDragLocked?: Callback;
+    onMouseDragEnd?: Callback;
 };
 
 // @public (undocumented)
@@ -4682,6 +4688,18 @@ export interface PointerEventsSystem {
     }, cb: EventSystemCallback): void;
     // @deprecated (undocumented)
     onPointerDown(entity: Entity, cb: EventSystemCallback, opts?: Partial<EventSystemOptions>): void;
+    onPointerDrag(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
+    onPointerDragEnd(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
+    onPointerDragLocked(pointerData: {
+        entity: Entity;
+        opts?: Partial<EventSystemOptions>;
+    }, cb: EventSystemCallback): void;
     onPointerHoverEnter(pointerData: {
         entity: Entity;
         opts?: Partial<EventSystemOptions>;
@@ -4713,6 +4731,9 @@ export interface PointerEventsSystem {
         opts?: Partial<EventSystemOptions>;
     }, cb: EventSystemCallback): void;
     removeOnPointerDown(entity: Entity): void;
+    removeOnPointerDrag(entity: Entity): void;
+    removeOnPointerDragEnd(entity: Entity): void;
+    removeOnPointerDragLocked(entity: Entity): void;
     removeOnPointerHoverEnter(entity: Entity): void;
     removeOnPointerHoverLeave(entity: Entity): void;
     removeOnPointerUp(entity: Entity): void;

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5014,6 +5014,8 @@ export type RaycastSystemOptions = {
     queryType: RaycastQueryType;
     continuous?: boolean | undefined;
     collisionMask?: number | undefined;
+    shape?: RaycastShape | undefined;
+    includeWorld?: boolean | undefined;
 };
 
 // @public (undocumented)

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5372,6 +5372,9 @@ export namespace ScrollPositionValue {
 }
 
 // @public
+export type ScrollVisibleType = 'horizontal' | 'vertical' | 'both' | 'hidden';
+
+// @public
 export function setCompositeProvider(engine: IEngine, provider: CompositeProvider): void;
 
 // @public
@@ -6020,6 +6023,7 @@ export interface UiTransformProps {
     // (undocumented)
     borderWidth?: Partial<Position> | PositionUnit;
     display?: DisplayType;
+    elementId?: string;
     flex?: number;
     flexBasis?: number;
     flexDirection?: FlexDirectionType;
@@ -6039,6 +6043,8 @@ export interface UiTransformProps {
     pointerFilter?: PointerFilterType;
     position?: Partial<Position> | PositionShorthand;
     positionType?: PositionType;
+    scrollPosition?: PBVector2 | string;
+    scrollVisible?: ScrollVisibleType;
     width?: PositionUnit | 'auto';
     zIndex?: number;
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -258,6 +258,9 @@ export const AvatarMovement: LastWriteWinElementSetComponentDefinition<PBAvatarM
 // @public (undocumented)
 export const AvatarMovementInfo: LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>;
 
+// @public (undocumented)
+export const AvatarNametag: LastWriteWinElementSetComponentDefinition<PBAvatarNametag>;
+
 // Warning: (ae-missing-release-tag) "AvatarShape" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -774,6 +777,7 @@ export const componentDefinitionByName: {
     "core::AvatarModifierArea": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarModifierArea>>;
     "core::AvatarMovement": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovement>>;
     "core::AvatarMovementInfo": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarMovementInfo>>;
+    "core::AvatarNametag": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarNametag>>;
     "core::AvatarShape": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBAvatarShape>>;
     "core::Billboard": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBBillboard>>;
     "core::CameraLayer": LwwComponentGetter<LastWriteWinElementSetComponentDefinition<PBCameraLayer>>;
@@ -2817,6 +2821,22 @@ export namespace PBAvatarMovementInfo {
     export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarMovementInfo;
     // (undocumented)
     export function encode(message: PBAvatarMovementInfo, writer?: _m0.Writer): _m0.Writer;
+}
+
+// @public (undocumented)
+export interface PBAvatarNametag {
+    backgroundColor?: PBColor3 | undefined;
+    borderColor?: PBColor3 | undefined;
+    label: string;
+    labelColor?: PBColor3 | undefined;
+}
+
+// @public (undocumented)
+export namespace PBAvatarNametag {
+    // (undocumented)
+    export function decode(input: _m0.Reader | Uint8Array, length?: number): PBAvatarNametag;
+    // (undocumented)
+    export function encode(message: PBAvatarNametag, writer?: _m0.Writer): _m0.Writer;
 }
 
 // @public (undocumented)

--- a/packages/@dcl/react-ecs/src/components/Button/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/Button/index.tsx
@@ -35,7 +35,18 @@ function getButtonProps(props: UiButtonProps) {
  */
 /* @__PURE__ */
 export function Button(props: UiButtonProps) {
-  const { uiTransform, uiBackground, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, ...otherProps } = props
+  const {
+    uiTransform,
+    uiBackground,
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd,
+    ...otherProps
+  } = props
   const buttonProps = getButtonProps(props)
   const uiBackgroundProps = parseUiBackground({
     ...buttonProps.uiBackground,
@@ -66,6 +77,9 @@ export function Button(props: UiButtonProps) {
       onMouseUp={!!props.disabled ? undefined : onMouseUp}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onMouseDrag={onMouseDrag}
+      onMouseDragLocked={onMouseDragLocked}
+      onMouseDragEnd={onMouseDragEnd}
       uiTransform={uiTransformProps}
       uiText={textProps}
       uiBackground={uiBackgroundProps}

--- a/packages/@dcl/react-ecs/src/components/Button/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/Button/index.tsx
@@ -35,7 +35,18 @@ function getButtonProps(props: UiButtonProps) {
  */
 /* @__PURE__ */
 export function Button(props: UiButtonProps) {
-  const { uiTransform, uiBackground, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, ...otherProps } = props
+  const {
+    uiTransform,
+    uiBackground,
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd,
+    ...otherProps
+  } = props
   const buttonProps = getButtonProps(props)
   const uiBackgroundProps = parseUiBackground({
     ...buttonProps.uiBackground,
@@ -71,6 +82,9 @@ export function Button(props: UiButtonProps) {
       onMouseUp={!!props.disabled ? undefined : onMouseUp}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onMouseDrag={onMouseDrag}
+      onMouseDragLocked={onMouseDragLocked}
+      onMouseDragEnd={onMouseDragEnd}
       uiTransform={uiTransformProps}
       uiText={textProps}
       uiBackground={uiBackgroundProps}

--- a/packages/@dcl/react-ecs/src/components/Dropdown/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/Dropdown/index.tsx
@@ -39,7 +39,18 @@ function parseUiDropdown(props: UiDropdownProps): PBUiDropdown {
  */
 /* @__PURE__ */
 export function Dropdown(props: UiDropdownProps) {
-  const { uiTransform, uiBackground, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, ...otherProps } = props
+  const {
+    uiTransform,
+    uiBackground,
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd,
+    ...otherProps
+  } = props
   const dropdownProps = parseUiDropdown(otherProps)
   const commonProps = parseProps({
     uiTransform,
@@ -47,7 +58,10 @@ export function Dropdown(props: UiDropdownProps) {
     onMouseDown,
     onMouseUp,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd
   })
   return <entity {...commonProps} uiDropdown={dropdownProps} />
 }

--- a/packages/@dcl/react-ecs/src/components/Input/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/Input/index.tsx
@@ -41,7 +41,18 @@ function parseUiInput(props: Partial<UiInputProps>): PBUiInput {
  * @category Component
  */ /* @__PURE__ */
 export function Input(props: EntityPropTypes & Partial<UiInputProps>) {
-  const { uiTransform, uiBackground, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, ...otherProps } = props
+  const {
+    uiTransform,
+    uiBackground,
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd,
+    ...otherProps
+  } = props
   const inputProps = parseUiInput(otherProps)
   const commonProps = parseProps({
     uiTransform,
@@ -49,7 +60,10 @@ export function Input(props: EntityPropTypes & Partial<UiInputProps>) {
     onMouseDown,
     onMouseUp,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd
   })
   return <entity {...commonProps} uiInput={inputProps} />
 }

--- a/packages/@dcl/react-ecs/src/components/Label/index.tsx
+++ b/packages/@dcl/react-ecs/src/components/Label/index.tsx
@@ -23,7 +23,18 @@ export { scaleFontSize } from './utils'
 
 /* @__PURE__ */
 export function Label(props: EntityPropTypes & UiLabelProps) {
-  const { uiTransform, uiBackground, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, ...uiTextProps } = props
+  const {
+    uiTransform,
+    uiBackground,
+    onMouseDown,
+    onMouseUp,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd,
+    ...uiTextProps
+  } = props
 
   const commonProps = parseProps({
     uiTransform,
@@ -31,7 +42,10 @@ export function Label(props: EntityPropTypes & UiLabelProps) {
     onMouseDown,
     onMouseUp,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    onMouseDrag,
+    onMouseDragLocked,
+    onMouseDragEnd
   })
   const { font, textAlign, fontSize, textWrap, ...textProps } = uiTextProps
   const uiText: PBUiText = {

--- a/packages/@dcl/react-ecs/src/components/listeners/types.ts
+++ b/packages/@dcl/react-ecs/src/components/listeners/types.ts
@@ -1,8 +1,11 @@
+import { PBPointerEventsResult } from '@dcl/ecs'
+
 /**
- * Callback function to be triggered on a specified event
+ * Callback function to be triggered on a specified event. Receives the pointer event that
+ * fired it (button, hit, and for drags the pointer delta), which handlers may ignore.
  * @public
  */
-export type Callback = () => void
+export type Callback = (event: PBPointerEventsResult) => void
 
 /**
  * User key event Listeners
@@ -17,13 +20,22 @@ export type Listeners = {
   onMouseEnter?: Callback
   /** triggered on mouse leave event */
   onMouseLeave?: Callback
+  /** triggered while the pointer is dragged after pressing on the element */
+  onMouseDrag?: Callback
+  /** triggered while the pointer is dragged with the cursor locked in place */
+  onMouseDragLocked?: Callback
+  /** triggered when a drag that started on the element ends */
+  onMouseDragEnd?: Callback
 }
 
 const listeners: Listeners = {
   onMouseDown: undefined,
   onMouseUp: undefined,
   onMouseEnter: undefined,
-  onMouseLeave: undefined
+  onMouseLeave: undefined,
+  onMouseDrag: undefined,
+  onMouseDragLocked: undefined,
+  onMouseDragEnd: undefined
 }
 const listenersKey = Object.keys(listeners)
 

--- a/packages/@dcl/react-ecs/src/components/uiBackground/types.ts
+++ b/packages/@dcl/react-ecs/src/components/uiBackground/types.ts
@@ -1,4 +1,4 @@
-import { BorderRect } from '@dcl/ecs'
+import { BorderRect, Entity } from '@dcl/ecs'
 import { Color4 } from '@dcl/ecs/dist/components/generated/pb/decentraland/common/colors.gen'
 
 /**
@@ -16,6 +16,8 @@ export interface UiBackgroundProps {
   uvs?: number[]
   /** AvatarTexture for the background */
   avatarTexture?: UiAvatarTexture
+  /** VideoTexture for the background: the frames of a VideoPlayer on another entity */
+  videoTexture?: UiVideoTexture
   /** Texture for the background */
   texture?: UiTexture
 }
@@ -25,6 +27,16 @@ export interface UiBackgroundProps {
  */
 export interface UiAvatarTexture {
   userId: string
+  wrapMode?: TextureWrapType
+  filterMode?: TextureFilterType
+}
+
+/**
+ * Video Texture
+ * @public
+ */
+export interface UiVideoTexture {
+  videoPlayerEntity: Entity
   wrapMode?: TextureWrapType
   filterMode?: TextureFilterType
 }

--- a/packages/@dcl/react-ecs/src/components/uiBackground/utils.ts
+++ b/packages/@dcl/react-ecs/src/components/uiBackground/utils.ts
@@ -35,6 +35,15 @@ export function getTexture(props: UiBackgroundProps): PBUiBackground['texture'] 
       }
     }
   }
+
+  if (props.videoTexture) {
+    return {
+      tex: {
+        $case: 'videoTexture',
+        videoTexture: parseTexture(props.videoTexture)
+      }
+    }
+  }
   return undefined
 }
 

--- a/packages/@dcl/react-ecs/src/components/uiTransform/index.ts
+++ b/packages/@dcl/react-ecs/src/components/uiTransform/index.ts
@@ -7,6 +7,8 @@ import {
   getOverflow,
   getPointerFilter,
   getPositionType,
+  getScrollPosition,
+  getScrollVisible,
   parseBorderColor,
   parseBorderRadius,
   parseBorderWidth,
@@ -102,6 +104,8 @@ export function parseUiTransform(props: UiTransformProps = {}): PBUiTransform {
     borderRadius,
     borderWidth,
     borderColor,
+    scrollPosition,
+    scrollVisible,
     ...otherProps
   } = props
 
@@ -130,6 +134,8 @@ export function parseUiTransform(props: UiTransformProps = {}): PBUiTransform {
     ...(flexWrap && getFlexWrap(flexWrap)),
     ...(borderRadius && parseBorderRadius(borderRadius)),
     ...(borderWidth && parseBorderWidth(borderWidth)),
-    ...(borderColor && parseBorderColor(borderColor))
+    ...(borderColor && parseBorderColor(borderColor)),
+    ...(scrollPosition && getScrollPosition(scrollPosition)),
+    ...(scrollVisible && getScrollVisible(scrollVisible))
   }
 }

--- a/packages/@dcl/react-ecs/src/components/uiTransform/types.ts
+++ b/packages/@dcl/react-ecs/src/components/uiTransform/types.ts
@@ -1,4 +1,5 @@
 import { Color4 } from '@dcl/ecs/dist/components/generated/pb/decentraland/common/colors.gen'
+import { Vector2 } from '@dcl/ecs/dist/components/generated/pb/decentraland/common/vectors.gen'
 import { ScaleUnit } from '../types'
 
 /**
@@ -155,4 +156,16 @@ export interface UiTransformProps {
   opacity?: number
   /** default 0 */
   zIndex?: number
+  /** A reference id for the element, e.g. as a scrollPosition target or for SetUiFocus. default empty */
+  elementId?: string
+  /** Scroll offset when overflow is 'scroll': a position, or the elementId of a child to scroll to. default (0, 0) */
+  scrollPosition?: Vector2 | string
+  /** Which scrollbars to show when overflow is 'scroll'. default 'both' */
+  scrollVisible?: ScrollVisibleType
 }
+
+/**
+ * Which scrollbars are shown when the overflow is scrollable
+ * @public
+ */
+export type ScrollVisibleType = 'horizontal' | 'vertical' | 'both' | 'hidden'

--- a/packages/@dcl/react-ecs/src/components/uiTransform/utils.ts
+++ b/packages/@dcl/react-ecs/src/components/uiTransform/utils.ts
@@ -7,7 +7,9 @@ import {
   YGPositionType,
   YGUnit,
   YGWrap,
-  PointerFilterMode
+  PointerFilterMode,
+  PBUiTransform,
+  ShowScrollBar
 } from '@dcl/ecs'
 import {
   AlignType,
@@ -21,9 +23,11 @@ import {
   PositionUnit,
   PositionShorthand,
   PointerFilterType,
+  ScrollVisibleType,
   BorderRadius,
   UiTransformProps
 } from './types'
+import { Vector2 } from '@dcl/ecs/dist/components/generated/pb/decentraland/common/vectors.gen'
 import { calcOnViewport, getUiScaleFactor } from '../utils'
 import { ScaleUnit } from '../types'
 import { Color4 } from '@dcl/ecs/dist/components/generated/pb/decentraland/common/colors.gen'
@@ -350,4 +354,28 @@ export function getPointerFilter(
 const parsePointerFilter: Readonly<Record<PointerFilterType, PointerFilterMode>> = {
   none: PointerFilterMode.PFM_NONE,
   block: PointerFilterMode.PFM_BLOCK
+}
+
+/**
+ * @internal
+ */
+export function getScrollPosition(scrollPosition: Vector2 | string): Pick<PBUiTransform, 'scrollPosition'> {
+  if (typeof scrollPosition === 'string') {
+    return { scrollPosition: { value: { $case: 'reference', reference: scrollPosition } } }
+  }
+  return { scrollPosition: { value: { $case: 'position', position: scrollPosition } } }
+}
+
+const parseScrollVisible: Readonly<Record<ScrollVisibleType, ShowScrollBar>> = {
+  both: ShowScrollBar.SSB_BOTH,
+  hidden: ShowScrollBar.SSB_HIDDEN,
+  horizontal: ShowScrollBar.SSB_ONLY_HORIZONTAL,
+  vertical: ShowScrollBar.SSB_ONLY_VERTICAL
+}
+
+/**
+ * @internal
+ */
+export function getScrollVisible(scrollVisible: ScrollVisibleType): Pick<PBUiTransform, 'scrollVisible'> {
+  return { scrollVisible: parseScrollVisible[scrollVisible] }
 }

--- a/packages/@dcl/react-ecs/src/react-ecs.ts
+++ b/packages/@dcl/react-ecs/src/react-ecs.ts
@@ -24,6 +24,9 @@ export type EntityComponents = {
   onMouseUp: Callback
   onMouseEnter: Callback
   onMouseLeave: Callback
+  onMouseDrag: Callback
+  onMouseDragLocked: Callback
+  onMouseDragEnd: Callback
 }
 
 /**

--- a/packages/@dcl/react-ecs/src/reconciler/index.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/index.ts
@@ -57,7 +57,10 @@ export function createReconciler(
     IEngine,
     'getComponent' | 'addEntity' | 'removeEntity' | 'defineComponentFromSchema' | 'getEntitiesWith'
   >,
-  pointerEvents: PointerEventsSystem
+  pointerEvents: PointerEventsSystem,
+  // When set, every entity this reconciler creates is parented to it -- a UiCanvas on the root
+  // entity then renders the tree to a texture instead of the screen.
+  rootEntity?: Entity
 ) {
   // Store all the entities so when we destroy the UI we can also destroy them
   const entities = new Set<Entity>()
@@ -75,6 +78,7 @@ export function createReconciler(
   const UiInputResult = components.UiInputResult(engine)
   const UiDropdown = components.UiDropdown(engine)
   const UiDropdownResult = components.UiDropdownResult(engine)
+  const Transform = components.Transform(engine)
   const UiInputBinding = components.UiInputBinding(engine)
 
   // Component ID Helper
@@ -336,6 +340,9 @@ export function createReconciler(
 
     createInstance(type: Type, props: Props): Instance {
       const entity = engine.addEntity()
+      if (rootEntity !== undefined) {
+        Transform.createOrReplace(entity, { parent: rootEntity })
+      }
       entities.add(entity)
       const instance: Instance = {
         entity,

--- a/packages/@dcl/react-ecs/src/reconciler/index.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/index.ts
@@ -5,7 +5,8 @@ import {
   PointerEventsSystem,
   PointerEventType,
   PBUiInputResult,
-  PBUiDropdownResult
+  PBUiDropdownResult,
+  PBPointerEventsResult
 } from '@dcl/ecs'
 import * as components from '@dcl/ecs/dist/components'
 import Reconciler, { HostConfig } from 'react-reconciler'
@@ -37,7 +38,10 @@ function getPointerEnum(pointerKey: keyof Listeners): PointerEventType {
     onMouseDown: PointerEventType.PET_DOWN,
     onMouseUp: PointerEventType.PET_UP,
     onMouseEnter: PointerEventType.PET_HOVER_ENTER,
-    onMouseLeave: PointerEventType.PET_HOVER_LEAVE
+    onMouseLeave: PointerEventType.PET_HOVER_LEAVE,
+    onMouseDrag: PointerEventType.PET_DRAG,
+    onMouseDragLocked: PointerEventType.PET_DRAG_LOCKED,
+    onMouseDragEnd: PointerEventType.PET_DRAG_END
   }
   return pointers[pointerKey]
 }
@@ -85,9 +89,9 @@ export function createReconciler(
     uiInputBinding: UiInputBinding.componentId
   }
 
-  function pointerEventCallback(entity: Entity, pointerEvent: PointerEventType) {
+  function pointerEventCallback(entity: Entity, pointerEvent: PointerEventType, event: PBPointerEventsResult) {
     const callback = clickEvents.get(entity)?.get(pointerEvent)
-    if (callback) callback()
+    if (callback) callback(event)
     return
   }
 
@@ -97,7 +101,18 @@ export function createReconciler(
 
   function upsertListener(
     instance: Instance,
-    update: Changes<keyof Pick<Listeners, 'onMouseDown' | 'onMouseUp' | 'onMouseEnter' | 'onMouseLeave'>>
+    update: Changes<
+      keyof Pick<
+        Listeners,
+        | 'onMouseDown'
+        | 'onMouseUp'
+        | 'onMouseEnter'
+        | 'onMouseLeave'
+        | 'onMouseDrag'
+        | 'onMouseDragLocked'
+        | 'onMouseDragEnd'
+      >
+    >
   ) {
     if (update.type === 'delete' || !update.props) {
       clickEvents.get(instance.entity)?.delete(getPointerEnum(update.component))
@@ -109,6 +124,12 @@ export function createReconciler(
         pointerEvents.removeOnPointerHoverEnter(instance.entity)
       } else if (update.component === 'onMouseLeave') {
         pointerEvents.removeOnPointerHoverLeave(instance.entity)
+      } else if (update.component === 'onMouseDrag') {
+        pointerEvents.removeOnPointerDrag(instance.entity)
+      } else if (update.component === 'onMouseDragLocked') {
+        pointerEvents.removeOnPointerDragLocked(instance.entity)
+      } else if (update.component === 'onMouseDragEnd') {
+        pointerEvents.removeOnPointerDragEnd(instance.entity)
       }
       return
     }
@@ -126,10 +147,16 @@ export function createReconciler(
         update.component === 'onMouseDown'
           ? pointerEvents.onPointerDown
           : update.component === 'onMouseUp'
-          ? pointerEvents.onPointerUp
-          : update.component === 'onMouseEnter'
-          ? pointerEvents.onPointerHoverEnter
-          : update.component === 'onMouseLeave' && pointerEvents.onPointerHoverLeave
+            ? pointerEvents.onPointerUp
+            : update.component === 'onMouseEnter'
+              ? pointerEvents.onPointerHoverEnter
+              : update.component === 'onMouseLeave'
+                ? pointerEvents.onPointerHoverLeave
+                : update.component === 'onMouseDrag'
+                  ? pointerEvents.onPointerDrag
+                  : update.component === 'onMouseDragLocked'
+                    ? pointerEvents.onPointerDragLocked
+                    : update.component === 'onMouseDragEnd' && pointerEvents.onPointerDragEnd
 
       if (pointerEventSystem) {
         pointerEventSystem(
@@ -142,7 +169,7 @@ export function createReconciler(
               showFeedback: true
             }
           },
-          () => pointerEventCallback(instance.entity, pointerEvent)
+          (event) => pointerEventCallback(instance.entity, pointerEvent, event)
         )
       }
     }

--- a/packages/@dcl/react-ecs/src/reconciler/utils.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/utils.ts
@@ -73,6 +73,9 @@ const entityComponent: EntityComponents = {
   onMouseUp: undefined as any,
   onMouseEnter: undefined as any,
   onMouseLeave: undefined as any,
+  onMouseDrag: undefined as any,
+  onMouseDragLocked: undefined as any,
+  onMouseDragEnd: undefined as any,
   uiInput: undefined as any,
   uiDropdown: undefined as any,
   uiInputBinding: undefined as any

--- a/packages/@dcl/react-ecs/src/system.ts
+++ b/packages/@dcl/react-ecs/src/system.ts
@@ -142,6 +142,20 @@ export interface ReactBasedUiSystem {
    * @param entity - The entity whose UI renderer should be removed
    */
   removeUiRenderer(entity: Entity): void
+  /**
+   * Render a UI tree to a texture. The tree is rooted at `entity`, which must carry a UiCanvas
+   * describing the texture; the result can be sampled through `TextureUnion.uiTexture`. Replaces
+   * any texture renderer already set on the entity, and is torn down when the entity is removed.
+   *
+   * @param entity - The UiCanvas entity the UI tree hangs from
+   * @param ui - The UI component to render
+   */
+  setTextureRenderer(entity: Entity, ui: UiComponent): void
+  /**
+   * Remove a texture renderer previously set with setTextureRenderer(), destroying its entities.
+   * @param entity - The UiCanvas entity the renderer was set on
+   */
+  removeTextureRenderer(entity: Entity): void
 }
 
 /**
@@ -152,6 +166,18 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
   let uiComponent: UiComponent | undefined = undefined
   let mainOptions: UiRendererOptions | undefined = undefined
   const additionalRenderers = new Map<Entity, { ui: UiComponent; options?: UiRendererOptions }>()
+  // UI trees rendered to a texture, keyed by their UiCanvas entity. Each needs its own reconciler
+  // because the root parent is a per-reconciler property.
+  const textureRenderers = new Map<Entity, { renderer: ReturnType<typeof createReconciler>; ui: UiComponent }>()
+
+  function destroyTextureRenderer(entity: Entity) {
+    const entry = textureRenderers.get(entity)
+    if (!entry) return
+    textureRenderers.delete(entity)
+    for (const uiEntity of entry.renderer.getEntities()) {
+      engine.removeEntity(uiEntity)
+    }
+  }
   const UiCanvasInformation = ecsComponents.UiCanvasInformation(engine)
 
   // Unique owner to prevent other UI systems resetting this scale factor.
@@ -282,6 +308,14 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
     } else {
       renderer.update(null)
     }
+
+    for (const [entity, entry] of textureRenderers) {
+      if (engine.getEntityState(entity) === EntityState.Removed) {
+        destroyTextureRenderer(entity)
+      } else {
+        entry.renderer.update(React.createElement(entry.ui as any))
+      }
+    }
   }
 
   function UiScaleSystem() {
@@ -348,6 +382,9 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
       for (const entity of renderer.getEntities()) {
         engine.removeEntity(entity)
       }
+      for (const entity of textureRenderers.keys()) {
+        destroyTextureRenderer(entity)
+      }
     },
     setUiRenderer(ui: UiComponent, options?: UiRendererOptions) {
       uiComponent = ui
@@ -358,6 +395,13 @@ export function createReactBasedUiSystem(engine: IEngine, pointerSystem: Pointer
     },
     removeUiRenderer(entity: Entity) {
       additionalRenderers.delete(entity)
+    },
+    setTextureRenderer(entity: Entity, ui: UiComponent) {
+      destroyTextureRenderer(entity)
+      textureRenderers.set(entity, { renderer: createReconciler(engine, pointerSystem, entity), ui })
+    },
+    removeTextureRenderer(entity: Entity) {
+      destroyTextureRenderer(entity)
     }
   }
 }

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33247403125.commit-6e4ee4a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
-      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
+      "version": "1.0.0-33668585153.commit-4a844e9",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
+      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-32863591307.commit-0b3d285",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-32863591307.commit-0b3d285.tgz",
-      "integrity": "sha512-Bg6xVXQLEUGtsr2LA7hGHNnDe/xQj4RXH3hANCS9b6B7O4LNuf6VHudyt06nfzwogEonxtz1Mcrs17JNpCwuOQ==",
+      "version": "1.0.0-33219725173.commit-dc40022",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33219725173.commit-dc40022",
-      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
-      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
+      "version": "1.0.0-33247403125.commit-6e4ee4a",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33247403125.commit-6e4ee4a.tgz",
+      "integrity": "sha512-FmR3J9QaK0VJUJRiDHwGoX9k1Fj24Isnx0k3/Ob102Bp8qdHr3BMkIiRK4z/6pR9QHUgrBobCNfXY3Qy/QbYnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33668585153.commit-4a844e9",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33668585153.commit-4a844e9.tgz",
-      "integrity": "sha512-I5cSEq7GA3QANs7xG8CWhUheSw1kC/3JA3OYHK82KNxF6YdpOdLFI82t9yraVwWb3+FaE3yYtlPW2Nf8abDIHA==",
+      "version": "1.0.0-33674022401.commit-882d4ee",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33674022401.commit-882d4ee.tgz",
+      "integrity": "sha512-+gFspUQ/HSt4oqjjWuoSuftp3u6ab3VbCB+nhA8QMlmgabqNNT5XfX87q1u/NCQLHhg61my7y9We656TYl/4cw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
+        "@dcl/protocol": "1.0.0-34100371654.commit-2ed0bdc",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33674022401.commit-882d4ee",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33674022401.commit-882d4ee.tgz",
-      "integrity": "sha512-+gFspUQ/HSt4oqjjWuoSuftp3u6ab3VbCB+nhA8QMlmgabqNNT5XfX87q1u/NCQLHhg61my7y9We656TYl/4cw==",
+      "version": "1.0.0-34100371654.commit-2ed0bdc",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-34100371654.commit-2ed0bdc.tgz",
+      "integrity": "sha512-AIcv8cV5HWIFB88JGUk8ZbrQR71VRJBH00GUwxhWybZiWVGgA8A/OftxiZYUYfj0IZAYXbv7tvbdSsJmGtJuxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package-lock.json
+++ b/packages/@dcl/sdk-commands/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-33421599964.commit-0e82dcd",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-33421599964.commit-0e82dcd.tgz",
-      "integrity": "sha512-iN5zs1UzZ/gdE/K/xxLMBt9RhBDD8NNmZdTNKIedSQCr6L/nsVb/Q5Xeh/NoobHTmA+v40d6e6V6z+SJvt/IaA==",
+      "version": "1.0.0-33219725173.commit-dc40022",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+      "integrity": "sha512-CnAn6V6Vvga7sNaAJ31GePGs4XcM7wAwzXoZoCVA3IxxyFTylVj//3c3i/RDMNwqDaYuYky9a3tcEa7Nb/9/tA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+    "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+    "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+    "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk-commands/package.json
+++ b/packages/@dcl/sdk-commands/package.json
@@ -14,7 +14,7 @@
     "@dcl/inspector": "7.36.3",
     "@dcl/linker-dapp": "0.15.2",
     "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-    "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
+    "@dcl/protocol": "1.0.0-34100371654.commit-2ed0bdc",
     "@dcl/quests-client": "^1.0.3",
     "@dcl/quests-manager": "^0.1.4",
     "@dcl/rpc": "^1.1.1",

--- a/packages/@dcl/sdk/src/players/index.ts
+++ b/packages/@dcl/sdk/src/players/index.ts
@@ -19,6 +19,7 @@ type GetPlayerDataRes = {
   avatar?: PBAvatarBase
   wearables: PBAvatarEquippedData['wearableUrns']
   emotes: PBAvatarEquippedData['emoteUrns']
+  forceRender: PBAvatarEquippedData['forceRender']
   position: TransformType['position'] | undefined
 }
 
@@ -94,6 +95,7 @@ export function definePlayerHelper(engine: IEngine) {
         avatar: avatarData ?? undefined,
         wearables: wearablesData?.wearableUrns ?? [],
         emotes: wearablesData?.emoteUrns ?? [],
+        forceRender: wearablesData?.forceRender ?? [],
         position: Transform.getOrNull(userEntity)?.position
       }
     }

--- a/packages/@dcl/sdk/src/testing/runtime.ts
+++ b/packages/@dcl/sdk/src/testing/runtime.ts
@@ -50,7 +50,6 @@ export function createTestRuntime(testingModule: TestingModule, engine: IEngine)
   // continue to run until it reaches a yield point
   function scheduleValue(value: any, env: RunnerEnvironment) {
     if (value && typeof value === 'object' && typeof value.then === 'function') {
-      console.log('⏱️ yield promise')
       // if the value is a promise, schedule it to be awaited after the current frame is finished
       nextTickFuture.push(async () => {
         try {
@@ -60,14 +59,12 @@ export function createTestRuntime(testingModule: TestingModule, engine: IEngine)
         }
       })
     } else if (typeof value === 'function') {
-      console.log('⏱️ yield function')
       // if the value is a function, schedule it to be called on the next frame
       nextTickFuture.push(() => {
         scheduleValue(value(), env)
       })
       return
     } else if (typeof value === 'undefined' || value === null) {
-      console.log('⏱️ yield')
       // if the value is undefined or null, continue processing the generator the next frame
       nextTickFuture.push(() => {
         consumeGenerator(env)

--- a/scripts/protocol-buffer-generation/generateIndex.ts
+++ b/scripts/protocol-buffer-generation/generateIndex.ts
@@ -15,7 +15,15 @@ function exportComponent(component: Component) {
   return `export * from './pb/decentraland/sdk/components/${component.componentFile}.gen'`
 }
 
-const GROWN_ONLY_COMPONENTS = ['PointerEventsResult', 'VideoEvent', 'AvatarEmoteCommand', 'AudioEvent', 'TriggerAreaResult', 'AssetLoadLoadingState', 'ExplorerUiEventsResult']
+const GROWN_ONLY_COMPONENTS = [
+  'PointerEventsResult',
+  'VideoEvent',
+  'AvatarEmoteCommand',
+  'AudioEvent',
+  'TriggerAreaResult',
+  'AssetLoadLoadingState',
+  'ExplorerUiEventsResult'
+]
 function isGrowOnlyValueSet(component: Component): boolean {
   return GROWN_ONLY_COMPONENTS.includes(component.componentPascalName)
 }
@@ -36,7 +44,15 @@ function defineComponentDecl(component: Component) {
   }
 }
 
-const skipExposeGlobally: string[] = ['Animator', 'MeshRenderer', 'MeshCollider', 'Material', 'Tween']
+const skipExposeGlobally: string[] = [
+  'Animator',
+  'MeshRenderer',
+  'MeshCollider',
+  'Material',
+  'Tween',
+  'AvatarShape',
+  'AvatarEquippedData'
+]
 function defineGlobalComponentDecl(component: Component) {
   if (skipExposeGlobally.includes(component.componentPascalName)) return ''
   if (isGrowOnlyValueSet(component)) {

--- a/test/ecs/components/AvatarEquippedData.spec.ts
+++ b/test/ecs/components/AvatarEquippedData.spec.ts
@@ -1,4 +1,5 @@
 ﻿import { Engine, components } from '../../../packages/@dcl/ecs/src'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { testComponentSerialization } from './assertion'
 
 describe('Generated AvatarEquippedData ProtoBuf', () => {
@@ -8,7 +9,27 @@ describe('Generated AvatarEquippedData ProtoBuf', () => {
 
     testComponentSerialization(AvatarEquippedData, {
       wearableUrns: ['boedo', 'casla'],
-      emoteUrns: ['wave', 'ortigoaz']
+      emoteUrns: ['wave', 'ortigoaz'],
+      forceRender: []
     })
+
+    testComponentSerialization(AvatarEquippedData, {
+      wearableUrns: ['boedo', 'casla'],
+      emoteUrns: ['wave', 'ortigoaz'],
+      forceRender: ['hands_wear']
+    })
+  })
+
+  it('serializes an omitted forceRender as an empty list', () => {
+    const newEngine = Engine()
+    const AvatarEquippedData = components.AvatarEquippedData(newEngine)
+    const entity = newEngine.addEntity()
+
+    AvatarEquippedData.create(entity, { wearableUrns: [], emoteUrns: [] })
+    expect(AvatarEquippedData.get(entity).forceRender).toBeUndefined()
+
+    const buffer = new ReadWriteByteBuffer()
+    AvatarEquippedData.schema.serialize(AvatarEquippedData.get(entity), buffer)
+    expect(AvatarEquippedData.schema.deserialize(buffer).forceRender).toStrictEqual([])
   })
 })

--- a/test/ecs/components/AvatarModifierArea.spec.ts
+++ b/test/ecs/components/AvatarModifierArea.spec.ts
@@ -9,13 +9,15 @@ describe('Generated Avatar ModifierArea ProtoBuf', () => {
     testComponentSerialization(AvatarModifierArea, {
       area: { x: 1, y: 2, z: 3 },
       modifiers: [AvatarModifierType.AMT_DISABLE_PASSPORTS, AvatarModifierType.AMT_HIDE_AVATARS],
-      excludeIds: ['exclude', 'testIdReal', 'numberAndString12837127371']
+      excludeIds: ['exclude', 'testIdReal', 'numberAndString12837127371'],
+      useColliderRange: undefined
     })
 
     testComponentSerialization(AvatarModifierArea, {
       area: { x: 3, y: 4, z: 5 },
       modifiers: [],
-      excludeIds: ['exclude_this', 'testId', '12837127371']
+      excludeIds: ['exclude_this', 'testId', '12837127371'],
+      useColliderRange: false
     })
   })
 })

--- a/test/ecs/components/AvatarShape.spec.ts
+++ b/test/ecs/components/AvatarShape.spec.ts
@@ -1,4 +1,5 @@
 ﻿import { Engine, components } from '../../../packages/@dcl/ecs/src'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { testComponentSerialization } from './assertion'
 
 describe('Generated AvatarShape ProtoBuf', () => {
@@ -18,7 +19,8 @@ describe('Generated AvatarShape ProtoBuf', () => {
       expressionTriggerTimestamp: 0,
       talking: true,
       emotes: [],
-      showOnlyWearables: false
+      showOnlyWearables: false,
+      forceRender: []
     })
 
     testComponentSerialization(AvatarShape, {
@@ -33,7 +35,21 @@ describe('Generated AvatarShape ProtoBuf', () => {
       expressionTriggerTimestamp: 1,
       talking: false,
       emotes: [],
-      showOnlyWearables: false
+      showOnlyWearables: false,
+      forceRender: ['hands_wear']
     })
+  })
+
+  it('serializes an omitted forceRender as an empty list', () => {
+    const newEngine = Engine()
+    const AvatarShape = components.AvatarShape(newEngine)
+    const entity = newEngine.addEntity()
+
+    AvatarShape.create(entity, { id: 'test', wearables: [], emotes: [] })
+    expect(AvatarShape.get(entity).forceRender).toBeUndefined()
+
+    const buffer = new ReadWriteByteBuffer()
+    AvatarShape.schema.serialize(AvatarShape.get(entity), buffer)
+    expect(AvatarShape.schema.deserialize(buffer).forceRender).toStrictEqual([])
   })
 })

--- a/test/ecs/components/CameraModeArea.spec.ts
+++ b/test/ecs/components/CameraModeArea.spec.ts
@@ -8,12 +8,14 @@ describe('Generated CameraModifierArea ProtoBuf', () => {
 
     testComponentSerialization(CameraModeArea, {
       area: { x: 1, y: 2, z: 3 },
-      mode: CameraType.CT_FIRST_PERSON
+      mode: CameraType.CT_FIRST_PERSON,
+      useColliderRange: false
     })
 
     testComponentSerialization(CameraModeArea, {
       area: { x: 3, y: 4, z: 5 },
-      mode: CameraType.CT_THIRD_PERSON
+      mode: CameraType.CT_THIRD_PERSON,
+      useColliderRange: true
     })
   })
 })

--- a/test/ecs/components/GltfContainerLoadingState.spec.ts
+++ b/test/ecs/components/GltfContainerLoadingState.spec.ts
@@ -7,7 +7,12 @@ describe('Generated GltfContainerLoadingState ProtoBuf', () => {
     const GltfContainerLoadingState = components.GltfContainerLoadingState(newEngine)
 
     testComponentSerialization(GltfContainerLoadingState, {
-      currentState: 1
+      currentState: 1,
+      nodePaths: [],
+      meshNames: [],
+      materialNames: [],
+      skinNames: [],
+      animationNames: []
     })
   })
 })

--- a/test/ecs/components/GltfNodeModifiers.spec.ts
+++ b/test/ecs/components/GltfNodeModifiers.spec.ts
@@ -38,65 +38,71 @@ describe('Generated GltfNodeModifiers ProtoBuf', () => {
         {
           path: 'test/path',
           castShadows: false,
-          material: createPbrMaterial({
-            albedoColor: { r: 0, g: 1, b: 1, a: 1 },
-            alphaTest: 1,
-            alphaTexture: undefined,
-            bumpTexture: {
-              tex: {
-                $case: 'texture',
-                texture: {
-                  wrapMode: TextureWrapMode.TWM_MIRROR,
-                  filterMode: TextureFilterMode.TFM_POINT,
-                  src: 'not-casla',
-                  tiling: undefined,
-                  offset: undefined
+          material: {
+            gltf: undefined,
+            ...createPbrMaterial({
+              albedoColor: { r: 0, g: 1, b: 1, a: 1 },
+              alphaTest: 1,
+              alphaTexture: undefined,
+              bumpTexture: {
+                tex: {
+                  $case: 'texture',
+                  texture: {
+                    wrapMode: TextureWrapMode.TWM_MIRROR,
+                    filterMode: TextureFilterMode.TFM_POINT,
+                    src: 'not-casla',
+                    tiling: undefined,
+                    offset: undefined
+                  }
                 }
-              }
-            },
-            emissiveTexture: {
-              tex: {
-                $case: 'texture',
-                texture: {
-                  wrapMode: TextureWrapMode.TWM_MIRROR,
-                  filterMode: TextureFilterMode.TFM_TRILINEAR,
-                  src: 'not-casla',
-                  tiling: undefined,
-                  offset: undefined
+              },
+              emissiveTexture: {
+                tex: {
+                  $case: 'texture',
+                  texture: {
+                    wrapMode: TextureWrapMode.TWM_MIRROR,
+                    filterMode: TextureFilterMode.TFM_TRILINEAR,
+                    src: 'not-casla',
+                    tiling: undefined,
+                    offset: undefined
+                  }
                 }
-              }
-            },
-            texture: {
-              tex: {
-                $case: 'avatarTexture',
-                avatarTexture: {
-                  userId: '',
-                  wrapMode: TextureWrapMode.TWM_REPEAT,
-                  filterMode: undefined
+              },
+              texture: {
+                tex: {
+                  $case: 'avatarTexture',
+                  avatarTexture: {
+                    userId: '',
+                    wrapMode: TextureWrapMode.TWM_REPEAT,
+                    filterMode: undefined
+                  }
                 }
-              }
-            },
-            castShadows: true,
-            directIntensity: 1,
-            emissiveColor: { r: 0, g: 0, b: 1 },
-            reflectivityColor: { r: 0, g: 0, b: 1 },
-            emissiveIntensity: 0,
-            metallic: 1,
-            roughness: 1,
-            specularIntensity: 0,
-            transparencyMode: MaterialTransparencyMode.MTM_ALPHA_BLEND
-          })
+              },
+              castShadows: true,
+              directIntensity: 1,
+              emissiveColor: { r: 0, g: 0, b: 1 },
+              reflectivityColor: { r: 0, g: 0, b: 1 },
+              emissiveIntensity: 0,
+              metallic: 1,
+              roughness: 1,
+              specularIntensity: 0,
+              transparencyMode: MaterialTransparencyMode.MTM_ALPHA_BLEND
+            })
+          }
         },
         {
           path: 'test/path',
           castShadows: false,
-          material: createUnlitMaterial({
-            castShadows: true,
-            diffuseColor: { r: 0, g: 1, b: 1, a: 1 },
-            alphaTexture: undefined,
-            alphaTest: undefined,
-            texture: undefined
-          })
+          material: {
+            gltf: undefined,
+            ...createUnlitMaterial({
+              castShadows: true,
+              diffuseColor: { r: 0, g: 1, b: 1, a: 1 },
+              alphaTexture: undefined,
+              alphaTest: undefined,
+              texture: undefined
+            })
+          }
         }
       ]
     })

--- a/test/ecs/components/Material.spec.ts
+++ b/test/ecs/components/Material.spec.ts
@@ -35,9 +35,9 @@ describe('Generated Material ProtoBuf', () => {
     const newEngine = Engine()
     const Material = components.Material(newEngine)
 
-    testComponentSerialization(
-      Material,
-      createPbrMaterial({
+    testComponentSerialization(Material, {
+      gltf: undefined,
+      ...createPbrMaterial({
         texture: {
           tex: {
             $case: 'avatarTexture',
@@ -63,11 +63,11 @@ describe('Generated Material ProtoBuf', () => {
         bumpTexture: undefined,
         emissiveTexture: undefined
       })
-    )
+    })
 
-    testComponentSerialization(
-      Material,
-      createPbrMaterial({
+    testComponentSerialization(Material, {
+      gltf: undefined,
+      ...createPbrMaterial({
         albedoColor: { r: 0, g: 1, b: 1, a: 1 },
         alphaTest: 1,
         alphaTexture: undefined,
@@ -115,18 +115,18 @@ describe('Generated Material ProtoBuf', () => {
         specularIntensity: 0,
         transparencyMode: MaterialTransparencyMode.MTM_ALPHA_BLEND
       })
-    )
+    })
 
-    testComponentSerialization(
-      Material,
-      createUnlitMaterial({
+    testComponentSerialization(Material, {
+      gltf: undefined,
+      ...createUnlitMaterial({
         castShadows: true,
         diffuseColor: { r: 0, g: 1, b: 1, a: 1 },
         alphaTexture: undefined,
         alphaTest: undefined,
         texture: undefined
       })
-    )
+    })
   })
 
   it('should test all helper cases', () => {

--- a/test/ecs/components/MeshCollider.spec.ts
+++ b/test/ecs/components/MeshCollider.spec.ts
@@ -103,4 +103,19 @@ describe('Generated MeshCollider ProtoBuf', () => {
     })
     expect(ColliderLayer.CL_PLAYER | ColliderLayer.CL_MAIN_PLAYER).toBe(12)
   })
+
+  it('should set a gltf mesh collider', () => {
+    const newEngine = Engine()
+    const entity = newEngine.addEntity()
+    const MeshCollider = components.MeshCollider(newEngine)
+
+    MeshCollider.setGltfMesh(entity, 'models/test.glb', 'someGltfMeshName', [
+      ColliderLayer.CL_POINTER,
+      ColliderLayer.CL_PHYSICS
+    ])
+    expect(MeshCollider.get(entity)).toStrictEqual({
+      collisionMask: ColliderLayer.CL_POINTER | ColliderLayer.CL_PHYSICS,
+      mesh: { $case: 'gltf', gltf: { gltfSrc: 'models/test.glb', name: 'someGltfMeshName' } }
+    })
+  })
 })

--- a/test/ecs/components/MeshRenderer.spec.ts
+++ b/test/ecs/components/MeshRenderer.spec.ts
@@ -93,4 +93,15 @@ describe('Generated MeshRenderer ProtoBuf', () => {
       }
     })
   })
+
+  it('should set a gltf mesh', () => {
+    const newEngine = Engine()
+    const MeshRenderer = components.MeshRenderer(newEngine)
+    const entity = newEngine.addEntity()
+
+    MeshRenderer.setGltfMesh(entity, 'models/test.glb', 'someGltfMeshName')
+    expect(MeshRenderer.get(entity)).toStrictEqual({
+      mesh: { $case: 'gltf', gltf: { gltfSrc: 'models/test.glb', name: 'someGltfMeshName' } }
+    })
+  })
 })

--- a/test/ecs/components/Raycast.spec.ts
+++ b/test/ecs/components/Raycast.spec.ts
@@ -1,4 +1,4 @@
-﻿import { Engine, components, RaycastQueryType } from '../../../packages/@dcl/ecs/src'
+﻿import { Engine, components, RaycastQueryType, RaycastShape } from '../../../packages/@dcl/ecs/src'
 import { Vector3 } from '../../../packages/@dcl/sdk/math'
 import { testComponentSerialization } from './assertion'
 
@@ -14,7 +14,9 @@ describe('Generated Raycast ProtoBuf', () => {
       timestamp: 0,
       direction: { $case: 'globalDirection', globalDirection: Vector3.Forward() },
       maxDistance: 100,
-      queryType: RaycastQueryType.RQT_HIT_FIRST
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      shape: RaycastShape.RS_RAY,
+      includeWorld: false
     })
 
     testComponentSerialization(Raycast, {
@@ -24,7 +26,9 @@ describe('Generated Raycast ProtoBuf', () => {
       timestamp: 0,
       direction: { $case: 'globalTarget', globalTarget: Vector3.Forward() },
       maxDistance: Infinity,
-      queryType: RaycastQueryType.RQT_HIT_FIRST
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      shape: RaycastShape.RS_RAY,
+      includeWorld: false
     })
 
     testComponentSerialization(Raycast, {
@@ -34,7 +38,9 @@ describe('Generated Raycast ProtoBuf', () => {
       timestamp: 0,
       direction: { $case: 'localDirection', localDirection: Vector3.Forward() },
       maxDistance: Infinity,
-      queryType: RaycastQueryType.RQT_HIT_FIRST
+      queryType: RaycastQueryType.RQT_HIT_FIRST,
+      shape: RaycastShape.RS_RAY,
+      includeWorld: false
     })
   })
 })

--- a/test/ecs/components/UiComponent.spec.ts
+++ b/test/ecs/components/UiComponent.spec.ts
@@ -89,6 +89,9 @@ describe('UiTransform component', () => {
       borderLeftColor: undefined,
       borderRightColor: undefined,
       opacity: undefined,
+      elementId: undefined,
+      scrollPosition: undefined,
+      scrollVisible: undefined,
       zIndex: undefined
     })
   })

--- a/test/ecs/components/UiInput.spec.ts
+++ b/test/ecs/components/UiInput.spec.ts
@@ -15,7 +15,9 @@ describe('UiInput component', () => {
       placeholderColor: Color4.Blue(),
       textAlign: TextAlignMode.TAM_BOTTOM_CENTER,
       font: Font.F_SANS_SERIF,
-      fontSize: 14
+      fontSize: 14,
+      multiLine: true,
+      clearOnSubmit: false
     })
   })
 })

--- a/test/ecs/events/system.spec.ts
+++ b/test/ecs/events/system.spec.ts
@@ -339,4 +339,91 @@ describe('Events System', () => {
     const feedback = PointerEvents.getOrNull(entity)?.pointerEvents
     expect(feedback?.length).toBe(0)
   })
+
+  it('should run pointer drag', async () => {
+    const entity = engine.addEntity()
+    let counter = 0
+    EventsSystem.onPointerDrag({ entity }, () => {
+      counter += 1
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG)
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('should remove pointer drag', async () => {
+    const entity = engine.addEntity()
+    const PointerEvents = components.PointerEvents(engine)
+    let counter = 0
+    EventsSystem.onPointerDrag({ entity, opts: { hoverText: 'test' } }, () => {
+      counter += 1
+      EventsSystem.removeOnPointerDrag(entity)
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG)
+    await engine.update(1)
+    expect(counter).toBe(1)
+
+    await engine.update(1)
+    expect(counter).toBe(1)
+    const feedback = PointerEvents.getOrNull(entity)?.pointerEvents
+    expect(feedback?.length).toBe(0)
+  })
+
+  it('should run pointer drag locked', async () => {
+    const entity = engine.addEntity()
+    let counter = 0
+    EventsSystem.onPointerDragLocked({ entity }, () => {
+      counter += 1
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG_LOCKED)
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('should remove pointer drag locked', async () => {
+    const entity = engine.addEntity()
+    const PointerEvents = components.PointerEvents(engine)
+    let counter = 0
+    EventsSystem.onPointerDragLocked({ entity, opts: { hoverText: 'test' } }, () => {
+      counter += 1
+      EventsSystem.removeOnPointerDragLocked(entity)
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG_LOCKED)
+    await engine.update(1)
+    expect(counter).toBe(1)
+
+    await engine.update(1)
+    expect(counter).toBe(1)
+    const feedback = PointerEvents.getOrNull(entity)?.pointerEvents
+    expect(feedback?.length).toBe(0)
+  })
+
+  it('should run pointer drag end', async () => {
+    const entity = engine.addEntity()
+    let counter = 0
+    EventsSystem.onPointerDragEnd({ entity }, () => {
+      counter += 1
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG_END)
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('should remove pointer drag end', async () => {
+    const entity = engine.addEntity()
+    const PointerEvents = components.PointerEvents(engine)
+    let counter = 0
+    EventsSystem.onPointerDragEnd({ entity, opts: { hoverText: 'test' } }, () => {
+      counter += 1
+      EventsSystem.removeOnPointerDragEnd(entity)
+    })
+    fakePointer(entity, PointerEventType.PET_DRAG_END)
+    await engine.update(1)
+    expect(counter).toBe(1)
+
+    await engine.update(1)
+    expect(counter).toBe(1)
+    const feedback = PointerEvents.getOrNull(entity)?.pointerEvents
+    expect(feedback?.length).toBe(0)
+  })
 })

--- a/test/react-ecs/background.spec.tsx
+++ b/test/react-ecs/background.spec.tsx
@@ -128,6 +128,25 @@ describe('UiBackground React Ecs', () => {
         }
       }
     })
+
+    backgroundProps = {
+      uiBackground: {
+        videoTexture: {
+          videoPlayerEntity: 512 as Entity,
+          wrapMode: 'repeat'
+        }
+      }
+    }
+    await engine.update(1)
+    expect(getBackground()?.texture).toMatchObject({
+      tex: {
+        $case: 'videoTexture',
+        videoTexture: {
+          videoPlayerEntity: 512,
+          wrapMode: TextureWrapMode.TWM_REPEAT
+        }
+      }
+    })
   })
 
   it('should text undefined background', async () => {

--- a/test/react-ecs/listeners.spec.tsx
+++ b/test/react-ecs/listeners.spec.tsx
@@ -1,5 +1,5 @@
 import { Entity } from '../../packages/@dcl/ecs'
-import { components, PointerEventType } from '../../packages/@dcl/ecs/src'
+import { components, PBPointerEventsResult, PointerEventType } from '../../packages/@dcl/ecs/src'
 import { ReactEcs, UiEntity } from '../../packages/@dcl/react-ecs/src'
 import { createTestPointerDownCommand } from '../ecs/events/utils'
 import { setupEngine } from './utils'
@@ -235,5 +235,184 @@ describe('Ui MouseLeave React Ecs', () => {
     mouseLeaveEvent()
     await engine.update(1)
     expect(counter).toBe(8888)
+  })
+})
+
+describe('Ui onMouseDrag React Ecs', () => {
+  const { engine, uiRenderer } = setupEngine()
+
+  const PointerEventsResult = components.PointerEventsResult(engine)
+  const uiEntity = ((engine.addEntity() as number) + 1) as Entity
+  let fakeCounter = 0
+  const dragEvent = () => {
+    PointerEventsResult.addValue(
+      uiEntity,
+      createTestPointerDownCommand(uiEntity, fakeCounter + 1, PointerEventType.PET_DRAG)
+    )
+    fakeCounter += 1
+  }
+  let counter = 0
+  let onMouseDrag: (() => void) | undefined = () => {
+    counter++
+  }
+
+  const ui = () => <UiEntity uiTransform={{ width: 100 }} onMouseDrag={onMouseDrag} />
+  uiRenderer.setUiRenderer(ui)
+
+  it('the counter should be 0 at the beginning', async () => {
+    expect(counter).toBe(0)
+    await engine.update(1)
+  })
+
+  it('a PET_DRAG event calls onMouseDrag and increments the counter', async () => {
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('after removing the onMouseDrag handler the counter no longer increments', async () => {
+    onMouseDrag = undefined
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('a replaced onMouseDrag callback is the one that gets called', async () => {
+    onMouseDrag = () => {
+      counter = 8888
+    }
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(8888)
+  })
+})
+
+describe('Ui onMouseDragLocked React Ecs', () => {
+  const { engine, uiRenderer } = setupEngine()
+
+  const PointerEventsResult = components.PointerEventsResult(engine)
+  const uiEntity = ((engine.addEntity() as number) + 1) as Entity
+  let fakeCounter = 0
+  const dragEvent = () => {
+    PointerEventsResult.addValue(
+      uiEntity,
+      createTestPointerDownCommand(uiEntity, fakeCounter + 1, PointerEventType.PET_DRAG_LOCKED)
+    )
+    fakeCounter += 1
+  }
+  let counter = 0
+  let onMouseDragLocked: (() => void) | undefined = () => {
+    counter++
+  }
+
+  const ui = () => <UiEntity uiTransform={{ width: 100 }} onMouseDragLocked={onMouseDragLocked} />
+  uiRenderer.setUiRenderer(ui)
+
+  it('the counter should be 0 at the beginning', async () => {
+    expect(counter).toBe(0)
+    await engine.update(1)
+  })
+
+  it('a PET_DRAG_LOCKED event calls onMouseDragLocked and increments the counter', async () => {
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('after removing the onMouseDragLocked handler the counter no longer increments', async () => {
+    onMouseDragLocked = undefined
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('a replaced onMouseDragLocked callback is the one that gets called', async () => {
+    onMouseDragLocked = () => {
+      counter = 8888
+    }
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(8888)
+  })
+})
+
+describe('Ui onMouseDragEnd React Ecs', () => {
+  const { engine, uiRenderer } = setupEngine()
+
+  const PointerEventsResult = components.PointerEventsResult(engine)
+  const uiEntity = ((engine.addEntity() as number) + 1) as Entity
+  let fakeCounter = 0
+  const dragEvent = () => {
+    PointerEventsResult.addValue(
+      uiEntity,
+      createTestPointerDownCommand(uiEntity, fakeCounter + 1, PointerEventType.PET_DRAG_END)
+    )
+    fakeCounter += 1
+  }
+  let counter = 0
+  let onMouseDragEnd: (() => void) | undefined = () => {
+    counter++
+  }
+
+  const ui = () => <UiEntity uiTransform={{ width: 100 }} onMouseDragEnd={onMouseDragEnd} />
+  uiRenderer.setUiRenderer(ui)
+
+  it('the counter should be 0 at the beginning', async () => {
+    expect(counter).toBe(0)
+    await engine.update(1)
+  })
+
+  it('a PET_DRAG_END event calls onMouseDragEnd and increments the counter', async () => {
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('after removing the onMouseDragEnd handler the counter no longer increments', async () => {
+    onMouseDragEnd = undefined
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(1)
+  })
+
+  it('a replaced onMouseDragEnd callback is the one that gets called', async () => {
+    onMouseDragEnd = () => {
+      counter = 8888
+    }
+    await engine.update(1)
+    dragEvent()
+    await engine.update(1)
+    expect(counter).toBe(8888)
+  })
+})
+
+describe('Ui listener callbacks receive the pointer event', () => {
+  const { engine, uiRenderer } = setupEngine()
+  const PointerEventsResult = components.PointerEventsResult(engine)
+  const uiEntity = ((engine.addEntity() as number) + 1) as Entity
+  let received: PBPointerEventsResult | undefined
+  const ui = () => (
+    <UiEntity
+      uiTransform={{ width: 100 }}
+      onMouseDrag={(event) => {
+        received = event
+      }}
+    />
+  )
+  uiRenderer.setUiRenderer(ui)
+
+  it('passes the PointerEventsResult that fired the handler', async () => {
+    await engine.update(1)
+    const command = createTestPointerDownCommand(uiEntity, 1, PointerEventType.PET_DRAG)
+    PointerEventsResult.addValue(uiEntity, command)
+    await engine.update(1)
+    expect(received).toBeDefined()
+    expect(received?.state).toBe(PointerEventType.PET_DRAG)
+    expect(received?.hit).toStrictEqual(command.hit)
   })
 })

--- a/test/react-ecs/texture-renderer.spec.tsx
+++ b/test/react-ecs/texture-renderer.spec.tsx
@@ -1,0 +1,72 @@
+import { Entity } from '../../packages/@dcl/ecs'
+import { components } from '../../packages/@dcl/ecs/src'
+import { ReactEcs, UiEntity } from '../../packages/@dcl/react-ecs/src'
+import { setupEngine } from './utils'
+
+describe('Texture renderer', () => {
+  it('parents every entity of the tree to the canvas entity and tears down with it', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const Transform = components.Transform(engine)
+    const UiTransform = components.UiTransform(engine)
+    const canvas = engine.addEntity()
+    const ui = () => (
+      <UiEntity uiTransform={{ width: 100 }}>
+        <UiEntity uiTransform={{ width: 50 }} />
+      </UiEntity>
+    )
+
+    uiRenderer.setTextureRenderer(canvas, ui)
+    await engine.update(1)
+
+    const uiEntities = Array.from(engine.getEntitiesWith(UiTransform)).map(([entity]) => entity)
+    expect(uiEntities).toHaveLength(2)
+    for (const entity of uiEntities) {
+      expect(Transform.get(entity).parent).toBe(canvas)
+    }
+
+    engine.removeEntity(canvas)
+    // removal is processed at the end of this tick; the UI system cleans up on the next
+    await engine.update(1)
+    await engine.update(1)
+    expect(Array.from(engine.getEntitiesWith(UiTransform))).toHaveLength(0)
+  })
+
+  it('replaces the tree when set again and destroys it on remove', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const canvas = engine.addEntity()
+    const count = () => Array.from(engine.getEntitiesWith(UiTransform)).length
+
+    uiRenderer.setTextureRenderer(canvas, () => <UiEntity uiTransform={{ width: 100 }} />)
+    await engine.update(1)
+    expect(count()).toBe(1)
+
+    uiRenderer.setTextureRenderer(canvas, () => (
+      <UiEntity uiTransform={{ width: 100 }}>
+        <UiEntity uiTransform={{ width: 50 }} />
+      </UiEntity>
+    ))
+    await engine.update(1)
+    expect(count()).toBe(2)
+
+    uiRenderer.removeTextureRenderer(canvas)
+    await engine.update(1)
+    expect(count()).toBe(0)
+  })
+
+  it('does not interfere with the main screen UI', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const Transform = components.Transform(engine)
+    const UiTransform = components.UiTransform(engine)
+    const canvas = engine.addEntity()
+
+    uiRenderer.setUiRenderer(() => <UiEntity uiTransform={{ width: 1 }} />, { screenInset: 'none' })
+    uiRenderer.setTextureRenderer(canvas, () => <UiEntity uiTransform={{ width: 2 }} />)
+    await engine.update(1)
+
+    const parents = Array.from(engine.getEntitiesWith(UiTransform)).map(
+      ([entity]) => Transform.getOrNull(entity)?.parent
+    )
+    expect(parents.sort()).toEqual([canvas, undefined].sort())
+  })
+})

--- a/test/react-ecs/transform.spec.tsx
+++ b/test/react-ecs/transform.spec.tsx
@@ -11,7 +11,7 @@ import {
   PointerFilterMode,
   PBUiTransform
 } from '../../packages/@dcl/ecs'
-import { components } from '../../packages/@dcl/ecs/src'
+import { components, ShowScrollBar } from '../../packages/@dcl/ecs/src'
 import {
   BorderRadius,
   Position,
@@ -672,5 +672,31 @@ describe('UiTransform React Ecs', () => {
     expect(getUiTransform(rootDivEntity)).toMatchObject({
       opacity: 1
     })
+  })
+
+  it('should parse scroll props', async () => {
+    const { engine, uiRenderer } = setupEngine()
+    const UiTransform = components.UiTransform(engine)
+    const byElementId = (id: string) =>
+      Array.from(engine.getEntitiesWith(UiTransform)).find(([, transform]) => transform.elementId === id)![1]
+
+    const ui = () => (
+      <UiEntity
+        uiTransform={{ overflow: 'scroll', elementId: 'list', scrollPosition: 'item-3', scrollVisible: 'vertical' }}
+      >
+        <UiEntity uiTransform={{ elementId: 'item-3', scrollPosition: { x: 10, y: 20 } }} />
+      </UiEntity>
+    )
+
+    uiRenderer.setUiRenderer(ui, WHOLE_SCREEN)
+    await engine.update(1)
+    expect(byElementId('list')).toMatchObject({
+      scrollPosition: { value: { $case: 'reference', reference: 'item-3' } },
+      scrollVisible: ShowScrollBar.SSB_ONLY_VERTICAL
+    })
+    expect(byElementId('item-3')).toMatchObject({
+      scrollPosition: { value: { $case: 'position', position: { x: 10, y: 20 } } }
+    })
+    expect(byElementId('item-3').scrollVisible).toBeUndefined()
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=673.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=674.8k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 18003
+  MALLOC_COUNT = 18035
   ALIVE_OBJS_DELTA ~= 3.56k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1651.66k bytes
+  MEMORY_USAGE_COUNT ~= 1654.38k bytes

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=673.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 74k
-  MALLOC_COUNT = 16880
-  ALIVE_OBJS_DELTA ~= 3.31k
+  OPCODES ~= 79k
+  MALLOC_COUNT = 18003
+  ALIVE_OBJS_DELTA ~= 3.56k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.59k bytes
+  MEMORY_USAGE_COUNT ~= 1651.66k bytes

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=673.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 74k
-  MALLOC_COUNT = 16884
-  ALIVE_OBJS_DELTA ~= 3.31k
+  OPCODES ~= 79k
+  MALLOC_COUNT = 18003
+  ALIVE_OBJS_DELTA ~= 3.56k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -46,7 +46,7 @@ CALL onStart()
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"ensure that cubes are in the scene on the first frame"}]}
   OPCODES ~= 20k
-  MALLOC_COUNT = 67
+  MALLOC_COUNT = 69
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
   LOG: ["🧪 Running test ensure that cubes are in the scene on the first frame"]
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.12k bytes
+  MEMORY_USAGE_COUNT ~= 1651.66k bytes

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=674.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=678.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 79k
-  MALLOC_COUNT = 18035
-  ALIVE_OBJS_DELTA ~= 3.56k
+  OPCODES ~= 80k
+  MALLOC_COUNT = 18130
+  ALIVE_OBJS_DELTA ~= 3.58k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   main.crdt: PUT_COMPONENT e=0x202 c=1 t=0 data={"position":{"x":4,"y":0.800000011920929,"z":8},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -46,7 +46,7 @@ CALL onStart()
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"ensure that cubes are in the scene on the first frame"}]}
   OPCODES ~= 20k
-  MALLOC_COUNT = 69
+  MALLOC_COUNT = 67
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
   LOG: ["🧪 Running test ensure that cubes are in the scene on the first frame"]
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1654.38k bytes
+  MEMORY_USAGE_COUNT ~= 1660.74k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=675.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18558
+  MALLOC_COUNT = 18584
   ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -28,7 +28,6 @@ CALL onUpdate(0.1)
   LOG: ["🧪 Running test two way communication"]
   LOG: ["✅ RootEntity has a transform"]
   LOG: ["✅ RootEntity has the correct scale"]
-  LOG: ["⏱️ yield"]
   Scene: PUT_COMPONENT e=0x0 c=1 t=2 data={"position":{"x":1,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
@@ -37,7 +36,6 @@ CALL onUpdate(0.1)
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
-  LOG: ["⏱️ yield"]
   Scene: DELETE_COMPONENT e=0x200 c=1 t=2 data=null
   Scene: DELETE_COMPONENT e=0x0 c=1 t=4 data=null
   Scene: DELETE_ENTITY e=0x200
@@ -45,7 +43,6 @@ CALL onUpdate(0.1)
   MALLOC_COUNT = -78
   ALIVE_OBJS_DELTA ~= -0.03k
 CALL onUpdate(0.1)
-  LOG: ["⏱️ yield"]
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -61,4 +58,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1657.43k bytes
+  MEMORY_USAGE_COUNT ~= 1659.51k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 84k
-  MALLOC_COUNT = 17435
-  ALIVE_OBJS_DELTA ~= 3.47k
+  OPCODES ~= 89k
+  MALLOC_COUNT = 18558
+  ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1657.43k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 84k
-  MALLOC_COUNT = 17439
-  ALIVE_OBJS_DELTA ~= 3.47k
+  OPCODES ~= 89k
+  MALLOC_COUNT = 18558
+  ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1657.43k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=675.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=678.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,8 +10,8 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18584
-  ALIVE_OBJS_DELTA ~= 3.72k
+  MALLOC_COUNT = 18679
+  ALIVE_OBJS_DELTA ~= 3.74k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -58,4 +58,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1659.51k bytes
+  MEMORY_USAGE_COUNT ~= 1665.93k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622k bytes
+SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 84k
-  MALLOC_COUNT = 17435
-  ALIVE_OBJS_DELTA ~= 3.47k
+  OPCODES ~= 89k
+  MALLOC_COUNT = 18558
+  ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.35k bytes
+  MEMORY_USAGE_COUNT ~= 1657.43k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=675.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18558
+  MALLOC_COUNT = 18584
   ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -28,7 +28,6 @@ CALL onUpdate(0.1)
   LOG: ["🧪 Running test two way communication"]
   LOG: ["✅ RootEntity has a transform"]
   LOG: ["✅ RootEntity has the correct scale"]
-  LOG: ["⏱️ yield"]
   Scene: PUT_COMPONENT e=0x0 c=1 t=2 data={"position":{"x":1,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
@@ -37,7 +36,6 @@ CALL onUpdate(0.1)
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
-  LOG: ["⏱️ yield"]
   Scene: DELETE_COMPONENT e=0x200 c=1 t=2 data=null
   Scene: DELETE_COMPONENT e=0x0 c=1 t=4 data=null
   Scene: DELETE_ENTITY e=0x200
@@ -45,7 +43,6 @@ CALL onUpdate(0.1)
   MALLOC_COUNT = -78
   ALIVE_OBJS_DELTA ~= -0.03k
 CALL onUpdate(0.1)
-  LOG: ["⏱️ yield"]
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -61,4 +58,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1657.43k bytes
+  MEMORY_USAGE_COUNT ~= 1659.51k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=675.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=678.9k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,8 +10,8 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18584
-  ALIVE_OBJS_DELTA ~= 3.72k
+  MALLOC_COUNT = 18679
+  ALIVE_OBJS_DELTA ~= 3.74k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -58,4 +58,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1659.51k bytes
+  MEMORY_USAGE_COUNT ~= 1665.93k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=674.4k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -9,9 +9,9 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 84k
-  MALLOC_COUNT = 17439
-  ALIVE_OBJS_DELTA ~= 3.47k
+  OPCODES ~= 89k
+  MALLOC_COUNT = 18558
+  ALIVE_OBJS_DELTA ~= 3.72k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=1 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1657.43k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
+        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
+        "@dcl/protocol": "1.0.0-33668585153.commit-4a844e9",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-32863591307.commit-0b3d285",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
+        "@dcl/protocol": "1.0.0-33247403125.commit-6e4ee4a",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33219725173.commit-dc40022.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33674022401.commit-882d4ee",
+        "@dcl/protocol": "1.0.0-34100371654.commit-2ed0bdc",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=294.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=294.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 93k
-  MALLOC_COUNT = 16806
-  ALIVE_OBJS_DELTA ~= 3.78k
+  MALLOC_COUNT = 16830
+  ALIVE_OBJS_DELTA ~= 3.79k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1210.74k bytes
+  MEMORY_USAGE_COUNT ~= 1212.43k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=294.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 88k
-  MALLOC_COUNT = 15760
-  ALIVE_OBJS_DELTA ~= 3.53k
+  OPCODES ~= 93k
+  MALLOC_COUNT = 16806
+  ALIVE_OBJS_DELTA ~= 3.78k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.45k bytes
+  MEMORY_USAGE_COUNT ~= 1210.74k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=294.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=296.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 93k
-  MALLOC_COUNT = 16830
-  ALIVE_OBJS_DELTA ~= 3.79k
+  OPCODES ~= 94k
+  MALLOC_COUNT = 16919
+  ALIVE_OBJS_DELTA ~= 3.81k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1212.43k bytes
+  MEMORY_USAGE_COUNT ~= 1217.37k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=294.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 88k
-  MALLOC_COUNT = 15763
-  ALIVE_OBJS_DELTA ~= 3.53k
+  OPCODES ~= 93k
+  MALLOC_COUNT = 16806
+  ALIVE_OBJS_DELTA ~= 3.78k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
   OPCODES ~= 8k
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.80k bytes
+  MEMORY_USAGE_COUNT ~= 1210.74k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=335.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 89k
-  MALLOC_COUNT = 18266
-  ALIVE_OBJS_DELTA ~= 4.00k
+  OPCODES ~= 95k
+  MALLOC_COUNT = 19312
+  ALIVE_OBJS_DELTA ~= 4.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.29k bytes
+  MEMORY_USAGE_COUNT ~= 1396.54k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=335.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=335.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 95k
-  MALLOC_COUNT = 19312
-  ALIVE_OBJS_DELTA ~= 4.25k
+  MALLOC_COUNT = 19341
+  ALIVE_OBJS_DELTA ~= 4.26k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1396.54k bytes
+  MEMORY_USAGE_COUNT ~= 1398.68k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=335.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 89k
-  MALLOC_COUNT = 18269
-  ALIVE_OBJS_DELTA ~= 4.00k
+  OPCODES ~= 95k
+  MALLOC_COUNT = 19312
+  ALIVE_OBJS_DELTA ~= 4.25k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.64k bytes
+  MEMORY_USAGE_COUNT ~= 1396.54k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=335.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=337.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 95k
-  MALLOC_COUNT = 19341
-  ALIVE_OBJS_DELTA ~= 4.26k
+  MALLOC_COUNT = 19430
+  ALIVE_OBJS_DELTA ~= 4.28k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1398.68k bytes
+  MEMORY_USAGE_COUNT ~= 1403.63k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 14877
-  ALIVE_OBJS_DELTA ~= 3.30k
+  OPCODES ~= 83k
+  MALLOC_COUNT = 15923
+  ALIVE_OBJS_DELTA ~= 3.55k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.53k bytes
+  MEMORY_USAGE_COUNT ~= 1172.82k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 15923
-  ALIVE_OBJS_DELTA ~= 3.55k
+  MALLOC_COUNT = 15950
+  ALIVE_OBJS_DELTA ~= 3.56k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1172.82k bytes
+  MEMORY_USAGE_COUNT ~= 1174.58k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 83k
-  MALLOC_COUNT = 15950
-  ALIVE_OBJS_DELTA ~= 3.56k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16039
+  ALIVE_OBJS_DELTA ~= 3.58k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1174.58k bytes
+  MEMORY_USAGE_COUNT ~= 1179.51k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 14880
-  ALIVE_OBJS_DELTA ~= 3.30k
+  OPCODES ~= 83k
+  MALLOC_COUNT = 15923
+  ALIVE_OBJS_DELTA ~= 3.55k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.87k bytes
+  MEMORY_USAGE_COUNT ~= 1172.82k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 14850
-  ALIVE_OBJS_DELTA ~= 3.29k
+  OPCODES ~= 83k
+  MALLOC_COUNT = 15896
+  ALIVE_OBJS_DELTA ~= 3.54k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.28k bytes
+  MEMORY_USAGE_COUNT ~= 1162.57k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 83k
-  MALLOC_COUNT = 15896
-  ALIVE_OBJS_DELTA ~= 3.54k
+  MALLOC_COUNT = 15920
+  ALIVE_OBJS_DELTA ~= 3.55k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1162.57k bytes
+  MEMORY_USAGE_COUNT ~= 1164.27k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 14853
-  ALIVE_OBJS_DELTA ~= 3.29k
+  OPCODES ~= 83k
+  MALLOC_COUNT = 15896
+  ALIVE_OBJS_DELTA ~= 3.54k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.63k bytes
+  MEMORY_USAGE_COUNT ~= 1162.57k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 83k
-  MALLOC_COUNT = 15920
-  ALIVE_OBJS_DELTA ~= 3.55k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16009
+  ALIVE_OBJS_DELTA ~= 3.57k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1164.27k bytes
+  MEMORY_USAGE_COUNT ~= 1169.20k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=335.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=336k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 134k
-  MALLOC_COUNT = 22649
-  ALIVE_OBJS_DELTA ~= 5.54k
+  OPCODES ~= 135k
+  MALLOC_COUNT = 22678
+  ALIVE_OBJS_DELTA ~= 5.55k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1621.02k bytes
+  MEMORY_USAGE_COUNT ~= 1623.16k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=335.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 129k
-  MALLOC_COUNT = 21603
-  ALIVE_OBJS_DELTA ~= 5.29k
+  OPCODES ~= 134k
+  MALLOC_COUNT = 22649
+  ALIVE_OBJS_DELTA ~= 5.54k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -562,7 +562,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1002k
+  OPCODES ~= 1003k
   MALLOC_COUNT = 6214
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
@@ -924,7 +924,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1286,7 +1286,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1648,7 +1648,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.76k bytes
+  MEMORY_USAGE_COUNT ~= 1621.02k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=335.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 129k
-  MALLOC_COUNT = 21606
-  ALIVE_OBJS_DELTA ~= 5.29k
+  OPCODES ~= 134k
+  MALLOC_COUNT = 22649
+  ALIVE_OBJS_DELTA ~= 5.54k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -562,7 +562,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x2b4 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1018 t=1 data={"mesh":{"$case":"box","box":{"uvs":[]}}}
-  OPCODES ~= 1002k
+  OPCODES ~= 1003k
   MALLOC_COUNT = 6214
   ALIVE_OBJS_DELTA ~= 1.83k
 CALL onUpdate(0.1)
@@ -924,7 +924,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=2 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1286,7 +1286,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=3 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
 CALL onUpdate(0.1)
@@ -1648,7 +1648,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x2b4 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b5 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
   Scene: PUT_COMPONENT e=0x2b6 c=1017 t=4 data={"material":{"$case":"pbr","pbr":{"albedoColor":{"r":0,"g":0,"b":1,"a":1}}}}
-  OPCODES ~= 725k
+  OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.11k bytes
+  MEMORY_USAGE_COUNT ~= 1621.02k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=336k bytes
+SCENE_COMPILED_JS_SIZE_PROD=337.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 135k
-  MALLOC_COUNT = 22678
-  ALIVE_OBJS_DELTA ~= 5.55k
+  MALLOC_COUNT = 22766
+  ALIVE_OBJS_DELTA ~= 5.57k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 727k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1623.16k bytes
+  MEMORY_USAGE_COUNT ~= 1628.08k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=291.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 16189
-  ALIVE_OBJS_DELTA ~= 3.63k
+  MALLOC_COUNT = 16221
+  ALIVE_OBJS_DELTA ~= 3.64k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1182.27k bytes
+  MEMORY_USAGE_COUNT ~= 1184.48k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 79k
-  MALLOC_COUNT = 15143
-  ALIVE_OBJS_DELTA ~= 3.38k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16189
+  ALIVE_OBJS_DELTA ~= 3.63k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.98k bytes
+  MEMORY_USAGE_COUNT ~= 1182.27k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 79k
-  MALLOC_COUNT = 15146
-  ALIVE_OBJS_DELTA ~= 3.38k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16189
+  ALIVE_OBJS_DELTA ~= 3.63k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.33k bytes
+  MEMORY_USAGE_COUNT ~= 1182.27k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=291.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=293.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 84k
-  MALLOC_COUNT = 16221
-  ALIVE_OBJS_DELTA ~= 3.64k
+  OPCODES ~= 85k
+  MALLOC_COUNT = 16310
+  ALIVE_OBJS_DELTA ~= 3.66k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1184.48k bytes
+  MEMORY_USAGE_COUNT ~= 1189.41k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14982
-  ALIVE_OBJS_DELTA ~= 3.33k
+  OPCODES ~= 87k
+  MALLOC_COUNT = 16028
+  ALIVE_OBJS_DELTA ~= 3.58k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1093.73k bytes
+  MEMORY_USAGE_COUNT ~= 1165.02k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 16028
+  MALLOC_COUNT = 16052
   ALIVE_OBJS_DELTA ~= 3.58k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1165.02k bytes
+  MEMORY_USAGE_COUNT ~= 1166.72k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=290.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14985
-  ALIVE_OBJS_DELTA ~= 3.33k
+  OPCODES ~= 87k
+  MALLOC_COUNT = 16028
+  ALIVE_OBJS_DELTA ~= 3.58k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.08k bytes
+  MEMORY_USAGE_COUNT ~= 1165.02k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=290.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=292.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 87k
-  MALLOC_COUNT = 16052
-  ALIVE_OBJS_DELTA ~= 3.58k
+  MALLOC_COUNT = 16141
+  ALIVE_OBJS_DELTA ~= 3.60k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1166.72k bytes
+  MEMORY_USAGE_COUNT ~= 1171.65k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=454.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=457.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,8 +9,8 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 96k
-  MALLOC_COUNT = 24190
-  ALIVE_OBJS_DELTA ~= 4.94k
+  MALLOC_COUNT = 24320
+  ALIVE_OBJS_DELTA ~= 4.97k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = -39
@@ -48,22 +48,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 155k
+  OPCODES ~= 159k
   MALLOC_COUNT = 1012
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 83k
+  OPCODES ~= 85k
   MALLOC_COUNT = 279
   ALIVE_OBJS_DELTA ~= 0.14k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=3 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.017452405765652657,"z":0,"w":0.9998477101325989},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 81k
+  OPCODES ~= 82k
   MALLOC_COUNT = 37
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=4 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.026176948100328445,"z":0,"w":0.9996573328971863},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 81k
+  OPCODES ~= 82k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2050.15k bytes
+  MEMORY_USAGE_COUNT ~= 2063.07k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=454.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,9 +8,9 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 91k
-  MALLOC_COUNT = 23146
-  ALIVE_OBJS_DELTA ~= 4.70k
+  OPCODES ~= 96k
+  MALLOC_COUNT = 24190
+  ALIVE_OBJS_DELTA ~= 4.94k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = -39
@@ -48,7 +48,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 154k
+  OPCODES ~= 155k
   MALLOC_COUNT = 1012
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1978.82k bytes
+  MEMORY_USAGE_COUNT ~= 2050.15k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=457.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=459.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,9 +8,9 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 96k
-  MALLOC_COUNT = 24320
-  ALIVE_OBJS_DELTA ~= 4.97k
+  OPCODES ~= 97k
+  MALLOC_COUNT = 24408
+  ALIVE_OBJS_DELTA ~= 4.99k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = -39
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 82k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 2063.07k bytes
+  MEMORY_USAGE_COUNT ~= 2068.16k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=431k bytes
+SCENE_COMPILED_JS_SIZE_PROD=454.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,9 +8,9 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 91k
-  MALLOC_COUNT = 23149
-  ALIVE_OBJS_DELTA ~= 4.70k
+  OPCODES ~= 96k
+  MALLOC_COUNT = 24190
+  ALIVE_OBJS_DELTA ~= 4.94k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = -39
@@ -48,7 +48,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 154k
+  OPCODES ~= 155k
   MALLOC_COUNT = 1012
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.35k bytes
+  MEMORY_USAGE_COUNT ~= 2050.15k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=291.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 16132
+  MALLOC_COUNT = 16161
   ALIVE_OBJS_DELTA ~= 3.60k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1182.05k bytes
+  MEMORY_USAGE_COUNT ~= 1184.19k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 15086
-  ALIVE_OBJS_DELTA ~= 3.35k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16132
+  ALIVE_OBJS_DELTA ~= 3.60k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1110.76k bytes
+  MEMORY_USAGE_COUNT ~= 1182.05k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=291.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,9 +7,9 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 78k
-  MALLOC_COUNT = 15089
-  ALIVE_OBJS_DELTA ~= 3.35k
+  OPCODES ~= 84k
+  MALLOC_COUNT = 16132
+  ALIVE_OBJS_DELTA ~= 3.60k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.11k bytes
+  MEMORY_USAGE_COUNT ~= 1182.05k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=291.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=293.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 16161
-  ALIVE_OBJS_DELTA ~= 3.60k
+  MALLOC_COUNT = 16250
+  ALIVE_OBJS_DELTA ~= 3.62k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1184.19k bytes
+  MEMORY_USAGE_COUNT ~= 1189.13k bytes


### PR DESCRIPTION
Supersedes #1563 (branch renamed to `experimental-bevy` so pushes publish every package to the `experimental-bevy` npm tag).

**Do not merge.** Integration branch that replaces `protocol-squad` on the SDK side: the squad-track features rebuilt as self-contained commits on top of `main`, pinned to the matching protocol build (decentraland/protocol#472). Opened as a PR so CI publishes `commit-…` package builds for `bevy-explorer` to pin.

One commit per feature:
- `MeshRenderer.setGltfMesh` / `MeshCollider.setGltfMesh`
- `forceRender` on `AvatarShape` / `AvatarEquippedData`, optional for scenes (serialised as `[]` when omitted); `players()` exposes it
- raycast `shape` (avatar capsule sweep) and `includeWorld`
- pointer drag events: `onPointerDrag` / `onPointerDragLocked` / `onPointerDragEnd`, `onMouseDrag*` on react-ecs elements; react-ecs listener callbacks now receive the `PointerEventsResult` that fired them
- `elementId` / `scrollPosition` / `scrollVisible` on `UiTransform`
- `setTextureRenderer(entity, ui)` — render a UI tree to a `UiCanvas` texture (rooted reconciler, torn down with the entity), plus `removeTextureRenderer`
- `videoTexture` background
- drop the per-yield console.log noise from the testing runtime

Everything else on the squad protocol (GlobalLight, TextureCamera, CameraLayer(s), UiCanvas, GltfNode / GltfNodeState, AvatarMovement / AvatarMovementInfo, UiInput `multiLine` / `clearOnSubmit`, the UI focus RPCs, WalkPlayerTo) is pure codegen and needs no SDK code.

Deliberately not carried over from `protocol-squad`: the multi-button / multi-callback UI event system (#1081 — replaced by main's design; drag is on the single-callback model as in #1052), `Label` outline props, the `rendererMessageInspector` debug hook, and the `start` command tweaks that `main` has since superseded (#1502).
