### PR TITLE
fix: stop logging storage 404s as errors

### DIFF
--- a/packages/@dcl/sdk/src/server/utils.ts
+++ b/packages/@dcl/sdk/src/server/utils.ts
@@ -58,7 +58,12 @@ export async function wrapSignedFetch<T = unknown>(signedFetchBody: SignedFetchR
 
   if (!response.ok) {
     const errorMessage = `${response.status} ${response.statusText}`
-    console.error(`Error in ${signedFetchBody.url} endpoint`, { response })
+    // 404 is a first-class outcome for storage/env lookups (key not created yet),
+    // not a failure: every caller branches on the status and treats it as absent.
+    // Logging it as ERROR printed one line per new visitor per missing key.
+    if (response.status !== 404) {
+      console.error(`Error in ${signedFetchBody.url} endpoint`, { response })
+    }
     return [errorMessage, null, response.status]
   }
 

--- a/test/sdk/server/utils.spec.ts
+++ b/test/sdk/server/utils.spec.ts
@@ -76,3 +76,32 @@ describe('wrapSignedFetch', () => {
     expect(status).toBeUndefined()
   })
 })
+
+describe('wrapSignedFetch 404 handling', () => {
+  beforeEach(() => {
+    mockSignedFetch.mockReset()
+  })
+
+  it('returns the status tuple for a 404 without logging an error', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockSignedFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', body: '{"error":"Not Found"}' })
+
+    const [error, data, status] = await wrapSignedFetch({ url: 'https://storage.test/values/missing-key' })
+
+    expect(error).toBe('404 Not Found')
+    expect(data).toBeNull()
+    expect(status).toBe(404)
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('still logs other failure statuses', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockSignedFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error', body: '' })
+
+    const [error, , status] = await wrapSignedFetch({ url: 'https://storage.test/values/k' })
+
+    expect(error).toBe('500 Server Error')
+    expect(status).toBe(500)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
A missing storage key is normal (`Storage.player.get()` for a never-written key — every first-time visitor triggers one per key), and every `wrapSignedFetch` caller already branches on the 404 status and returns null/absent. But the wrapper itself logged an ERROR before callers could decide, flooding server logs on busy scenes — one line per new Genesis Plaza visitor. Now 404 returns the same `['404 Not Found', null, 404]` tuple silently; every other failure status still logs.

Closes decentraland/sdk-multiplayer-server#139.

## What could break
Nothing behavioral — the return tuple is unchanged for all statuses, only the log line is gated. Anything grepping logs for storage 404s loses that signal (it was noise by consensus on the issue).

## How to test
`npx jest test/sdk/server/utils.spec.ts` — the new case `returns the status tuple for a 404 without logging an error` fails on auth-server before this change (verified) and passes after; a companion case pins that 500s still log.