### PR TITLE
fix(ecs): keep pointer event entries in step with their handlers

### DIFF
--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -207,12 +207,30 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     ProximityEnter,
     ProximityLeave
   }
-  type EventMapType = Map<EventType, { cb: EventSystemCallback; opts: EventSystemOptions }>
+  type EventMapType = Map<string, { cb: EventSystemCallback; opts: EventSystemOptions; eventType: EventType }>
 
   const eventsMap = new Map<Entity, EventMapType>()
 
   function getEvent(entity: Entity) {
     return eventsMap.get(entity) || eventsMap.set(entity, new Map()).get(entity)!
+  }
+
+  // A cursor handler and a proximity handler are separate registrations that
+  // produce separate PointerEvents entries, so they need separate slots here
+  // too. Keying on the event type alone made onProximityDown evict whatever
+  // onPointerDown had left.
+  function eventKey(type: EventType, interactionType: InteractionType) {
+    return `${type}:${interactionType}`
+  }
+
+  function setEvent(
+    entity: Entity,
+    type: EventType,
+    cb: EventSystemCallback,
+    opts: EventSystemOptions,
+    interactionType: InteractionType = InteractionType.CURSOR
+  ) {
+    getEvent(entity).set(eventKey(type, interactionType), { cb, opts, eventType: type })
   }
 
   function setPointerEvent(
@@ -246,14 +264,19 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
   ) {
     const pointerEvent = PointerEvents.getMutableOrNull(entity)
     if (!pointerEvent) return
-    pointerEvent.pointerEvents = pointerEvent.pointerEvents.filter(
+
+    // One registration pushed one entry, so drop one. Removing every match
+    // would also take out an entry another registration owns, since onClick and
+    // onPointerDown both describe themselves as PET_DOWN.
+    const index = pointerEvent.pointerEvents.findIndex(
       (pointer) =>
-        !(
-          pointer.eventInfo?.button === button &&
-          pointer.eventType === type &&
-          pointer.interactionType === interactionType
-        )
+        pointer.eventInfo?.button === button &&
+        pointer.eventType === type &&
+        pointer.interactionType === interactionType
     )
+    if (index === -1) return
+
+    pointerEvent.pointerEvents = pointerEvent.pointerEvents.filter((_, current) => current !== index)
   }
 
   function getPointerEvent(eventType: EventType) {
@@ -273,13 +296,18 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
 
   function removeEvent(entity: Entity, type: EventType, interactionType: InteractionType = InteractionType.CURSOR) {
     const event = getEvent(entity)
-    const pointerEvent = event.get(type)
+    const key = eventKey(type, interactionType)
+    const pointerEvent = event.get(key)
 
-    if (pointerEvent?.opts.hoverText) {
-      removePointerEvent(entity, getPointerEvent(type), pointerEvent.opts.button)
+    // Every registration adds an entry, not only the ones carrying a hoverText,
+    // so every removal has to take one away. Gating on hoverText left the
+    // renderer showing an interaction whose callback was already gone, and made
+    // re-registering grow the component by one entry each time.
+    if (pointerEvent) {
+      removePointerEvent(entity, getPointerEvent(type), pointerEvent.opts.button, interactionType)
     }
 
-    event.delete(type)
+    event.delete(key)
   }
 
   engine.addSystem(function PointerEventSystem() {
@@ -289,7 +317,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
         continue
       }
 
-      for (const [eventType, { cb, opts }] of event) {
+      for (const [, { cb, opts, eventType }] of event) {
         if (eventType === EventType.Click) {
           const command = inputSystem.getClick(opts.button, entity)
           if (command)
@@ -321,7 +349,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.Down)
-    getEvent(entity).set(EventType.Down, { cb, opts: options })
+    setEvent(entity, EventType.Down, cb, options)
     setPointerEvent(entity, PointerEventType.PET_DOWN, options)
   }
 
@@ -333,7 +361,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.Up)
-    getEvent(entity).set(EventType.Up, { cb, opts: options })
+    setEvent(entity, EventType.Up, cb, options)
     setPointerEvent(entity, PointerEventType.PET_UP, options)
   }
 
@@ -342,7 +370,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.HoverEnter)
-    getEvent(entity).set(EventType.HoverEnter, { cb, opts: options })
+    setEvent(entity, EventType.HoverEnter, cb, options)
     setPointerEvent(entity, PointerEventType.PET_HOVER_ENTER, options)
   }
 
@@ -351,7 +379,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.HoverLeave)
-    getEvent(entity).set(EventType.HoverLeave, { cb, opts: options })
+    setEvent(entity, EventType.HoverLeave, cb, options)
     setPointerEvent(entity, PointerEventType.PET_HOVER_LEAVE, options)
   }
 
