### PR TITLE
fix(sdk-commands): stop asset migration replacing and dropping files

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/asset-migrator.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/asset-migrator.ts
@@ -210,6 +210,16 @@ function replaceAssetPaths(data: any, pathMapping: Map<string, string>): { data:
 }
 
 /**
+ * Whether `target` stays inside `directory`. Used on paths built from glTF dependency
+ * URIs, which are scene data: a `..` chain or an absolute path would otherwise resolve
+ * outside the folder being migrated.
+ */
+function isInside(target: string, directory: string): boolean {
+  const relative = path.relative(directory, target)
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+}
+
+/**
  * Main asset migration function
  *
  * Process:
@@ -276,12 +286,24 @@ export async function migrateAssets(
 
       const allDependencies = [...dependencies.textures, ...dependencies.binaries]
 
+      const sourceDir = path.dirname(absoluteOriginalPath)
+      const modelDir = path.dirname(newAbsolutePath)
+
       for (const depFileName of allDependencies) {
-        const depOriginalPath = path.join(path.dirname(absoluteOriginalPath), depFileName)
+        // A dependency URI comes out of the glTF, so it is scene data rather than
+        // anything this command controls. Resolving it and checking that both ends stay
+        // under their directory keeps a `..` chain, an absolute path or a scheme from
+        // reading or writing outside the migration, which matters because the copy below
+        // now creates directories on the way.
+        const depOriginalPath = path.resolve(sourceDir, depFileName)
+        const depNewPath = path.resolve(modelDir, depFileName)
+
+        if (!isInside(depOriginalPath, sourceDir) || !isInside(depNewPath, modelDir)) {
+          logger.warn(`  ⚠  Skipping GLTF dependency that resolves outside the model folder: ${depFileName}`)
+          continue
+        }
 
         if (await fs.fileExists(depOriginalPath)) {
-          const depNewPath = path.join(path.dirname(newAbsolutePath), depFileName)
-
           // A glTF may point at its textures and buffers through a subfolder,
           // which does not exist yet under the model's new home.
           await fs.mkdir(path.dirname(depNewPath), { recursive: true })

--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/asset-migrator.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/asset-migrator.ts
@@ -108,21 +108,35 @@ async function extractGltfDependencies(
 }
 
 /**
- * Builds the destination path following Creator Hub conventions
+ * Builds the destination path following Creator Hub conventions.
+ *
+ * Destinations are keyed by file name, so two assets called the same thing in
+ * different source folders would land on top of each other. `claimedPaths`
+ * carries the ones already handed out so later assets get a suffix instead of
+ * replacing an earlier one.
  */
