### PR TITLE
chore: sync-main-to-experimental auto-pr refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 on:
+  # An extra entry point; the push trigger below is unchanged. For workflows like
+  # merge-sync-to-experimental.yml, whose merge is written with GITHUB_TOKEN: GitHub
+  # starts no workflow from that token's events, and workflow_dispatch is the exception.
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/merge-sync-to-experimental.yml
+++ b/.github/workflows/merge-sync-to-experimental.yml
@@ -1,0 +1,146 @@
+name: Merge sync PR into experimental
+
+# The repo allows only squash merges, and squashing the sync PR would drop main's
+# commits and freeze the merge base. This lands it as a real merge commit instead;
+# GitHub closes the sync PR as merged once its commits are reachable from experimental.
+on:
+  workflow_dispatch:
+
+# Shared with sync-main-to-experimental.yml: see the note there.
+concurrency:
+  group: chore-sync-branch
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  # Dispatching CI on experimental once the merge lands; see the Publish step.
+  actions: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge chore/sync into experimental
+        id: merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --force --prune origin
+
+          if ! git rev-parse --verify --quiet refs/remotes/origin/chore/sync >/dev/null; then
+            echo "::error::chore/sync does not exist on the remote; there is no sync to land."
+            exit 1
+          fi
+
+          if git merge-base --is-ancestor origin/chore/sync origin/experimental; then
+            echo "experimental already contains chore/sync; nothing to merge."
+            # It is fully merged, so a leftover branch is only a failed cleanup.
+            git push origin --delete chore/sync || true
+            # This path cleans up but publishes nothing, so say so: it is also where a
+            # re-run lands after a run whose merge succeeded and whose dispatch failed.
+            echo "::warning::Nothing was merged, so CI was not dispatched. If a previous run merged but failed to publish, run the CI workflow against experimental yourself."
+            exit 0
+          fi
+
+          PR_NUMBER="$(gh pr list --base experimental --head chore/sync --state open --json number --jq '.[0].number // empty')"
+
+          # The sync PR is opened as a draft so it cannot be squashed. Take it out of
+          # draft before the merge lands, so GitHub applies its normal
+          # merged-by-reachability handling to it.
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr ready "$PR_NUMBER" \
+              || echo "::warning::Could not mark PR #$PR_NUMBER ready; it may close as Closed rather than Merged."
+          fi
+
+          MERGE_MESSAGE="chore: sync main to experimental${PR_NUMBER:+ (#$PR_NUMBER)}"
+
+          # experimental requires signed commits, so the merge is created server-side:
+          # GitHub signs what the API authors, while a merge commit made on the runner is
+          # unsigned and its push is rejected. --no-ff is implicit — the API always
+          # records a merge commit.
+          if MERGE_OUT="$(gh api -X POST "repos/$GITHUB_REPOSITORY/merges" \
+                            -f base=experimental \
+                            -f head=chore/sync \
+                            -f commit_message="$MERGE_MESSAGE" 2>&1)"; then
+            echo "Merged chore/sync into experimental."
+          else
+            echo "$MERGE_OUT"
+            case "$MERGE_OUT" in
+              *"Merge conflict"*|*"merge conflict"*)
+                echo "::error::chore/sync does not merge cleanly into experimental. Resolve it on chore/sync, push, and re-run this workflow."
+                exit 1
+                ;;
+              *)
+                echo "::error::The merges API refused to write to experimental. That endpoint honours branch protection, so this usually means the github-actions bot is not allowed to push to experimental. Allow it to bypass the pull-request requirement on that branch (Settings -> Branches -> experimental), or land the merge by hand: git checkout experimental && git merge --no-ff origin/chore/sync && git push origin experimental, then re-run this workflow to publish and clean up."
+                exit 1
+                ;;
+            esac
+          fi
+
+          # Signals the Publish step below. The no-op and merge-failure paths never
+          # reach here, so neither dispatches a pointless build.
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+
+          # A PR closed by a push is not covered by delete_branch_on_merge, so remove the
+          # now fully-merged branch here: the sync job treats an existing chore/sync as a
+          # sync still in flight. Deleting a head branch also closes its PR, so wait for
+          # GitHub to register the merge first — otherwise the PR reads Closed, not Merged.
+          STATE=""
+          if [ -n "$PR_NUMBER" ]; then
+            for _ in $(seq 1 10); do
+              STATE="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
+              [ "$STATE" = "MERGED" ] && break
+              sleep 3
+            done
+            if [ "$STATE" != "MERGED" ]; then
+              echo "::warning::PR #$PR_NUMBER still reads $STATE, so chore/sync is left in place rather than closing the PR unmerged. Re-run this workflow to clean it up."
+              exit 0
+            fi
+          fi
+
+          # Non-fatal: experimental is already merged, so a failed cleanup is not a
+          # failed sync. The no-op path above finishes the job on any later run.
+          git push origin --delete chore/sync \
+            || echo "::warning::Could not delete chore/sync; re-run this workflow to clean it up."
+
+      # The merge above is written with GITHUB_TOKEN, and GitHub does not start
+      # workflows from events that token creates. So the CI run that publishes the
+      # @experimental npm tag never fires on its own — experimental silently keeps
+      # serving whatever the last human-pushed merge published.
+      # A separate step rather than a line in the merge script: that script exits 0
+      # on the "PR did not register as merged" path, which must still publish.
+      - name: Publish experimental
+        if: steps.merge.outputs.merged == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # GitHub reads the workflow_dispatch trigger from the target ref, and the
+          # merge above may be the push that first puts it on experimental. Retry
+          # while GitHub indexes the ref, rather than failing the whole sync on a race.
+          for attempt in $(seq 1 5); do
+            if gh workflow run ci.yml --ref experimental; then
+              echo "Dispatched CI against experimental; its build job republishes the @experimental npm tag."
+              exit 0
+            fi
+            echo "Dispatch attempt $attempt failed; retrying."
+            sleep 5
+          done
+
+          echo "::error::experimental was merged, but starting CI failed, so the @experimental npm tag is now behind the branch. Recover by running the CI workflow manually against experimental."
+          exit 1

