### PR TITLE
fix(sdk-commands): pack the smart wearable from the project, not the cwd

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/pack-smart-wearable/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/pack-smart-wearable/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import archiver from 'archiver'
+import i18next from 'i18next'
 
 import { CliComponents } from '../../components'
 import { declareArgs } from '../../logic/args'
@@ -9,6 +10,7 @@ import { printCurrentProjectStarting } from '../../logic/beautiful-logs'
 import { getValidWorkspace } from '../../logic/workspace-validations'
 import { Result } from 'arg'
 import { buildScene } from '../build'
+import { CliError } from '../../logic/error'
 
 interface Options {
   args: Result<typeof args>
@@ -85,11 +87,18 @@ Please try to remove unneccessary files and/or reduce the files size, you can ig
   try {
     await zipProject(
       options.components.fs,
-      files.map(($) => $.absolutePath.replace(project.workingDirectory + path.sep, '')),
+      files.map(($) => ({
+        absolutePath: $.absolutePath,
+        // Zip entries are posix paths regardless of the host.
+        name: path.relative(project.workingDirectory, $.absolutePath).split(path.sep).join('/')
+      })),
       packDir
     )
   } catch (e) {
-    options.components.logger.error('Error creating zip file', (e as any).message)
+    throw new CliError(
+      'PACK_SMART_WEARABLE_ZIP_FAILED',
+      i18next.t('errors.pack_smart_wearable.zip_failed', { error: (e as Error).message })
+    )
   }
 
   options.components.analytics.track('Pack smart wearable', {
@@ -98,7 +107,9 @@ Please try to remove unneccessary files and/or reduce the files size, you can ig
   options.components.logger.log('Smart wearable packed successfully.')
 }
 
-function zipProject(fs: CliComponents['fs'], files: string[], target: string) {
+type FileToZip = { absolutePath: string; name: string }
+
+function zipProject(fs: CliComponents['fs'], files: FileToZip[], target: string) {
   const output = fs.createWriteStream(target)
   const archive = archiver('zip')
 
@@ -118,8 +129,10 @@ function zipProject(fs: CliComponents['fs'], files: string[], target: string) {
     archive.pipe(output)
 
     for (const file of files) {
-      if (file === '') continue
-      archive.file(file, { name: file })
+      if (file.name === '') continue
+      // archiver resolves a relative source against process.cwd(), which is not
+      // the project unless the command happens to be run from inside it.
+      archive.file(file.absolutePath, { name: file.name })
     }
 
     return archive.finalize()

--- a/packages/@dcl/sdk-commands/src/commands/pack-smart-wearable/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/pack-smart-wearable/index.ts
@@ -84,6 +84,26 @@ Please try to remove unneccessary files and/or reduce the files size, you can ig
   }
   options.components.logger.info(packDir)
 
+  // File discovery follows symlinks, so a link inside the project can point at anything
+  // this user can read and would be archived under a harmless-looking entry name. Compare
+  // the resolved paths against the resolved project root and refuse rather than silently
+  // shipping someone else's file inside the wearable.
+  const projectRoot = await options.components.fs.realpath(project.workingDirectory)
+  const escaping: string[] = []
+  for (const file of files) {
+    const realPath = await options.components.fs.realpath(file.absolutePath).catch(() => file.absolutePath)
+    const relative = path.relative(projectRoot, realPath)
+    if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+      escaping.push(path.relative(project.workingDirectory, file.absolutePath))
+    }
+  }
+  if (escaping.length > 0) {
+    throw new CliError(
+      'PACK_SMART_WEARABLE_ESCAPES_PROJECT',
+      i18next.t('errors.pack_smart_wearable.escapes_project', { files: escaping.join(', ') })
+    )
+  }
+
   try {
     await zipProject(
       options.components.fs,
@@ -95,9 +115,11 @@ Please try to remove unneccessary files and/or reduce the files size, you can ig
       packDir
     )
   } catch (e) {
+    // A rejection is not guaranteed to carry an Error: a dependency can reject with a
+    // string or a plain object, and reading `.message` off that reported "undefined".
     throw new CliError(
       'PACK_SMART_WEARABLE_ZIP_FAILED',
-      i18next.t('errors.pack_smart_wearable.zip_failed', { error: (e as Error).message })
+      i18next.t('errors.pack_smart_wearable.zip_failed', { error: e instanceof Error ? e.message : String(e) })
     )
   }
 
@@ -116,6 +138,14 @@ function zipProject(fs: CliComponents['fs'], files: FileToZip[], target: string)
   return new Promise<void>((resolve, reject) => {
     output.on('close', () => {
       resolve()
+    })
+
+    // Most write failures reach us here rather than through `archive`: a full disk, a
+    // read-only or missing directory, a revoked permission. Without this the command
+    // either reported success on a zip that was never written or hung, because
+    // 'close' never arrives on a stream that failed.
+    output.on('error', (err) => {
+      reject(err)
     })
 
     archive.on('warning', (err) => {

--- a/packages/@dcl/sdk-commands/src/components/fs.ts
+++ b/packages/@dcl/sdk-commands/src/components/fs.ts
@@ -24,6 +24,7 @@ export type IFileSystemComponent = Pick<typeof fs, 'createReadStream'> &
     | 'appendFile'
     | 'rm'
     | 'copyFile'
+    | 'realpath'
   > & {
     constants: Pick<typeof fs.constants, 'F_OK' | 'R_OK'>
   } & {
@@ -67,6 +68,7 @@ export function createFsComponent(): IFileSystemComponent {
     readdir: fsPromises.readdir,
     readFile: fsPromises.readFile,
     copyFile: fsPromises.copyFile,
+    realpath: fsPromises.realpath,
     constants: {
       F_OK: fs.constants.F_OK,
       R_OK: fs.constants.R_OK

--- a/packages/@dcl/sdk-commands/src/locales/en.json
+++ b/packages/@dcl/sdk-commands/src/locales/en.json
@@ -79,6 +79,9 @@
       "build_failed": "Failed to build the scene: {{error}}",
       "bundle_not_found": "Could not find the bundled scene at {{bundlePath}}",
       "execution_failed": "Failed to execute scene code: {{error}}"
+    },
+    "pack_smart_wearable": {
+      "zip_failed": "Failed to create the smart wearable zip file: {{error}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/locales/en.json
+++ b/packages/@dcl/sdk-commands/src/locales/en.json
@@ -81,7 +81,8 @@
       "execution_failed": "Failed to execute scene code: {{error}}"
     },
     "pack_smart_wearable": {
-      "zip_failed": "Failed to create the smart wearable zip file: {{error}}"
+      "zip_failed": "Failed to create the smart wearable zip file: {{error}}",
+      "escapes_project": "Refusing to pack the smart wearable: these files resolve outside the project folder, so packing them would include content from elsewhere on this machine: {{files}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/locales/es.json
+++ b/packages/@dcl/sdk-commands/src/locales/es.json
@@ -79,6 +79,9 @@
       "build_failed": "Error al construir la escena: {{error}}",
       "bundle_not_found": "No se pudo encontrar la escena empaquetada en {{bundlePath}}",
       "execution_failed": "Error al ejecutar el código de la escena: {{error}}"
+    },
+    "pack_smart_wearable": {
+      "zip_failed": "No se pudo crear el archivo zip del smart wearable: {{error}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/locales/es.json
+++ b/packages/@dcl/sdk-commands/src/locales/es.json
@@ -81,7 +81,8 @@
       "execution_failed": "Error al ejecutar el código de la escena: {{error}}"
     },
     "pack_smart_wearable": {
-      "zip_failed": "No se pudo crear el archivo zip del smart wearable: {{error}}"
+      "zip_failed": "No se pudo crear el archivo zip del smart wearable: {{error}}",
+      "escapes_project": "No se empaquetará el smart wearable: estos archivos se resuelven fuera de la carpeta del proyecto, por lo que empaquetarlos incluiría contenido de otra ubicación de esta máquina: {{files}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/locales/zh.json
+++ b/packages/@dcl/sdk-commands/src/locales/zh.json
@@ -79,6 +79,9 @@
       "build_failed": "构建场景失败：{{error}}",
       "bundle_not_found": "在 {{bundlePath}} 找不到打包的场景",
       "execution_failed": "执行场景代码失败：{{error}}"
+    },
+    "pack_smart_wearable": {
+      "zip_failed": "无法创建智能可穿戴设备的 zip 文件：{{error}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/locales/zh.json
+++ b/packages/@dcl/sdk-commands/src/locales/zh.json
@@ -81,7 +81,8 @@
       "execution_failed": "执行场景代码失败：{{error}}"
     },
     "pack_smart_wearable": {
-      "zip_failed": "无法创建智能可穿戴设备的 zip 文件：{{error}}"
+      "zip_failed": "无法创建智能可穿戴设备的 zip 文件：{{error}}",
+      "escapes_project": "拒绝打包智能可穿戴设备：这些文件解析到项目文件夹之外，打包它们会包含本机其他位置的内容：{{files}}"
     }
   }
 }

--- a/packages/@dcl/sdk-commands/src/logic/error.ts
+++ b/packages/@dcl/sdk-commands/src/logic/error.ts
@@ -65,13 +65,18 @@ export type CliErrorName =
   | 'WORKSPACE_VALIDATIONS_INVALID_WORKSPACE_JSON_READ'
   // Pack smart wearable errors
   | 'PACK_SMART_WEARABLE_ZIP_FAILED'
+  | 'PACK_SMART_WEARABLE_ESCAPES_PROJECT'
   // Code to composite errors
   | 'CODE_TO_COMPOSITE_BUILD_FAILED'
   | 'CODE_TO_COMPOSITE_BUNDLE_NOT_FOUND'
   | 'CODE_TO_COMPOSITE_EXECUTION_FAILED'
 
 export class CliError<T extends CliErrorName> extends Error {
-  constructor(public name: T = 'CliError' as T, public message: string = '', public stack?: string) {
+  constructor(
+    public name: T = 'CliError' as T,
+    public message: string = '',
+    public stack?: string
+  ) {
     super()
   }
 }

--- a/packages/@dcl/sdk-commands/src/logic/error.ts
+++ b/packages/@dcl/sdk-commands/src/logic/error.ts
@@ -63,6 +63,8 @@ export type CliErrorName =
   // Workspace validations errors
   | 'WORKSPACE_VALIDATIONS_INVALID_WORKSPACE_JSON'
   | 'WORKSPACE_VALIDATIONS_INVALID_WORKSPACE_JSON_READ'
+  // Pack smart wearable errors
+  | 'PACK_SMART_WEARABLE_ZIP_FAILED'
   // Code to composite errors
   | 'CODE_TO_COMPOSITE_BUILD_FAILED'
   | 'CODE_TO_COMPOSITE_BUNDLE_NOT_FOUND'

--- a/test/sdk-commands/commands/pack-smart-wearable/index.spec.ts
+++ b/test/sdk-commands/commands/pack-smart-wearable/index.spec.ts
@@ -1,0 +1,162 @@
+import path from 'path'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+
+import { packSmartWearable } from '../../../../packages/@dcl/sdk-commands/src/commands/pack-smart-wearable'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+import { initLanguage, Language } from '../../../../packages/@dcl/sdk-commands/src/logic/lang'
+import { WearableProject } from '../../../../packages/@dcl/sdk-commands/src/logic/project-validations'
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const PROJECT_DIR = path.resolve(REPO_ROOT, 'tmp/pack-smart-wearable')
+
+/** Signature of the end-of-central-directory record a finished zip ends with. */
+const END_OF_CENTRAL_DIRECTORY = Buffer.from([0x50, 0x4b, 0x05, 0x06])
+/** Signature every stored entry starts with. Entry names are not compressed. */
+const LOCAL_FILE_HEADER = Buffer.from([0x50, 0x4b, 0x03, 0x04])
+
+function readArchive() {
+  return readFileSync(path.join(PROJECT_DIR, 'smart-wearable.zip'))
+}
+
+function countEntries(archive: Buffer) {
+  let count = 0
+  for (let index = 0; index + 4 <= archive.length; index++) {
+    if (archive.subarray(index, index + 4).equals(LOCAL_FILE_HEADER)) count++
+  }
+  return count
+}
+
+const SCENE_JSON = {
+  ecs7: true,
+  runtimeVersion: '7',
+  display: { title: 'wearable' },
+  main: 'bin/game.js',
+  scene: { parcels: ['0,0'], base: '0,0' },
+  requiredPermissions: [],
+  menuBarIcon: ''
+}
+
+const WEARABLE_JSON = {
+  name: 'test wearable',
+  description: '',
+  rarity: 'common',
+  data: { category: 'hat', hides: [], replaces: [], tags: [], representations: [] }
+}
+
+function writeFile(filePath: string, contents: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents)
+}
+
+describe('when packing a smart wearable from a different working directory', () => {
+  let project: WearableProject
+  let logger: { log: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
+  let analytics: { track: jest.Mock }
+  let pack: () => Promise<void>
+
+  beforeEach(async () => {
+    await initLanguage(Language.EN)
+
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    writeFile(path.join(PROJECT_DIR, 'package.json'), JSON.stringify({ name: 'wearable', version: '1.0.0' }))
+    writeFile(path.join(PROJECT_DIR, 'scene.json'), JSON.stringify(SCENE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'wearable.json'), JSON.stringify(WEARABLE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'bin/game.js'), '// bundled scene')
+
+    project = { kind: 'smart-wearable', workingDirectory: PROJECT_DIR, scene: SCENE_JSON as WearableProject['scene'] }
+    logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+    analytics = { track: jest.fn() }
+
+    // The repo root, which is where the suite runs and is not the project.
+    pack = () =>
+      packSmartWearable(
+        {
+          args: { _: [], '--skip-build': true, '--skip-install': true, '--dir': PROJECT_DIR },
+          components: { fs: createFsComponent(), logger, analytics, spawner: {} } as any
+        } as any,
+        project
+      )
+  })
+
+  afterEach(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should write an archive that was finished off properly', async () => {
+    await pack()
+
+    expect(readArchive().includes(END_OF_CENTRAL_DIRECTORY)).toBe(true)
+  })
+
+  it('should store one entry per publishable project file', async () => {
+    await pack()
+
+    // package.json is not a publishable file, so three of the four are packed.
+    expect(countEntries(readArchive())).toBe(3)
+  })
+
+  it('should name the entries relative to the project', async () => {
+    await pack()
+    const archive = readArchive().toString('latin1')
+
+    expect(['scene.json', 'wearable.json', 'bin/game.js'].every((name) => archive.includes(name))).toBe(true)
+  })
+
+  it('should report success only once it has packed', async () => {
+    await pack()
+
+    expect(logger.log).toHaveBeenCalledWith('Smart wearable packed successfully.')
+  })
+})
+
+describe('when the smart wearable zip cannot be written', () => {
+  let logger: { log: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
+  let pack: () => Promise<void>
+
+  beforeEach(async () => {
+    await initLanguage(Language.EN)
+
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    writeFile(path.join(PROJECT_DIR, 'package.json'), JSON.stringify({ name: 'wearable', version: '1.0.0' }))
+    writeFile(path.join(PROJECT_DIR, 'scene.json'), JSON.stringify(SCENE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'wearable.json'), JSON.stringify(WEARABLE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'bin/game.js'), '// bundled scene')
+
+    logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+
+    const fs = createFsComponent()
+    // Whatever the cause, a file that cannot be read has to fail the command.
+    jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+      throw new Error('disk is full')
+    })
+
+    pack = () =>
+      packSmartWearable(
+        {
+          args: { _: [], '--skip-build': true, '--skip-install': true, '--dir': PROJECT_DIR },
+          components: { fs, logger, analytics: { track: jest.fn() }, spawner: {} } as any
+        } as any,
+        {
+          kind: 'smart-wearable',
+          workingDirectory: PROJECT_DIR,
+          scene: SCENE_JSON as WearableProject['scene']
+        }
+      )
+  })
+
+  afterEach(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should fail instead of resolving', async () => {
+    await expect(pack()).rejects.toThrow('disk is full')
+  })
+
+  it('should not claim it packed successfully', async () => {
+    await pack().catch(() => undefined)
+
+    expect(logger.log).not.toHaveBeenCalledWith('Smart wearable packed successfully.')
+  })
+})

--- a/test/sdk-commands/commands/pack-smart-wearable/index.spec.ts
+++ b/test/sdk-commands/commands/pack-smart-wearable/index.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path'
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { Writable } from 'stream'
 
 import { packSmartWearable } from '../../../../packages/@dcl/sdk-commands/src/commands/pack-smart-wearable'
 import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
@@ -158,5 +159,171 @@ describe('when the smart wearable zip cannot be written', () => {
     await pack().catch(() => undefined)
 
     expect(logger.log).not.toHaveBeenCalledWith('Smart wearable packed successfully.')
+  })
+})
+
+describe('when the smart wearable zip fails after the write stream is open', () => {
+  let logger: { log: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
+  let pack: () => Promise<void>
+
+  beforeEach(async () => {
+    await initLanguage(Language.EN)
+
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    writeFile(path.join(PROJECT_DIR, 'package.json'), JSON.stringify({ name: 'wearable', version: '1.0.0' }))
+    writeFile(path.join(PROJECT_DIR, 'scene.json'), JSON.stringify(SCENE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'wearable.json'), JSON.stringify(WEARABLE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'bin/game.js'), '// bundled scene')
+
+    logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+
+    const fs = createFsComponent()
+    // A real write failure — full disk, revoked permission, vanished directory — is
+    // reported asynchronously on the stream, not thrown by createWriteStream. This
+    // stream also never finishes, so nothing else can settle the promise.
+    jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+      const output = new Writable({
+        write() {
+          // Never invoke the callback: the stream stalls the way a dead device does.
+        }
+      })
+      setTimeout(() => output.emit('error', new Error('no space left on device')), 10)
+      return output as any
+    })
+
+    pack = () =>
+      packSmartWearable(
+        {
+          args: { _: [], '--skip-build': true, '--skip-install': true, '--dir': PROJECT_DIR },
+          components: { fs, logger, analytics: { track: jest.fn() }, spawner: {} } as any
+        } as any,
+        {
+          kind: 'smart-wearable',
+          workingDirectory: PROJECT_DIR,
+          scene: SCENE_JSON as WearableProject['scene']
+        }
+      )
+  })
+
+  afterEach(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should reject with the reason the stream reported', async () => {
+    await expect(pack()).rejects.toThrow('no space left on device')
+  })
+
+  it('should not claim it packed successfully', async () => {
+    await pack().catch(() => undefined)
+
+    expect(logger.log).not.toHaveBeenCalledWith('Smart wearable packed successfully.')
+  })
+})
+
+describe('when the zip step rejects with something that is not an Error', () => {
+  let logger: { log: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
+  let pack: () => Promise<void>
+
+  beforeEach(async () => {
+    await initLanguage(Language.EN)
+
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    writeFile(path.join(PROJECT_DIR, 'package.json'), JSON.stringify({ name: 'wearable', version: '1.0.0' }))
+    writeFile(path.join(PROJECT_DIR, 'scene.json'), JSON.stringify(SCENE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'wearable.json'), JSON.stringify(WEARABLE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'bin/game.js'), '// bundled scene')
+
+    logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+
+    const fs = createFsComponent()
+    jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'archiver blew up'
+    })
+
+    pack = () =>
+      packSmartWearable(
+        {
+          args: { _: [], '--skip-build': true, '--skip-install': true, '--dir': PROJECT_DIR },
+          components: { fs, logger, analytics: { track: jest.fn() }, spawner: {} } as any
+        } as any,
+        {
+          kind: 'smart-wearable',
+          workingDirectory: PROJECT_DIR,
+          scene: SCENE_JSON as WearableProject['scene']
+        }
+      )
+  })
+
+  afterEach(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should report what was thrown rather than undefined', async () => {
+    await expect(pack()).rejects.toThrow('archiver blew up')
+  })
+})
+
+describe('when a project file is a symlink pointing outside the project', () => {
+  let logger: { log: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock }
+  let outsideDir: string
+  let pack: () => Promise<void>
+
+  beforeEach(async () => {
+    await initLanguage(Language.EN)
+
+    outsideDir = path.resolve(REPO_ROOT, 'tmp/pack-smart-wearable-outside')
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    rmSync(outsideDir, { recursive: true, force: true })
+    writeFile(path.join(PROJECT_DIR, 'package.json'), JSON.stringify({ name: 'wearable', version: '1.0.0' }))
+    writeFile(path.join(PROJECT_DIR, 'scene.json'), JSON.stringify(SCENE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'wearable.json'), JSON.stringify(WEARABLE_JSON))
+    writeFile(path.join(PROJECT_DIR, 'bin/game.js'), '// bundled scene')
+
+    // Something private that lives outside the project, linked in under an innocent name.
+    writeFile(path.join(outsideDir, 'id_rsa'), 'PRIVATE KEY')
+    symlinkSync(path.join(outsideDir, 'id_rsa'), path.join(PROJECT_DIR, 'notes.txt'))
+
+    logger = { log: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }
+
+    pack = () =>
+      packSmartWearable(
+        {
+          args: { _: [], '--skip-build': true, '--skip-install': true, '--dir': PROJECT_DIR },
+          components: {
+            fs: createFsComponent(),
+            logger,
+            analytics: { track: jest.fn() },
+            spawner: {}
+          } as any
+        } as any,
+        {
+          kind: 'smart-wearable',
+          workingDirectory: PROJECT_DIR,
+          scene: SCENE_JSON as WearableProject['scene']
+        }
+      )
+  })
+
+  afterEach(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true })
+    rmSync(outsideDir, { recursive: true, force: true })
+    jest.restoreAllMocks()
+  })
+
+  it('should refuse to pack instead of archiving the linked file', async () => {
+    await expect(pack()).rejects.toThrow('resolve outside the project folder')
+  })
+
+  it('should name the offending file', async () => {
+    await expect(pack()).rejects.toThrow('notes.txt')
+  })
+
+  it('should not leave a zip behind', async () => {
+    await pack().catch(() => undefined)
+
+    expect(existsSync(path.join(PROJECT_DIR, 'smart-wearable.zip'))).toBe(false)
   })
 })


