### PR TITLE
sdk-commands: zone Pulse preview for LSD multiplayer testing

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -260,9 +260,12 @@ export async function main(options: Options) {
       const sortedURLs = availableURLs.sort((a, _b) => {
         return a.toLowerCase().includes('localhost') || a.includes('127.0.0.1') || a.includes('0.0.0.0') ? -1 : 1
       })
-      const bevyUrl = `https://decentraland.org/bevy-web/?preview=true&realm=${
+      // Zone Pulse test build: the client and the auth server must target the SAME Pulse
+      // instance for presence to flow, so this pairs with the PULSE_SERVER env set on the
+      // server process in multiplayer-server.ts (web speaks WebTransport, hence :7743).
+      const bevyUrl = `https://decentraland.zone/bevy-web/?preview=true&realm=${
         new URL(sortedURLs[0]).origin
-      }&position=${baseCoords.x},${baseCoords.y}`
+      }&position=${baseCoords.x},${baseCoords.y}&pulseServer=pulse-server.decentraland.zone:7743`
       if (bevyWeb) {
         components.logger.log('Available on:\n')
         components.logger.log(`    ${bevyUrl}`)
@@ -271,7 +274,7 @@ export async function main(options: Options) {
           'Chromium-based browsers require permission for websites to reach localhost (Local Network Access).\n' +
             'When the browser asks to access apps on your device, click "Allow".\n' +
             'If the scene never loads and no prompt appears, enable it manually and reload:\n' +
-            '  chrome://settings/content/siteDetails?site=https%3A%2F%2Fdecentraland.org\n' +
+            '  chrome://settings/content/siteDetails?site=https%3A%2F%2Fdecentraland.zone\n' +
             '  → "Apps on device" (Chrome 145+) or "Local network access" (Chrome 142-144) → Allow'
         )
       }

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -21,6 +21,7 @@ import { wireFileWatcherToWebSockets } from './server/file-watch-notifier'
 import { wireRouter } from './server/routes'
 import { createWsComponent } from './server/ws'
 import { b64HashingFunction } from '../../logic/project-files'
+import { lsdRealmKey } from '../../logic/lsd-realm'
 import { DataLayer, createDataLayer } from './data-layer/rpc'
 import { createExitSignalComponent } from '../../components/exit-signal'
 import { getValidWorkspace } from '../../logic/workspace-validations'