--- a/.github/workflows/merge-sync-to-experimental.yml
+++ b/.github/workflows/merge-sync-to-experimental.yml
@@ -85,7 +85,7 @@ jobs:
                 exit 1
                 ;;
               *)
-                echo "::error::The merges API refused to write to experimental. That endpoint honours branch protection, so this usually means the github-actions bot is not allowed to push to experimental. Allow it to bypass the pull-request requirement on that branch (Settings -> Branches -> experimental), or land the merge by hand: git checkout experimental && git merge --no-ff origin/chore/sync && git push origin experimental, then re-run this workflow to publish and clean up."
+                echo "::error::The merges API refused to write to experimental. That endpoint honours branch protection, so this usually means the github-actions bot is not allowed to push to experimental. Allow it to bypass the pull-request requirement on that branch (Settings -> Branches -> experimental), or land the merge by hand with a signed commit, since experimental requires one: git checkout experimental && git merge --no-ff -S origin/chore/sync && git push origin experimental (needs commit signing configured locally), then re-run this workflow to publish and clean up."
                 exit 1
                 ;;
             esac

--- a/.github/workflows/sync-main-to-experimental.yml
+++ b/.github/workflows/sync-main-to-experimental.yml
@@ -85,7 +85,10 @@ jobs:
       - name: Discard broken snapshots
         id: snapshot_guard
         run: |
-          set -uo pipefail
+          # -e so a failing checkout/clean stops the run rather than letting the broken
+          # snapshots it was meant to remove reach the commit below. The greps that are
+          # allowed to find nothing are guarded individually.
+          set -euo pipefail
 
           # An ERR! line means the QuickJS eval threw mid-run, so the snapshot captured a
           # truncated scene and would mask real regressions. Keeping the committed
@@ -102,8 +105,19 @@ jobs:
           fi
 
       - name: Commit and push the sync branch
+        env:
+          REGEN_OUTCOME: ${{ steps.regen.outcome }}
         run: |
           set -euo pipefail
+
+          # A regeneration that stopped partway leaves a half-applied protocol bump —
+          # lockfiles rewritten, generated sources not. Drop all of it and keep only the
+          # merge; the PR says the pin and snapshots are stale. Ignored paths such as
+          # node_modules survive: no -x on the clean.
+          if [ "$REGEN_OUTCOME" = "failure" ]; then
+            git checkout -- .
+            git clean -fdq .
+          fi
 
           git add -A .
           git commit -m "chore: update protocol and snapshots" || echo "Nothing regenerated to commit"

