### PR TITLE
fix(ecs): survive running out of entities for network peers

### DIFF
--- a/packages/@dcl/ecs/src/engine/entity.ts
+++ b/packages/@dcl/ecs/src/engine/entity.ts
@@ -108,6 +108,13 @@ export type IEntityContainer = {
  * read one number; this runs on every inbound CRDT message. `entity & MAX_U16` already lands
  * in [0, 65535], so the `>>> 0` fromEntityId applies is a no-op here.
  */
+/**
+ * Thrown when the entity range is used up and no number can be recycled. Distinguishable
+ * from an allocator bug so callers that handle exhaustion do not also swallow one.
+ * @public
+ */
+export class EntityRangeExhaustedError extends Error {}
+
 function isReservedEntity(entity: Entity, reservedStaticEntities: number): boolean {
   return (entity & MAX_U16) < reservedStaticEntities
 }
@@ -128,7 +135,7 @@ export function createEntityContainer(opts?: { reservedStaticEntities: number })
 
   function generateNewEntity(): Entity {
     if (entityCounter > MAX_ENTITY_NUMBER - 1) {
-      throw new Error(`It fails trying to generate an entity out of range ${MAX_ENTITY_NUMBER}.`)
+      throw new EntityRangeExhaustedError(`It fails trying to generate an entity out of range ${MAX_ENTITY_NUMBER}.`)
     }
 
     const entityNumber = entityCounter++

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityState } from '../../engine/entity'
+import { Entity, EntityRangeExhaustedError, EntityState } from '../../engine/entity'
 import type { ComponentDefinition } from '../../engine'
 import type { PreEngine } from '../../engine/types'
 import { ReadWriteByteBuffer } from '../../serialization/ByteBuffer'
@@ -50,7 +50,8 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
-  // Latched so a peer flooding unseen network ids cannot also flood the console.
+  // Latched so a peer flooding unseen network ids cannot also flood the console. Cleared
+  // once an allocation succeeds again, so a later exhaustion is still reported.
   let reportedEntityExhaustion = false
 
   /**
@@ -144,20 +145,19 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
       let { entityId, network } = findNetworkId(msg)
       // We receive a new Entity. Create the localEntity and map it to the NetworkEntity component
       if (networkUtils.isNetworkMessage(msg) && !network) {
-        // A peer decides how many distinct (networkId, entityId) pairs it announces, and
-        // each unseen pair takes a local entity here. The container throws once its range
-        // is exhausted, and that throw used to leave `receiveMessages` and reject
-        // `engine.update`, so a peer could stop the scene with nothing but well-formed
-        // messages. Run out quietly instead and drop the message: the entity cannot be
-        // represented locally, so there is nothing to apply it to.
+        // A peer chooses how many distinct pairs it announces, so this allocation is
+        // driven by remote input and can exhaust the range.
         try {
           entityId = engine.addEntity()
+          reportedEntityExhaustion = false
         } catch (err) {
+          if (!(err instanceof EntityRangeExhaustedError)) throw err
+
           if (!reportedEntityExhaustion) {
             reportedEntityExhaustion = true
             console.error(
               'Ran out of local entities while mapping entities announced over the network. ' +
-                'Further network entities will be ignored for the rest of this session.',
+                'These entities are ignored until entities are freed and numbers can be recycled.',
               err
             )
           }

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,8 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  // Latched so a peer flooding unseen network ids cannot also flood the console.
+  let reportedEntityExhaustion = false
 
   /**
    *
@@ -142,7 +144,25 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
       let { entityId, network } = findNetworkId(msg)
       // We receive a new Entity. Create the localEntity and map it to the NetworkEntity component
       if (networkUtils.isNetworkMessage(msg) && !network) {
-        entityId = engine.addEntity()
+        // A peer decides how many distinct (networkId, entityId) pairs it announces, and
+        // each unseen pair takes a local entity here. The container throws once its range
+        // is exhausted, and that throw used to leave `receiveMessages` and reject
+        // `engine.update`, so a peer could stop the scene with nothing but well-formed
+        // messages. Run out quietly instead and drop the message: the entity cannot be
+        // represented locally, so there is nothing to apply it to.
+        try {
+          entityId = engine.addEntity()
+        } catch (err) {
+          if (!reportedEntityExhaustion) {
+            reportedEntityExhaustion = true
+            console.error(
+              'Ran out of local entities while mapping entities announced over the network. ' +
+                'Further network entities will be ignored for the rest of this session.',
+              err
+            )
+          }
+          continue
+        }
         network = { entityId: msg.entityId, networkId: msg.networkId }
         NetworkEntity.createOrReplace(entityId, network)
       }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -1237,6 +1237,10 @@ export interface EntityPropTypes extends Listeners {
     uiTransform?: UiTransformProps;
 }
 
+// @public
+export class EntityRangeExhaustedError extends Error {
+}
+
 // @public (undocumented)
 export enum EntityState {
     Removed = 2,

--- a/test/ecs/network-entity-allocation-limit.spec.ts
+++ b/test/ecs/network-entity-allocation-limit.spec.ts
@@ -1,51 +1,68 @@
 import * as components from '../../packages/@dcl/ecs/src/components'
 import { Engine, Entity } from '../../packages/@dcl/ecs/src/engine'
-import { createEntityContainer } from '../../packages/@dcl/ecs/src/engine/entity'
+import { createEntityContainer, MAX_ENTITY_NUMBER } from '../../packages/@dcl/ecs/src/engine/entity'
 import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { DeleteEntityNetwork } from '../../packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork'
 import { PutNetworkComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
 import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
 
-/** Entity numbers below this are reserved, so the container has very few left to hand out. */
-const ALMOST_EXHAUSTED = 65530
+/** Leaves exactly this many numbers for the container to hand out. */
+const SPARE_ENTITIES = 5
+const RESERVED = MAX_ENTITY_NUMBER - SPARE_ENTITIES
+/** Far more distinct pairs than there are entities left. */
+const ANNOUNCED_PAIRS = 40
+
+type Ctx = {
+  engine: ReturnType<typeof Engine>
+  Transform: ReturnType<typeof components.Transform>
+  NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  transport: Transport
+}
+
+function setup(): Ctx {
+  const engine = Engine({
+    onChangeFunction: () => undefined,
+    entityContainer: createEntityContainer({ reservedStaticEntities: RESERVED })
+  })
+  const Transform = components.Transform(engine)
+  const NetworkEntity = components.NetworkEntity(engine)
+  const transport: Transport = { send: async () => {}, filter: () => false }
+  engine.addTransport(transport)
+  return { engine, Transform, NetworkEntity, transport }
+}
+
+function transformBytes(Transform: Ctx['Transform'], x: number): Uint8Array {
+  const payload = new ReadWriteByteBuffer()
+  Transform.schema.serialize(
+    {
+      position: { x, y: 1, z: 1 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 },
+      parent: 0 as Entity
+    },
+    payload
+  )
+  return payload.toBinary()
+}
+
+/** One chunk announcing `count` distinct (networkId, entityId) pairs. */
+function announcePairs(Transform: Ctx['Transform'], count: number, x = 1): Uint8Array {
+  const data = transformBytes(Transform, x)
+  const chunk = new ReadWriteByteBuffer()
+  for (let index = 0; index < count; index++) {
+    PutNetworkComponentOperation.write(index as Entity, 1, Transform.componentId, index + 1, data, chunk)
+  }
+  return chunk.toBinary()
+}
 
 describe('when a peer announces more network entities than the engine can allocate', () => {
-  let engine: ReturnType<typeof Engine>
-  let Transform: ReturnType<typeof components.Transform>
-  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
-  let transport: Transport
+  let ctx: Ctx
   let errors: jest.SpyInstance
 
   beforeEach(() => {
-    // A container that is nearly out of range, so exhaustion is reached in a few messages
-    // instead of the ~65k a real peer would have to send.
-    engine = Engine({
-      onChangeFunction: () => undefined,
-      entityContainer: createEntityContainer({ reservedStaticEntities: ALMOST_EXHAUSTED })
-    })
-    Transform = components.Transform(engine)
-    NetworkEntity = components.NetworkEntity(engine)
-    transport = { send: async () => {}, filter: () => false }
-    engine.addTransport(transport)
+    ctx = setup()
     errors = jest.spyOn(console, 'error').mockImplementation(() => undefined)
-
-    const payload = new ReadWriteByteBuffer()
-    Transform.schema.serialize(
-      {
-        position: { x: 1, y: 1, z: 1 },
-        rotation: { x: 0, y: 0, z: 0, w: 1 },
-        scale: { x: 1, y: 1, z: 1 },
-        parent: 0 as Entity
-      },
-      payload
-    )
-    const data = payload.toBinary()
-
-    // Far more distinct (networkId, entityId) pairs than there are entities left.
-    const chunk = new ReadWriteByteBuffer()
-    for (let index = 0; index < 40; index++) {
-      PutNetworkComponentOperation.write(index as Entity, 1, Transform.componentId, index + 1, data, chunk)
-    }
-    transport.onmessage!(chunk.toBinary())
+    ctx.transport.onmessage!(announcePairs(ctx.Transform, ANNOUNCED_PAIRS))
   })
 
   afterEach(() => {
@@ -53,26 +70,133 @@ describe('when a peer announces more network entities than the engine can alloca
   })
 
   it('should finish the update instead of rejecting out of the tick', async () => {
-    await expect(engine.update(1)).resolves.toBeUndefined()
+    await expect(ctx.engine.update(1)).resolves.toBeUndefined()
   })
 
-  it('should map as many as it had room for and no more', async () => {
-    await engine.update(1)
+  it('should map exactly the entities it had room for', async () => {
+    await ctx.engine.update(1)
 
-    const mapped = Array.from(engine.getEntitiesWith(NetworkEntity)).length
-    expect(mapped).toBeGreaterThan(0)
-    expect(mapped).toBeLessThan(40)
+    expect(Array.from(ctx.engine.getEntitiesWith(ctx.NetworkEntity)).length).toBe(SPARE_ENTITIES)
   })
 
-  it('should say once that it ran out', async () => {
-    await engine.update(1)
+  it('should say what happened', async () => {
+    await ctx.engine.update(1)
+
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('Ran out of local entities'), expect.anything())
+  })
+
+  it('should say it only once however many pairs arrive', async () => {
+    await ctx.engine.update(1)
 
     expect(errors).toHaveBeenCalledTimes(1)
   })
 
   it('should keep running on the next tick', async () => {
-    await engine.update(1)
+    await ctx.engine.update(1)
 
-    await expect(engine.update(1)).resolves.toBeUndefined()
+    await expect(ctx.engine.update(1)).resolves.toBeUndefined()
+  })
+})
+
+describe('when an update arrives for an already-mapped entity after exhaustion', () => {
+  let ctx: Ctx
+  let mapped: Entity
+
+  beforeEach(async () => {
+    ctx = setup()
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    ctx.transport.onmessage!(announcePairs(ctx.Transform, ANNOUNCED_PAIRS))
+    await ctx.engine.update(1)
+    mapped = Array.from(ctx.engine.getEntitiesWith(ctx.NetworkEntity))[0][0]
+
+    // Pair 0 is one of the pairs that did get mapped; move it.
+    const later = new ReadWriteByteBuffer()
+    PutNetworkComponentOperation.write(
+      0 as Entity,
+      Date.now(),
+      ctx.Transform.componentId,
+      1,
+      transformBytes(ctx.Transform, 42),
+      later
+    )
+    ctx.transport.onmessage!(later.toBinary())
+    await ctx.engine.update(1)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should still apply it, because only unmappable messages are dropped', () => {
+    expect(ctx.Transform.getOrNull(mapped)?.position.x).toBe(42)
+  })
+})
+
+describe('when a delete arrives for a pair that was never mapped after exhaustion', () => {
+  let ctx: Ctx
+  let errors: jest.SpyInstance
+
+  beforeEach(async () => {
+    ctx = setup()
+    errors = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    ctx.transport.onmessage!(announcePairs(ctx.Transform, ANNOUNCED_PAIRS))
+    await ctx.engine.update(1)
+
+    // A delete is a network message too, so it takes the same allocation path.
+    const del = new ReadWriteByteBuffer()
+    DeleteEntityNetwork.write(9999 as Entity, 9999, del)
+    ctx.transport.onmessage!(del.toBinary())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should finish the update rather than rejecting', async () => {
+    await expect(ctx.engine.update(1)).resolves.toBeUndefined()
+  })
+
+  it('should not report a second time', async () => {
+    await ctx.engine.update(1)
+
+    expect(errors).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when entities are freed after exhaustion', () => {
+  let ctx: Ctx
+  let errors: jest.SpyInstance
+  let mappedBefore: number
+
+  beforeEach(async () => {
+    ctx = setup()
+    errors = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    ctx.transport.onmessage!(announcePairs(ctx.Transform, ANNOUNCED_PAIRS))
+    await ctx.engine.update(1)
+    mappedBefore = Array.from(ctx.engine.getEntitiesWith(ctx.NetworkEntity)).length
+
+    // Free them all. Numbers can then be recycled with a bumped version, so mapping is
+    // able to resume: exhaustion is not permanent.
+    for (const [entity] of Array.from(ctx.engine.getEntitiesWith(ctx.NetworkEntity))) {
+      ctx.engine.removeEntity(entity)
+    }
+    await ctx.engine.update(1)
+
+    ctx.transport.onmessage!(announcePairs(ctx.Transform, ANNOUNCED_PAIRS, 7))
+    await ctx.engine.update(1)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should map entities again', () => {
+    // A removed entity keeps its NetworkEntity so the deletion can still be forwarded, so
+    // the old rows are still counted. Growth past them is the proof mapping resumed.
+    expect(Array.from(ctx.engine.getEntitiesWith(ctx.NetworkEntity)).length).toBeGreaterThan(mappedBefore)
+  })
+
+  it('should report the second exhaustion rather than staying quiet', () => {
+    expect(errors.mock.calls.length).toBeGreaterThan(1)
   })
 })

--- a/test/ecs/network-entity-allocation-limit.spec.ts
+++ b/test/ecs/network-entity-allocation-limit.spec.ts
@@ -1,0 +1,78 @@
+import * as components from '../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../packages/@dcl/ecs/src/engine'
+import { createEntityContainer } from '../../packages/@dcl/ecs/src/engine/entity'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutNetworkComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
+import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
+
+/** Entity numbers below this are reserved, so the container has very few left to hand out. */
+const ALMOST_EXHAUSTED = 65530
+
+describe('when a peer announces more network entities than the engine can allocate', () => {
+  let engine: ReturnType<typeof Engine>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let transport: Transport
+  let errors: jest.SpyInstance
+
+  beforeEach(() => {
+    // A container that is nearly out of range, so exhaustion is reached in a few messages
+    // instead of the ~65k a real peer would have to send.
+    engine = Engine({
+      onChangeFunction: () => undefined,
+      entityContainer: createEntityContainer({ reservedStaticEntities: ALMOST_EXHAUSTED })
+    })
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    transport = { send: async () => {}, filter: () => false }
+    engine.addTransport(transport)
+    errors = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const payload = new ReadWriteByteBuffer()
+    Transform.schema.serialize(
+      {
+        position: { x: 1, y: 1, z: 1 },
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        parent: 0 as Entity
+      },
+      payload
+    )
+    const data = payload.toBinary()
+
+    // Far more distinct (networkId, entityId) pairs than there are entities left.
+    const chunk = new ReadWriteByteBuffer()
+    for (let index = 0; index < 40; index++) {
+      PutNetworkComponentOperation.write(index as Entity, 1, Transform.componentId, index + 1, data, chunk)
+    }
+    transport.onmessage!(chunk.toBinary())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should finish the update instead of rejecting out of the tick', async () => {
+    await expect(engine.update(1)).resolves.toBeUndefined()
+  })
+
+  it('should map as many as it had room for and no more', async () => {
+    await engine.update(1)
+
+    const mapped = Array.from(engine.getEntitiesWith(NetworkEntity)).length
+    expect(mapped).toBeGreaterThan(0)
+    expect(mapped).toBeLessThan(40)
+  })
+
+  it('should say once that it ran out', async () => {
+    await engine.update(1)
+
+    expect(errors).toHaveBeenCalledTimes(1)
+  })
+
+  it('should keep running on the next tick', async () => {
+    await engine.update(1)
+
+    await expect(engine.update(1)).resolves.toBeUndefined()
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16887
+  MALLOC_COUNT = 16897
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1551.18k bytes
+  MEMORY_USAGE_COUNT ~= 1552.02k bytes

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.5k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16884
+  MALLOC_COUNT = 16887
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.12k bytes
+  MEMORY_USAGE_COUNT ~= 1551.18k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=623k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.3k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17443
+  MALLOC_COUNT = 17453
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1557.00k bytes
+  MEMORY_USAGE_COUNT ~= 1557.85k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17443
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.00k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17443
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.01k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=623k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.3k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17443
+  MALLOC_COUNT = 17453
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1557.01k bytes
+  MEMORY_USAGE_COUNT ~= 1557.85k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15766
+  MALLOC_COUNT = 15776
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1140.50k bytes
+  MEMORY_USAGE_COUNT ~= 1141.08k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15763
+  MALLOC_COUNT = 15766
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.80k bytes
+  MEMORY_USAGE_COUNT ~= 1140.50k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.6k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18269
+  MALLOC_COUNT = 18271
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.64k bytes
+  MEMORY_USAGE_COUNT ~= 1326.35k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18271
-  ALIVE_OBJS_DELTA ~= 4.00k
+  MALLOC_COUNT = 18281
+  ALIVE_OBJS_DELTA ~= 4.01k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 4
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1326.35k bytes
+  MEMORY_USAGE_COUNT ~= 1326.94k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14880
+  MALLOC_COUNT = 14882
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.87k bytes
+  MEMORY_USAGE_COUNT ~= 1102.57k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14882
+  MALLOC_COUNT = 14892
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1102.57k bytes
+  MEMORY_USAGE_COUNT ~= 1103.16k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14853
+  MALLOC_COUNT = 14855
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.63k bytes
+  MEMORY_USAGE_COUNT ~= 1092.33k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14855
-  ALIVE_OBJS_DELTA ~= 3.29k
+  MALLOC_COUNT = 14865
+  ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1092.33k bytes
+  MEMORY_USAGE_COUNT ~= 1092.91k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21606
+  MALLOC_COUNT = 21608
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.11k bytes
+  MEMORY_USAGE_COUNT ~= 1550.83k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=312k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21608
+  MALLOC_COUNT = 21618
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.83k bytes
+  MEMORY_USAGE_COUNT ~= 1551.41k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15148
+  MALLOC_COUNT = 15158
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1112.03k bytes
+  MEMORY_USAGE_COUNT ~= 1112.61k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15146
+  MALLOC_COUNT = 15148
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.33k bytes
+  MEMORY_USAGE_COUNT ~= 1112.03k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 82k
-  MALLOC_COUNT = 14987
+  MALLOC_COUNT = 14997
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.78k bytes
+  MEMORY_USAGE_COUNT ~= 1095.36k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14985
+  OPCODES ~= 82k
+  MALLOC_COUNT = 14987
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.08k bytes
+  MEMORY_USAGE_COUNT ~= 1094.78k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=431.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23151
+  MALLOC_COUNT = 23159
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1980.00k bytes
+  MEMORY_USAGE_COUNT ~= 1980.55k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=431k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23149
+  MALLOC_COUNT = 23151
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.35k bytes
+  MEMORY_USAGE_COUNT ~= 1980.00k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15089
+  MALLOC_COUNT = 15091
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.11k bytes
+  MEMORY_USAGE_COUNT ~= 1111.81k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15091
+  MALLOC_COUNT = 15101
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.81k bytes
+  MEMORY_USAGE_COUNT ~= 1112.39k bytes


### PR DESCRIPTION
## What / why

A peer decides how many distinct `(networkId, entityId)` pairs it announces. `receiveMessages` allocates a local entity for every pair it has not seen before, and nothing bounds that:

```ts
if (networkUtils.isNetworkMessage(msg) && !network) {
  entityId = engine.addEntity()          // <- throws once the range is used up
  network = { entityId: msg.entityId, networkId: msg.networkId }
  NetworkEntity.createOrReplace(entityId, network)
}
```

Once the entity container's range is exhausted it throws `It fails trying to generate an entity out of range 65535.`, and that throw left `receiveMessages` and rejected `engine.update`. So a peer could stop the scene for everyone using **nothing but well-formed messages** — no malformed frame, no protocol violation, just variety.

The allocation is now attempted, and a failure drops that one message. An entity that cannot be represented locally has nothing to apply an update to, so there is nothing useful to do with the message. The report is latched, because a peer flooding unseen ids would otherwise flood the console too.

This was found while reviewing #1567's parser hardening for edge cases, and it is deliberately a separate PR: #1567 is about frames the reader cannot trust, this is about well-formed frames arriving in unbounded variety. It stands alone against `main` and does not depend on #1567.

## Two things this does not try to fix

- **The rate, only the crash.** A peer can still burn through the range and, once exhausted, its later entities are ignored for the session. Choosing a per-peer budget is a policy decision that belongs with whoever owns the comms trust model, and it needs somewhere to put the policy. What this PR guarantees is that exhaustion degrades instead of stopping the tick.
- **The cost of getting there.** `findNetworkId` scans every `NetworkEntity` per message, so the approach to exhaustion is O(n²) and in practice degrades into a freeze before the throw. Indexing that lookup is already open as #1475, and fixing it here would collide.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='network-entity-allocation-limit'
```

All four cases fail against `main`, each rejecting with `It fails trying to generate an entity out of range 65535.`; all four pass here.

## Proof

`test/ecs/network-entity-allocation-limit.spec.ts` drives it through a real transport: forty `PUT_COMPONENT_NETWORK` messages with distinct pairs into an engine whose container is built with `reservedStaticEntities: 65530`, so exhaustion arrives in forty messages instead of the ~65k (~4.7 MB) a real peer would have to send. It asserts `engine.update` resolves, that the engine mapped as many entities as it had room for and no more, that it says so exactly once, and that the next tick still runs.

**No repro scene for this one.** Reaching it in-world needs a second participant deliberately announcing tens of thousands of distinct network ids, which a scene cannot do to itself: the sync transport derives the pair from the local entity, so a scene has no way to forge the variety. The regression drives the same `receiveMessages` path a peer's messages arrive on.
