### PR TITLE
fix(sdk-commands): isolate code-to-composite projects from each other

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
+++ b/packages/@dcl/sdk-commands/src/commands/code-to-composite/scene-executor.ts
@@ -38,6 +38,25 @@ function getInspectorComponentsIds() {
   return ids
 }
 
+// The engine and its transport are process-wide, so a workspace with more than
+// one project reuses them. Both are set up once and the state is cleared per
+// project; there is no API to remove a transport once added.
+let captureTransport: Transport | undefined
+
+/**
+ * Drops every component from every entity, so what the engine holds afterwards
+ * belongs to one project only.
+ */
+function clearEngineState(engine: IEngine) {
+  for (const component of engine.componentsIter()) {
+    if ('deleteFrom' in component) {
+      for (const [entity] of engine.getEntitiesWith(component)) {
+        component.deleteFrom(entity)
+      }
+    }
+  }
+}
+
 /**
  * Initializes the ECS engine with a mock transport layer.
  *
@@ -45,16 +64,20 @@ function getInspectorComponentsIds() {
  * This allows us to capture the state of all entities and components.
  */
 function initEngine(): { engine: IEngine; transport: Transport } {
-  const transport: Transport = {
-    filter: () => true,
-    send: async (_messages) => {}
+  if (!captureTransport) {
+    captureTransport = {
+      filter: () => true,
+      send: async (_messages) => {}
+    }
+
+    engine.addTransport(captureTransport)
   }
 
-  engine.addTransport(transport)
+  clearEngineState(engine)
 
   return {
     engine,
-    transport
+    transport: captureTransport
   }
 }
 


### PR DESCRIPTION
## What / why

Migrating a workspace with more than one scene writes the **first** project's scene into the **second** project's composite, and the second project's own content is lost.

The engine that captures scene state is the process-wide one from `@dcl/ecs`, and `main()` loops over every project in a single process, so project two starts on top of whatever project one left behind. It does not merely add to it: each project's scene bundle runs on its own engine and starts its Lamport clock from scratch, so project two's writes carry timestamps the capture engine has already seen and CRDT rejects them as conflicts. The leftovers win.

Two scenes, the first with entities reading `ONLY-IN-S1-A` and `ONLY-IN-S1-B`, the second with one reading `ONLY-IN-S2`. The `TextShape` data in **s2's** generated composite on `main`:

```
{"512":{"json":{"text":"ONLY-IN-S1-A"}},"513":{"json":{"text":"ONLY-IN-S1-B"}}}
```

The generated names leak the same way, which is what the `Generated names for 0 entity/entities` line in the output is really saying.

The components are now cleared before each project, and the transport is added once instead of once per project, since there is no API to remove one.

## How to test

Build the CLI and lay out a workspace with two scenes, the first creating two entities and the second creating one, each with a distinguishable `TextShape`:

```bash
make build
# tmp/ws/dcl-workspace.json -> { "folders": [{ "path": "s1" }, { "path": "s2" }] }
node packages/@dcl/sdk-commands/dist/index.js code-to-composite --dir tmp/ws --yes
node -e 'const c=JSON.parse(require("fs").readFileSync("tmp/ws/s2/assets/scene/main.composite","utf8")); console.log(JSON.stringify(c.components.find(x=>x.name==="core::TextShape").data))'
```

## Proof

Measured with the layout above:

| | s2's TextShape data | s2's generated name | names reported for s2 |
| --- | --- | --- | --- |
| `main` | `512: ONLY-IN-S1-A`, `513: ONLY-IN-S1-B` | `Text: ONLY-IN-S1...` | 0 |
| this branch | `512: ONLY-IN-S2` | `Text: ONLY-IN-S2` | 1 |

s1 is correct in both. I also migrated s2 on its own and byte-compared the composite against the one produced inside the workspace: identical on this branch, so a project no longer depends on what it is migrated alongside.

**No automated test, same reason as #1569.** `executeSceneCode` mocks the `~system/*` modules by patching `Module.prototype.require`, and jest loads the scene bundle through its own registry, so the hook never binds. Covering this needs the executor to take an injectable module resolver.

I kept the shared engine rather than building a fresh one per project. A fresh `Engine()` has no components defined, and the ones that matter here are not all reachable from the generated `componentDefinitionByName` map, `Transform` among them, so getting that list wrong would silently drop component data instead of leaking it. Clearing is the change I can verify.

Touches the same function as #1569. They are independent and both are small, but whichever lands second will want a look.

**No repro scene for this one.** `code-to-composite` runs in Node as part of the CLI, and a scene runs in the explorer's QuickJS sandbox, so a scene cannot exercise it. The reproduction above is the runnable equivalent.