@@ -360,7 +388,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.Down, InteractionType.PROXIMITY)
-    getEvent(entity).set(EventType.Down, { cb, opts: options })
+    setEvent(entity, EventType.Down, cb, options, InteractionType.PROXIMITY)
     setPointerEvent(entity, PointerEventType.PET_DOWN, options, InteractionType.PROXIMITY)
   }
 
@@ -369,7 +397,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.Up, InteractionType.PROXIMITY)
-    getEvent(entity).set(EventType.Up, { cb, opts: options })
+    setEvent(entity, EventType.Up, cb, options, InteractionType.PROXIMITY)
     setPointerEvent(entity, PointerEventType.PET_UP, options, InteractionType.PROXIMITY)
   }
 
@@ -378,7 +406,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.ProximityEnter, InteractionType.PROXIMITY)
-    getEvent(entity).set(EventType.ProximityEnter, { cb, opts: options })
+    setEvent(entity, EventType.ProximityEnter, cb, options, InteractionType.PROXIMITY)
     setPointerEvent(entity, PointerEventType.PET_PROXIMITY_ENTER, options, InteractionType.PROXIMITY)
   }
 
@@ -387,7 +415,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     const { entity, opts } = data
     const options = getDefaultOpts(opts)
     removeEvent(entity, EventType.ProximityLeave, InteractionType.PROXIMITY)
-    getEvent(entity).set(EventType.ProximityLeave, { cb, opts: options })
+    setEvent(entity, EventType.ProximityLeave, cb, options, InteractionType.PROXIMITY)
     setPointerEvent(entity, PointerEventType.PET_PROXIMITY_LEAVE, options, InteractionType.PROXIMITY)
   }
 
@@ -435,7 +463,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
       removeEvent(entity, EventType.Click)
 
       // Set new event
