### PR TITLE
fix(react-ecs): keep input props and their echo baseline honest

### DIFF
--- a/packages/@dcl/react-ecs/src/reconciler/index.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/index.ts
@@ -161,14 +161,20 @@ export function createReconciler(
   ) {
     const componentId = getComponentId[componentName]
 
-    const onChangeExists = 'onChange' in props
-    const onSubmitExists = 'onSubmit' in props
+    // Worked on a copy from here on. On the create path this object is React's
+    // own props, and deleting keys from it makes the next diff believe they
+    // were never set, so a listener dropped on the very next render is never
+    // seen as removed and keeps firing.
+    const nextProps = { ...props } as Partial<EngineComponents[K]>
+
+    const onChangeExists = 'onChange' in nextProps
+    const onSubmitExists = 'onSubmit' in nextProps
     const entityState = changeEvents.get(instance.entity)?.get(componentId)
     const onChange = onChangeExists
-      ? (props['onChange'] as OnChangeState['onChangeCallback'])
+      ? (nextProps['onChange'] as OnChangeState['onChangeCallback'])
       : entityState?.onChangeCallback
     const onSubmit = onSubmitExists
-      ? (props['onSubmit'] as OnChangeState['onSubmitCallback'])
+      ? (nextProps['onSubmit'] as OnChangeState['onSubmitCallback'])
       : entityState?.onSubmitCallback
 
     if (onChangeExists || onSubmitExists) {
@@ -176,8 +182,8 @@ export function createReconciler(
         onChangeCallback: onChange,
         onSubmitCallback: onSubmit
       })
-      delete (props as any).onChange
-      delete (props as any).onSubmit
+      delete (nextProps as any).onChange
+      delete (nextProps as any).onSubmit
     }
 
     // Prevent keystroke drops: when React echoes back the same value the renderer