-function getDestinationPath(sceneRoot: string, originalPath: string): string {
+function getDestinationPath(sceneRoot: string, originalPath: string, claimedPaths: Set<string>): string {
   const fileName = path.basename(originalPath)
   const extension = path.extname(originalPath)
   const assetType = getAssetType(extension)
+  const baseName = path.basename(originalPath, extension)
 
-  if (assetType === 'Models') {
-    // Models get their own folder: assets/scene/Models/{modelName}/file.glb
-    const modelName = path.basename(originalPath, extension)
-    return path.join(sceneRoot, 'assets', 'scene', 'Models', modelName, fileName)
+  const buildPath = (suffix: string) =>
+    assetType === 'Models'
+      ? // Models get their own folder: assets/scene/Models/{modelName}/file.glb
+        path.join(sceneRoot, 'assets', 'scene', 'Models', `${baseName}${suffix}`, fileName)
+      : // Other assets go directly in type folder: assets/scene/Images/file.png
+        path.join(sceneRoot, 'assets', 'scene', assetType, `${baseName}${suffix}${extension}`)
+
+  let attempt = 1
+  let destination = buildPath('')
+  while (claimedPaths.has(destination)) {
+    attempt++
+    destination = buildPath(`-${attempt}`)
   }
 
-  // Other assets go directly in type folder: assets/scene/Images/file.png
-  return path.join(sceneRoot, 'assets', 'scene', assetType, fileName)
+  claimedPaths.add(destination)
+  return destination
 }
 
 /**
@@ -231,6 +245,7 @@ export async function migrateAssets(
 
   // Step 2: copy files to new locations
   const pathMapping = new Map<string, string>()
+  const claimedPaths = new Set<string>()
 
   for (const originalPath of assetPaths) {
     const absoluteOriginalPath = path.isAbsolute(originalPath) ? originalPath : path.join(sceneRoot, originalPath)
@@ -241,7 +256,7 @@ export async function migrateAssets(
     }
 
     const assetType = getAssetType(path.extname(originalPath))
-    const newAbsolutePath = getDestinationPath(sceneRoot, originalPath)
+    const newAbsolutePath = getDestinationPath(sceneRoot, originalPath, claimedPaths)
     const newRelativePath = path.relative(sceneRoot, newAbsolutePath)
 
     await fs.mkdir(path.dirname(newAbsolutePath), { recursive: true })
@@ -267,6 +282,9 @@ export async function migrateAssets(
         if (await fs.fileExists(depOriginalPath)) {
           const depNewPath = path.join(path.dirname(newAbsolutePath), depFileName)
 
+          // A glTF may point at its textures and buffers through a subfolder,
+          // which does not exist yet under the model's new home.
+          await fs.mkdir(path.dirname(depNewPath), { recursive: true })
           await fs.copyFile(depOriginalPath, depNewPath)
 
           const depOriginalRelative = path.join(path.dirname(originalPath), depFileName)

--- a/test/sdk-commands/commands/code-to-composite/asset-migrator.spec.ts
+++ b/test/sdk-commands/commands/code-to-composite/asset-migrator.spec.ts
@@ -1,0 +1,160 @@
+import path from 'path'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+
+import * as components from '../../../../packages/@dcl/ecs/src/components'
+import { Engine } from '../../../../packages/@dcl/ecs/src/engine'
+import { migrateAssets } from '../../../../packages/@dcl/sdk-commands/src/commands/code-to-composite/asset-migrator'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+import { SceneProject } from '../../../../packages/@dcl/sdk-commands/src/logic/project-validations'
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+
+function makeLogger() {
+  return { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}
+
+function makeProject(workingDirectory: string): SceneProject {
+  return {
+    kind: 'scene',
+    workingDirectory,
+    scene: { main: 'bin/game.js', scene: { base: '0,0', parcels: ['0,0'] } } as SceneProject['scene']
+  }
+}
+
+function writeFile(filePath: string, contents: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents)
+}
+
+describe('when two models in different folders share a file name', () => {
+  let sceneRoot: string
+  let engine: ReturnType<typeof Engine>
+  let GltfContainer: ReturnType<typeof components.GltfContainer>
+  let firstEntity: ReturnType<typeof engine.addEntity>
+  let secondEntity: ReturnType<typeof engine.addEntity>
+
+  beforeEach(async () => {
+    sceneRoot = path.resolve(REPO_ROOT, 'tmp/asset-migrator-collision')
+    rmSync(sceneRoot, { recursive: true, force: true })
+    writeFile(path.join(sceneRoot, 'models/a/tree.glb'), 'FIRST MODEL')
+    writeFile(path.join(sceneRoot, 'models/b/tree.glb'), 'SECOND MODEL')
+
+    engine = Engine()
+    GltfContainer = components.GltfContainer(engine)
+    firstEntity = engine.addEntity()
+    secondEntity = engine.addEntity()
+    GltfContainer.create(firstEntity, { src: 'models/a/tree.glb' })
+    GltfContainer.create(secondEntity, { src: 'models/b/tree.glb' })
+
+    await migrateAssets({ fs: createFsComponent(), logger: makeLogger() } as any, makeProject(sceneRoot), engine as any)
+  })
+
+  afterEach(() => {
+    rmSync(sceneRoot, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should point the two components at different files', () => {
+    expect(GltfContainer.get(firstEntity).src).not.toBe(GltfContainer.get(secondEntity).src)
+  })
+
+  it('should keep the contents of the first model', () => {
+    const migrated = path.join(sceneRoot, GltfContainer.get(firstEntity).src)
+
+    expect(readFileSync(migrated, 'utf8')).toBe('FIRST MODEL')
+  })
+
+  it('should keep the contents of the second model', () => {
+    const migrated = path.join(sceneRoot, GltfContainer.get(secondEntity).src)
+
+    expect(readFileSync(migrated, 'utf8')).toBe('SECOND MODEL')
+  })
+})
+
+describe('when two images in different folders share a file name', () => {
+  let sceneRoot: string
+  let engine: ReturnType<typeof Engine>
+  let Material: ReturnType<typeof components.Material>
+  let firstEntity: ReturnType<typeof engine.addEntity>
+  let secondEntity: ReturnType<typeof engine.addEntity>
+
+  beforeEach(async () => {
+    sceneRoot = path.resolve(REPO_ROOT, 'tmp/asset-migrator-image-collision')
+    rmSync(sceneRoot, { recursive: true, force: true })
+    writeFile(path.join(sceneRoot, 'images/ui/logo.png'), 'UI LOGO')
+    writeFile(path.join(sceneRoot, 'images/world/logo.png'), 'WORLD LOGO')
+
+    engine = Engine()
+    Material = components.Material(engine)
+    firstEntity = engine.addEntity()
+    secondEntity = engine.addEntity()
+    Material.setBasicMaterial(firstEntity, { texture: Material.Texture.Common({ src: 'images/ui/logo.png' }) })
+    Material.setBasicMaterial(secondEntity, { texture: Material.Texture.Common({ src: 'images/world/logo.png' }) })
+
+    await migrateAssets({ fs: createFsComponent(), logger: makeLogger() } as any, makeProject(sceneRoot), engine as any)
+  })
+
+  afterEach(() => {
+    rmSync(sceneRoot, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should write both images instead of one replacing the other', () => {
+    const written = [
+      path.join(sceneRoot, 'assets/scene/Images/logo.png'),
+      path.join(sceneRoot, 'assets/scene/Images/logo-2.png')
+    ]
+
+    expect(written.map((file) => readFileSync(file, 'utf8')).sort()).toEqual(['UI LOGO', 'WORLD LOGO'])
+  })
+})
+
+describe('when a model points at a texture inside a subfolder', () => {
+  let sceneRoot: string
+  let engine: ReturnType<typeof Engine>
+  let logger: ReturnType<typeof makeLogger>
+  let migrate: () => Promise<number>
+
+  beforeEach(() => {
+    sceneRoot = path.resolve(REPO_ROOT, 'tmp/asset-migrator-nested-dep')
+    rmSync(sceneRoot, { recursive: true, force: true })
+    writeFile(
+      path.join(sceneRoot, 'models/house.gltf'),
+      JSON.stringify({
+        asset: { version: '2.0' },
+        images: [{ uri: 'textures/wall.png' }],
+        buffers: [{ uri: 'data/house.bin', byteLength: 4 }]
+      })
+    )
+    writeFile(path.join(sceneRoot, 'models/textures/wall.png'), 'WALL')
+    writeFile(path.join(sceneRoot, 'models/data/house.bin'), 'BIN')
+
+    engine = Engine()
+    const GltfContainer = components.GltfContainer(engine)
+    GltfContainer.create(engine.addEntity(), { src: 'models/house.gltf' })
+
+    logger = makeLogger()
+    migrate = () => migrateAssets({ fs: createFsComponent(), logger } as any, makeProject(sceneRoot), engine as any)
+  })
+
+  afterEach(() => {
+    rmSync(sceneRoot, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should finish the migration instead of throwing', async () => {
+    await expect(migrate()).resolves.toEqual(expect.any(Number))
+  })
+
+  it('should copy the texture into the model folder', async () => {
+    await migrate()
+
+    expect(existsSync(path.join(sceneRoot, 'assets/scene/Models/house/textures/wall.png'))).toBe(true)
+  })
+
+  it('should copy the buffer into the model folder', async () => {
+    await migrate()
+
+    expect(existsSync(path.join(sceneRoot, 'assets/scene/Models/house/data/house.bin'))).toBe(true)
+  })
+})

--- a/test/sdk-commands/commands/code-to-composite/asset-migrator.spec.ts
+++ b/test/sdk-commands/commands/code-to-composite/asset-migrator.spec.ts
@@ -158,3 +158,69 @@ describe('when a model points at a texture inside a subfolder', () => {
     expect(existsSync(path.join(sceneRoot, 'assets/scene/Models/house/data/house.bin'))).toBe(true)
   })
 })
+
+describe('when a model points at a dependency outside its own folder', () => {
+  let sceneRoot: string
+  let engine: ReturnType<typeof Engine>
+  let logger: ReturnType<typeof makeLogger>
+  let migrate: () => Promise<number>
+
+  beforeEach(() => {
+    sceneRoot = path.resolve(REPO_ROOT, 'tmp/asset-migrator-traversal')
+    rmSync(sceneRoot, { recursive: true, force: true })
+    // The dependency URI walks out of the model's folder. It is scene data, so a
+    // hostile or simply broken glTF can carry this.
+    writeFile(
+      path.join(sceneRoot, 'models/house.gltf'),
+      JSON.stringify({
+        asset: { version: '2.0' },
+        images: [{ uri: '../../secrets/id_rsa.png' }],
+        buffers: [{ uri: 'data/house.bin', byteLength: 4 }]
+      })
+    )
+    writeFile(path.join(sceneRoot, 'models/data/house.bin'), 'BIN')
+    writeFile(path.resolve(sceneRoot, '../secrets/id_rsa.png'), 'PRIVATE')
+
+    engine = Engine()
+    const GltfContainer = components.GltfContainer(engine)
+    GltfContainer.create(engine.addEntity(), { src: 'models/house.gltf' })
+
+    logger = makeLogger()
+    migrate = () => migrateAssets({ fs: createFsComponent(), logger } as any, makeProject(sceneRoot), engine as any)
+  })
+
+  afterEach(() => {
+    rmSync(sceneRoot, { recursive: true, force: true })
+    rmSync(path.resolve(sceneRoot, '../secrets'), { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should finish the migration instead of throwing', async () => {
+    await expect(migrate()).resolves.toEqual(expect.any(Number))
+  })
+
+  it('should not follow the dependency out of the model folder', async () => {
+    await migrate()
+
+    // Joining the uri onto the model's new home lands here, two levels above it.
+    expect(existsSync(path.join(sceneRoot, 'assets/scene/secrets/id_rsa.png'))).toBe(false)
+  })
+
+  it('should leave the file it pointed at untouched', async () => {
+    await migrate()
+
+    expect(readFileSync(path.resolve(sceneRoot, '../secrets/id_rsa.png'), 'utf8')).toBe('PRIVATE')
+  })
+
+  it('should say which dependency it skipped', async () => {
+    await migrate()
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('resolves outside the model folder'))
+  })
+
+  it('should still copy the dependency that stays inside', async () => {
+    await migrate()
+
+    expect(existsSync(path.join(sceneRoot, 'assets/scene/Models/house/data/house.bin'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What / why

Two defects in the `code-to-composite` asset migrator. Both lose files, both silently.

**Same file name, different folders.** Destinations are built from the base name alone: a model goes to `assets/scene/Models/{name}/{file}`, everything else to `assets/scene/{type}/{file}`. Two assets called the same thing in different source folders resolve to the same destination, and `copyFile` replaces the first with the second. Both components then point at one file, and the other model is simply gone from the migrated scene. `models/a/tree.glb` and `models/b/tree.glb` is not an unusual layout.

**Dependencies in a subfolder.** A glTF may reference its textures and buffers through a relative subfolder, and the validator hands those URIs back verbatim. They were copied straight into the model's new folder without creating the subfolder, so `copyFile` threw `ENOENT` and took the whole migration down partway through: some assets copied, components not yet rewritten, source not yet commented out. Any scene with `models/house.gltf` pointing at `textures/wall.png` cannot be migrated at all.

Destinations now get a suffix when one is already taken, and the dependency's directory is created before the copy.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='code-to-composite/asset-migrator'
```

On `main` six of the seven cases fail: the first model's file comes back reading `SECOND MODEL`, the second image never gets written, and the nested-dependency migration rejects with `ENOENT ... copyfile ... textures/wall.png`. On this branch all seven pass.

## Proof

`test/sdk-commands/commands/code-to-composite/asset-migrator.spec.ts` is new, and it is the first test of any kind for this command. It builds real scene folders under `tmp/`, runs `migrateAssets` against a real engine, and reads the migrated files back: two models with one name keep their own contents, two images with one name both survive, and a model with a texture and a buffer in subfolders migrates without throwing and lands both files under its folder.

## Note

Naming is `logo.png`, then `logo-2.png` for the next one, and `Models/tree/`, then `Models/tree-2/` for models, where the model keeps its own file name so its glTF references still resolve against the siblings copied next to it. If the Creator Hub expects a different disambiguation, say so and I will match it.

**No repro scene for this one.** The asset migrator runs in Node as part of the CLI, and a scene runs in the explorer's QuickJS sandbox, so a scene cannot exercise it. The reproduction above is the runnable equivalent.