-      getEvent(entity).set(EventType.Click, { cb, opts: options })
+      setEvent(entity, EventType.Click, cb, options)
       setPointerEvent(entity, PointerEventType.PET_DOWN, options)
     },
 

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -259,21 +259,41 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
   function removePointerEvent(
     entity: Entity,
     type: PointerEventType,
-    button: InputAction,
+    opts: EventSystemOptions,
     interactionType: InteractionType = InteractionType.CURSOR
   ) {
     const pointerEvent = PointerEvents.getMutableOrNull(entity)
     if (!pointerEvent) return
 
-    // One registration pushed one entry, so drop one. Removing every match
-    // would also take out an entry another registration owns, since onClick and
-    // onPointerDown both describe themselves as PET_DOWN.
-    const index = pointerEvent.pointerEvents.findIndex(
+    type Entry = (typeof pointerEvent.pointerEvents)[number]
+    const sameSlot = (pointer: Entry) => pointer.eventType === type && pointer.interactionType === interactionType
+
+    // onClick and onPointerDown both describe themselves as PET_DOWN, so the event
+    // type and button alone do not say which registration an entry belongs to. Match
+    // everything the entry was built from, or removing one handler can take the
+    // other's descriptor and leave the renderer advertising the wrong interaction.
+    let index = pointerEvent.pointerEvents.findIndex(
       (pointer) =>
-        pointer.eventInfo?.button === button &&
-        pointer.eventType === type &&
-        pointer.interactionType === interactionType
+        sameSlot(pointer) &&
+        pointer.eventInfo?.button === opts.button &&
+        pointer.eventInfo?.hoverText === opts.hoverText &&
+        pointer.eventInfo?.showFeedback === opts.showFeedback &&
+        pointer.eventInfo?.showHighlight === opts.showHighlight &&
+        pointer.eventInfo?.maxDistance === opts.maxDistance &&
+        pointer.eventInfo?.maxPlayerDistance === opts.maxPlayerDistance &&
+        pointer.eventInfo?.priority === opts.priority &&
+        pointer.eventInfo?.maxCameraDistance === opts.maxCameraDistance
     )
+
+    // The entry can come back from the renderer with proto defaults in place of the
+    // undefined fields it was written with, which no exact match survives. Falling
+    // back to the button keeps a stale descriptor from outliving its handler; with
+    // one registration per slot, which is the ordinary case, it is the same entry.
+    if (index === -1) {
+      index = pointerEvent.pointerEvents.findIndex(
+        (pointer) => sameSlot(pointer) && pointer.eventInfo?.button === opts.button
+      )
+    }
     if (index === -1) return
 
     pointerEvent.pointerEvents.splice(index, 1)
@@ -304,7 +324,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     // renderer showing an interaction whose callback was already gone, and made
     // re-registering grow the component by one entry each time.
     if (pointerEvent) {
-      removePointerEvent(entity, getPointerEvent(type), pointerEvent.opts.button, interactionType)
+      removePointerEvent(entity, getPointerEvent(type), pointerEvent.opts, interactionType)
     }
 
     event.delete(key)

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -276,7 +276,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     )
     if (index === -1) return
 
-    pointerEvent.pointerEvents = pointerEvent.pointerEvents.filter((_, current) => current !== index)
+    pointerEvent.pointerEvents.splice(index, 1)
   }
 
   function getPointerEvent(eventType: EventType) {

--- a/packages/@dcl/ecs/src/systems/events.ts
+++ b/packages/@dcl/ecs/src/systems/events.ts
@@ -272,7 +272,7 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
     // type and button alone do not say which registration an entry belongs to. Match
     // everything the entry was built from, or removing one handler can take the
     // other's descriptor and leave the renderer advertising the wrong interaction.
-    let index = pointerEvent.pointerEvents.findIndex(
+    const index = pointerEvent.pointerEvents.findIndex(
       (pointer) =>
         sameSlot(pointer) &&
         pointer.eventInfo?.button === opts.button &&
@@ -285,15 +285,6 @@ export function createPointerEventsSystem(engine: IEngine, inputSystem: IInputSy
         pointer.eventInfo?.maxCameraDistance === opts.maxCameraDistance
     )
 
-    // The entry can come back from the renderer with proto defaults in place of the
-    // undefined fields it was written with, which no exact match survives. Falling
-    // back to the button keeps a stale descriptor from outliving its handler; with
-    // one registration per slot, which is the ordinary case, it is the same entry.
-    if (index === -1) {
-      index = pointerEvent.pointerEvents.findIndex(
-        (pointer) => sameSlot(pointer) && pointer.eventInfo?.button === opts.button
-      )
-    }
     if (index === -1) return
 
     pointerEvent.pointerEvents.splice(index, 1)

--- a/test/ecs/events/pointer-event-entries.spec.ts
+++ b/test/ecs/events/pointer-event-entries.spec.ts
@@ -1,0 +1,144 @@
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createInputSystem } from '../../../packages/@dcl/ecs/src/engine/input'
+import { createPointerEventsSystem, PointerEventsSystem } from '../../../packages/@dcl/ecs/src/systems/events'
+import {
+  InputAction,
+  InteractionType,
+  PointerEventType
+} from '../../../packages/@dcl/ecs/src/components/generated/pb/decentraland/sdk/components/common/input_action.gen'
+import { createTestPointerDownCommand } from './utils'
+
+type Engines = {
+  engine: ReturnType<typeof Engine>
+  pointerEvents: PointerEventsSystem
+  PointerEvents: ReturnType<typeof components.PointerEvents>
+  PointerEventsResult: ReturnType<typeof components.PointerEventsResult>
+}
+
+function setup(): Engines {
+  const engine = Engine()
+  const pointerEvents = createPointerEventsSystem(engine, createInputSystem(engine))
+  return {
+    engine,
+    pointerEvents,
+    PointerEvents: components.PointerEvents(engine),
+    PointerEventsResult: components.PointerEventsResult(engine)
+  }
+}
+
+describe('when a pointer event without a hover text is registered more than once', () => {
+  let ctx: Engines
+  let entity: Entity
+
+  beforeEach(() => {
+    ctx = setup()
+    entity = ctx.engine.addEntity()
+    ctx.pointerEvents.onPointerDown(entity, () => {})
+    ctx.pointerEvents.onPointerDown(entity, () => {})
+    ctx.pointerEvents.onPointerDown(entity, () => {})
+  })
+
+  it('should describe the interaction once', () => {
+    expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(1)
+  })
+
+  it('should describe nothing after it is removed', () => {
+    ctx.pointerEvents.removeOnPointerDown(entity)
+
+    expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(0)
+  })
+})
+
+describe('when a pointer event with a hover text is removed', () => {
+  let ctx: Engines
+  let entity: Entity
+
+  beforeEach(() => {
+    ctx = setup()
+    entity = ctx.engine.addEntity()
+    ctx.pointerEvents.onPointerDown({ entity, opts: { hoverText: 'Open' } }, () => {})
+    ctx.pointerEvents.removeOnPointerDown(entity)
+  })
+
+  it('should describe nothing', () => {
+    expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(0)
+  })
+})
+
+describe('when a proximity handler is registered on an entity that already has a cursor one', () => {
+  let ctx: Engines
+  let entity: Entity
+  let cursorCallback: jest.Mock
+  let proximityCallback: jest.Mock
+
+  beforeEach(() => {
+    ctx = setup()
+    entity = ctx.engine.addEntity()
+    cursorCallback = jest.fn()
+    proximityCallback = jest.fn()
+    ctx.pointerEvents.onPointerDown({ entity, opts: { hoverText: 'cursor' } }, cursorCallback)
+    ctx.pointerEvents.onProximityDown({ entity, opts: { hoverText: 'proximity' } }, proximityCallback)
+  })
+
+  it('should describe both interactions', () => {
+    expect(ctx.PointerEvents.get(entity).pointerEvents.map((pointer) => pointer.interactionType)).toEqual([
+      InteractionType.CURSOR,
+      InteractionType.PROXIMITY
+    ])
+  })
+
+  it('should keep the cursor callback registered', async () => {
+    ctx.PointerEventsResult.addValue(entity, createTestPointerDownCommand(entity, 1, PointerEventType.PET_DOWN))
+    await ctx.engine.update(1)
+
+    expect(cursorCallback).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when a proximity handler is removed', () => {
+  let ctx: Engines
+  let entity: Entity
+
+  beforeEach(() => {
+    ctx = setup()
+    entity = ctx.engine.addEntity()
+    ctx.pointerEvents.onPointerDown({ entity, opts: { hoverText: 'cursor' } }, () => {})
+    ctx.pointerEvents.onProximityDown({ entity, opts: { hoverText: 'proximity' } }, () => {})
+    ctx.pointerEvents.removeOnProximityDown(entity)
+  })
+
+  it('should stop describing the proximity interaction', () => {
+    const described = ctx.PointerEvents.get(entity).pointerEvents
+
+    expect(described.some((pointer) => pointer.interactionType === InteractionType.PROXIMITY)).toBe(false)
+  })
+
+  it('should leave the cursor interaction alone', () => {
+    const described = ctx.PointerEvents.get(entity).pointerEvents
+
+    expect(described.map((pointer) => pointer.eventInfo?.hoverText)).toEqual(['cursor'])
+  })
+})
+
+describe('when an entity carries both an onClick and an onPointerDown for the same button', () => {
+  let ctx: Engines
+  let entity: Entity
+
+  beforeEach(() => {
+    ctx = setup()
+    entity = ctx.engine.addEntity()
+    ctx.pointerEvents.onClick({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'click' } }, () => {})
+    ctx.pointerEvents.onPointerDown({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'down' } }, () => {})
+  })
+
+  it('should describe one interaction per registration', () => {
+    expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(2)
+  })
+
+  it('should leave the other registration described when one is removed', () => {
+    ctx.pointerEvents.removeOnClick(entity)
+
+    expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(1)
+  })
+})

--- a/test/ecs/events/pointer-event-entries.spec.ts
+++ b/test/ecs/events/pointer-event-entries.spec.ts
@@ -142,3 +142,67 @@ describe('when an entity carries both an onClick and an onPointerDown for the sa
     expect(ctx.PointerEvents.get(entity).pointerEvents).toHaveLength(1)
   })
 })