--- a/.github/workflows/sync-main-to-experimental.yml
+++ b/.github/workflows/sync-main-to-experimental.yml
@@ -5,67 +5,189 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Shared with merge-sync-to-experimental.yml: both workflows mutate chore/sync, and
+# interleaving them either rejects this push or recreates a branch that one just
+# deleted. One group serializes every writer.
+concurrency:
+  group: chore-sync-branch
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
-      - name: Check out code
+      - name: Check out the code
         uses: actions/checkout@v4
         with:
+          # full history, otherwise the merges below have no common ancestor
           fetch-depth: 0
 
-      - name: Configure Git
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24.16.0
+          cache: 'npm'
+
+      - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config pull.rebase false  # Always merge, never rebase
 
-      - name: Sync main into experimental branch
+      - name: Create or update sync branch
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --force --prune origin
+
+          # An existing chore/sync is a sync still in flight: keep it, so commits
+          # arriving on main accumulate on it and a manual conflict resolution pushed
+          # to it survives. The branch is deleted when its PR merges, so the next sync
+          # starts from experimental again.
+          BASE=origin/experimental
+          if git rev-parse --verify --quiet refs/remotes/origin/chore/sync >/dev/null; then
+            BASE=origin/chore/sync
+          fi
+          git checkout -B chore/sync "$BASE"
+
+          # chore/sync must be experimental + main: anything that only exists on
+          # experimental has to survive the sync. No -X theirs — resolving conflicts in
+          # main's favour silently drops experimental-only code. A conflict stops the run
+          # instead, and the resolution pushed to chore/sync is reused by later runs.
+          for REF in origin/experimental origin/main; do
+            if ! git merge -m "chore: merge $REF into chore/sync" "$REF"; then
+              git merge --abort || true
+              echo "::error::Merging $REF into chore/sync failed. To recover: branch chore/sync off experimental (or check out the existing one), merge main into it, resolve, push it, and open a PR against experimental. Later runs merge on top of that resolution."
+              exit 1
+            fi
+          done
+
+      # Non-fatal on purpose: a regeneration that fails on a transient npm/protocol
+      # hiccup must not stop main's commits from reaching the sync PR. The guard below
+      # keeps a half-finished regeneration from being committed, and the PR says so.
+      - name: Update protocol and regenerate snapshots
+        id: regen
         continue-on-error: true
         run: |
-          BRANCH_NAME="chore/sync"
-          git checkout -B $BRANCH_NAME origin/experimental
+          # Explicit: the step must stop at the first failing target so its outcome is
+          # recorded, rather than building on top of a half-applied protocol bump.
+          set -e
 
-          # Merge main changes into experimental, preferring main changes on conflicts
-          git fetch origin main
-          git merge -X theirs origin/main --no-edit || echo "Merge completed (conflicts auto-resolved in favor of main)"
-
-          # Run required update steps
-          make update-protocol 'experimental'
+          make update-protocol
           make install
           make build
           make update-snapshots
 
-      - name: Commit and push changes in experimental
+      - name: Discard broken snapshots
+        id: snapshot_guard
         run: |
-          BRANCH_NAME="chore/sync"
-          # Commit if there are changes
-          git add -A .
-          git commit --no-edit -m "updated protocol and snapshots" || echo "No changes to commit"
+          set -uo pipefail
 
-          # Push (force to keep PR updated)
-          git push --force --set-upstream origin $BRANCH_NAME
+          # An ERR! line means the QuickJS eval threw mid-run, so the snapshot captured a
+          # truncated scene and would mask real regressions. Keeping the committed
+          # snapshot is strictly better than committing that.
+          if grep -rlq "ERR!" test/snapshots/ 2>/dev/null; then
+            grep -rln "ERR!" test/snapshots/ || true
+            git checkout -- test/snapshots/
+            # checkout restores tracked files; a brand-new broken snapshot is untracked.
+            git clean -fdq test/snapshots/
+            echo "broken=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Regenerated snapshots contained ERR! traces and were discarded; the sync PR keeps the previous ones."
+          else
+            echo "broken=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push the sync branch
+        run: |
+          set -euo pipefail
+
+          git add -A .
+          git commit -m "chore: update protocol and snapshots" || echo "Nothing regenerated to commit"
+
+          # Push whenever the recomputed branch differs from the remote, so a stale
+          # chore/sync can never stay the head of an open PR. Skip it when there is
+          # nothing to propose either, so a no-op run does not leave a branch behind
+          # that later runs would read as a sync in flight.
+          REMOTE_HEAD="$(git rev-parse --verify --quiet refs/remotes/origin/chore/sync || echo absent)"
+          if [ "$(git rev-parse HEAD)" = "$REMOTE_HEAD" ] \
+             || git merge-base --is-ancestor HEAD origin/experimental; then
+            echo "Nothing to push: chore/sync is current, or experimental already contains it."
+          else
+            git push --force-with-lease origin chore/sync
+          fi
 
       - name: Create or update PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGEN_OUTCOME: ${{ steps.regen.outcome }}
