### PR TITLE
fix(ecs): report grow-only appends that cannot reach other players

### DIFF
--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -50,6 +50,8 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
   const receivedMessages: ReceiveMessage[] = []
   // Messages already processed by the engine but that we need to broadcast to other transports.
   const broadcastMessages: ReceiveMessage[] = []
+  // Latched per engine so a per-tick append cannot flood the console.
+  let reportedUnsyncableAppend = false
 
   /**
    *
@@ -328,6 +330,22 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           const networkData = NetworkEntity.getOrNull(message.entityId)
           // If it has networkData convert the message to PUT_NETWORK_COMPONENT.
           if (networkData) {
+            // There is no APPEND_VALUE_NETWORK, so an append on a synced entity has no way
+            // to carry the peer's entity id and localMessageToNetwork writes nothing for
+            // it. The value is kept locally and simply never reaches the other players.
+            // Nothing can be sent until the protocol grows the message type, so say it
+            // once instead of losing the append in silence.
+            if (message.type === CrdtMessageType.APPEND_VALUE && !reportedUnsyncableAppend) {
+              reportedUnsyncableAppend = true
+              const name =
+                ('componentId' in message && engine.getComponentOrNull(message.componentId)?.componentName) ||
+                'a grow-only component'
+              console.error(
+                `Values appended to a grow-only value set on a synced entity are not sent to other players: ` +
+                  `${name} on entity ${message.entityId} stays local. ` +
+                  `Use a last-write-wins component for state that has to be shared.`
+              )
+            }
             networkUtils.localMessageToNetwork(message, networkData, buffer, transportBuffer)
             // Iterate the next message
             continue

--- a/test/ecs/append-value-not-synced.spec.ts
+++ b/test/ecs/append-value-not-synced.spec.ts
@@ -1,0 +1,113 @@
+import { Schemas } from '../../packages/@dcl/ecs/src'
+import * as components from '../../packages/@dcl/ecs/src/components'
+import { Engine, Entity } from '../../packages/@dcl/ecs/src/engine'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { readMessage } from '../../packages/@dcl/ecs/src/serialization/crdt/message'
+import { CrdtMessage, CrdtMessageType } from '../../packages/@dcl/ecs/src/serialization/crdt/types'
+import { Transport } from '../../packages/@dcl/ecs/src/systems/crdt/types'
+
+function collect(chunks: Uint8Array[]): CrdtMessageType[] {
+  const types: CrdtMessageType[] = []
+  for (const chunk of chunks) {
+    const buffer = new ReadWriteByteBuffer(chunk, 0)
+    let message: CrdtMessage | null
+    while ((message = readMessage(buffer))) types.push(message.type)
+  }
+  return types
+}
+
+describe('when a grow-only value is appended to a synced entity', () => {
+  let engine: ReturnType<typeof Engine>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let Events: ReturnType<ReturnType<typeof Engine>['defineValueSetComponentFromSchema']>
+  let sent: Uint8Array[]
+  let errors: jest.SpyInstance
+  let entity: Entity
+
+  beforeEach(async () => {
+    engine = Engine()
+    NetworkEntity = components.NetworkEntity(engine)
+    Events = engine.defineValueSetComponentFromSchema('test::events', Schemas.Map({ timestamp: Schemas.Int }), {
+      timestampFunction: (value) => value.timestamp,
+      maxElements: 10
+    })
+    sent = []
+    const network: Transport = {
+      type: 'network',
+      filter: () => true,
+      send: async (messages) => {
+        for (const chunk of [messages].flat()) if (chunk.byteLength) sent.push(new Uint8Array(chunk))
+      }
+    }
+    engine.addTransport(network)
+    errors = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    entity = engine.addEntity()
+    NetworkEntity.create(entity, { entityId: 5 as Entity, networkId: 1 })
+    await engine.update(1)
+    sent = []
+
+    Events.addValue(entity, { timestamp: 1 } as any)
+    await engine.update(1)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should still send nothing, because the protocol has no network append', () => {
+    // Documenting the limitation, not endorsing it: translating the local entity id needs
+    // an APPEND_VALUE_NETWORK message type that does not exist yet.
+    expect(collect(sent)).not.toContain(CrdtMessageType.APPEND_VALUE)
+  })
+
+  it('should report that the append cannot cross the network', () => {
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('not sent to other players'))
+  })
+
+  it('should name the component so the cause is actionable', () => {
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('test::events'))
+  })
+
+  it('should report it only once however many appends follow', async () => {
+    const before = errors.mock.calls.length
+
+    Events.addValue(entity, { timestamp: 2 } as any)
+    await engine.update(1)
+    Events.addValue(entity, { timestamp: 3 } as any)
+    await engine.update(1)
+
+    expect(errors.mock.calls.length).toBe(before)
+  })
+})
+
+describe('when a grow-only value is appended to an entity that is not synced', () => {
+  let engine: ReturnType<typeof Engine>
+  let Events: ReturnType<ReturnType<typeof Engine>['defineValueSetComponentFromSchema']>
+  let sent: Uint8Array[]
+
+  beforeEach(async () => {
+    engine = Engine()
+    components.NetworkEntity(engine)
+    Events = engine.defineValueSetComponentFromSchema('test::events', Schemas.Map({ timestamp: Schemas.Int }), {
+      timestampFunction: (value) => value.timestamp,
+      maxElements: 10
+    })
+    sent = []
+    const network: Transport = {
+      type: 'network',
+      filter: () => true,
+      send: async (messages) => {
+        for (const chunk of [messages].flat()) if (chunk.byteLength) sent.push(new Uint8Array(chunk))
+      }
+    }
+    engine.addTransport(network)
+
+    Events.addValue(engine.addEntity(), { timestamp: 1 } as any)
+    await engine.update(1)
+  })
+
+  it('should send the append, since no id translation is needed', () => {
+    expect(collect(sent)).toContain(CrdtMessageType.APPEND_VALUE)
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 74k
-  MALLOC_COUNT = 16884
+  MALLOC_COUNT = 16890
   ALIVE_OBJS_DELTA ~= 3.31k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.12k bytes
+  MEMORY_USAGE_COUNT ~= 1551.76k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17446
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.58k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=622.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=623.2k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17439
+  MALLOC_COUNT = 17446
   ALIVE_OBJS_DELTA ~= 3.47k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1555.95k bytes
+  MEMORY_USAGE_COUNT ~= 1557.59k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=270.4k bytes
+SCENE_COMPILED_JS_SIZE_PROD=270.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15763
+  MALLOC_COUNT = 15769
   ALIVE_OBJS_DELTA ~= 3.53k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1139.80k bytes
+  MEMORY_USAGE_COUNT ~= 1141.00k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 89k
-  MALLOC_COUNT = 18269
+  MALLOC_COUNT = 18274
   ALIVE_OBJS_DELTA ~= 4.00k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 12k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1325.64k bytes
+  MEMORY_USAGE_COUNT ~= 1326.86k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14880
+  MALLOC_COUNT = 14885
   ALIVE_OBJS_DELTA ~= 3.30k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1101.87k bytes
+  MEMORY_USAGE_COUNT ~= 1103.08k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14853
+  MALLOC_COUNT = 14858
   ALIVE_OBJS_DELTA ~= 3.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1091.63k bytes
+  MEMORY_USAGE_COUNT ~= 1092.83k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=311.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=312.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 129k
-  MALLOC_COUNT = 21606
+  MALLOC_COUNT = 21611
   ALIVE_OBJS_DELTA ~= 5.29k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 725k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1550.11k bytes
+  MEMORY_USAGE_COUNT ~= 1551.34k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.5k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.8k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15146
+  MALLOC_COUNT = 15151
   ALIVE_OBJS_DELTA ~= 3.38k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.33k bytes
+  MEMORY_USAGE_COUNT ~= 1112.54k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=266.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=266.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -7,8 +7,8 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
-  OPCODES ~= 81k
-  MALLOC_COUNT = 14985
+  OPCODES ~= 82k
+  MALLOC_COUNT = 14990
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1094.08k bytes
+  MEMORY_USAGE_COUNT ~= 1095.28k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=431k bytes
+SCENE_COMPILED_JS_SIZE_PROD=431.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23149
+  MALLOC_COUNT = 23154
   ALIVE_OBJS_DELTA ~= 4.70k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1979.35k bytes
+  MEMORY_USAGE_COUNT ~= 1980.51k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=267.6k bytes
+SCENE_COMPILED_JS_SIZE_PROD=267.9k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 15089
+  MALLOC_COUNT = 15094
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1111.11k bytes
+  MEMORY_USAGE_COUNT ~= 1112.31k bytes


### PR DESCRIPTION
## What / why

A value appended to a grow-only component on a **synced** entity never reaches other players, and nothing says so.

`sendMessages` routes an outbound message for a synced entity through `localMessageToNetwork`, which handles three types:

```ts
if (message.type === CrdtMessageType.PUT_COMPONENT) { ... }
else if (message.type === CrdtMessageType.DELETE_COMPONENT) { ... }
else if (message.type === CrdtMessageType.DELETE_ENTITY) { ... }
// APPEND_VALUE falls through, writes nothing
destinationBuffer.writeBuffer(buffer.buffer().subarray(offset, buffer.currentWriteOffset()), false)
```

`APPEND_VALUE` falls off the end, zero bytes are written, and `continue` skips the ordinary relay, so the append is dropped. Measured on a real transport:

| append target | what the network transport receives |
| --- | --- |
| entity with `NetworkEntity` (synced) | nothing |
| plain entity | `APPEND_VALUE` |

So whether an append is shared depends on whether the entity happens to be synced, which is exactly backwards from what a developer would expect, and it fails silently.

## What this PR does, and does not, do

It does **not** make the append sync. It cannot: carrying the peer's entity id needs an `APPEND_VALUE_NETWORK` message type and the protocol has none, so that belongs in [`@dcl/protocol`](https://github.com/decentraland/protocol) with an ADR, not here.

What it does is stop the silence. The drop is reported once per engine, naming the component and the entity, so a developer sees the cause instead of debugging why a peer never observes their events. Latched because an append can happen every tick.

The honest fix, in rough order of cost: add the network message type; or exclude grow-only components from `syncEntity` the way `NOT_SYNC_COMPONENTS` already excludes others, so it fails loudly at registration rather than per append. I did not do the second here because it changes which components are considered syncable, and that deserves its own decision.

## Why coverage never caught it

`localMessageToNetwork` sits under a whole-function `/* istanbul ignore next */` in `serialization/crdt/network/utils.ts`, one of four in that file covering the entire transport-to-transport re-framing path. The missing branch was invisible to the gate. This PR does not remove those ignores, because doing so drops the package under its coverage threshold and wants its own PR.

## Scope

Found while reviewing #1567 for edge cases; it is not that PR's doing. The branch has been missing since the function was written. Affects `AssetLoadLoadingState`, `AvatarEmoteCommand` and `ExplorerUiEventsResult`, all grow-only and none of them in `NOT_SYNC_COMPONENTS`, plus any grow-only component a scene defines and syncs. Independent of #1567 and #1598.

## How to test

```
node_modules/.bin/jest --colors --forceExit --testPathPatterns='append-value-not-synced'
```

Two of the five cases fail against `main` (no report is emitted); all five pass here.

## Proof

`test/ecs/append-value-not-synced.spec.ts` drives a real network transport and asserts the append is absent from the wire for a synced entity, that the report names the component, that it is emitted once across several appends, and, as a control, that an append on a non-synced entity still goes out.

**No repro scene for this one.** The symptom is the absence of a message at a second participant, which a single scene cannot observe about itself. The regression asserts on the bytes handed to the transport, which is the same boundary.
