### PR TITLE
fix(ecs): let a plain force replace a repulsion from the same source

### DIFF
--- a/packages/@dcl/ecs/src/systems/physics-force.ts
+++ b/packages/@dcl/ecs/src/systems/physics-force.ts
@@ -76,6 +76,10 @@ export function createPhysicsForceHelper(engine: IEngine): PhysicsForceHelper {
       finalVector = vector
     }
 
+    // A source holds one force. Leaving a repulsion registered for it would let
+    // the per-tick recalculation overwrite this vector on the very next frame.
+    repulsionSources.delete(source)
+
     forceSources.set(source, finalVector)
     recalcForce()
   }

--- a/test/ecs/events/physics-force-replace.spec.ts
+++ b/test/ecs/events/physics-force-replace.spec.ts
@@ -1,0 +1,68 @@
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createPhysicsSystem } from '../../../packages/@dcl/ecs/src/systems/physics'
+
+describe('when a plain force replaces a repulsion from the same source', () => {
+  let engine: ReturnType<typeof Engine>
+  let PhysicsCombinedForce: ReturnType<typeof components.PhysicsCombinedForce>
+  let physics: ReturnType<typeof createPhysicsSystem>
+  let source: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    const Transform = components.Transform(engine)
+    PhysicsCombinedForce = components.PhysicsCombinedForce(engine)
+    physics = createPhysicsSystem(engine)
+
+    Transform.create(engine.PlayerEntity, { position: { x: 10, y: 0, z: 0 } })
+    source = engine.addEntity()
+    await engine.update(1)
+
+    physics.applyRepulsionForceToPlayer(source, { x: 0, y: 0, z: 0 }, 5)
+    physics.applyForceToPlayer(source, { x: 0, y: 7, z: 0 })
+  })
+
+  it('should apply the new force straight away', () => {
+    expect(PhysicsCombinedForce.get(engine.PlayerEntity).vector).toEqual({ x: 0, y: 7, z: 0 })
+  })
+
+  it('should keep it after the next tick', async () => {
+    await engine.update(1)
+
+    expect(PhysicsCombinedForce.get(engine.PlayerEntity).vector).toEqual({ x: 0, y: 7, z: 0 })
+  })
+
+  it('should keep it after several ticks', async () => {
+    await engine.update(1)
+    await engine.update(1)
+    await engine.update(1)
+
+    expect(PhysicsCombinedForce.get(engine.PlayerEntity).vector).toEqual({ x: 0, y: 7, z: 0 })
+  })
+})
+
+describe('when a repulsion is left in place', () => {
+  let engine: ReturnType<typeof Engine>
+  let PhysicsCombinedForce: ReturnType<typeof components.PhysicsCombinedForce>
+  let Transform: ReturnType<typeof components.Transform>
+
+  beforeEach(async () => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    PhysicsCombinedForce = components.PhysicsCombinedForce(engine)
+    const physics = createPhysicsSystem(engine)
+
+    Transform.create(engine.PlayerEntity, { position: { x: 10, y: 0, z: 0 } })
+    const source = engine.addEntity()
+    await engine.update(1)
+
+    physics.applyRepulsionForceToPlayer(source, { x: 0, y: 0, z: 0 }, 5)
+  })
+
+  it('should keep tracking the player as they move', async () => {
+    Transform.getMutable(engine.PlayerEntity).position = { x: 0, y: 0, z: 10 }
+    await engine.update(1)
+
+    expect(PhysicsCombinedForce.get(engine.PlayerEntity).vector).toEqual({ x: 0, y: 0, z: 5 })
+  })
+})


### PR DESCRIPTION
## What / why

`applyForceToPlayer` records the new vector for its source but leaves any repulsion registered for that same source in place:

```ts
forceSources.set(source, finalVector)
recalcForce()
```

The background system then recomputes every repulsion each tick and writes it straight back over `forceSources`:

```ts
for (const [source, { fromPosition, magnitude, radius, falloff }] of repulsionSources) {
  const vector = computeRepulsionVector(...)
  if (vector) forceSources.set(source, vector)
```

So the force the scene applied holds until the end of the frame and is gone by the next one:

| | force on the player |
| --- | --- |
| right after `applyForceToPlayer` | `{ x: 0, y: 7, z: 0 }` |
| one tick later, on `main` | `{ x: 5, y: 0, z: 0 }`, the repulsion again |
| one tick later, on this branch | `{ x: 0, y: 7, z: 0 }` |

The documented contract for these helpers is that calling one again with the same source replaces that source's previous force. A source holds one force, so applying a plain one now clears the repulsion it replaces. `applyForceToPlayerForDuration` goes through the same path and gets the same fix.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events'
```

On `main` two of the four cases in the new file fail, showing the repulsion vector back in place a tick later. On this branch all 17 suites and 176 tests pass.

## Proof

`test/ecs/events/physics-force-replace.spec.ts` is new. It applies a repulsion, replaces it with a plain force, and checks the new force is there immediately, after one tick, and after several. A second block leaves a repulsion alone and moves the player, checking it still tracks them, so the fix cannot be "stop recalculating repulsions".

Snapshots were regenerated, sizes and allocation counters only.

`physics-force.ts` fails `prettier --check` identically on `main` and on this branch, over a `console.warn` block neither touches.

A scene that shows the force being undone is at [`physics-force-clobber`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/physics-force-clobber).