### PR TITLE
fix(ecs): keep delivering loading states once the set is full

### DIFF
--- a/packages/@dcl/ecs/src/systems/assetLoad.ts
+++ b/packages/@dcl/ecs/src/systems/assetLoad.ts
@@ -27,6 +27,10 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
     {
       callback: AssetLoadLoadingStateSystemCallback
       lastConsumedTimestamp: number
+      // How many events carrying `lastConsumedTimestamp` were already delivered. This
+      // is a grow-only value set, so several events can share a timestamp; a cursor
+      // that only remembered the timestamp dropped every later one of them.
+      consumedAtLastTimestamp: number
     }
   >()
 
@@ -35,7 +39,8 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
     entitiesCallbackAssetLoadLoadingStateMap.set(entity, {
       callback: callback,
       // -1 rather than 0, so a first event stamped 0 still counts as new.
-      lastConsumedTimestamp: existing?.lastConsumedTimestamp ?? -1
+      lastConsumedTimestamp: existing?.lastConsumedTimestamp ?? -1,
+      consumedAtLastTimestamp: existing?.consumedAtLastTimestamp ?? 0
     })
   }
 
@@ -59,22 +64,42 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
       // Tracked by timestamp rather than by how many values are stored: the
       // set drops its oldest value once it is full, so its size stops growing
       // and every later event looked like nothing had happened.
+      //
+      // The timestamp alone is not a cursor though, because this set allows several
+      // events to share one. The count of how many were already delivered at the
+      // boundary timestamp is carried too, so an event appended at that same timestamp
+      // in a later tick is still new. Values arrive in insertion order within a
+      // timestamp, so counting is enough to tell the delivered ones from the rest.
       let lastConsumedTimestamp = data.lastConsumedTimestamp
+      let consumedAtLastTimestamp = data.consumedAtLastTimestamp
+      let seenAtBoundary = 0
 
       for (const value of loadingState.values()) {
-        if (value.timestamp <= data.lastConsumedTimestamp) continue
+        if (value.timestamp < data.lastConsumedTimestamp) continue
+
+        if (value.timestamp === data.lastConsumedTimestamp) {
+          seenAtBoundary++
+          if (seenAtBoundary <= data.consumedAtLastTimestamp) continue
+        }
 
         data.callback(value)
 
         if (value.timestamp > lastConsumedTimestamp) {
           lastConsumedTimestamp = value.timestamp
+          consumedAtLastTimestamp = 1
+        } else {
+          consumedAtLastTimestamp++
         }
       }
 
-      if (lastConsumedTimestamp !== data.lastConsumedTimestamp) {
+      if (
+        lastConsumedTimestamp !== data.lastConsumedTimestamp ||
+        consumedAtLastTimestamp !== data.consumedAtLastTimestamp
+      ) {
         entitiesCallbackAssetLoadLoadingStateMap.set(entity, {
           callback: data.callback,
-          lastConsumedTimestamp
+          lastConsumedTimestamp,
+          consumedAtLastTimestamp
         })
       }
     }

--- a/packages/@dcl/ecs/src/systems/assetLoad.ts
+++ b/packages/@dcl/ecs/src/systems/assetLoad.ts
@@ -26,7 +26,7 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
     Entity,
     {
       callback: AssetLoadLoadingStateSystemCallback
-      lastLoadingStateLength: number
+      lastConsumedTimestamp: number
     }
   >()
 
@@ -34,7 +34,8 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
     const existing = entitiesCallbackAssetLoadLoadingStateMap.get(entity)
     entitiesCallbackAssetLoadLoadingStateMap.set(entity, {
       callback: callback,
-      lastLoadingStateLength: existing?.lastLoadingStateLength ?? 0
+      // -1 rather than 0, so a first event stamped 0 still counts as new.
+      lastConsumedTimestamp: existing?.lastConsumedTimestamp ?? -1
     })
   }
 
@@ -53,19 +54,29 @@ export function createAssetLoadLoadingStateSystem(engine: IEngine): AssetLoadLoa
 
       const loadingState = assetLoadLoadingStateComponent.get(entity)
 
-      if (loadingState.size === 0 || loadingState.size === data.lastLoadingStateLength) continue
+      if (loadingState.size === 0) continue
 
