### PR TITLE
fix(ecs): let a raycast removal cancel a registration from the same frame

### DIFF
--- a/packages/@dcl/ecs/src/systems/raycast.ts
+++ b/packages/@dcl/ecs/src/systems/raycast.ts
@@ -240,7 +240,10 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
     }
   })
 
-  const nextTickRaycasts: (() => void)[] = []
+  // Keyed by entity so a removal in the same frame can cancel the registration
+  // it is undoing. A second registration for one entity replaces the first,
+  // which is what createOrReplace would have done anyway.
+  const nextTickRaycasts = new Map<Entity, () => void>()
   function registerRaycastWithCallback(
     entity: Entity,
     raycastValue: RaycastSystemOptions,
@@ -259,10 +262,14 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
 
       entitiesCallbackResultMap.set(entity, { callback: callback })
     }
-    nextTickRaycasts.push(onNextTick)
+    nextTickRaycasts.set(entity, onNextTick)
   }
 
   function removeRaycast(entity: Entity) {
+    // The registration this is undoing may not have run yet: it is deliberately
+    // delayed a frame, and leaving it queued would install the raycast a tick
+    // after the scene asked for it to go.
+    nextTickRaycasts.delete(entity)
     Raycast.deleteFrom(entity)
     RaycastResult.deleteFrom(entity)
     entitiesCallbackResultMap.delete(entity)
@@ -270,10 +277,10 @@ export function createRaycastSystem(engine: IEngine): RaycastSystem {
 
   // @internal
   engine.addSystem(function RaycastEventSystem() {
-    for (const addMissingRaycast of nextTickRaycasts) {
+    for (const addMissingRaycast of nextTickRaycasts.values()) {
       addMissingRaycast()
     }
-    nextTickRaycasts.length = 0
+    nextTickRaycasts.clear()
 
     for (const [entity, data] of entitiesCallbackResultMap) {
       const raycast = Raycast.getOrNull(entity)

--- a/test/ecs/events/raycast-same-frame-removal.spec.ts
+++ b/test/ecs/events/raycast-same-frame-removal.spec.ts
@@ -1,0 +1,77 @@
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createRaycastSystem } from '../../../packages/@dcl/ecs/src/systems/raycast'
+
+describe('when a raycast is registered and removed in the same frame', () => {
+  let engine: ReturnType<typeof Engine>
+  let Raycast: ReturnType<typeof components.Raycast>
+  let entity: Entity
+  let callback: jest.Mock
+
+  beforeEach(async () => {
+    engine = Engine()
+    Raycast = components.Raycast(engine)
+    const raycastSystem = createRaycastSystem(engine)
+
+    entity = engine.addEntity()
+    callback = jest.fn()
+    raycastSystem.registerLocalDirectionRaycast({ entity }, callback)
+    raycastSystem.removeRaycasterEntity(entity)
+
+    await engine.update(1)
+  })
+
+  it('should not ask the renderer for the raycast', () => {
+    expect(Raycast.has(entity)).toBe(false)
+  })
+
+  it('should still not ask for it a tick later', async () => {
+    await engine.update(1)
+
+    expect(Raycast.has(entity)).toBe(false)
+  })
+})
+
+describe('when a raycast is registered and left alone', () => {
+  let engine: ReturnType<typeof Engine>
+  let Raycast: ReturnType<typeof components.Raycast>
+  let entity: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    Raycast = components.Raycast(engine)
+    const raycastSystem = createRaycastSystem(engine)
+
+    entity = engine.addEntity()
+    raycastSystem.registerLocalDirectionRaycast({ entity }, jest.fn())
+
+    await engine.update(1)
+  })
+
+  it('should ask the renderer for the raycast', () => {
+    expect(Raycast.has(entity)).toBe(true)
+  })
+})
+
+describe('when a raycast is removed and then registered again in the same frame', () => {
+  let engine: ReturnType<typeof Engine>
+  let Raycast: ReturnType<typeof components.Raycast>
+  let entity: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    Raycast = components.Raycast(engine)
+    const raycastSystem = createRaycastSystem(engine)
+
+    entity = engine.addEntity()
+    raycastSystem.registerLocalDirectionRaycast({ entity }, jest.fn())
+    raycastSystem.removeRaycasterEntity(entity)
+    raycastSystem.registerLocalDirectionRaycast({ entity }, jest.fn())
+
+    await engine.update(1)
+  })
+
+  it('should honour the last thing the scene asked for', () => {
+    expect(Raycast.has(entity)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What / why

Registering a raycast is deliberately delayed a frame, and the comment explaining why is explicit about the case:

```ts
// Raycasts registration is delayed 1 frame to avoid same-frame raycast
// removal/adding (the client never receives the removal on those situations)
const onNextTick = () => { ... }
nextTickRaycasts.push(onNextTick)
```

But `removeRaycast` only clears the component and the callback entry:

```ts
function removeRaycast(entity: Entity) {
  Raycast.deleteFrom(entity)
  RaycastResult.deleteFrom(entity)
  entitiesCallbackResultMap.delete(entity)
}
```

The queued registration is untouched, so it still runs on the next tick. Register and remove in one frame and the raycast is installed a tick after the scene asked for it to go: the renderer runs a query nobody wants, and the callback fires on its result.

```ts
raycastSystem.registerLocalDirectionRaycast({ entity }, onHit)
raycastSystem.removeRaycasterEntity(entity)   // on main, the raycast exists next tick anyway
```

That is the exact shape the delay was added to survive. Keying the pending registrations by entity lets a removal drop the one it is undoing, which is the missing half.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/events'
```

On `main` two of the four cases in the new file fail: the component exists after the tick and still exists a tick later. On this branch all 17 suites and 176 tests pass.

## Proof

`test/ecs/events/raycast-same-frame-removal.spec.ts` is new. It covers register-then-remove, which must leave nothing behind on this tick or the next, a plain registration that must still install, and remove-then-register in one frame, where the last thing the scene asked for is what should happen. That last case is why the queue is keyed by entity rather than simply filtered.

Snapshots were regenerated, sizes and allocation counters only.

A scene that shows the uncancelled raycast is at [`raycast-same-frame-removal`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/raycast-same-frame-removal).