### PR TITLE
fix(ecs): stop one entity's input hiding another's in the same frame

### DIFF
--- a/packages/@dcl/ecs/src/engine/input.ts
+++ b/packages/@dcl/ecs/src/engine/input.ts
@@ -139,22 +139,25 @@ export function createInputSystem(engine: IEngine): IInputSystem {
       const arrayCommands = Array.from(commands)
       for (let i = arrayCommands.length - 1; i >= 0; i--) {
         const command = arrayCommands[i]
+
+        // Commands are kept sorted by timestamp, so this one and every one
+        // below it belongs to a frame that was already accounted for. Stopping
+        // on the button state instead would end this entity's whole loop over
+        // a button another entity had already reported this frame.
+        if (command.timestamp <= globalState.previousFrameMaxTimestamp) {
+          break
+        }
+
         if (command.timestamp > maxTimestamp) {
           maxTimestamp = command.timestamp
         }
 
-        if (command.timestamp > globalState.previousFrameMaxTimestamp) {
-          globalState.thisFrameCommands.push(command)
-        }
+        globalState.thisFrameCommands.push(command)
 
         if (command.state === PointerEventType.PET_UP || command.state === PointerEventType.PET_DOWN) {
           const prevCommand = globalState.buttonState.get(command.button)
           if (!prevCommand || command.timestamp > prevCommand.timestamp) {
             globalState.buttonState.set(command.button, command)
-          } else {
-            // since we are iterating a descending array, we can early finish the
-            // loop
-            break
           }
         }
       }

--- a/test/ecs/events/input-across-entities.spec.ts
+++ b/test/ecs/events/input-across-entities.spec.ts
@@ -1,8 +1,8 @@
-import * as components from '../../packages/@dcl/ecs/src/components'
-import { Engine, Entity } from '../../packages/@dcl/ecs/src/engine'
-import { createInputSystem, IInputSystem } from '../../packages/@dcl/ecs/src/engine/input'
-import { InputAction, PointerEventType } from '../../packages/@dcl/ecs/src'
-import { createTestPointerDownCommand } from './events/utils'
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createInputSystem, IInputSystem } from '../../../packages/@dcl/ecs/src/engine/input'
+import { InputAction, PointerEventType } from '../../../packages/@dcl/ecs/src'
+import { createTestPointerDownCommand } from './utils'
 
 describe('when two entities report input in the same frame and the later one is older', () => {
   let engine: ReturnType<typeof Engine>

--- a/test/ecs/input-across-entities.spec.ts
+++ b/test/ecs/input-across-entities.spec.ts
@@ -1,0 +1,83 @@
+import * as components from '../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../packages/@dcl/ecs/src/engine'
+import { createInputSystem, IInputSystem } from '../../packages/@dcl/ecs/src/engine/input'
+import { InputAction, PointerEventType } from '../../packages/@dcl/ecs/src'
+import { createTestPointerDownCommand } from './events/utils'
+
+describe('when two entities report input in the same frame and the later one is older', () => {
+  let engine: ReturnType<typeof Engine>
+  let input: IInputSystem
+  let clickedEntity: Entity
+  let otherEntity: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    input = createInputSystem(engine)
+    const PointerEventsResult = components.PointerEventsResult(engine)
+
+    clickedEntity = engine.addEntity()
+    otherEntity = engine.addEntity()
+
+    // The pointer is released on one entity, and on another the player also
+    // pressed a key and clicked, both earlier in the same frame. Timestamps
+    // are a single counter shared by every entity.
+    PointerEventsResult.addValue(
+      clickedEntity,
+      createTestPointerDownCommand(clickedEntity, 3, PointerEventType.PET_UP, InputAction.IA_POINTER)
+    )
+    PointerEventsResult.addValue(
+      otherEntity,
+      createTestPointerDownCommand(otherEntity, 1, PointerEventType.PET_DOWN, InputAction.IA_PRIMARY)
+    )
+    PointerEventsResult.addValue(
+      otherEntity,
+      createTestPointerDownCommand(otherEntity, 2, PointerEventType.PET_DOWN, InputAction.IA_POINTER)
+    )
+
+    await engine.update(1)
+  })
+
+  it('should hold the key reported by the second entity as pressed', () => {
+    expect(input.isPressed(InputAction.IA_PRIMARY)).toBe(true)
+  })
+
+  it('should report that key as triggered globally', () => {
+    expect(input.isTriggered(InputAction.IA_PRIMARY, PointerEventType.PET_DOWN)).toBe(true)
+  })
+
+  it('should still report the key as triggered on its own entity', () => {
+    expect(input.isTriggered(InputAction.IA_PRIMARY, PointerEventType.PET_DOWN, otherEntity)).toBe(true)
+  })
+
+  it('should keep the newest state for the button both entities reported', () => {
+    expect(input.isPressed(InputAction.IA_POINTER)).toBe(false)
+  })
+})
+
+describe('when a frame brings no new commands', () => {
+  let engine: ReturnType<typeof Engine>
+  let input: IInputSystem
+  let entity: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    input = createInputSystem(engine)
+    const PointerEventsResult = components.PointerEventsResult(engine)
+
+    entity = engine.addEntity()
+    PointerEventsResult.addValue(
+      entity,
+      createTestPointerDownCommand(entity, 1, PointerEventType.PET_DOWN, InputAction.IA_PRIMARY)
+    )
+    await engine.update(1)
+    await engine.update(1)
+  })
+
+  it('should keep the button pressed', () => {
+    expect(input.isPressed(InputAction.IA_PRIMARY)).toBe(true)
+  })
+
+  it('should stop reporting it as triggered this frame', () => {
+    expect(input.isTriggered(InputAction.IA_PRIMARY, PointerEventType.PET_DOWN)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What / why

`buttonStateUpdateSystem` walks each entity's commands newest first and stops as soon as it meets one that is not newer than what the button state already holds:

```ts
if (!prevCommand || command.timestamp > prevCommand.timestamp) {
  globalState.buttonState.set(command.button, command)
} else {
  // since we are iterating a descending array, we can early finish the loop
  break
}
```

The comment is right about the array and wrong about the state. `buttonState` is global and shared across entities, so the entry being compared against is often one an entity processed **earlier in the same frame** put there. The scan then abandons the current entity's remaining commands, and those are not only for the same button, they are for every other button too.

Release the pointer over one entity while a key goes down over another in the same frame and the key is lost: `isPressed` and the global `isTriggered` both answer `false`, while the per-entity `isTriggered` still answers `true`. Timestamps are one counter shared by every entity, so which entity is processed first is enough to decide whether an input registers.

The scan now stops at the frame boundary instead. Commands are kept sorted by timestamp, so the first one at or below the previous frame's maximum means everything below it was already accounted for. That ends the scan at least as early in the common case, and it does not depend on what another entity reported.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events'
```

On `main` two cases fail, `isPressed` and the global `isTriggered` for the key that was pressed over the second entity. On this branch all pass, along with the 17 existing suites under `test/ecs/events`, `sameTimestamp.spec.ts` included.

## Proof

`test/ecs/events/input-across-entities.spec.ts` is new: a pointer release on one entity plus a key press and a click on another, all in one frame, with the key press carrying the oldest timestamp so it sits behind the early exit. It also checks that a button stays pressed across a frame that brings no new commands and stops being reported as triggered, which is the behaviour the frame boundary has to preserve.

`input.ts` keeps the branch coverage it had, 97.1%, with the same two lines uncovered as on `main`, unrelated to this change. `EngineInfo` and `PointerEvents` fail here and on `main` alike because the locally installed `@dcl/protocol` is behind the pin.

A scene that reproduces this in-world is at [`input-across-entities`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/input-across-entities): it writes the three pointer results itself on a private engine and reports the same three questions a scene would ask.