+          SNAPSHOTS_BROKEN: ${{ steps.snapshot_guard.outputs.broken }}
+          # Backticks here are data, not shell source: they reach gh through the
+          # variable and are never re-evaluated.
+          PR_BODY: |
+            :crown: *An automated PR to keep experimental in sync with main, with protocol updates, build and snapshots*
+
+            **This PR is a draft on purpose: it is landed by a workflow, not by a button.**
+
+            ### How to land it
+
+            1. Test the packages published by the **build** job on this PR — the CI comment
+               below carries the `npm install` URLs and the `/changerealm` link.
+            2. Go to **Actions -> Merge sync PR into experimental -> Run workflow**, from
+               `main`.
+            3. That workflow marks this PR ready, merges `chore/sync` into `experimental`
+               as a real merge commit, dispatches CI on `experimental` so the
+               `@experimental` npm tag is republished, and this PR closes as **Merged**.
+
+            Further commits on `main` are merged onto this same branch while the PR is
+            open, so it stays current on its own.
+
+            > [!IMPORTANT]
+            > Do not take this PR out of draft in order to squash it. Squash is the only
+            > merge this repo allows, and squashing replaces `main`'s commits with a single
+            > new one: `main` stops being an ancestor of `experimental`, the merge base
+            > freezes, and every later sync re-applies changes `experimental` already has,
+            > conflicting within a couple of runs.
+            >
+            > If it does get squashed, restore the ancestry with
+            > `git merge -s ours origin/main` on `experimental`.
         run: |
-          PR_NUMBER=$(gh pr list --base experimental --head chore/sync --state open --json number --jq '.[0].number')
+          set -euo pipefail
+
+          # gh pr create fails with "No commits between ..." when nothing is ahead.
+          # The tree check also covers a net-zero round of main changes, where commits
+          # exist but there is nothing left to propose.
+          if git merge-base --is-ancestor HEAD origin/experimental \
+             || git diff --quiet origin/experimental HEAD; then
+            echo "experimental already has everything chore/sync would propose."
+            exit 0
+          fi
+
+          NOTE=""
+          if [ "$REGEN_OUTCOME" = "failure" ]; then
+            NOTE="$NOTE"$'\n\n> [!WARNING]\n> `make update-protocol` / `make update-snapshots` failed on this run, so the protocol pin and snapshots on this branch may be stale. Check the workflow log before landing.'
+          fi
+          if [ "$SNAPSHOTS_BROKEN" = "true" ]; then
+            NOTE="$NOTE"$'\n\n> [!WARNING]\n> Regenerated snapshots contained `ERR!` traces and were discarded. Fix the scene-load failure (usually a missing mock in `test/snapshots.spec.ts`) and re-run this workflow.'
+          fi
+
+          PR_NUMBER="$(gh pr list --base experimental --head chore/sync --state open --json number --jq '.[0].number // empty')"
 
           if [ -n "$PR_NUMBER" ]; then
-            echo "PR #$PR_NUMBER already exists, adding comment..."
-            gh pr comment $PR_NUMBER --body "🔄 Updated with latest changes from **main** on $(date -u '+%Y-%m-%d %H:%M UTC')"
+            echo "PR #$PR_NUMBER already exists, adding a comment..."
+            gh pr comment "$PR_NUMBER" --body "🔄 Updated with latest changes from **main** on $(date -u '+%Y-%m-%d %H:%M UTC')${NOTE}"
           else
             echo "Creating new PR..."
+            # --draft: squash is the only merge the repo allows, and squashing this PR
+            # breaks the ancestry. A draft has no merge button at all.
             gh pr create \
+              --draft \
               --base experimental \
               --head chore/sync \
               --title "chore: sync main to experimental" \
-              --body ":crown: *Automated PR to keep experimental in sync with main (with protocol updates, build & snapshots)*" \
+              --body "${PR_BODY}${NOTE}" \
               --label "auto-pr"
           fi


