### PR TITLE
fix(ecs): stop trigger areas replaying their history on re-subscribe

### DIFF
--- a/packages/@dcl/ecs/src/systems/triggerArea.ts
+++ b/packages/@dcl/ecs/src/systems/triggerArea.ts
@@ -165,10 +165,13 @@ export function createTriggerAreaEventsSystem(engine: IEngine): TriggerAreaEvent
     const triggerCallbackMap = entitiesMap.get(entity)!.triggerCallbackMap
     triggerCallbackMap.delete(triggerType)
 
-    // Remove entity if no more trigger callbacks are registered.
-    // insideTriggerers is intentionally left populated so that re-subscription picks up
-    // in-flight sessions without missing the first synthesized onStay.
-    if (triggerCallbackMap.size === 0) entitiesMap.delete(entity)
+    // The entry stays even with no callbacks left, which is what keeps
+    // insideTriggerers and the consumed-events cursor alive for a later
+    // re-subscription. Dropping it rewound the cursor to -1, so the next
+    // callback registered was handed the entity's whole event history again.
+    // The system loop only fires callbacks that exist, so an entry with none
+    // just keeps its bookkeeping current. Entries are cleaned up when the
+    // entity is removed.
   }
 
   function onTriggerEnter(entity: Entity, cb: TriggerAreaEventSystemCallback) {

--- a/test/ecs/events/trigger-area-resubscribe.spec.ts
+++ b/test/ecs/events/trigger-area-resubscribe.spec.ts
@@ -1,0 +1,87 @@
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createTriggerAreaEventsSystem } from '../../../packages/@dcl/ecs/src/systems/triggerArea'
+import { TriggerAreaEventType } from '../../../packages/@dcl/ecs/src/components/generated/pb/decentraland/sdk/components/trigger_area_result.gen'
+
+function triggerResult(triggered: Entity, triggerer: Entity, eventType: TriggerAreaEventType, timestamp: number) {
+  return {
+    triggeredEntity: triggered as number,
+    triggeredEntityPosition: { x: 0, y: 0, z: 0 },
+    triggeredEntityRotation: { x: 0, y: 0, z: 0, w: 1 },
+    eventType,
+    timestamp,
+    trigger: {
+      entity: triggerer as number,
+      layers: 0,
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 }
+    }
+  }
+}
+
+describe('when trigger callbacks are swapped for new ones', () => {
+  let engine: ReturnType<typeof Engine>
+  let TriggerAreaResult: ReturnType<typeof components.TriggerAreaResult>
+  let system: ReturnType<typeof createTriggerAreaEventsSystem>
+  let area: Entity
+  let triggerer: Entity
+  let replacementEnter: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    TriggerAreaResult = components.TriggerAreaResult(engine)
+    system = createTriggerAreaEventsSystem(engine)
+
+    area = engine.addEntity()
+    triggerer = engine.addEntity()
+
+    // A player walks in and out while the first pair of callbacks is listening.
+    system.onTriggerEnter(area, jest.fn())
+    system.onTriggerExit(area, jest.fn())
+    TriggerAreaResult.addValue(area, triggerResult(area, triggerer, TriggerAreaEventType.TAET_ENTER, 1))
+    TriggerAreaResult.addValue(area, triggerResult(area, triggerer, TriggerAreaEventType.TAET_EXIT, 2))
+    await engine.update(1)
+
+    system.removeOnTriggerEnter(area)
+    system.removeOnTriggerExit(area)
+
+    replacementEnter = jest.fn()
+    system.onTriggerEnter(area, replacementEnter)
+    await engine.update(1)
+  })
+
+  it('should not replay events the previous callbacks already consumed', () => {
+    expect(replacementEnter).not.toHaveBeenCalled()
+  })
+
+  it('should deliver an event that arrives after the swap', async () => {
+    TriggerAreaResult.addValue(area, triggerResult(area, triggerer, TriggerAreaEventType.TAET_ENTER, 3))
+    await engine.update(1)
+
+    expect(replacementEnter).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when a trigger callback is registered for the first time', () => {
+  let engine: ReturnType<typeof Engine>
+  let onEnter: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    const TriggerAreaResult = components.TriggerAreaResult(engine)
+    const system = createTriggerAreaEventsSystem(engine)
+
+    const area = engine.addEntity()
+    const triggerer = engine.addEntity()
+
+    onEnter = jest.fn()
+    system.onTriggerEnter(area, onEnter)
+    TriggerAreaResult.addValue(area, triggerResult(area, triggerer, TriggerAreaEventType.TAET_ENTER, 1))
+    await engine.update(1)
+  })
+
+  it('should receive the event', () => {
+    expect(onEnter).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What / why

Removing the last trigger callback from an entity deleted the entity's whole entry:

```ts
// Remove entity if no more trigger callbacks are registered.
// insideTriggerers is intentionally left populated so that re-subscription picks up
// in-flight sessions without missing the first synthesized onStay.
if (triggerCallbackMap.size === 0) entitiesMap.delete(entity)
```

That entry holds two things besides the callbacks: `lastConsumedTimestamp`, the cursor marking how far the entity's event history has been consumed, and `insideTriggerers`. Deleting it rebuilds both from scratch on the next registration, with the cursor back at `-1`, so the new callback is handed **every event the entity has ever received**.

The comment says `insideTriggerers` is deliberately kept. The code two lines under it throws it away.

Swapping a handler is the ordinary way in:

```ts
triggerAreaEventsSystem.removeOnTriggerEnter(area)
triggerAreaEventsSystem.onTriggerEnter(area, newHandler)   // fires for old, stale events
```

A player who walked through the area ten minutes ago produces a fresh enter, followed by their exit. Anything the handler does on enter, spawning, granting, counting, happens again for nobody.

Keeping the entry fixes it. The system loop already guards every callback lookup with `has`, so an entry with no callbacks just keeps its bookkeeping current, and entries are still cleaned up when the entity is removed.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events'
```

On `main` two of the three cases in the new file fail: the replacement handler fires once for a stale enter, and twice by the time a real event arrives. On this branch all 17 suites and 175 tests pass.

## Proof

`test/ecs/events/trigger-area-resubscribe.spec.ts` is new. A player enters and leaves while the first pair of callbacks listens, the callbacks are then swapped, and the replacement must stay silent until a genuinely new event arrives, which it must still receive. A second block confirms a first-time registration is unaffected.

Branch coverage on `triggerArea.ts` reads 75% against 77.41% on `main`. Nothing became uncovered: deleting a covered `if` removes it from the denominator too. The file was already below 100% on `main`, at the same two lines.

Snapshots were regenerated, sizes and allocation counters only.

A scene that shows the stale replay is at [`trigger-area-replay`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/trigger-area-replay).