### PR TITLE
fix(ecs): end the cyclic parenting walk at any cycle

### DIFF
--- a/packages/@dcl/ecs/src/systems/cyclicParentingChecker.ts
+++ b/packages/@dcl/ecs/src/systems/cyclicParentingChecker.ts
@@ -1,4 +1,5 @@
 import * as components from '../components'
+import { Entity } from '../engine/entity'
 import { IEngine } from '../engine/types'
 
 /**
@@ -18,16 +19,25 @@ import { IEngine } from '../engine/types'
  */
 export function cyclicParentingChecker(engine: IEngine) {
   const Transform = components.Transform(engine)
+  // Reused by every walk: the checker is synchronous, so only one is ever in
+  // flight. A cycle anywhere above the entity has to end the walk, not only one
+  // the entity is part of, otherwise the ancestors repeat forever.
+  const visited = new Set<Entity>()
+
   return () => {
     for (const entity of Transform.dirtyIterator()) {
+      visited.clear()
+      visited.add(entity)
+
       let transform = Transform.getOrNull(entity)
       while (transform && transform.parent) {
-        if (transform.parent === entity) {
+        if (visited.has(transform.parent)) {
           console.error(`There is a cyclic parent with entity ${entity}`)
           break
-        } else {
-          transform = Transform.getOrNull(transform.parent)
         }
+
+        visited.add(transform.parent)
+        transform = Transform.getOrNull(transform.parent)
       }
     }
   }

--- a/test/ecs/cyclic-parenting.spec.ts
+++ b/test/ecs/cyclic-parenting.spec.ts
@@ -1,0 +1,138 @@
+import { components, cyclicParentingChecker } from '../../packages/@dcl/ecs/src'
+import { Engine, Entity, IEngine } from '../../packages/@dcl/ecs/src/engine'
+
+const errorFor = (entity: Entity) => `There is a cyclic parent with entity ${entity}`
+
+describe('when a dirty transform is parented above a cycle it is not part of', () => {
+  let engine: IEngine
+  let Transform: ReturnType<typeof components.Transform>
+  let consoleError: jest.SpyInstance
+  let insideCycle: Entity
+  let alsoInsideCycle: Entity
+  let outsideCycle: Entity
+
+  beforeEach(async () => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    engine = Engine()
+    Transform = components.Transform(engine)
+    engine.addSystem(cyclicParentingChecker(engine))
+
+    insideCycle = engine.addEntity()
+    alsoInsideCycle = engine.addEntity()
+    outsideCycle = engine.addEntity()
+
+    // The cycle is reported and settles on the tick its own members are dirty.
+    Transform.create(insideCycle).parent = alsoInsideCycle
+    Transform.create(alsoInsideCycle).parent = insideCycle
+    await engine.update(1 / 30)
+    consoleError.mockClear()
+
+    // From here only the entity hanging off the cycle is dirty.
+    Transform.create(outsideCycle).parent = insideCycle
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should finish the update instead of walking the cycle forever', async () => {
+    await expect(engine.update(1 / 30)).resolves.toBeUndefined()
+  })
+
+  it('should report the entity whose ancestors reach the cycle', async () => {
+    await engine.update(1 / 30)
+
+    expect(consoleError).toHaveBeenCalledWith(errorFor(outsideCycle))
+  })
+
+  it('should report it once per tick', async () => {
+    await engine.update(1 / 30)
+
+    expect(consoleError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when a dirty transform is its own parent', () => {
+  let engine: IEngine
+  let Transform: ReturnType<typeof components.Transform>
+  let consoleError: jest.SpyInstance
+  let entity: Entity
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    engine = Engine()
+    Transform = components.Transform(engine)
+    engine.addSystem(cyclicParentingChecker(engine))
+
+    entity = engine.addEntity()
+    Transform.create(entity).parent = entity
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should report that entity', async () => {
+    await engine.update(1 / 30)
+
+    expect(consoleError).toHaveBeenCalledWith(errorFor(entity))
+  })
+})
+
+describe('when a dirty transform has a parent chain that ends at the root', () => {
+  let engine: IEngine
+  let Transform: ReturnType<typeof components.Transform>
+  let consoleError: jest.SpyInstance
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    engine = Engine()
+    Transform = components.Transform(engine)
+    engine.addSystem(cyclicParentingChecker(engine))
+
+    const root = engine.addEntity()
+    const middle = engine.addEntity()
+    const leaf = engine.addEntity()
+    Transform.create(root)
+    Transform.create(middle).parent = root
+    Transform.create(leaf).parent = middle
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should not report anything', async () => {
+    await engine.update(1 / 30)
+
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+})
+
+describe('when two entities of the same cycle are dirty on the same tick', () => {
+  let engine: IEngine
+  let Transform: ReturnType<typeof components.Transform>
+  let consoleError: jest.SpyInstance
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    engine = Engine()
+    Transform = components.Transform(engine)
+    engine.addSystem(cyclicParentingChecker(engine))
+
+    const first = engine.addEntity()
+    const second = engine.addEntity()
+    Transform.create(first).parent = second
+    Transform.create(second).parent = first
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should report each of them', async () => {
+    await engine.update(1 / 30)
+
+    expect(consoleError).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## What / why

`cyclicParentingChecker` walks a dirty transform's ancestors and stops only when it comes back to the entity it started from:

```ts
while (transform && transform.parent) {
  if (transform.parent === entity) { ...report...; break }
  else transform = Transform.getOrNull(transform.parent)
}
```

A cycle that does not include the starting entity is never equal to it, so the walk goes round that cycle forever and the scene thread freezes. There is no recovery: no frames, no input.

Getting there does not take a strange scene. Two entities pointing at each other are reported on the tick they are dirty and then settle. Parent anything onto that pair afterwards and only the newcomer is dirty, so the very next walk is the one that never ends.

The fix tracks the entities seen during a walk and stops on the first repeat. That covers a cycle the entity is part of and one it merely hangs off, and the reported message is unchanged. The `Set` is created once per system and cleared per entity, so the checker still allocates nothing per tick.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/cyclic-parenting|test/ecs/engine'
```

Heads up for anyone checking this against `main`: the first describe in the new file **hangs** there rather than failing, because the defect is an infinite loop in synchronous code and jest cannot interrupt it. Measured with a 40 s alarm on `main` it produced no output and exited 142; on this branch the whole file finishes in under a second. The pre-existing cyclic test in `engine.spec.ts` passes on both.

## Proof

`test/ecs/cyclic-parenting.spec.ts` is new: the entity hanging off a cycle (the hang), an entity that is its own parent, two entities of one cycle both dirty, and a healthy chain that must stay quiet. The changed file keeps 100% statement, branch, function and line coverage.

A scene that reproduces the freeze in-world is at [`cyclic-parenting-hang`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/cyclic-parenting-hang).