### PR TITLE
fix(ecs): declare the real length of a network entity delete

### DIFF
--- a/packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork.ts
+++ b/packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork.ts
@@ -10,8 +10,11 @@ export namespace DeleteEntityNetwork {
   export const MESSAGE_HEADER_LENGTH = 8
 
   export function write(entity: Entity, networkId: number, buf: ByteBuffer) {
-    // Write CrdtMessage header
-    buf.writeUint32(CRDT_MESSAGE_HEADER_LENGTH + 4)
+    // Write CrdtMessage header. The body is the entity and the network id, so
+    // it is MESSAGE_HEADER_LENGTH long: declaring 4 described a message four
+    // bytes shorter than the one being written, and anything that skips by the
+    // declared length landed in the middle of it.
+    buf.writeUint32(CRDT_MESSAGE_HEADER_LENGTH + MESSAGE_HEADER_LENGTH)
     buf.writeUint32(CrdtMessageType.DELETE_ENTITY_NETWORK)
     // body
     buf.writeUint32(entity)

--- a/test/ecs/delete-entity-network-framing.spec.ts
+++ b/test/ecs/delete-entity-network-framing.spec.ts
@@ -1,0 +1,36 @@
+import { Entity } from '../../packages/@dcl/ecs/src/engine'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { CrdtMessageProtocol } from '../../packages/@dcl/ecs/src/serialization/crdt'
+import { DeleteEntityNetwork } from '../../packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork'
+import { CrdtMessageType } from '../../packages/@dcl/ecs/src/serialization/crdt/types'
+
+const ENTITY = 512 as Entity
+const NETWORK_ID = 7
+
+describe('when a network entity delete is written', () => {
+  let buffer: ReadWriteByteBuffer
+  let bytesWritten: number
+
+  beforeEach(() => {
+    buffer = new ReadWriteByteBuffer()
+    DeleteEntityNetwork.write(ENTITY, NETWORK_ID, buffer)
+    bytesWritten = buffer.currentWriteOffset()
+  })
+
+  it('should declare the length it actually wrote', () => {
+    expect(CrdtMessageProtocol.getHeader(buffer)?.length).toBe(bytesWritten)
+  })
+
+  it('should let a reader that skips by the declared length land on the next message', () => {
+    DeleteEntityNetwork.write(ENTITY, NETWORK_ID, buffer)
+    CrdtMessageProtocol.consumeMessage(buffer)
+
+    expect(CrdtMessageProtocol.getHeader(buffer)?.type).toBe(CrdtMessageType.DELETE_ENTITY_NETWORK)
+  })
+
+  it('should still read its own fields back', () => {
+    const message = DeleteEntityNetwork.read(buffer)
+
+    expect(message).toMatchObject({ entityId: ENTITY, networkId: NETWORK_ID })
+  })
+})

--- a/test/ecs/delete-entity-network-framing.spec.ts
+++ b/test/ecs/delete-entity-network-framing.spec.ts
@@ -1,6 +1,7 @@
 import { Entity } from '../../packages/@dcl/ecs/src/engine'
 import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { CrdtMessageProtocol } from '../../packages/@dcl/ecs/src/serialization/crdt'
+import { DeleteEntity } from '../../packages/@dcl/ecs/src/serialization/crdt/deleteEntity'
 import { DeleteEntityNetwork } from '../../packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork'
 import { CrdtMessageType } from '../../packages/@dcl/ecs/src/serialization/crdt/types'
 
@@ -32,5 +33,30 @@ describe('when a network entity delete is written', () => {
     const message = DeleteEntityNetwork.read(buffer)
 
     expect(message).toMatchObject({ entityId: ENTITY, networkId: NETWORK_ID })
+  })
+})
+
+describe('when there is no message left to read', () => {
+  let buffer: ReadWriteByteBuffer
+
+  beforeEach(() => {
+    buffer = new ReadWriteByteBuffer()
+  })
+
+  it('should return nothing rather than read past the end', () => {
+    expect(DeleteEntityNetwork.read(buffer)).toBeNull()
+  })
+})
+
+describe('when the next message is of another type', () => {
+  let buffer: ReadWriteByteBuffer
+
+  beforeEach(() => {
+    buffer = new ReadWriteByteBuffer()
+    DeleteEntity.write(ENTITY, buffer)
+  })
+
+  it('should refuse to read it as a network delete', () => {
+    expect(() => DeleteEntityNetwork.read(buffer)).toThrow('tried to read another message type')
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16881
+  MALLOC_COUNT = 16884
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1549.94k bytes
+  MEMORY_USAGE_COUNT ~= 1550.03k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17436
+  MALLOC_COUNT = 17439
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.77k bytes
+  MEMORY_USAGE_COUNT ~= 1555.86k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17436
+  MALLOC_COUNT = 17439
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.77k bytes
+  MEMORY_USAGE_COUNT ~= 1555.86k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15761
+  MALLOC_COUNT = 15763
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.72k bytes
+  MEMORY_USAGE_COUNT ~= 1139.76k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18267
+  MALLOC_COUNT = 18269
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.57k bytes
+  MEMORY_USAGE_COUNT ~= 1325.60k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14878
+  MALLOC_COUNT = 14880
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.80k bytes
+  MEMORY_USAGE_COUNT ~= 1101.84k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14851
+  MALLOC_COUNT = 14853
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.56k bytes
+  MEMORY_USAGE_COUNT ~= 1091.59k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21604
+  MALLOC_COUNT = 21606
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.04k bytes
+  MEMORY_USAGE_COUNT ~= 1550.08k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15144
+  MALLOC_COUNT = 15146
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.26k bytes
+  MEMORY_USAGE_COUNT ~= 1111.29k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 81k
-  MALLOC_COUNT = 14983
+  MALLOC_COUNT = 14985
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.01k bytes
+  MEMORY_USAGE_COUNT ~= 1094.04k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23147
+  MALLOC_COUNT = 23149
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.19k bytes
+  MEMORY_USAGE_COUNT ~= 1979.22k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15087
+  MALLOC_COUNT = 15089
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.04k bytes
+  MEMORY_USAGE_COUNT ~= 1111.07k bytes


### PR DESCRIPTION
## What / why

`DeleteEntityNetwork.write` writes an eight byte body, the entity and the network id, and declares its message four bytes shorter than that:

```ts
export const MESSAGE_HEADER_LENGTH = 8      // declared, never used

export function write(entity: Entity, networkId: number, buf: ByteBuffer) {
  buf.writeUint32(CRDT_MESSAGE_HEADER_LENGTH + 4)     // says 12
  buf.writeUint32(CrdtMessageType.DELETE_ENTITY_NETWORK)
  buf.writeUint32(entity)                             // writes 16
  buf.writeUint32(networkId)
}
```

The namespace already carries the right constant and simply is not using it. Its sibling `DeleteComponentNetwork` does exactly that:

```ts
const messageLength = CRDT_MESSAGE_HEADER_LENGTH + MESSAGE_HEADER_LENGTH
```

The SDK reads these messages by consuming their fields rather than by framing, so SDK-to-SDK traffic never notices. A reader that skips a message by its declared length, which is what the protocol asks of anything meeting a type it does not know, lands four bytes into the message instead of past it and then reads the rest of the chunk as garbage.

| | declared | actually written |
| --- | --- | --- |
| `main` | 12 | 16 |
| this branch | 16 | 16 |

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs'
```

On `main` two of the three cases in the new file fail: the declared length does not match what was written, and a reader skipping by it does not land on the next message. On this branch all 106 suites pass.

## Proof

`test/ecs/delete-entity-network-framing.spec.ts` is new. It checks the declared length against the bytes actually written, writes two messages back to back and confirms that consuming the first by its declared length lands exactly on the second, and confirms the message still reads its own fields back. Two more cases cover `read`'s guards, nothing left to read and a message of another type, which brings `deleteEntityNetwork.ts` to 100% from 9.1% on `main`.

**No repro scene for this one.** The symptom is a byte count in a message header, visible to a reader that frames by length rather than to anything a scene can show in world. The spec measures it directly.

Snapshots were regenerated, sizes and allocation counters only.

Worth knowing when this lands: any implementation that has been compensating for the short length, by skipping 12 and resynchronising, would need to stop. I found nothing in this repo doing that.
