### PR TITLE
fix(sdk): notify aliased scene observables once per event

### DIFF
--- a/packages/@dcl/sdk/src/observables.ts
+++ b/packages/@dcl/sdk/src/observables.ts
@@ -223,38 +223,51 @@ export async function pollEvents(sendBatch: (body: ManyEntityAction) => Promise<
 const SDK7ComponentsObservable = processObservables()
 function processObservables() {
   const subscriptions = new Set<keyof IEvents>()
+  // Which underlying listeners are already installed. Some of them serve two
+  // event names, and tracking installation by name alone installed the listener
+  // a second time, so both observables were notified twice per event.
+  const installedListeners = new Set<string>()
+
+  function installListener(name: string, install: () => void) {
+    if (installedListeners.has(name)) return
+    installedListeners.add(name)
+    install()
+  }
 
   function subscribe(eventName: keyof IEvents) {
     if (subscriptions.has(eventName)) return
+    // Recorded before installing, because the listeners read this to decide
+    // which observables to notify.
+    subscriptions.add(eventName)
+
     switch (eventName) {
       case 'playerClicked': {
-        subscribePlayerClick()
+        installListener('playerClick', subscribePlayerClick)
         break
       }
       case 'onEnterScene':
       case 'playerConnected': {
-        subscribeEnterScene()
+        installListener('enterScene', subscribeEnterScene)
         break
       }
       case 'onLeaveScene':
       case 'playerDisconnected': {
-        subscribeLeaveScene()
+        installListener('leaveScene', subscribeLeaveScene)
         break
       }
       case 'onRealmChanged': {
-        subscribeRealmChange()
+        installListener('realmChange', subscribeRealmChange)
         break
       }
       case 'playerExpression': {
-        subscribePlayerExpression()
+        installListener('playerExpression', subscribePlayerExpression)
         break
       }
       case 'profileChanged': {
-        subscribeProfileChange()
+        installListener('profileChange', subscribeProfileChange)
         break
       }
     }
-    subscriptions.add(eventName)
   }
   /**
    * PLAYER ENTER/CONNECTED observable

--- a/test/sdk/observables-aliases.spec.ts
+++ b/test/sdk/observables-aliases.spec.ts
@@ -1,0 +1,125 @@
+describe('SDK observables that share one underlying subscription', () => {
+  let onEnterScene: jest.Mock
+  let onLeaveScene: jest.Mock
+  let observables: typeof import('../../packages/@dcl/sdk/src/observables')
+
+  beforeEach(() => {
+    onEnterScene = jest.fn()
+    onLeaveScene = jest.fn()
+
+    jest.resetModules()
+    jest.doMock(
+      '@dcl/ecs',
+      () => ({
+        AvatarBase: { onChange: jest.fn() },
+        AvatarEmoteCommand: { onChange: jest.fn() },
+        AvatarEquippedData: { onChange: jest.fn() },
+        PlayerIdentityData: { getOrNull: jest.fn() },
+        PointerEventsResult: { onChange: jest.fn() },
+        RealmInfo: { onChange: jest.fn() },
+        engine: {
+          addSystem: jest.fn(),
+          getEntitiesWith: jest.fn().mockReturnValue([]),
+          PlayerEntity: 1,
+          removeSystem: jest.fn(),
+          RootEntity: 0
+        }
+      }),
+      { virtual: true }
+    )
+    jest.doMock('../../packages/@dcl/sdk/src/players', () => ({
+      __esModule: true,
+      default: { onEnterScene, onLeaveScene }
+    }))
+    jest.doMock('~system/EngineApi', () => ({ subscribe: jest.fn() }))
+
+    jest.isolateModules(() => {
+      observables = jest.requireActual('../../packages/@dcl/sdk/src/observables')
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+  })
+
+  /** The players helper calls every callback registered with it, not just one. */
+  function emitEnterScene(userId: string) {
+    for (const [callback] of onEnterScene.mock.calls) callback({ userId })
+  }
+
+  function emitLeaveScene(userId: string) {
+    for (const [callback] of onLeaveScene.mock.calls) callback(userId)
+  }
+
+  describe('when observers are added to both enter-scene observables', () => {
+    let enterSceneObserver: jest.Mock
+    let playerConnectedObserver: jest.Mock
+
+    beforeEach(() => {
+      enterSceneObserver = jest.fn()
+      playerConnectedObserver = jest.fn()
+      observables.onEnterSceneObservable.add(enterSceneObserver)
+      observables.onPlayerConnectedObservable.add(playerConnectedObserver)
+    })
+
+    it('should register a single player listener', () => {
+      expect(onEnterScene).toHaveBeenCalledTimes(1)
+    })
+
+    it('should notify the enter-scene observer once per player', () => {
+      emitEnterScene('0xtest')
+
+      expect(enterSceneObserver).toHaveBeenCalledTimes(1)
+    })
+
+    it('should notify the player-connected observer once per player', () => {
+      emitEnterScene('0xtest')
+
+      expect(playerConnectedObserver).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when observers are added to both leave-scene observables', () => {
+    let leaveSceneObserver: jest.Mock
+    let playerDisconnectedObserver: jest.Mock
+
+    beforeEach(() => {
+      leaveSceneObserver = jest.fn()
+      playerDisconnectedObserver = jest.fn()
+      observables.onLeaveSceneObservable.add(leaveSceneObserver)
+      observables.onPlayerDisconnectedObservable.add(playerDisconnectedObserver)
+    })
+
+    it('should register a single player listener', () => {
+      expect(onLeaveScene).toHaveBeenCalledTimes(1)
+    })
+
+    it('should notify the leave-scene observer once per player', () => {
+      emitLeaveScene('0xtest')
+
+      expect(leaveSceneObserver).toHaveBeenCalledTimes(1)
+    })
+
+    it('should notify the player-disconnected observer once per player', () => {
+      emitLeaveScene('0xtest')
+
+      expect(playerDisconnectedObserver).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when an observer is added to only one of the two', () => {
+    let playerConnectedObserver: jest.Mock
+
+    beforeEach(() => {
+      playerConnectedObserver = jest.fn()
+      observables.onPlayerConnectedObservable.add(playerConnectedObserver)
+    })
+
+    it('should still notify it', () => {
+      emitEnterScene('0xtest')
+
+      expect(playerConnectedObserver).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=621.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16881
+  MALLOC_COUNT = 16901
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.00k bytes
+  MEMORY_USAGE_COUNT ~= 1551.36k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17436
+  MALLOC_COUNT = 17456
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.76k bytes
+  MEMORY_USAGE_COUNT ~= 1557.12k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17436
+  MALLOC_COUNT = 17456
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.77k bytes
+  MEMORY_USAGE_COUNT ~= 1557.13k bytes

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
+        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/package-lock.json
+++ b/test/snapshots/package-lock.json
@@ -49,7 +49,7 @@
         "@dcl/inspector": "7.36.3",
         "@dcl/linker-dapp": "0.15.2",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-33421599964.commit-0e82dcd",
+        "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-33189663741.commit-641dbdf.tgz",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15761
+  MALLOC_COUNT = 15777
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.72k bytes
+  MEMORY_USAGE_COUNT ~= 1140.55k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18267
-  ALIVE_OBJS_DELTA ~= 4.00k
+  MALLOC_COUNT = 18283
+  ALIVE_OBJS_DELTA ~= 4.01k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.56k bytes
+  MEMORY_USAGE_COUNT ~= 1326.39k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14878
+  MALLOC_COUNT = 14894
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.80k bytes
+  MEMORY_USAGE_COUNT ~= 1102.63k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14851
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14867
+  ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.55k bytes
+  MEMORY_USAGE_COUNT ~= 1092.38k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21604
+  MALLOC_COUNT = 21620
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.04k bytes
+  MEMORY_USAGE_COUNT ~= 1550.86k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15144
+  MALLOC_COUNT = 15160
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.26k bytes
+  MEMORY_USAGE_COUNT ~= 1112.08k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14983
+  OPCODES ~= 82k
+  MALLOC_COUNT = 14999
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.00k bytes
+  MEMORY_USAGE_COUNT ~= 1094.83k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23147
+  MALLOC_COUNT = 23163
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.19k bytes
+  MEMORY_USAGE_COUNT ~= 1980.01k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15087
+  MALLOC_COUNT = 15103
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.04k bytes
+  MEMORY_USAGE_COUNT ~= 1111.86k bytes


### PR DESCRIPTION
## What / why

`onEnterScene` and `playerConnected` are two names for one underlying players subscription, and so are `onLeaveScene` and `playerDisconnected`. Installation was tracked by event name:

```ts
function subscribe(eventName: keyof IEvents) {
  if (subscriptions.has(eventName)) return
  switch (eventName) {
    case 'onEnterScene':
    case 'playerConnected': {
      subscribeEnterScene()      // installs another players.onEnterScene listener
      break
    }
```

so subscribing to both names of a pair installs the listener twice. Each copy notifies **both** observables, because that is how the aliasing works, and every observer therefore runs twice per player:

```ts
onEnterSceneObservable.add(a)
onPlayerConnectedObservable.add(b)   // a and b now fire twice for one player
```

The name set has a second job, deciding which observables a listener should notify, so it stays. Which listeners are installed is now tracked separately.

This is adjacent to #1467 but not the same defect: that one added the missing `break`s to the switch, this one is the gate in front of it.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/sdk/observables'
```

On `main` six of the seven cases in the new file fail, each reporting two calls where one was expected. On this branch all three observables suites pass.

## Proof

`test/sdk/observables-aliases.spec.ts` is new. It counts the listeners registered with the players helper and then fires **every** one of them, which is what the helper itself does, so the doubling is visible rather than hidden by only invoking the first. Both pairs are covered, plus a control that subscribes to only one name of a pair and still gets notified.

Snapshots were regenerated: sizes and allocation counters only, no CRDT message changed.

A scene that shows the double notification is at [`observable-alias-double-fire`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/observable-alias-double-fire).