@@ -185,24 +191,31 @@ export function createReconciler(
     // This avoids sending a stale value that overwrites what the user is currently typing.
     if (
       componentName === 'uiInput' &&
-      'value' in props &&
+      'value' in nextProps &&
       lastInputResultValues.has(instance.entity) &&
-      (props as any).value === lastInputResultValues.get(instance.entity)
+      (nextProps as any).value === lastInputResultValues.get(instance.entity)
     ) {
-      delete (props as any).value
+      delete (nextProps as any).value
     }
 
     // We check if there is any key pending to be changed to avoid updating the existing component
-    if (!Object.keys(props).length) {
+    if (!Object.keys(nextProps).length) {
       return
     }
     const ComponentDef = engine.getComponent(componentId) as components.LastWriteWinElementSetComponentDefinition<
       EngineComponents[K]
     >
     const component = ComponentDef.getMutableOrNull(instance.entity) || ComponentDef.create(instance.entity)
-    for (const key in props) {
+    for (const key in nextProps) {
       const keyProp = key as keyof EngineComponents[K]
-      component[keyProp] = props[keyProp]!
+      component[keyProp] = nextProps[keyProp]!
+    }
+
+    // A value the scene actually pushed becomes the baseline the echo check
+    // compares against. Leaving the renderer's older value in place meant a
+    // later push back to it looked like an echo and was dropped.
+    if (componentName === 'uiInput' && 'value' in nextProps) {
+      lastInputResultValues.set(instance.entity, (nextProps as any).value)
     }
   }
 

--- a/packages/@dcl/react-ecs/src/reconciler/index.ts
+++ b/packages/@dcl/react-ecs/src/reconciler/index.ts
@@ -60,9 +60,13 @@ export function createReconciler(
   // Store the onChange callbacks to be runned every time a Result has changed
   const changeEvents = new Map<Entity, Map<number, OnChangeState | undefined>>()
   const clickEvents = new Map<Entity, Map<PointerEventType, Callback>>()
-  // Track the last value reported by the renderer for each input entity,
-  // so we can avoid echoing it back and causing keystroke drops.
-  const lastInputResultValues = new Map<Entity, string | undefined>()
+  // The value each input entity is believed to already hold, used to suppress echoes
+  // that would drop keystrokes. It is source-neutral on purpose: the renderer's reported
+  // value seeds it, and a value the scene itself writes replaces it, because otherwise a
+  // scene pushing a field back to what the renderer last reported looked like an echo and
+  // was swallowed. Read it as "what the field is already showing", not "what the renderer
+  // last said".
+  const knownInputValues = new Map<Entity, string | undefined>()
   // Initialize components
   const UiTransform = components.UiTransform(engine)
   const UiText = components.UiText(engine)
@@ -126,10 +130,10 @@ export function createReconciler(
         update.component === 'onMouseDown'
           ? pointerEvents.onPointerDown
           : update.component === 'onMouseUp'
-          ? pointerEvents.onPointerUp
-          : update.component === 'onMouseEnter'
-          ? pointerEvents.onPointerHoverEnter
-          : update.component === 'onMouseLeave' && pointerEvents.onPointerHoverLeave
+            ? pointerEvents.onPointerUp
+            : update.component === 'onMouseEnter'
+              ? pointerEvents.onPointerHoverEnter
+              : update.component === 'onMouseLeave' && pointerEvents.onPointerHoverLeave
 
       if (pointerEventSystem) {
         pointerEventSystem(
@@ -192,8 +196,8 @@ export function createReconciler(
     if (
       componentName === 'uiInput' &&
       'value' in nextProps &&
-      lastInputResultValues.has(instance.entity) &&
-      (nextProps as any).value === lastInputResultValues.get(instance.entity)
+      knownInputValues.has(instance.entity) &&
+      (nextProps as any).value === knownInputValues.get(instance.entity)
     ) {
       delete (nextProps as any).value
     }
@@ -215,7 +219,7 @@ export function createReconciler(
     // compares against. Leaving the renderer's older value in place meant a
     // later push back to it looked like an echo and was dropped.
     if (componentName === 'uiInput' && 'value' in nextProps) {
-      lastInputResultValues.set(instance.entity, (nextProps as any).value)
+      knownInputValues.set(instance.entity, (nextProps as any).value)
     }
   }
 
@@ -223,7 +227,7 @@ export function createReconciler(
     entities.delete(instance.entity)
     changeEvents.delete(instance.entity)
     clickEvents.delete(instance.entity)
-    lastInputResultValues.delete(instance.entity)
+    knownInputValues.delete(instance.entity)
     engine.removeEntity(instance.entity)
     for (const child of instance._child) {
       removeChildEntity(child)
@@ -291,7 +295,7 @@ export function createReconciler(
         componentId === UiDropdown.componentId ? UiDropdownResult.componentId : UiInputResult.componentId
       engine.getComponent<PBUiInputResult | PBUiDropdownResult>(resultComponentId).onChange(entity, (value) => {
         if (resultComponentId === UiInputResult.componentId) {
-          lastInputResultValues.set(entity, value?.value as string | undefined)
+          knownInputValues.set(entity, value?.value as string | undefined)
         }
         if ((value as PBUiInputResult)?.isSubmit) {
           const onSubmit = changeEvents.get(entity)?.get(componentId)?.onSubmitCallback

--- a/test/react-ecs/input-lifecycle.spec.tsx
+++ b/test/react-ecs/input-lifecycle.spec.tsx
@@ -1,0 +1,143 @@
+import { Entity, components } from '../../packages/@dcl/ecs/src'
+import { Input, ReactEcs } from '../../packages/@dcl/react-ecs/src'
+import { setupEngine, WHOLE_SCREEN } from './utils'
+
+function inputEntity(engine: ReturnType<typeof setupEngine>['engine']) {
+  const UiInput = components.UiInput(engine)
+  let found: Entity = 0 as Entity
+  for (const [entity] of engine.getEntitiesWith(UiInput)) found = entity
+  return found
+}
+
+describe('when an onChange prop is dropped on the render right after mount', () => {
+  let engine: ReturnType<typeof setupEngine>['engine']
+  let onChange: jest.Mock
+  let entity: Entity
+
+  beforeEach(async () => {
+    const setup = setupEngine()
+    engine = setup.engine
+    onChange = jest.fn()
+
+    let editing = true
+    // Omitting the prop entirely, which is what a conditional spread produces.
+    setup.uiRenderer.setUiRenderer(() => <Input {...(editing ? { onChange } : {})} />, WHOLE_SCREEN)
+    await engine.update(1)
+
+    editing = false
+    await engine.update(1)
+
+    entity = inputEntity(engine)
+    components.UiInputResult(engine).create(entity, { value: 'typed' })
+    await engine.update(1)
+  })
+
+  it('should stop calling the handler that is no longer rendered', () => {
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('when an onChange prop is kept', () => {
+  let engine: ReturnType<typeof setupEngine>['engine']
+  let onChange: jest.Mock
+
+  beforeEach(async () => {
+    const setup = setupEngine()
+    engine = setup.engine
+    onChange = jest.fn()
+
+    setup.uiRenderer.setUiRenderer(() => <Input onChange={onChange} />, WHOLE_SCREEN)
+    await engine.update(1)
+    await engine.update(1)
+
+    components.UiInputResult(engine).create(inputEntity(engine), { value: 'typed' })
+    await engine.update(1)
+  })
+
+  it('should call it', () => {
+    expect(onChange).toHaveBeenCalledWith('typed')
+  })
+})
+
+describe('when the scene restores a value the renderer reported earlier', () => {
+  let engine: ReturnType<typeof setupEngine>['engine']
+  let UiInput: ReturnType<typeof components.UiInput>
+  let entity: Entity
+  let value: string
+
+  beforeEach(async () => {
+    const setup = setupEngine()
+    engine = setup.engine
+    UiInput = components.UiInput(engine)
+    value = ''
+
+    setup.uiRenderer.setUiRenderer(
+      () => (
+        <Input
+          value={value}
+          onChange={(typed) => {
+            value = typed
+          }}
+        />
+      ),
+      WHOLE_SCREEN
+    )
+    await engine.update(1)
+
+    // The player types, and the renderer reports it.
+    entity = inputEntity(engine)
+    components.UiInputResult(engine).create(entity, { value: 'gm' })
+    await engine.update(1)
+
+    // React re-renders with what it was told, which is the echo the reconciler
+    // is right to drop.
+    await engine.update(1)
+
+    // The scene clears the field, the way a chat box does after sending.
+    value = ''
+    await engine.update(1)
+
+    // And then restores what was typed, the way a "repeat last" button does.
+    value = 'gm'
+    await engine.update(1)
+  })
+
+  it('should put the restored value in the field', () => {
+    expect(UiInput.get(entity).value).toBe('gm')
+  })
+})
+
+describe('when React re-renders with the value the renderer just reported', () => {
+  let engine: ReturnType<typeof setupEngine>['engine']
+  let UiInput: ReturnType<typeof components.UiInput>
+  let entity: Entity
+
+  beforeEach(async () => {
+    const setup = setupEngine()
+    engine = setup.engine
+    UiInput = components.UiInput(engine)
+    let value = ''
+
+    setup.uiRenderer.setUiRenderer(
+      () => (
+        <Input
+          value={value}
+          onChange={(typed) => {
+            value = typed
+          }}
+        />
+      ),
+      WHOLE_SCREEN
+    )
+    await engine.update(1)
+
+    entity = inputEntity(engine)
+    components.UiInputResult(engine).create(entity, { value: 'gm' })
+    await engine.update(1)
+    await engine.update(1)
+  })
+
+  it('should not write that echo back onto the component', () => {
+    expect(UiInput.get(entity).value).toBe('')
+  })
+})

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=430.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -48,22 +48,22 @@ CALL onUpdate(0)
   Scene: PUT_COMPONENT e=0x202 c=1093 t=1 data={"placeholder":"SARASA","disabled":false}
   Scene: PUT_COMPONENT e=0x209 c=1093 t=1 data={"placeholder":"","disabled":false}
   Scene: PUT_COMPONENT e=0x201 c=1094 t=1 data={"acceptEmpty":false,"options":["BOEDO","CASLA"],"selectedIndex":0,"disabled":false,"color":{"r":1,"g":0,"b":0,"a":1}}
-  OPCODES ~= 154k
-  MALLOC_COUNT = 1012
+  OPCODES ~= 155k
+  MALLOC_COUNT = 1011
   ALIVE_OBJS_DELTA ~= 0.33k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=2 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.008726535364985466,"z":0,"w":0.9999619126319885},"scale":{"x":1,"y":1,"z":1},"parent":0}
   OPCODES ~= 83k
-  MALLOC_COUNT = 279
+  MALLOC_COUNT = 277
   ALIVE_OBJS_DELTA ~= 0.14k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=3 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.017452405765652657,"z":0,"w":0.9998477101325989},"scale":{"x":1,"y":1,"z":1},"parent":0}
   OPCODES ~= 81k
-  MALLOC_COUNT = 37
+  MALLOC_COUNT = 40
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=4 data={"position":{"x":8,"y":1,"z":8},"rotation":{"x":0,"y":0.026176948100328445,"z":0,"w":0.9996573328971863},"scale":{"x":1,"y":1,"z":1},"parent":0}
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.19k bytes
+  MEMORY_USAGE_COUNT ~= 1979.41k bytes


### PR DESCRIPTION
## What / why

Two problems in `upsertComponent`, both around `UiInput`.

**It deletes from React's own props.** After wiring the callbacks up it does:

```ts
delete (props as any).onChange
delete (props as any).onSubmit
```

On the create path that object is the element's live props. The next diff therefore sees no `onChange` key in the *old* props, so dropping the handler on the very next render emits no change at all and the stale callback keeps firing:

```tsx
<Input {...(editing ? { onChange: handler } : {})} />
```

Mount with `editing` true, render again with it false, type in the field, and `handler` still runs. Working on a copy fixes it. Any render after the first is unaffected, because `commitUpdate` passes a fresh object, which is why this only bites on the render right after mount.

**The echo baseline goes stale.** `lastInputResultValues` exists to stop React writing back a value the renderer just reported and clobbering what the player is typing. It is only ever written from the renderer's side, so a value the scene pushes itself leaves it pointing at something older. Push back to that older value and it looks like an echo and is dropped:

```tsx
// chat box: player types "gm", scene sends it and clears the field,
// then a "repeat last" button puts "gm" back — and nothing happens
```

Recording what the scene writes keeps the comparison meaningful.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/react-ecs'
```

On `main` two of the four cases in the new file fail: the dropped handler is called once, and the restored value never reaches the component. On this branch all 21 suites and 156 tests pass.

## Proof

`test/react-ecs/input-lifecycle.spec.tsx` is new. It covers a handler dropped on the render right after mount, a handler that is kept and must still fire, the clear-and-restore sequence, and the echo itself, which must still be dropped so the fix cannot be "stop suppressing echoes".

## Known limitation, unchanged by this PR

The echo baseline is still a single remembered value rather than a per-edit session. If the scene changes its state twice between two renders, so React never renders the intermediate value, the diff it eventually emits can still be mistaken for an echo. Fixing that properly means tracking the field's editing session rather than its last value, which is a bigger change than this one and I did not want to fold it in.

Snapshots were regenerated, sizes and allocation counters only. `reconciler/index.ts` fails `prettier --check` and reports the same six eslint problems on `main` and on this branch alike.

A scene that shows both is at [`react-ecs-input-lifecycle`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/react-ecs-input-lifecycle).