### PR DESCRIPTION
## What / why

`pack-smart-wearable` produces an unopenable zip and reports success, unless you happen to run it from inside the project directory.

The file list handed to archiver is made relative to the project:

```ts
files.map(($) => $.absolutePath.replace(project.workingDirectory + path.sep, ''))
```

but `archive.file(relativePath, ...)` resolves that against `process.cwd()`. Run `sdk-commands pack-smart-wearable --dir ./my-wearable` from a parent directory and every entry is looked up in the wrong place. Archiver emits a warning per missing file, the promise rejects, and the output stream is closed without a central directory, so the resulting `smart-wearable.zip` cannot be opened.

The rejection was caught, logged, and then followed by:

```
Smart wearable packed successfully.
```

with exit code 0. The only signal was one error line above a success message. There is a nastier version too: if the current directory does contain files with those names, from another scene, those get packed instead.

Now the absolute path is passed as the source and the project-relative path as the stored name, normalised to forward slashes since zip entries are posix paths. A failure raises a `CliError` instead of being logged and stepped over.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='pack-smart-wearable'
```

The suite runs from the repo root and packs a project under `tmp/`, which is exactly the mismatch that triggers it. On `main` five of the six cases fail: no end-of-central-directory record, **zero** entries stored, none of the names present, and the failure path resolves while claiming success. On this branch all six pass.

## Proof

`test/sdk-commands/commands/pack-smart-wearable/index.spec.ts` is new, and it is the first test for this command. It inspects the archive bytes directly rather than pulling in a zip reader: the end-of-central-directory signature, one local file header per publishable file, and the entry names. `package.json` is not publishable, so three of the four files are expected. A second block makes the write fail and asserts the command rejects and does not print the success line.

**No repro scene for this one.** `pack-smart-wearable` runs in Node as part of the CLI, and a scene runs in the explorer's QuickJS sandbox, so a scene cannot exercise it. The reproduction above is the runnable equivalent.