+
+describe('when a click and a pointer down are registered on the same button', () => {
+  let engine: ReturnType<typeof Engine>
+  let PointerEvents: ReturnType<typeof components.PointerEvents>
+  let pointerEvents: PointerEventsSystem
+  let entity: Entity
+
+  const descriptors = () =>
+    (PointerEvents.getOrNull(entity)?.pointerEvents ?? []).map((pointer) => pointer.eventInfo?.hoverText)
+
+  beforeEach(() => {
+    engine = Engine()
+    PointerEvents = components.PointerEvents(engine)
+    pointerEvents = createPointerEventsSystem(engine, createInputSystem(engine))
+    entity = engine.addEntity()
+  })
+
+  describe('and the pointer down was registered first', () => {
+    beforeEach(() => {
+      // Both describe themselves as PET_DOWN on the same button, so only the rest of
+      // the descriptor tells the two entries apart.
+      pointerEvents.onPointerDown({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'down' } }, () => {})
+      pointerEvents.onClick({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'click' } }, () => {})
+    })
+
+    it('should leave the pointer down descriptor behind when the click is removed', () => {
+      pointerEvents.removeOnClick(entity)
+
+      expect(descriptors()).toEqual(['down'])
+    })
+
+    it('should leave the click descriptor behind when the pointer down is removed', () => {
+      pointerEvents.removeOnPointerDown(entity)
+
+      expect(descriptors()).toEqual(['click'])
+    })
+  })
+
+  describe('and the click was registered first', () => {
+    beforeEach(() => {
+      pointerEvents.onClick({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'click' } }, () => {})
+      pointerEvents.onPointerDown({ entity, opts: { button: InputAction.IA_POINTER, hoverText: 'down' } }, () => {})
+    })
+
+    it('should still leave the pointer down descriptor behind when the click is removed', () => {
+      pointerEvents.removeOnClick(entity)
+
+      expect(descriptors()).toEqual(['down'])
+    })
+  })
+
+  describe('and both were registered with identical options', () => {
+    beforeEach(() => {
+      pointerEvents.onPointerDown({ entity, opts: { button: InputAction.IA_POINTER } }, () => {})
+      pointerEvents.onClick({ entity, opts: { button: InputAction.IA_POINTER } }, () => {})
+    })
+
+    it('should drop exactly one entry, since the two are indistinguishable', () => {
+      pointerEvents.removeOnClick(entity)
+
+      expect(PointerEvents.getOrNull(entity)?.pointerEvents.length).toBe(1)
+    })
+  })
+})