@@ -286,7 +287,10 @@ export async function main(options: Options) {
       }
 
       if (isMobile && !skipClient && lanUrl) {
-        const deepLink = `decentraland://open?preview=${lanUrl}&position=${baseCoords.x},${baseCoords.y}`
+        // Zone Pulse test build: point mobile clients at the same zone Pulse instance and the
+        // same LSD realm key the server derives (see bevyUrl above for the web equivalent).
+        const pulseRealm = encodeURIComponent(lsdRealmKey(workspace.projects[0].workingDirectory))
+        const deepLink = `decentraland://open?preview=${lanUrl}&position=${baseCoords.x},${baseCoords.y}&pulse-realm=${pulseRealm}&pulse-server=pulse-server.decentraland.zone:7777`
         QRCode.toString(deepLink, { type: 'terminal', small: true }, (err, qr) => {
           if (!err) {
             components.logger.log(colors.bold('\nScan to preview on mobile: \n'))

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,10 +11,9 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-// `latest` moves only when someone dispatches bevy-explorer's publish-headless
-// workflow with dist_tag=latest — engine pushes to main land on `next` and cannot
-// change what previews run. DCL_SERVER_PACKAGE overrides for local builds.
-const BEVY_VERSION = 'latest'
+// Zone Pulse test build: the Pulse-capable engine (bevy-explorer #1137) is only published
+// on `next` — `latest` still predates it. DCL_SERVER_PACKAGE overrides for local builds.
+const BEVY_VERSION = 'next'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
 // missing binary, bad arguments). We fail the preview loudly instead of retrying:
@@ -164,6 +163,13 @@ export function startMultiplayerServer(
   // (scene_runner::renderer_context) and real warnings. An explicit RUST_LOG wins.
   if (engine === 'bevy' && !env.RUST_LOG) {
     env.RUST_LOG = 'warn,scene_runner::renderer_context=info'
+  }
+
+  // Zone Pulse test build: point the engine's Pulse listener at the same zone instance the
+  // web client is sent to (see bevyUrl in index.ts); the server side speaks ENet, hence :7777.
+  // An explicit PULSE_SERVER wins; the engine's own default is the production server.
+  if (engine === 'bevy' && !env.PULSE_SERVER) {
+    env.PULSE_SERVER = 'pulse-server.decentraland.zone:7777'
   }
 
   // Bevy output goes through the line filter below; hammurabi keeps the terminal directly.

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,9 +11,11 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-// Zone Pulse test build: the Pulse-capable engine (bevy-explorer #1137) is only published
-// on `next` — `latest` still predates it. DCL_SERVER_PACKAGE overrides for local builds.
-const BEVY_VERSION = 'next'
+// Zone Pulse test build: exact pin on the bevy-explorer #1137 merge (a2abfe6d) — the
+// Pulse-capable engine. Deliberately NOT the floating `next` tag: engines past #1134 sign
+// gatekeeper requests in a format comms-gatekeeper-local rejects (401), and a moving tag
+// re-broke the rig overnight. DCL_SERVER_PACKAGE overrides for local builds.
+const BEVY_VERSION = '0.1.0-33416687486.commit-a2abfe6'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
 // missing binary, bad arguments). We fail the preview loudly instead of retrying:

--- a/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/multiplayer-server.ts
@@ -11,11 +11,11 @@ const HAMMURABI_PACKAGE = '@dcl/hammurabi-server'
 const HAMMURABI_VERSION = 'next'
 
 const BEVY_PACKAGE = '@dcl-regenesislabs/bevy-headless-server'
-// Zone Pulse test build: exact pin on the bevy-explorer #1137 merge (a2abfe6d) — the
-// Pulse-capable engine. Deliberately NOT the floating `next` tag: engines past #1134 sign
-// gatekeeper requests in a format comms-gatekeeper-local rejects (401), and a moving tag
-// re-broke the rig overnight. DCL_SERVER_PACKAGE overrides for local builds.
-const BEVY_VERSION = '0.1.0-33416687486.commit-a2abfe6'
+// Zone Pulse test build: exact pin on current bevy-explorer main (3926f331), the same
+// engine sdk-multiplayer-server #138 pins for the zone deployment. Deliberately NOT the
+// floating `next` tag: a moving tag re-broke the rig overnight once already.
+// DCL_SERVER_PACKAGE overrides for local builds.
+const BEVY_VERSION = '0.1.0-34588802161.commit-3926f33'
 
 // The bevy server exits with this when it can never run here (unsupported platform,
 // missing binary, bad arguments). We fail the preview loudly instead of retrying:

--- a/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/routes.ts
@@ -10,6 +10,7 @@ import { setupEcs6Endpoints } from './endpoints'
 import { setupStorageEndpoints } from './storage-service'
 import { setupRealmAndComms } from './realm'
 import { getLanUrl } from '../utils'
+import { lsdRealmKey } from '../../../logic/lsd-realm'
 
 export const sceneUpdateClients = new Set<WebSocket>()
 export async function wireRouter(components: PreviewComponents, workspace: Workspace, dataLayer?: DataLayer) {
@@ -52,7 +53,9 @@ export async function wireRouter(components: PreviewComponents, workspace: Works
     }
 
     const [x, y] = baseParcel.split(',')
-    const deepLink = `decentraland://open?preview=${lanUrl}&position=${x},${y}`
+    // Zone Pulse test build: same zone Pulse endpoint + LSD realm key as the terminal QR
+    const pulseRealm = encodeURIComponent(lsdRealmKey(workspace.projects[0].workingDirectory))
+    const deepLink = `decentraland://open?preview=${lanUrl}&position=${x},${y}&pulse-realm=${pulseRealm}&pulse-server=pulse-server.decentraland.zone:7777`
     const qrDataUrl = await QRCode.toDataURL(deepLink)
 
     return {

--- a/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
+++ b/packages/@dcl/sdk-commands/src/logic/lsd-realm.ts
@@ -1,0 +1,27 @@
+// Local Scene Development identity and the Pulse realm key.
+// Pulse matches realms by exact string and nothing is exchanged, so a derivation
+// that drifts is invisible: peers just never see each other.
+// Contract and caveats: docs/lsd-identity-and-pulse-realm.md
+import { createHash } from 'crypto'
+import { b64HashingFunction } from './project-files'
+
+/** Pulse's `MaxRealmLength`. */
+export const PULSE_MAX_REALM_LENGTH = 255
+
+const LSD_REALM_PREFIX = 'lsd:'
+const LSD_REALM_HASHED_PREFIX = 'lsd:sha256:'
+
+/** The scene entity id the preview server already serves, reused verbatim. */
+export function lsdPreviewSceneId(projectRoot: string): string {
+  return b64HashingFunction(projectRoot)
+}
+
+export function lsdRealmKey(projectRoot: string): string {
+  const previewSceneId = lsdPreviewSceneId(projectRoot)
+  const realmKey = LSD_REALM_PREFIX + previewSceneId
+
+  // hashed, not truncated: every party must land on the same string unprompted
+  if (realmKey.length <= PULSE_MAX_REALM_LENGTH) return realmKey
+
+  return LSD_REALM_HASHED_PREFIX + createHash('sha256').update(previewSceneId).digest('hex')
+}


### PR DESCRIPTION
`start` points local scene development at the zone Pulse stack: the bevy-web preview opens on decentraland.zone with `?pulseServer=pulse-server.decentraland.zone:7743`, and the spawned multiplayer server gets `PULSE_SERVER=pulse-server.decentraland.zone:7777` in its env (an explicit `PULSE_SERVER` still wins). The engine dist-tag moves `latest` → `next` because the Pulse-capable engine (decentraland/bevy-explorer#1137) is only published on `next`.

For testing client LSD+Pulse implementations (e.g. decentraland/unity-explorer#9857) against zone: client and server each derive the `lsd:` realm key from the preview server independently, so an sdk-launched server and any client pointed at the same preview + zone Pulse see each other.

Test scene: https://github.com/robtfm/lsd-zone-scene — an auth-server scene whose server broadcasts its player roster (addresses + positions) to all clients through a synced component; clients display it in a UI panel and render a marker sphere at each server-reported position. Its README covers running the server with the published sdk (env vars only) and connecting bevy native / bevy web / unity clients.

Draft: the zone endpoints are hard-coded, so this is a testing branch — if we want it permanent it should gate behind `--dclenv`.