### PR TITLE
fix(sdk-commands): keep existing main.crdt entities in code-to-composite

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
@@ -459,6 +459,17 @@ export async function executeSceneCode(
 
   const crdtState = await getMainCrdtFile(components, crdtFilePath)
   const { engine, transport } = initEngine()
+
+  // The scene's own engine is handed this state through crdtGetState, but CRDT
+  // never echoes a received message back to the transport it came from, so the
+  // engine capturing the result would only ever see what the scene itself
+  // creates. Seed it here too, before the scene runs, or every entity already
+  // in main.crdt is dropped when the file is written back.
+  if (crdtState.length) {
+    transport.onmessage!(crdtState)
+    await engine.update(0)
+  }
+
   const restoreRequire = setupRequireHook(engine, transport, crdtState)
 
   try {

--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
@@ -437,6 +437,35 @@ async function bundle(components: Pick<CliComponents, 'fs' | 'logger'>, project:
  *
  * The returned engine can then be used to generate composite/CRDT files.
  */
+/**
+ * Builds the engine that captures the scene's state and seeds it with whatever
+ * `main.crdt` already holds.
+ *
+ * The scene's own engine is handed that state through `crdtGetState`, but CRDT never
+ * echoes a received message back to the transport it came from, so this engine would
+ * otherwise only ever see what the scene itself creates and every entity already in
+ * `main.crdt` would be dropped when the file is written back.
+ *
+ * Exported so that seeding can be covered on its own: executing the bundle needs a
+ * `require` hook that jest's module registry bypasses.
+ *
+ * @internal
+ */
+export async function seedCaptureEngine(
+  components: Pick<CliComponents, 'fs' | 'logger'>,
+  crdtFilePath: string
+): Promise<{ engine: IEngine; transport: Transport; crdtState: Uint8Array }> {
+  const crdtState = await getMainCrdtFile(components, crdtFilePath)
+  const { engine, transport } = initEngine()
+
+  if (crdtState.length) {
+    transport.onmessage!(crdtState)
+    await engine.update(0)
+  }
+
+  return { engine, transport, crdtState }
+}
+
 export async function executeSceneCode(
   components: Pick<CliComponents, 'fs' | 'logger'>,
   project: SceneProject,
@@ -457,18 +486,7 @@ export async function executeSceneCode(
 
   logger.log('Executing scene code to capture engine state...')
 
-  const crdtState = await getMainCrdtFile(components, crdtFilePath)
-  const { engine, transport } = initEngine()
-
-  // The scene's own engine is handed this state through crdtGetState, but CRDT
-  // never echoes a received message back to the transport it came from, so the
-  // engine capturing the result would only ever see what the scene itself
-  // creates. Seed it here too, before the scene runs, or every entity already
-  // in main.crdt is dropped when the file is written back.
-  if (crdtState.length) {
-    transport.onmessage!(crdtState)
-    await engine.update(0)
-  }
+  const { engine, transport, crdtState } = await seedCaptureEngine(components, crdtFilePath)
 
   const restoreRequire = setupRequireHook(engine, transport, crdtState)
 

--- a/test/sdk-commands/commands/code-to-composite/scene-executor.spec.ts
+++ b/test/sdk-commands/commands/code-to-composite/scene-executor.spec.ts
@@ -1,0 +1,104 @@
+import path from 'path'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+
+import * as components from '../../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../../packages/@dcl/ecs/src/engine'
+import { ReadWriteByteBuffer } from '../../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutComponentOperation } from '../../../../packages/@dcl/ecs/src/serialization/crdt/putComponent'
+import { seedCaptureEngine } from '../../../../packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const WORK_DIR = path.resolve(REPO_ROOT, 'tmp/code-to-composite-seed')
+
+/** An entity number well clear of anything the shared engine allocates itself. */
+const PRE_EXISTING_ENTITY = 700 as Entity
+const MODEL_SRC = 'models/from-the-inspector.glb'
+
+function makeLogger() {
+  return { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}
+
+/**
+ * A main.crdt of the shape the Creator Hub writes: one entity carrying components
+ * that exist only in that file, never in the scene's own code.
+ */
+function writeMainCrdt(filePath: string) {
+  const source = Engine()
+  const Transform = components.Transform(source)
+  const GltfContainer = components.GltfContainer(source)
+
+  const transformData = new ReadWriteByteBuffer()
+  Transform.schema.serialize(
+    {
+      position: { x: 8, y: 1, z: 8 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 },
+      parent: 0 as Entity
+    } as any,
+    transformData
+  )
+  const gltfData = new ReadWriteByteBuffer()
+  GltfContainer.schema.serialize({ src: MODEL_SRC } as any, gltfData)
+
+  const out = new ReadWriteByteBuffer()
+  PutComponentOperation.write(PRE_EXISTING_ENTITY, 1, Transform.componentId, transformData.toBinary(), out)
+  PutComponentOperation.write(PRE_EXISTING_ENTITY, 1, GltfContainer.componentId, gltfData.toBinary(), out)
+
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, out.toBinary())
+}
+
+describe('when the capture engine is seeded from an existing main.crdt', () => {
+  let crdtFilePath: string
+  let seeded: Awaited<ReturnType<typeof seedCaptureEngine>>
+
+  beforeEach(async () => {
+    rmSync(WORK_DIR, { recursive: true, force: true })
+    crdtFilePath = path.join(WORK_DIR, 'main.crdt')
+    writeMainCrdt(crdtFilePath)
+
+    seeded = await seedCaptureEngine({ fs: createFsComponent(), logger: makeLogger() } as any, crdtFilePath)
+  })
+
+  afterEach(() => {
+    rmSync(WORK_DIR, { recursive: true, force: true })
+  })
+
+  it('should read the file into the state it hands back', () => {
+    expect(seeded.crdtState.byteLength).toBeGreaterThan(0)
+  })
+
+  it('should keep the entity that existed only in the crdt file', () => {
+    const Transform = components.Transform(seeded.engine as any)
+
+    expect(Transform.getOrNull(PRE_EXISTING_ENTITY)).not.toBe(null)
+  })
+
+  it('should keep the components that came with it', () => {
+    const GltfContainer = components.GltfContainer(seeded.engine as any)
+
+    expect(GltfContainer.getOrNull(PRE_EXISTING_ENTITY)?.src).toBe(MODEL_SRC)
+  })
+})
+
+describe('when there is no main.crdt to seed from', () => {
+  let seeded: Awaited<ReturnType<typeof seedCaptureEngine>>
+
+  beforeEach(async () => {
+    rmSync(WORK_DIR, { recursive: true, force: true })
+
+    seeded = await seedCaptureEngine(
+      { fs: createFsComponent(), logger: makeLogger() } as any,
+      path.join(WORK_DIR, 'missing.crdt')
+    )
+  })
+
+  it('should hand back an empty state instead of failing', () => {
+    expect(seeded.crdtState.byteLength).toBe(0)
+  })
+
+  it('should still give back a usable engine', () => {
+    expect(typeof seeded.engine.addEntity).toBe('function')
+  })
+})


### PR DESCRIPTION
## What / why

`code-to-composite` destroys scene content that was already in `main.crdt`.

It reads the existing file and hands it to the scene through the `crdtGetState` mock, so the scene's own engine does start from it. But the engine that *captures* the result is a different one, and it is fed only by what the scene sends over the transport. CRDT never echoes a received message back to the transport it came from, so those entities never arrive. The command then writes `main.crdt` and `main.composite` from the capture engine, and everything that was in the file is gone.

That hits exactly the hybrid scenes the command is for: anything already authored in the Creator Hub is silently dropped the first time someone runs the migration over it. The prompt warns that files will be moved around, not that existing entities will be deleted.

The fix seeds the capture engine with the same state before the scene runs. Ids cannot collide: the runtime applies this state before the startup system calls `main()`, so the scene's `addEntity()` already allocates past whatever the file used. The reproduction below shows the scene entity landing on 513 both before and after the change.

## How to test

Build the CLI, then make a scene with one entity in code and one entity already in `main.crdt`:

```bash
make build
D=tmp/c2c && rm -rf $D && mkdir -p $D/src $D/node_modules/@dcl
for p in sdk ecs js-runtime; do ln -s "$PWD/packages/@dcl/$p" "$D/node_modules/@dcl/$p"; done
echo '{ "name": "c2c", "version": "1.0.0" }' > $D/package.json
echo '{ "ecs7": true, "runtimeVersion": "7", "display": { "title": "c2c" }, "contact": { "name": "", "email": "" }, "owner": "", "scene": { "parcels": ["0,0"], "base": "0,0" }, "main": "bin/game.js", "tags": [] }' > $D/scene.json
echo '{ "compilerOptions": { "allowJs": true, "baseUrl": "." }, "extends": "@dcl/sdk/types/tsconfig.ecs7.json" }' > $D/tsconfig.json
cat > $D/src/index.ts <<'TS'
import { engine, Transform } from '@dcl/sdk/ecs'
export function main() {
  const entity = engine.addEntity()
  Transform.create(entity, { position: { x: 1, y: 2, z: 3 } })
}
TS
```

Write a `main.crdt` holding entity 512 with a Transform at `7,7,7` and the name `PreExisting`:

```bash
node -e '
const R = process.cwd()
const { Engine, components } = require(R + "/packages/@dcl/ecs/dist-cjs")
const { ReadWriteByteBuffer } = require(R + "/packages/@dcl/ecs/dist-cjs/serialization/ByteBuffer")
const { PutComponentOperation } = require(R + "/packages/@dcl/ecs/dist-cjs/serialization/crdt/putComponent")
const e = Engine(), T = components.Transform(e), N = components.Name(e)
const t = new ReadWriteByteBuffer()
T.schema.serialize({ position: {x:7,y:7,z:7}, scale: {x:1,y:1,z:1}, rotation: {x:0,y:0,z:0,w:1}, parent: 0 }, t)
const m = new ReadWriteByteBuffer()
PutComponentOperation.write(512, 1, T.componentId, t.toBinary(), m)
const n = new ReadWriteByteBuffer()
N.schema.serialize({ value: "PreExisting" }, n)
PutComponentOperation.write(512, 1, N.componentId, n.toBinary(), m)
require("fs").writeFileSync("tmp/c2c/main.crdt", m.toBinary())
'
node packages/@dcl/sdk-commands/dist/index.js code-to-composite --dir tmp/c2c --yes
node -e 'const c=JSON.parse(require("fs").readFileSync("tmp/c2c/assets/scene/main.composite","utf8")); for (const x of c.components) console.log(x.name, "->", Object.keys(x.data).join(","))'
```

## Proof

Measured with the commands above, on `main` and on this branch:

| | entities in the generated main.composite | main.crdt |
| --- | --- | --- |
| `main` | `core::Transform -> 513` | 107 bytes in, **68 bytes out** |
| this branch | `core::Transform -> 512,513` and `core-schema::Name -> 512` | preserved and extended |

On `main` the pre-existing entity, its position and its name are gone from both generated files. On this branch both entities are present and the code-created one still lands on 513.

**No automated test, deliberately.** `executeSceneCode` mocks the `~system/*` modules by patching `Module.prototype.require`, and jest loads the scene bundle through its own module registry, so the hook never binds and the bundle gets a `~system/EngineApi` without `crdtGetState`. Covering this in jest needs the executor to take an injectable module resolver, which is a refactor I did not want to fold into a data-loss fix. Worth doing as a follow-up, and it would then cover the rest of this command too, which has no tests at all.

**No repro scene for this one.** `code-to-composite` runs in Node as part of the CLI, and a scene runs in the explorer's QuickJS sandbox, so a scene cannot exercise it. The reproduction above is the runnable equivalent.