--- a/test/ecs/events/pointer-event-entries.spec.ts
+++ b/test/ecs/events/pointer-event-entries.spec.ts
@@ -206,3 +206,49 @@ describe('when a click and a pointer down are registered on the same button', ()
     })
   })
 })
+
+describe('when two different handlers are registered on one entity and one is removed', () => {
+  /** Every registration the system exposes, with the removal that pairs with it. */
+  const HANDLERS = [
+    ['onClick', 'removeOnClick'],
+    ['onPointerDown', 'removeOnPointerDown'],
+    ['onPointerUp', 'removeOnPointerUp'],
+    ['onPointerHoverEnter', 'removeOnPointerHoverEnter'],
+    ['onPointerHoverLeave', 'removeOnPointerHoverLeave'],
+    ['onProximityDown', 'removeOnProximityDown'],
+    ['onProximityUp', 'removeOnProximityUp'],
+    ['onProximityEnter', 'removeOnProximityEnter'],
+    ['onProximityLeave', 'removeOnProximityLeave']
+  ] as const
+
+  let mismatches: string[]
+
+  beforeEach(() => {
+    mismatches = []
+
+    for (const [kept] of HANDLERS) {
+      for (const [dropped, remove] of HANDLERS) {
+        if (kept === dropped) continue
+
+        const engine = Engine()
+        const PointerEvents = components.PointerEvents(engine)
+        const system = createPointerEventsSystem(engine, createInputSystem(engine)) as any
+        const entity = engine.addEntity()
+
+        // Same button on purpose: the button is what used to be relied on to tell two
+        // registrations apart, and onClick and onPointerDown share a PET_DOWN slot.
+        system[kept]({ entity, opts: { button: InputAction.IA_POINTER, hoverText: kept } }, () => {})
+        system[dropped]({ entity, opts: { button: InputAction.IA_POINTER, hoverText: dropped } }, () => {})
+        system[remove](entity)
+
+        const left = (PointerEvents.getOrNull(entity)?.pointerEvents ?? []).map((p) => p.eventInfo?.hoverText)
+        if (!left.includes(kept)) mismatches.push(`${remove} took ${kept}'s descriptor`)
+        if (left.includes(dropped)) mismatches.push(`${remove} left ${dropped}'s descriptor behind`)
+      }
+    }
+  })
+
+  it('should leave the other handler its descriptor and take only its own', () => {
+    expect(mismatches).toEqual([])
+  })
+})