### PR DESCRIPTION
Ports the sync flow from `decentraland/protocol`([#479](https://github.com/decentraland/protocol/pull/479),
[#483](https://github.com/decentraland/protocol/pull/483)) to this repo.

## What / why

`chore/sync` was force-recreated from `experimental` on every push to `main` and merged with
`-X theirs`, then the PR was landed with the green button. Squash is the only merge this repo
allows, so landing it rewrites `main`'s commits into one new commit: `main` stops being an
ancestor of `experimental`, the merge base freezes, and later syncs re-apply changes
`experimental` already has until they conflict. `-X theirs` also resolves every conflict in
`main`'s favour, silently dropping experimental-only code.

**`sync-main-to-experimental.yml`** — builds `chore/sync` as `experimental` + `main`

- reuses an in-flight `chore/sync` instead of recreating it, so commits from `main` accumulate
  on the open PR and a manual conflict resolution pushed to the branch survives later runs
- plain merge, no `-X theirs`; a conflict aborts, pushes nothing, and fails with recovery
  instructions (safe now that a hand-resolved branch is no longer thrown away)
- opens the PR as a **draft** so there is no merge button to squash, and pushes only when the
  recomputed branch actually differs from the remote
- the regeneration (`make update-protocol` → `install` → `build` → `update-snapshots`) is the
  only tolerant step; the merge itself now fails loudly instead of being swallowed by a
  blanket `continue-on-error`. Regenerated snapshots containing `ERR!` traces are discarded
  rather than committed (AGENTS.md), and both cases are called out on the PR
- drops the stray `'experimental'` argument to `make update-protocol` — the target takes no
  arguments, so make exited with ``No rule to make target `experimental'`` on every run
- adds `actions/setup-node@v3` (24.16.0), matching CI, instead of the runner default

**`merge-sync-to-experimental.yml`** — new, manual (`workflow_dispatch`), lands the sync

Marks the PR ready, merges `chore/sync` into `experimental` as a real merge commit, waits for
GitHub to register the PR as **Merged**, then deletes the branch — `delete_branch_on_merge`
only fires for button merges, and the sync job reads an existing `chore/sync` as "a sync is
still in flight". The merge is created through the `/merges` API rather than pushed from the
runner, because `experimental` requires signed commits and GitHub signs what the API writes.

**`ci.yml`** — adds a `workflow_dispatch:` entry point (push triggers unchanged)

GitHub starts no workflow from events created with `GITHUB_TOKEN`, so the merge above would
never trigger the CI run that republishes the `@experimental` npm tag. The merge workflow
dispatches it explicitly.

## Prerequisite to verify before merging

Unlike `protocol`, this repo's `experimental` branch is protected (1 required review,
required `build`/`lint`/`test` checks, required signatures). Confirm `github-actions[bot]`
can write to it — Settings → Branches → `experimental` → allow it to bypass the pull-request
requirement. If it can't, the merge step stops with an error naming the manual fallback
(`git merge --no-ff origin/chore/sync && git push origin experimental`, then re-run the
workflow to publish and clean up); nothing is left half-landed.

## How to test

On a fork, or on this repo once the branch protection above is settled:

1. Merge anything into `main`. The sync workflow opens a **draft** `chore: sync main to
   experimental` PR, and CI on it publishes the S3 tarballs as usual.
2. Merge a second commit into `main`. The *same* PR picks it up — no new branch, no force
   reset, and the PR gets a "🔄 Updated with latest changes" comment.
3. Push a hand-made commit to `chore/sync`, then merge a third commit into `main`. The
   hand-made commit is still there afterwards (this is what the old force-recreate destroyed).
4. **Actions → Merge sync PR into experimental → Run workflow.** The PR closes as **Merged**,
   `experimental` gains one merge commit, `chore/sync` is deleted, and a CI run starts on
   `experimental` that republishes `@experimental`.
5. Re-run the same workflow with no `chore/sync` present: it fails with
   "there is no sync to land" rather than doing anything.

## Full cycle, once merged

1. A PR lands on `main` → the sync workflow builds `chore/sync` and opens the draft PR.
2. More commits on `main` accumulate on the same branch, so the PR stays current on its own.
3. Test the packages from the CI comment on the PR, review the diff.
4. **Actions → Merge sync PR into experimental → Run workflow.** Not the green button.
5. The next push to `main` starts a fresh cycle from `experimental`.

If the PR is squashed anyway, restore the ancestry with a no-content merge:

```bash
git checkout experimental
git merge -s ours origin/main -m "chore: record main ancestry"
git push origin experimental
```