### PR TITLE
fix(sdk): stop the internal observable and provider calling back twice

### DIFF
--- a/packages/@dcl/sdk/src/internal/Observable.ts
+++ b/packages/@dcl/sdk/src/internal/Observable.ts
@@ -234,14 +234,17 @@ export class Observable<T> {
       }
 
       if (obs.mask & mask) {
+        // Marked before the call, not after: a callback that notifies this same
+        // observable would otherwise still see a once-observer as live and run
+        // it a second time.
+        if (obs.unregisterOnNextCall) {
+          this._deferUnregister(obs)
+        }
+
         if (obs.scope) {
           state.lastReturnValue = obs.callback.apply(obs.scope, [eventData, state])
         } else {
           state.lastReturnValue = obs.callback(eventData, state)
-        }
-
-        if (obs.unregisterOnNextCall) {
-          this._deferUnregister(obs)
         }
       }
       if (state.skipNextObservers) {

--- a/packages/@dcl/sdk/src/internal/provider.ts
+++ b/packages/@dcl/sdk/src/internal/provider.ts
@@ -35,17 +35,27 @@ export function getEthereumProvider(sendAsync: SendAsyncType) {
     // @internal
     send(message: RPCSendableMessage, callback?: (error: Error | null, result?: any) => void): void {
       if (message && callback && callback instanceof Function) {
+        // Failure is handled as .then's second argument, not as a .catch after
+        // it: chained, a throw from the success callback would run the callback
+        // a second time with its own error, as though the call had failed. The
+        // trailing catch reports that throw instead of losing it.
         request(message)
-          .then((x: any) => callback(null, x))
-          .catch(callback)
+          .then(
+            (x: any) => callback(null, x),
+            (error: Error) => callback(error)
+          )
+          .catch(console.error)
       } else {
         throw new Error('Decentraland provider only allows async calls')
       }
     },
     sendAsync(message: RPCSendableMessage, callback: (error: Error | null, result?: any) => void): void {
       request(message)
-        .then((x: any) => callback(null, x))
-        .catch(callback)
+        .then(
+          (x: any) => callback(null, x),
+          (error: Error) => callback(error)
+        )
+        .catch(console.error)
     }
   }
 }

--- a/test/sdk/internal-callbacks.spec.ts
+++ b/test/sdk/internal-callbacks.spec.ts
@@ -1,0 +1,118 @@
+import { Observable } from '../../packages/@dcl/sdk/src/internal/Observable'
+import { getEthereumProvider } from '../../packages/@dcl/sdk/src/internal/provider'
+
+describe('when a once-observer notifies the same observable from inside its callback', () => {
+  let observable: Observable<number>
+  let calls: number[]
+
+  beforeEach(() => {
+    observable = new Observable<number>()
+    calls = []
+    observable.addOnce((value) => {
+      calls.push(value)
+      if (value === 1) {
+        observable.notifyObservers(2)
+      }
+    })
+    observable.notifyObservers(1)
+  })
+
+  it('should run the callback once', () => {
+    expect(calls).toEqual([1])
+  })
+})
+
+describe('when a once-observer is notified twice in the ordinary way', () => {
+  let observable: Observable<number>
+  let calls: number[]
+
+  beforeEach(() => {
+    observable = new Observable<number>()
+    calls = []
+    observable.addOnce((value) => calls.push(value))
+    observable.notifyObservers(1)
+    observable.notifyObservers(2)
+  })
+
+  it('should run the callback for the first notification only', () => {
+    expect(calls).toEqual([1])
+  })
+})
+
+describe('when an ordinary observer is notified', () => {
+  let observable: Observable<number>
+  let calls: number[]
+
+  beforeEach(() => {
+    observable = new Observable<number>()
+    calls = []
+    observable.add((value) => calls.push(value))
+    observable.notifyObservers(1)
+    observable.notifyObservers(2)
+  })
+
+  it('should keep running for every notification', () => {
+    expect(calls).toEqual([1, 2])
+  })
+})
+
+describe('when a provider callback throws on success', () => {
+  let calls: { error: Error | null; result?: unknown }[]
+  let consoleError: jest.SpyInstance
+
+  beforeEach(async () => {
+    calls = []
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const { sendAsync } = getEthereumProvider(async () => ({ jsonAnyResponse: JSON.stringify({ ok: true }) }))
+
+    await new Promise<void>((resolve) => {
+      sendAsync({ id: 1, jsonrpc: '2.0', method: 'test', params: [] }, (error, result) => {
+        calls.push({ error, result })
+        setTimeout(resolve, 0)
+        throw new Error('the scene handler threw')
+      })
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should call it once', () => {
+    expect(calls).toHaveLength(1)
+  })
+
+  it('should call it with the result rather than an error', () => {
+    expect(calls[0].error).toBeNull()
+  })
+
+  it('should report the throw rather than lose it', () => {
+    expect(consoleError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when a provider request fails', () => {
+  let calls: { error: Error | null; result?: unknown }[]
+
+  beforeEach(async () => {
+    calls = []
+    const { sendAsync } = getEthereumProvider(async () => {
+      throw new Error('the request failed')
+    })
+
+    await new Promise<void>((resolve) => {
+      sendAsync({ id: 1, jsonrpc: '2.0', method: 'test', params: [] }, (error, result) => {
+        calls.push({ error, result })
+        resolve()
+      })
+    })
+  })
+
+  it('should report the failure to the callback once', () => {
+    expect(calls).toHaveLength(1)
+  })
+
+  it('should pass the error', () => {
+    expect(calls[0].error).toEqual(expect.objectContaining({ message: 'the request failed' }))
+  })
+})


### PR DESCRIPTION
## What / why

Two callback-dispatch bugs in `packages/@dcl/sdk/src/internal`, both of which run a scene's callback a second time. They are shipped together because they are the same mistake in two places.

**The observable marks a once-observer too late.** `notifyObservers` invokes the callback and only then defers the unregistration:

```ts
state.lastReturnValue = obs.callback(eventData, state)

if (obs.unregisterOnNextCall) {
  this._deferUnregister(obs)
}
```

A callback that notifies the same observable, which is how one event triggers the next, therefore finds the observer still live and runs it again:

```ts
observable.addOnce((value) => {
  if (value === 1) observable.notifyObservers(2)   // the callback runs for 2 as well
})
observable.notifyObservers(1)
```

Marking before the call fixes it. Upstream Babylon, which this is ported from, made the same move.

**The provider chains catch onto then.**

```ts
request(message)
  .then((x: any) => callback(null, x))
  .catch(callback)
```

`.catch` sits after the success handler, so a throw from the callback is caught and handed straight back to that same callback as an error, as though the request had failed. The scene sees its own bug reported as a network failure, and its handler runs twice for one request.

Failure is now `.then`'s second argument, so only a request failure reaches the error path. A throw from either callback is reported through `console.error` rather than lost, which matches how this package already surfaces scene-thrown errors elsewhere.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/sdk/'
```

On `main` four of the eight cases in the new file fail. On this branch all 12 suites and 110 tests pass.

## Proof

`test/sdk/internal-callbacks.spec.ts` is new. For the observable: the re-entrant case, a once-observer notified twice the ordinary way, and an ordinary observer that must keep firing. For the provider: a callback that throws on success must run once, be given the result rather than an error, and have its throw reported; and a request that genuinely fails must still reach the callback once with the error.

Snapshots were regenerated, sizes and allocation counters only.

No scene: both need a callback that throws or re-enters, which a spec expresses directly and an in-world readout would only obscure.