--- a/test/react-ecs/button.spec.tsx
+++ b/test/react-ecs/button.spec.tsx
@@ -65,7 +65,7 @@ describe('Button React Ecs', () => {
     disabled = true // changes text and background color alpha value
 
     await engine.update(1)
-    expect(getPointerEvent(rootDivEntity) === null)
+    expect(getPointerEvent(rootDivEntity)).toBeNull()
     expect(getText(rootDivEntity)).toMatchObject({
       value: 'BOEDO',
       color: { r: 1, g: 0.2, b: 0.3, a: 0.5 }

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=432.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=433k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23243
+  MALLOC_COUNT = 23247
   ALIVE_OBJS_DELTA ~= 4.72k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1985.70k bytes
+  MEMORY_USAGE_COUNT ~= 1987.44k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=433k bytes
+SCENE_COMPILED_JS_SIZE_PROD=432.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23247
+  MALLOC_COUNT = 23245
   ALIVE_OBJS_DELTA ~= 4.72k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1987.44k bytes
+  MEMORY_USAGE_COUNT ~= 1987.04k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23232
+  MALLOC_COUNT = 23243
   ALIVE_OBJS_DELTA ~= 4.72k
 CALL onStart()
   OPCODES ~= 0k
@@ -49,7 +49,7 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
   OPCODES ~= 155k
-  MALLOC_COUNT = 1012
+  MALLOC_COUNT = 1015
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1984.95k bytes
+  MEMORY_USAGE_COUNT ~= 1985.70k bytes


### PR DESCRIPTION
## What / why

Registering a pointer handler always pushes an entry onto the entity's `PointerEvents` component, but removing one only took an entry away when the handler had been given a `hoverText`:

```ts
if (pointerEvent?.opts.hoverText) {
  removePointerEvent(entity, getPointerEvent(type), pointerEvent.opts.button)
}
```

Everything else left the entry behind. The renderer keeps offering an interaction whose callback is gone, and re-registering grows the component by one entry each time, re-shipping the whole array over CRDT on every change.

React UI walks straight into it, because the reconciler adds and drops listeners as props change. Measured on `main` with a `UiEntity` whose `onMouseDown` is toggled:

| | entries after add | after dropping the handler | after five toggles |
| --- | --- | --- | --- |
| `main` | 1 | 1 | 6 |
| this branch | 1 | 0 | 0 |

A `Button` shows the user-visible half: on `main` a disabled one still advertises both of its interactions, so it keeps its hover feedback and keeps swallowing the pointer. On this branch it advertises none.

Two more things were wrong in the same place, and they are why this is one change rather than three.

The callback map was keyed by event type alone, while the component keys its entries by event type **and** interaction type. `onProximityDown` on an entity that already had `onPointerDown` therefore evicted the cursor callback, and `removeEvent` never forwarded the interaction type, so removal matched entries against `CURSOR` whatever the caller asked and a proximity entry could never be taken away. The map is now keyed the way the component is.

Removal drops one entry rather than filtering every match, because `onClick` and `onPointerDown` both describe themselves as `PET_DOWN` and should not remove each other's.

**One behaviour change worth flagging.** `PBPointerEventsResult` carries no interaction type, so the SDK cannot tell whether a `PET_DOWN` came from the cursor or from proximity. With both handlers now surviving registration, both run for a matching result. Previously one of them was silently discarded at registration time, which I do not think is the better of the two.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events|test/react-ecs'
```

On `main` seven of the nine cases in the new file fail. On this branch all 37 suites and 333 tests pass, the existing events and react-ecs suites included.

## Proof

`test/ecs/events/pointer-event-entries.spec.ts` is new: repeated registration describes the interaction once, removal describes nothing, a proximity handler no longer evicts a cursor one, removing the proximity handler leaves the cursor entry alone, and `onClick` plus `onPointerDown` keep one entry each.

`events.ts` keeps exactly the coverage it had on `main`, 80.64% statements and 90.74% branches, with the same lines uncovered.

Snapshots were regenerated. Only `ui.ts.crdt` moved, and only its size and allocation counters: no CRDT message changed.

A scene that shows the accumulation in-world is at [`pointer-event-entry-leak`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/pointer-event-entry-leak).