### PR TITLE
fix(ecs): drop a component update whose payload the schema cannot read

### DIFF
--- a/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
+++ b/packages/@dcl/ecs/src/engine/lww-element-set-component-definition.ts
@@ -130,13 +130,17 @@ export function createUpdateLwwFromCrdt(
     switch (action) {
       case ProcessMessageResultType.StateUpdatedData:
       case ProcessMessageResultType.StateUpdatedTimestamp: {
-        timestamps.set(entity, msg.timestamp)
-
         if (msg.type === CrdtMessageType.PUT_COMPONENT || msg.type === CrdtMessageType.PUT_COMPONENT_NETWORK) {
-          const buf = new ReadWriteByteBuffer(msg.data!)
-          data.set(entity, schema.deserialize(buf))
+          // Deserialize before touching any state. A peer can send a payload this
+          // schema cannot read (a truncated buffer, say), and deserialize then throws.
+          // Reading it first leaves timestamps and data untouched on failure, so the
+          // caller can drop the message and a later well-formed update still wins.
+          const value = schema.deserialize(new ReadWriteByteBuffer(msg.data!))
+          timestamps.set(entity, msg.timestamp)
+          data.set(entity, value)
           lastSentData.set(entity, new Uint8Array(msg.data!))
         } else {
+          timestamps.set(entity, msg.timestamp)
           data.delete(entity)
           lastSentData.delete(entity)
         }

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -22,6 +22,22 @@ import {
 import { INetowrkEntityType } from '../../components/types'
 import * as networkUtils from '../../serialization/crdt/network/utils'
 
+/**
+ * Whether a component's schema can read this payload without running off the end. Used as
+ * a trust boundary for CRDT input from peers: a payload that fails here is dropped before
+ * it can allocate an entity or mutate a component. Deserialize has no side effects, so the
+ * value it produces is discarded and read again when the message is actually applied.
+ */
+function payloadIsReadable(component: ComponentDefinition<unknown>, data: Uint8Array | undefined): boolean {
+  if (!data) return false
+  try {
+    component.schema.deserialize(new ReadWriteByteBuffer(data))
+    return true
+  } catch {
+    return false
+  }
+}
+
 // NetworkMessages can only have a MAX_SIZE of 12kb. So we need to send it in chunks.
 export const LIVEKIT_MAX_SIZE = 12
 
@@ -140,6 +156,22 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
 
     for (const msg of messagesToProcess) {
       let { entityId, network } = findNetworkId(msg)
+
+      // A peer can send a component payload this schema cannot read (a truncated buffer,
+      // say). Drop it here, before anything mutates: no network entity is allocated for a
+      // message we are going to discard, and the apply path below can then trust its input
+      // instead of guarding every read. Only these three carry a payload to deserialize.
+      if (
+        msg.type === CrdtMessageType.PUT_COMPONENT ||
+        msg.type === CrdtMessageType.PUT_COMPONENT_NETWORK ||
+        msg.type === CrdtMessageType.APPEND_VALUE
+      ) {
+        const component = engine.getComponentOrNull(msg.componentId)
+        if (component && !payloadIsReadable(component, msg.data)) {
+          continue
+        }
+      }
+
       // We receive a new Entity. Create the localEntity and map it to the NetworkEntity component
       if (networkUtils.isNetworkMessage(msg) && !network) {
         entityId = engine.addEntity()
@@ -172,17 +204,9 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           ) {
             msg.data = networkUtils.fixTransformParent(msg)
           }
-          let conflictMessage: ReturnType<typeof component.updateFromCrdt>[0]
-          let value: ReturnType<typeof component.updateFromCrdt>[1]
-          try {
-            ;[conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
-          } catch {
-            // The component's schema could not read this message's payload (a peer sent
-            // a truncated or otherwise invalid buffer). The component left its state
-            // untouched, so we drop just this message: the rest of the batch, and the
-            // scene, keep running instead of the whole tick aborting.
-            continue
-          }
+          // The payload was validated at the top of the loop, so this only throws on a
+          // genuine engine bug now, which should surface rather than be swallowed.
+          const [conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
           if (!conflictMessage) {
             // Add message to transport queue to be processed by others transports
             broadcastMessages.push(msg)

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -172,7 +172,17 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           ) {
             msg.data = networkUtils.fixTransformParent(msg)
           }
-          const [conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
+          let conflictMessage: ReturnType<typeof component.updateFromCrdt>[0]
+          let value: ReturnType<typeof component.updateFromCrdt>[1]
+          try {
+            ;[conflictMessage, value] = component.updateFromCrdt({ ...msg, entityId })
+          } catch {
+            // The component's schema could not read this message's payload (a peer sent
+            // a truncated or otherwise invalid buffer). The component left its state
+            // untouched, so we drop just this message: the rest of the batch, and the
+            // scene, keep running instead of the whole tick aborting.
+            continue
+          }
           if (!conflictMessage) {
             // Add message to transport queue to be processed by others transports
             broadcastMessages.push(msg)

--- a/test/ecs/crdt-malformed-payload.spec.ts
+++ b/test/ecs/crdt-malformed-payload.spec.ts
@@ -1,0 +1,211 @@
+import { components, Schemas } from '../../packages/@dcl/ecs/src'
+import { Engine } from '../../packages/@dcl/ecs/src/engine'
+import { Entity } from '../../packages/@dcl/ecs/src/engine/entity'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { AppendValueOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/appendValue'
+import { PutComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/putComponent'
+import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
+
+/**
+ * A well-framed PUT_COMPONENT whose data buffer is shorter than the component's
+ * schema needs. The frame is valid — the header, the fields and the announced
+ * data length all agree — so the message is read; only the deserialize that
+ * follows runs past the end of the buffer.
+ */
+function craftShortPut(entity: Entity, componentId: number, timestamp: number, dataBytes: number): Uint8Array {
+  const buffer = new ReadWriteByteBuffer()
+  PutComponentOperation.write(entity, timestamp, componentId, new Uint8Array(dataBytes), buffer)
+  return buffer.toBinary()
+}
+
+function craftShortAppend(entity: Entity, componentId: number, timestamp: number, dataBytes: number): Uint8Array {
+  const buffer = new ReadWriteByteBuffer()
+  AppendValueOperation.write(entity, timestamp, componentId, new Uint8Array(dataBytes), buffer)
+  return buffer.toBinary()
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const chunk = new Uint8Array(parts.reduce((total, part) => total + part.byteLength, 0))
+  let offset = 0
+  for (const part of parts) {
+    chunk.set(part, offset)
+    offset += part.byteLength
+  }
+  return chunk
+}
+
+describe('when a peer sends a last-write-wins component update whose payload is too short for the schema', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let transport: Transport
+  let entity: Entity
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    entity = 512 as Entity
+    transport.onmessage!(craftShortPut(entity, Transform.componentId, 1, 4))
+  })
+
+  it('should let the engine finish the update instead of throwing out of the tick', async () => {
+    await expect(engine.update(1)).resolves.toBeUndefined()
+  })
+
+  it('should leave the component with no value for that entity', async () => {
+    await engine.update(1)
+
+    expect(Transform.getOrNull(entity)).toBe(null)
+  })
+})
+
+describe('when a malformed last-write-wins update is followed in the same batch by a well-formed one', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let transport: Transport
+  let malformedEntity: Entity
+  let healthyEntity: Entity
+  let healthyPosition: { x: number; y: number; z: number }
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    malformedEntity = 512 as Entity
+    healthyEntity = 513 as Entity
+    healthyPosition = { x: 4, y: 5, z: 6 }
+
+    const healthy = new ReadWriteByteBuffer()
+    const healthyData = new ReadWriteByteBuffer()
+    Transform.schema.serialize(
+      {
+        position: healthyPosition,
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        parent: 0 as Entity
+      },
+      healthyData
+    )
+    PutComponentOperation.write(healthyEntity, 1, Transform.componentId, healthyData.toBinary(), healthy)
+
+    transport.onmessage!(concat(craftShortPut(malformedEntity, Transform.componentId, 1, 4), healthy.toBinary()))
+  })
+
+  it('should still apply the well-formed update that follows the malformed one', async () => {
+    await engine.update(1)
+
+    expect(Transform.getOrNull(healthyEntity)?.position).toEqual(healthyPosition)
+  })
+
+  it('should leave no value for the entity of the malformed update', async () => {
+    await engine.update(1)
+
+    expect(Transform.getOrNull(malformedEntity)).toBe(null)
+  })
+})
+
+describe('when a well-formed update arrives after a dropped malformed one for the same entity', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let transport: Transport
+  let entity: Entity
+  let laterPosition: { x: number; y: number; z: number }
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    entity = 512 as Entity
+    laterPosition = { x: 7, y: 8, z: 9 }
+
+    // The malformed update is dropped without advancing the entity's timestamp,
+    // so a well-formed update at the same lamport number is still a first write.
+    transport.onmessage!(craftShortPut(entity, Transform.componentId, 1, 4))
+
+    const healthy = new ReadWriteByteBuffer()
+    const healthyData = new ReadWriteByteBuffer()
+    Transform.schema.serialize(
+      {
+        position: laterPosition,
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        parent: 0 as Entity
+      },
+      healthyData
+    )
+    PutComponentOperation.write(entity, 1, Transform.componentId, healthyData.toBinary(), healthy)
+    transport.onmessage!(healthy.toBinary())
+  })
+
+  it('should apply the well-formed update', async () => {
+    await engine.update(1)
+
+    expect(Transform.getOrNull(entity)?.position).toEqual(laterPosition)
+  })
+})
+
+describe('when a malformed last-write-wins update is delivered on one transport', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let source: Transport
+  let sink: Transport
+  let sinkReceived: number
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    sinkReceived = 0
+    source = { send: async () => {}, filter: () => true, type: 'network' }
+    sink = {
+      send: async (messages) => {
+        for (const message of [messages].flat()) {
+          sinkReceived += message.byteLength
+        }
+      },
+      filter: () => true,
+      type: 'network'
+    }
+    engine.addTransport(source)
+    engine.addTransport(sink)
+    source.onmessage!(craftShortPut(512 as Entity, Transform.componentId, 1, 4))
+  })
+
+  it('should not relay the dropped message to the other transport', async () => {
+    await engine.update(1)
+
+    expect(sinkReceived).toBe(0)
+  })
+})
+
+describe('when a peer appends a grow-only value whose payload is too short for the schema', () => {
+  const schema = Schemas.Map({ timestamp: Schemas.Int, text: Schemas.String })
+  let engine: ReturnType<typeof Engine>
+  let GrowOnly: ReturnType<ReturnType<typeof Engine>['defineValueSetComponentFromSchema']>
+  let transport: Transport
+  let entity: Entity
+
+  beforeEach(() => {
+    engine = Engine()
+    GrowOnly = engine.defineValueSetComponentFromSchema('test-grow-only', schema, {
+      timestampFunction: (value) => value.timestamp,
+      maxElements: 10
+    })
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    entity = 512 as Entity
+    transport.onmessage!(craftShortAppend(entity, GrowOnly.componentId, 1, 2))
+  })
+
+  it('should let the engine finish the update instead of throwing out of the tick', async () => {
+    await expect(engine.update(1)).resolves.toBeUndefined()
+  })
+
+  it('should not add any value to the set for that entity', async () => {
+    await engine.update(1)
+
+    expect(Array.from(GrowOnly.get(entity))).toEqual([])
+  })
+})