-      // Get last added values (can be multiple per tick, just not for the same asset)
-      const lastValues = Array.from(loadingState.values()).slice(data.lastLoadingStateLength)
+      // Tracked by timestamp rather than by how many values are stored: the
+      // set drops its oldest value once it is full, so its size stops growing
+      // and every later event looked like nothing had happened.
+      let lastConsumedTimestamp = data.lastConsumedTimestamp
 
-      lastValues.forEach((value) => {
+      for (const value of loadingState.values()) {
+        if (value.timestamp <= data.lastConsumedTimestamp) continue
+
         data.callback(value)
-      })
 
-      entitiesCallbackAssetLoadLoadingStateMap.set(entity, {
-        callback: data.callback,
-        lastLoadingStateLength: loadingState.size
-      })
+        if (value.timestamp > lastConsumedTimestamp) {
+          lastConsumedTimestamp = value.timestamp
+        }
+      }
+
+      if (lastConsumedTimestamp !== data.lastConsumedTimestamp) {
+        entitiesCallbackAssetLoadLoadingStateMap.set(entity, {
+          callback: data.callback,
+          lastConsumedTimestamp
+        })
+      }
     }
 
     // Clean up garbage entries

--- a/test/ecs/events/asset-load-state-cap.spec.ts
+++ b/test/ecs/events/asset-load-state-cap.spec.ts
@@ -1,0 +1,86 @@
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createAssetLoadLoadingStateSystem } from '../../../packages/@dcl/ecs/src/systems/assetLoad'
+import { LoadingState } from '../../../packages/@dcl/ecs/src/components/generated/pb/decentraland/sdk/components/common/loading_state.gen'
+
+/** What the grow-only value set keeps before it starts dropping the oldest. */
+const STORED_VALUES = 100
+
+describe('when more loading states arrive than the component can store', () => {
+  let engine: ReturnType<typeof Engine>
+  let AssetLoadLoadingState: ReturnType<typeof components.AssetLoadLoadingState>
+  let entity: Entity
+  let callback: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    AssetLoadLoadingState = components.AssetLoadLoadingState(engine)
+    const system = createAssetLoadLoadingStateSystem(engine)
+
+    entity = engine.addEntity()
+    callback = jest.fn()
+    system.registerAssetLoadLoadingStateEntity(entity, callback)
+
+    for (let index = 1; index <= STORED_VALUES; index++) {
+      AssetLoadLoadingState.addValue(entity, {
+        asset: `asset-${index}`,
+        currentState: LoadingState.LOADING,
+        timestamp: index
+      })
+    }
+    await engine.update(1)
+  })
+
+  it('should have delivered everything stored so far', () => {
+    expect(callback).toHaveBeenCalledTimes(STORED_VALUES)
+  })
+
+  it('should keep delivering once the set is full', async () => {
+    AssetLoadLoadingState.addValue(entity, {
+      asset: 'asset-after-the-cap',
+      currentState: LoadingState.FINISHED,
+      timestamp: STORED_VALUES + 1
+    })
+    await engine.update(1)
+
+    expect(callback).toHaveBeenCalledTimes(STORED_VALUES + 1)
+  })
+
+  it('should deliver the value that arrived after the cap', async () => {
+    AssetLoadLoadingState.addValue(entity, {
+      asset: 'asset-after-the-cap',
+      currentState: LoadingState.FINISHED,
+      timestamp: STORED_VALUES + 1
+    })
+    await engine.update(1)
+
+    expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ asset: 'asset-after-the-cap' }))
+  })
+})
+
+describe('when a tick brings no new loading state', () => {
+  let engine: ReturnType<typeof Engine>
+  let callback: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    const AssetLoadLoadingState = components.AssetLoadLoadingState(engine)
+    const system = createAssetLoadLoadingStateSystem(engine)
+
+    const entity = engine.addEntity()
+    callback = jest.fn()
+    system.registerAssetLoadLoadingStateEntity(entity, callback)
+
+    AssetLoadLoadingState.addValue(entity, {
+      asset: 'asset',
+      currentState: LoadingState.LOADING,
+      timestamp: 1
+    })
+    await engine.update(1)
+    await engine.update(1)
+  })
+
+  it('should not deliver the same value twice', () => {
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/ecs/events/asset-load-state-cap.spec.ts
+++ b/test/ecs/events/asset-load-state-cap.spec.ts
@@ -84,3 +84,77 @@ describe('when a tick brings no new loading state', () => {
     expect(callback).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('when two loading states share a timestamp but arrive in different ticks', () => {
+  let engine: ReturnType<typeof Engine>
+  let AssetLoadLoadingState: ReturnType<typeof components.AssetLoadLoadingState>
+  let entity: Entity
+  let callback: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    AssetLoadLoadingState = components.AssetLoadLoadingState(engine)
+    const system = createAssetLoadLoadingStateSystem(engine)
+
+    entity = engine.addEntity()
+    callback = jest.fn()
+    system.registerAssetLoadLoadingStateEntity(entity, callback)
+
+    AssetLoadLoadingState.addValue(entity, { asset: 'a', currentState: LoadingState.LOADING, timestamp: 1 })
+    await engine.update(1)
+
+    // The set allows several values at one timestamp, so this is a new event even
+    // though its timestamp matches the one already delivered.
+    AssetLoadLoadingState.addValue(entity, { asset: 'b', currentState: LoadingState.LOADING, timestamp: 1 })
+    await engine.update(1)
+  })
+
+  it('should deliver both of them', () => {
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not deliver either of them twice', async () => {
+    await engine.update(1)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('when several loading states share a timestamp within one tick', () => {
+  let engine: ReturnType<typeof Engine>
+  let AssetLoadLoadingState: ReturnType<typeof components.AssetLoadLoadingState>
+  let entity: Entity
+  let callback: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    AssetLoadLoadingState = components.AssetLoadLoadingState(engine)
+    const system = createAssetLoadLoadingStateSystem(engine)
+
+    entity = engine.addEntity()
+    callback = jest.fn()
+    system.registerAssetLoadLoadingStateEntity(entity, callback)
+
+    for (const asset of ['a', 'b', 'c']) {
+      AssetLoadLoadingState.addValue(entity, { asset, currentState: LoadingState.LOADING, timestamp: 4 })
+    }
+    await engine.update(1)
+  })
+
+  it('should deliver every one of them', () => {
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('should not repeat them on the next tick', async () => {
+    await engine.update(1)
+
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('should still deliver a later event at a higher timestamp', async () => {
+    AssetLoadLoadingState.addValue(entity, { asset: 'd', currentState: LoadingState.LOADING, timestamp: 5 })
+    await engine.update(1)
+
+    expect(callback).toHaveBeenCalledTimes(4)
+  })
+})


### PR DESCRIPTION
## What / why

`createAssetLoadLoadingStateSystem` decides which values are new by comparing sizes:

```ts
if (loadingState.size === 0 || loadingState.size === data.lastLoadingStateLength) continue
const lastValues = Array.from(loadingState.values()).slice(data.lastLoadingStateLength)
```

`AssetLoadLoadingState` is a grow-only value set with a cap. Once it is full it drops its oldest value for every new one, so `size` stops changing, the guard reads that as "nothing happened", and the callback never fires again. The loading events keep arriving and the scene stops hearing about them, in the middle of loading, permanently.

| loading states delivered | |
| --- | --- |
| first hundred | delivered |
| everything after | **never delivered** |

`slice(lastLoadingStateLength)` has the same flaw from the other side: after an eviction the index no longer points at the first unseen value.

The fix tracks the last timestamp handed to the callback. The set is already ordered by that timestamp, it is what the component's `timestampFunction` returns, and eviction cannot disturb it. The initial value is `-1` rather than `0` so a first event stamped `0` still counts as new.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events'
```

On `main` two of the four cases in the new file fail: the hundred-and-first value is never delivered. On this branch all 17 suites and 176 tests pass, the existing `assetLoadEventsSystem.spec.ts` included.

## Proof

`test/ecs/events/asset-load-state-cap.spec.ts` is new. It fills the set to its cap, checks everything so far was delivered, then adds one more and checks both that the count went up and that the value delivered is the new one. A second block checks a tick with nothing new does not redeliver, which is the property the old size comparison was there to provide.

`assetLoad.ts` is at 100% across the board. Snapshots were regenerated, sizes and allocation counters only.

A scene that shows the callbacks going quiet is at [`asset-load-state-cap`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/asset-load-state-cap).