--- a/test/ecs/crdt-malformed-payload.spec.ts
+++ b/test/ecs/crdt-malformed-payload.spec.ts
@@ -4,6 +4,7 @@ import { Entity } from '../../packages/@dcl/ecs/src/engine/entity'
 import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
 import { AppendValueOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/appendValue'
 import { PutComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/putComponent'
+import { PutNetworkComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
 import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
 
 /**
@@ -21,6 +22,18 @@ function craftShortPut(entity: Entity, componentId: number, timestamp: number, d
 function craftShortAppend(entity: Entity, componentId: number, timestamp: number, dataBytes: number): Uint8Array {
   const buffer = new ReadWriteByteBuffer()
   AppendValueOperation.write(entity, timestamp, componentId, new Uint8Array(dataBytes), buffer)
+  return buffer.toBinary()
+}
+
+function craftShortNetworkPut(
+  entity: Entity,
+  componentId: number,
+  networkId: number,
+  timestamp: number,
+  dataBytes: number
+): Uint8Array {
+  const buffer = new ReadWriteByteBuffer()
+  PutNetworkComponentOperation.write(entity, timestamp, componentId, networkId, new Uint8Array(dataBytes), buffer)
   return buffer.toBinary()
 }
 
@@ -207,5 +220,118 @@ describe('when a peer appends a grow-only value whose payload is too short for t
     await engine.update(1)
 
     expect(Array.from(GrowOnly.get(entity))).toEqual([])
+  })
+})
+
+describe('when a peer sends a malformed network component update for an unseen network entity', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let source: Transport
+  let sink: Transport
+  let sinkReceived: number
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    sinkReceived = 0
+    source = { send: async () => {}, filter: () => true, type: 'network' }
+    sink = {
+      send: async (messages) => {
+        for (const message of [messages].flat()) {
+          sinkReceived += message.byteLength
+        }
+      },
+      filter: () => true,
+      type: 'network'
+    }
+    engine.addTransport(source)
+    engine.addTransport(sink)
+    source.onmessage!(craftShortNetworkPut(7 as Entity, Transform.componentId, 123, 1, 4))
+  })
+
+  it('should let the engine finish the update instead of throwing out of the tick', async () => {
+    await expect(engine.update(1)).resolves.toBeUndefined()
+  })
+
+  it('should not allocate a network entity mapping for it', async () => {
+    await engine.update(1)
+
+    expect(Array.from(engine.getEntitiesWith(NetworkEntity))).toEqual([])
+  })
+
+  it('should not relay the dropped message to the other transport', async () => {
+    await engine.update(1)
+
+    expect(sinkReceived).toBe(0)
+  })
+})
+
+describe('when a peer sends more than one malformed network component update', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let transport: Transport
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    transport.onmessage!(craftShortNetworkPut(7 as Entity, Transform.componentId, 123, 1, 4))
+    transport.onmessage!(craftShortNetworkPut(8 as Entity, Transform.componentId, 124, 1, 4))
+  })
+
+  it('should not accumulate ghost network entities', async () => {
+    await engine.update(1)
+
+    expect(Array.from(engine.getEntitiesWith(NetworkEntity))).toEqual([])
+  })
+})
+
+describe('when a peer sends a well-formed network component update for an unseen network entity', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let transport: Transport
+  let networkId: number
+  let remoteEntity: Entity
+  let position: { x: number; y: number; z: number }
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    networkId = 123
+    remoteEntity = 7 as Entity
+    position = { x: 4, y: 5, z: 6 }
+
+    const data = new ReadWriteByteBuffer()
+    Transform.schema.serialize(
+      { position, rotation: { x: 0, y: 0, z: 0, w: 1 }, scale: { x: 1, y: 1, z: 1 }, parent: 0 as Entity },
+      data
+    )
+    const buffer = new ReadWriteByteBuffer()
+    PutNetworkComponentOperation.write(remoteEntity, 1, Transform.componentId, networkId, data.toBinary(), buffer)
+    transport.onmessage!(buffer.toBinary())
+  })
+
+  it('should allocate exactly one network entity mapping for it', async () => {
+    await engine.update(1)
+
+    expect(Array.from(engine.getEntitiesWith(NetworkEntity)).map(([, value]) => value)).toEqual([
+      { entityId: remoteEntity, networkId }
+    ])
+  })
+
+  it('should apply the component to the mapped local entity', async () => {
+    await engine.update(1)
+
+    const [localEntity] = Array.from(engine.getEntitiesWith(NetworkEntity))[0]
+    expect(Transform.getOrNull(localEntity)?.position).toEqual(position)
   })
 })

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16884
+  MALLOC_COUNT = 16890
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -45,7 +45,7 @@ CALL onStart()
   ALIVE_OBJS_DELTA ~= 0.09k
 CALL onUpdate(0)
    ~system/Testing: plan {"tests":[{"name":"ensure that cubes are in the scene on the first frame"}]}
-  OPCODES ~= 20k
+  OPCODES ~= 30k
   MALLOC_COUNT = 67
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.12k bytes
+  MEMORY_USAGE_COUNT ~= 1551.54k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17445
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -33,7 +33,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -49,7 +49,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 9k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.36k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17445
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -33,7 +33,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=1"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=3 data={"position":{"x":2,"y":1,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":9,"y":9,"z":9},"parent":0}
-  OPCODES ~= 11k
+  OPCODES ~= 12k
   MALLOC_COUNT = 80
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -49,7 +49,7 @@ CALL onUpdate(0.1)
   Scene: PUT_COMPONENT e=0x0 c=1 t=5 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   LOG: ["Adding one to position.y=0"]
   Renderer: PUT_COMPONENT e=0x0 c=1 t=6 data={"position":{"x":1,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
-  OPCODES ~= 8k
+  OPCODES ~= 9k
   MALLOC_COUNT = 48
   ALIVE_OBJS_DELTA ~= 0.02k
 CALL onUpdate(0.1)
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.37k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15763
+  MALLOC_COUNT = 15768
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -22,7 +22,7 @@ CALL onUpdate(0)
   LOG: ["✅ Has DOWN command"]
   Scene: PUT_COMPONENT e=0x200 c=1 t=1 data={"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":2,"analog":5,"tickNumber":0}
-  OPCODES ~= 18k
+  OPCODES ~= 21k
   MALLOC_COUNT = 95
   ALIVE_OBJS_DELTA ~= 0.03k
 CALL onUpdate(0.1)
@@ -32,7 +32,7 @@ CALL onUpdate(0.1)
   LOG: ["✅ UP Was triggered"]
   LOG: ["✅ Doesn't have DOWN command"]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":3,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 18k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -41,7 +41,7 @@ CALL onUpdate(0.1)
   LOG: ["✅ Was triggered"]
   LOG: ["✅ Has DOWN command"]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":0,"timestamp":4,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 18k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
 CALL onUpdate(0.1)
@@ -51,7 +51,7 @@ CALL onUpdate(0.1)
   LOG: ["isTriggered(RootEntity)=",false]
   LOG: ["getCommand(RootEntity)=",null]
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":5,"analog":5,"tickNumber":0}
-  OPCODES ~= 15k
+  OPCODES ~= 18k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.80k bytes
+  MEMORY_USAGE_COUNT ~= 1140.66k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18269
+  MALLOC_COUNT = 18274
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.64k bytes
+  MEMORY_USAGE_COUNT ~= 1326.51k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14880
+  MALLOC_COUNT = 14885
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.87k bytes
+  MEMORY_USAGE_COUNT ~= 1102.74k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14853
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14858
+  ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.63k bytes
+  MEMORY_USAGE_COUNT ~= 1092.50k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=312k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21606
+  MALLOC_COUNT = 21611
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.11k bytes
+  MEMORY_USAGE_COUNT ~= 1550.98k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15146
+  MALLOC_COUNT = 15151
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.33k bytes
+  MEMORY_USAGE_COUNT ~= 1112.20k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14985
+  OPCODES ~= 82k
+  MALLOC_COUNT = 14990
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.08k bytes
+  MEMORY_USAGE_COUNT ~= 1094.95k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=431k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23149
+  MALLOC_COUNT = 23153
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.35k bytes
+  MEMORY_USAGE_COUNT ~= 1980.20k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15089
+  MALLOC_COUNT = 15094
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.11k bytes
+  MEMORY_USAGE_COUNT ~= 1111.98k bytes


### PR DESCRIPTION
## What / why

A CRDT `PUT_COMPONENT` or `APPEND_VALUE` carries a component's serialized value as its payload. The frame around it can be well-formed — header, fields and the announced data length all agree — while the payload itself is shorter than the component's schema needs. The message reads fine; the **deserialize** the engine runs next walks off the end of the buffer and throws `Outside of the bounds of writen data.`

That deserialize happens in `crdtSceneSystem.receiveMessages`, which runs at the very start of every `engine.update`, so one malformed payload aborted the whole tick: every other message in the same batch was lost, and the runtime driving the scene saw its `update` reject.

Worse, the damage was not limited to the dropped message. For a network message announcing a `networkId` this engine had not seen, `receiveMessages` allocated a local entity and wrote its `NetworkEntity` mapping **before** the payload was validated. When the payload then failed, the entity and mapping stayed behind, so a peer varying the `networkId` accumulated ghost entities one per malformed message.

The chunk arrives straight from a transport's `onmessage`. In `@dcl/sdk` that is the sync transport `@dcl/sdk/network` installs, so the bytes come from another player in the room. A peer whose schema for a shared component differs, or that simply truncates a write, could take down the tick for everyone who received it.

## How it works

The payload is checked at the top of the loop, before anything mutates. For `PUT_COMPONENT`, `PUT_COMPONENT_NETWORK` and `APPEND_VALUE` — the three types that carry one — the component's own `schema` deserializes the buffer, and a payload it cannot read is dropped there. No entity is allocated, no component is touched, and nothing is relayed to other transports.

Because the payload is validated up front, the apply path can trust its input, so there is no broad `try/catch` around `updateFromCrdt`. `fixTransformParent` and `updateFromCrdt` only throw on a payload that fails the same check, so anything else that surfaces is a real bug rather than something swallowed.

The last-write-wins component also deserializes into a local before mutating its timestamp or data, so a failure leaves its state untouched rather than half-updated. The grow-only component already deserialized before appending.

A dropped message advances nothing, so a later well-formed update for the same entity at the same lamport timestamp is still a first write and still wins.

## Merge order

This is queued to merge **second, straight after #1567**. The two were verified to stack: with #1567 applied first, rebasing this on top produces no source conflict — they edit the same file in different places, the parse loop there and the receive path here — and the combined tree typechecks with both suites passing together.

The guards are complementary, not redundant: #1567 rejects a malformed *frame*, this rejects a payload the component's schema cannot read inside a well-formed frame. Because both regenerate the QuickJS goldens, this PR will conflict on the twelve `.crdt` files the moment #1567 lands. That is a single `UPDATE_SNAPSHOTS=true` regeneration with no code change.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='test/ecs/crdt-malformed-payload'
```

All 14 cases pass here; against `main` the tick rejects instead.

## Proof

`test/ecs/crdt-malformed-payload.spec.ts` drives everything through a transport and a real `engine.update`:

- a too-short `PUT_COMPONENT` for a Transform — `update` resolves and the entity ends with no value;
- a malformed message followed in the same chunk by a well-formed one — the well-formed one still applies;
- a well-formed update after a dropped one for the same entity — it wins, proving the timestamp was not advanced;
- a malformed message on one of two transports — nothing is relayed to the other;
- a too-short `APPEND_VALUE` on a grow-only component — `update` resolves and the set stays empty;
- a malformed `PUT_COMPONENT_NETWORK` for an unseen `networkId` — no entity and no mapping are created and nothing is relayed, repeated ones accumulate no ghosts, and a well-formed network put still maps exactly one entity and applies its component.

A scene reproducing it in-world is at [`crdt-short-component-payload`](https://github.com/LautaroPetaccio/js-sdk-bug-repros/tree/main/crdt-short-component-payload): it hands a private engine a chunk holding a 4-byte Transform payload followed by a valid one, then calls `engine.update`. On `@dcl/sdk@7.26.0` the update rejects and the sign reads `BUG REPRODUCED`; here it resolves, the malformed entity has no Transform, the healthy one does, and the sign reads `FIXED`. Its README carries the headless before/after table.
