### PR TITLE
fix: only let a peer create network entities in its own id space

### DIFF
--- a/packages/@dcl/ecs/src/runtime/types.ts
+++ b/packages/@dcl/ecs/src/runtime/types.ts
@@ -1,5 +1,5 @@
 export type { SystemFn, SYSTEMS_REGULAR_PRIORITY } from '../engine/systems'
-export type { TransportMessage, ReceiveMessage, Transport } from '../systems/crdt/types'
+export type { TransportMessage, ReceiveMessage, Transport, TransportSender } from '../systems/crdt/types'
 export { TransformType, TransformComponent } from '../components/manual/Transform'
 export * from '../engine/component'
 export * from '../schemas/typing'

--- a/packages/@dcl/ecs/src/systems/crdt/index.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/index.ts
@@ -12,7 +12,7 @@ import { DeleteComponent } from '../../serialization/crdt/deleteComponent'
 import { DeleteEntity } from '../../serialization/crdt/deleteEntity'
 import { PutComponentOperation } from '../../serialization/crdt/putComponent'
 import { CrdtMessageType, CrdtMessageHeader, CrdtMessage } from '../../serialization/crdt/types'
-import { ReceiveMessage, Transport } from './types'
+import { ReceiveMessage, Transport, TransportSender } from './types'
 import { PutNetworkComponentOperation } from '../../serialization/crdt/network/putComponentNetwork'
 import {
   NetworkEntity as defineNetworkEntity,
@@ -24,6 +24,10 @@ import * as networkUtils from '../../serialization/crdt/network/utils'
 
 // NetworkMessages can only have a MAX_SIZE of 12kb. So we need to send it in chunks.
 export const LIVEKIT_MAX_SIZE = 12
+
+// Entities that every client announces under the same id share this networkId, so it
+// names a namespace instead of an owner.
+const SHARED_NETWORK_ID = 0
 
 /**
  * @public
@@ -62,7 +66,7 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
      * Component Operation Messages at messages queue
      * @param chunkMessage A chunk of binary messages
      */
-    return function parseChunkMessage(chunkMessage: Uint8Array) {
+    return function parseChunkMessage(chunkMessage: Uint8Array, sender?: TransportSender) {
       const buffer = new ReadWriteByteBuffer(chunkMessage)
 
       let header: CrdtMessageHeader | null
@@ -89,11 +93,14 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
           buffer.incrementReadOffset(header.length)
         }
         if (message) {
-          receivedMessages.push({
+          const receivedMessage: ReceiveMessage = {
             ...message,
             transportId,
             messageBuffer: buffer.buffer().subarray(offset, buffer.currentReadOffset())
-          })
+          }
+          if (!sender || senderMayCreate(receivedMessage, sender)) {
+            receivedMessages.push(receivedMessage)
+          }
         }
       }
     }
@@ -128,6 +135,24 @@ export function crdtSceneSystem(engine: PreEngine, onProcessEntityComponentChang
     }
 
     return { entityId: msg.entityId }
+  }
+
+  /**
+   * Every network message we cannot match to a known entity makes the engine spend
+   * a local entity on the name it carries, and nothing in the message proves the
+   * peer was entitled to spend one. Transports that know who sent a chunk let us
+   * ask, and a peer may only spend from the id space its own networkId names.
+   *
+   * Writing to an entity that already exists stays open to everyone, because that
+   * is what syncEntity is for: whoever placed the door is not the only one allowed
+   * to open it.
+   */
+  function senderMayCreate(msg: ReceiveMessage, sender: TransportSender): boolean {
+    if (!networkUtils.isNetworkMessage(msg) || findNetworkId(msg).network) return true
+
+    // The shared namespace holds the entities every client registers for itself
+    // during main(), so an unknown one is never something to take on faith.
+    return msg.networkId !== SHARED_NETWORK_ID && msg.networkId === sender.networkId
   }
 
   /**

--- a/packages/@dcl/ecs/src/systems/crdt/types.ts
+++ b/packages/@dcl/ecs/src/systems/crdt/types.ts
@@ -23,6 +23,16 @@ export type TransportMessage = Omit<ReceiveMessage, 'data'>
 
 /**
  * @public
+ * Who a transport attests a chunk of messages came from. Transports that cannot
+ * attest to an origin leave it out.
+ */
+export type TransportSender = {
+  address: string
+  networkId: number
+}
+
+/**
+ * @public
  */
 export type Transport = {
   /**
@@ -30,7 +40,11 @@ export type Transport = {
    *  For Renderer & Other transports we send a single Uint8Array
    */
   send(message: Uint8Array | Uint8Array[]): Promise<void>
-  onmessage?(message: Uint8Array): void
+  /**
+   * Network messages name their own owner, so without a `sender` the engine has to
+   * take that name at face value.
+   */
+  onmessage?(message: Uint8Array, sender?: TransportSender): void
   filter(message: Omit<TransportMessage, 'messageBuffer'>): boolean
   type?: string
 }

--- a/packages/@dcl/playground-assets/etc/playground-assets.api.md
+++ b/packages/@dcl/playground-assets/etc/playground-assets.api.md
@@ -5289,13 +5289,19 @@ export const enum TransitionMode {
 // @public (undocumented)
 export type Transport = {
     send(message: Uint8Array | Uint8Array[]): Promise<void>;
-    onmessage?(message: Uint8Array): void;
+    onmessage?(message: Uint8Array, sender?: TransportSender): void;
     filter(message: Omit<TransportMessage, 'messageBuffer'>): boolean;
     type?: string;
 };
 
 // @public (undocumented)
 export type TransportMessage = Omit<ReceiveMessage, 'data'>;
+
+// @public
+export type TransportSender = {
+    address: string;
+    networkId: number;
+};
 
 // Warning: (ae-missing-release-tag) "TriggerArea" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -4,7 +4,7 @@ import { type SendBinaryRequest, type SendBinaryResponse } from '~system/Communi
 import { syncFilter } from './filter'
 import { engineToCrdt } from './state'
 import { BinaryMessageBus, CommsMessage, decodeString, encodeString } from './binary-message-bus'
-import { fetchProfile } from './utils'
+import { fetchProfile, senderIdentity } from './utils'
 import { entityUtils } from './entities'
 import { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdentity'
 import { definePlayerHelper } from '../players'
@@ -77,6 +77,8 @@ export function addSyncTransport(
     const { sender, data } = decodeCRDTState(value)
     if (sender !== myProfile.userId) return
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
+    // A join snapshot is one peer relaying the whole scene, every other peer's
+    // entities included, so its contents cannot be attributed to whoever sent it.
     transport.onmessage!(data)
     stateIsSyncronized = true
   })
@@ -91,10 +93,10 @@ export function addSyncTransport(
   })
 
   // Process CRDT messages here
-  binaryMessageBus.on(CommsMessage.CRDT, (value) => {
+  binaryMessageBus.on(CommsMessage.CRDT, (value, sender) => {
     DEBUG_NETWORK_MESSAGES() &&
       console.log(Array.from(serializeCrdtMessages('[NetworkMessage received]:', value, engine)))
-    transport.onmessage!(value)
+    transport.onmessage!(value, senderIdentity(sender))
   })
 
   async function requestState(retryCount: number = 1) {

--- a/packages/@dcl/sdk/src/network/utils.ts
+++ b/packages/@dcl/sdk/src/network/utils.ts
@@ -1,8 +1,16 @@
-import { EngineInfo as _EngineInfo, NetworkEntity as _NetworkEntity } from '@dcl/ecs'
+import { EngineInfo as _EngineInfo, NetworkEntity as _NetworkEntity, TransportSender } from '@dcl/ecs'
 import { componentNumberFromName } from '@dcl/ecs/dist/components/component-number'
 
 import type { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdentity'
 import { IProfile } from './message-bus-sync'
+
+/**
+ * The runtime stamps the address a comms message arrived from before the scene sees
+ * it, which makes it the one part of an incoming message a peer cannot choose.
+ */
+export function senderIdentity(address: string): TransportSender {
+  return { address, networkId: componentNumberFromName(address) }
+}
 
 // Retrieve userId to start sending this info as the networkId
 export function fetchProfile(

--- a/test/ecs/network-sender-validation.spec.ts
+++ b/test/ecs/network-sender-validation.spec.ts
@@ -1,0 +1,258 @@
+import { Engine } from '../../packages/@dcl/ecs/src/engine'
+import { Entity } from '../../packages/@dcl/ecs/src/engine/entity'
+import { components, EntityState, IEngine, Transport, TransportSender } from '../../packages/@dcl/ecs/src'
+import { componentNumberFromName } from '../../packages/@dcl/ecs/src/components/component-number'
+import { ReadWriteByteBuffer } from '../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutNetworkComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
+import { DeleteComponentNetwork } from '../../packages/@dcl/ecs/src/serialization/crdt/network/deleteComponentNetwork'
+import { DeleteEntityNetwork } from '../../packages/@dcl/ecs/src/serialization/crdt/network/deleteEntityNetwork'
+import { PutComponentOperation } from '../../packages/@dcl/ecs/src/serialization/crdt/putComponent'
+import { createNetworkManager, SandBox } from './utils'
+
+type Mapping = { entity: Entity; networkId: number; entityId: number }
+
+function mappings(engine: IEngine): Mapping[] {
+  const NetworkEntity = components.NetworkEntity(engine)
+  return Array.from(engine.getEntitiesWith(NetworkEntity)).map(([entity, network]) => ({
+    entity,
+    networkId: network.networkId,
+    entityId: network.entityId
+  }))
+}
+
+describe('when a transport reports which peer a chunk of messages came from', () => {
+  let engine: IEngine
+  let transport: Transport
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let buffer: ReadWriteByteBuffer
+  let transformData: Uint8Array
+  let sender: TransportSender
+  let otherPeerNetworkId: number
+
+  beforeEach(() => {
+    engine = Engine()
+    transport = createNetworkManager()
+    engine.addTransport(transport)
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+
+    const dataBuffer = new ReadWriteByteBuffer()
+    Transform.schema.serialize(SandBox.DEFAULT_POSITION, dataBuffer)
+    transformData = dataBuffer.toBinary()
+
+    buffer = new ReadWriteByteBuffer()
+    sender = {
+      address: '0x0000000000000000000000000000000000000001',
+      networkId: componentNumberFromName('0x0000000000000000000000000000000000000001')
+    }
+    otherPeerNetworkId = componentNumberFromName('0x0000000000000000000000000000000000000002')
+  })
+
+  describe('and the peer announces a new entity in its own id space', () => {
+    beforeEach(async () => {
+      PutNetworkComponentOperation.write(
+        500 as Entity,
+        1,
+        Transform.componentId,
+        sender.networkId,
+        transformData,
+        buffer
+      )
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should map the announced entity to a local one', () => {
+      expect(mappings(engine)).toEqual([expect.objectContaining({ networkId: sender.networkId, entityId: 500 })])
+    })
+
+    it('should apply the component to the mapped entity', () => {
+      expect(Transform.getOrNull(mappings(engine)[0].entity)).toMatchObject(SandBox.DEFAULT_POSITION)
+    })
+  })
+
+  describe("and the peer announces a new entity in another peer's id space", () => {
+    beforeEach(async () => {
+      PutNetworkComponentOperation.write(
+        500 as Entity,
+        1,
+        Transform.componentId,
+        otherPeerNetworkId,
+        transformData,
+        buffer
+      )
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should not spend a local entity on it', () => {
+      expect(mappings(engine)).toEqual([])
+    })
+  })
+
+  describe('and a chunk mixes an entity the peer owns with one it does not', () => {
+    beforeEach(async () => {
+      PutNetworkComponentOperation.write(
+        500 as Entity,
+        1,
+        Transform.componentId,
+        otherPeerNetworkId,
+        transformData,
+        buffer
+      )
+      PutNetworkComponentOperation.write(
+        501 as Entity,
+        1,
+        Transform.componentId,
+        sender.networkId,
+        transformData,
+        buffer
+      )
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should create only the entity the peer owns', () => {
+      expect(mappings(engine)).toEqual([expect.objectContaining({ networkId: sender.networkId, entityId: 501 })])
+    })
+  })
+
+  describe("and a message writes to another peer's entity that already exists", () => {
+    let shared: Entity
+
+    beforeEach(async () => {
+      shared = engine.addEntity()
+      NetworkEntity.create(shared, { networkId: otherPeerNetworkId, entityId: 500 as Entity })
+      await engine.update(1)
+
+      PutNetworkComponentOperation.write(
+        500 as Entity,
+        1,
+        Transform.componentId,
+        otherPeerNetworkId,
+        transformData,
+        buffer
+      )
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should apply the write, since shared entities are writable by any peer', () => {
+      expect(Transform.getOrNull(shared)).toMatchObject(SandBox.DEFAULT_POSITION)
+    })
+  })
+
+  describe('and a delete-component message names an entity of another peer that does not exist', () => {
+    beforeEach(async () => {
+      DeleteComponentNetwork.write(500 as Entity, Transform.componentId, 100, otherPeerNetworkId, buffer)
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should not spend an entity on a payload-free message', () => {
+      expect(mappings(engine)).toEqual([])
+    })
+  })
+
+  describe('and a delete-entity message names an entity of another peer that does not exist', () => {
+    beforeEach(async () => {
+      DeleteEntityNetwork.write(500 as Entity, otherPeerNetworkId, buffer)
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should not spend an entity that is removed the same tick', () => {
+      expect(engine.getEntityState(mappings(engine)[0]?.entity ?? (0 as Entity))).not.toEqual(EntityState.Removed)
+    })
+  })
+
+  describe('and a message uses the shared networkId for an entity registered locally', () => {
+    let sharedEntity: Entity
+
+    beforeEach(async () => {
+      sharedEntity = engine.addEntity()
+      NetworkEntity.create(sharedEntity, { networkId: 0, entityId: 7 as Entity })
+      await engine.update(1)
+
+      PutNetworkComponentOperation.write(7 as Entity, 1, Transform.componentId, 0, transformData, buffer)
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should apply the component to the locally registered entity', () => {
+      expect(Transform.getOrNull(sharedEntity)).toMatchObject(SandBox.DEFAULT_POSITION)
+    })
+  })
+
+  describe('and a message uses the shared networkId for an entity nobody registered locally', () => {
+    beforeEach(async () => {
+      PutNetworkComponentOperation.write(7 as Entity, 1, Transform.componentId, 0, transformData, buffer)
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should not mint an entity in the shared namespace', () => {
+      expect(mappings(engine)).toEqual([])
+    })
+  })
+
+  describe('and the peer floods the chunk with entities it does not own', () => {
+    beforeEach(async () => {
+      for (let entityId = 1; entityId <= 200; entityId++) {
+        PutNetworkComponentOperation.write(
+          entityId as Entity,
+          1,
+          Transform.componentId,
+          otherPeerNetworkId,
+          transformData,
+          buffer
+        )
+      }
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should not consume a single entity of the local range', () => {
+      expect(mappings(engine)).toEqual([])
+    })
+  })
+
+  describe('and the chunk carries a plain local message', () => {
+    beforeEach(async () => {
+      PutComponentOperation.write(512 as Entity, 1, Transform.componentId, transformData, buffer)
+      transport.onmessage!(buffer.toBinary(), sender)
+      await engine.update(1)
+    })
+
+    it('should apply it, since local ids carry no ownership claim', () => {
+      expect(Transform.getOrNull(512 as Entity)).toMatchObject(SandBox.DEFAULT_POSITION)
+    })
+  })
+})
+
+describe('when a transport cannot report who sent a chunk of messages', () => {
+  let engine: IEngine
+  let transport: Transport
+  let Transform: ReturnType<typeof components.Transform>
+  let buffer: ReadWriteByteBuffer
+
+  beforeEach(async () => {
+    engine = Engine()
+    transport = createNetworkManager()
+    engine.addTransport(transport)
+    Transform = components.Transform(engine)
+
+    const dataBuffer = new ReadWriteByteBuffer()
+    Transform.schema.serialize(SandBox.DEFAULT_POSITION, dataBuffer)
+
+    buffer = new ReadWriteByteBuffer()
+    PutNetworkComponentOperation.write(500 as Entity, 1, Transform.componentId, 1234, dataBuffer.toBinary(), buffer)
+    transport.onmessage!(buffer.toBinary())
+    await engine.update(1)
+  })
+
+  it('should accept the network message unchanged', () => {
+    expect(mappings(engine)).toEqual([expect.objectContaining({ networkId: 1234, entityId: 500 })])
+  })
+})

--- a/test/snapshots/development-bundles/static-scene.test.ts.crdt
+++ b/test/snapshots/development-bundles/static-scene.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=625.7k bytes
+SCENE_COMPILED_JS_SIZE_PROD=626.1k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/static-scene.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 75k
-  MALLOC_COUNT = 16978
+  MALLOC_COUNT = 16989
   ALIVE_OBJS_DELTA ~= 3.33k
 CALL onStart()
   main.crdt: PUT_COMPONENT e=0x200 c=1 t=0 data={"position":{"x":5.880000114440918,"y":2.7916901111602783,"z":7.380000114440918},"rotation":{"x":0,"y":0,"z":0,"w":1},"scale":{"x":1,"y":1,"z":1},"parent":0}
@@ -55,4 +55,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = -5
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1557.74k bytes
+  MEMORY_USAGE_COUNT ~= 1559.08k bytes

--- a/test/snapshots/development-bundles/testing-fw.test.ts.crdt
+++ b/test/snapshots/development-bundles/testing-fw.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=626.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=626.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/testing-fw.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17533
+  MALLOC_COUNT = 17548
   ALIVE_OBJS_DELTA ~= 3.49k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1563.63k bytes
+  MEMORY_USAGE_COUNT ~= 1565.04k bytes

--- a/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
+++ b/test/snapshots/development-bundles/two-way-crdt.test.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=626.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=626.6k bytes
 THE BUNDLE HAS SOURCEMAPS
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
@@ -10,7 +10,7 @@ EVAL test/snapshots/development-bundles/two-way-crdt.test.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 84k
-  MALLOC_COUNT = 17533
+  MALLOC_COUNT = 17548
   ALIVE_OBJS_DELTA ~= 3.49k
 CALL onStart()
   LOG: ["Adding one to position.y=0"]
@@ -61,4 +61,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 6k
   MALLOC_COUNT = -53
   ALIVE_OBJS_DELTA ~= -0.01k
-  MEMORY_USAGE_COUNT ~= 1563.64k bytes
+  MEMORY_USAGE_COUNT ~= 1565.04k bytes

--- a/test/snapshots/production-bundles/append-value-crdt.ts.crdt
+++ b/test/snapshots/production-bundles/append-value-crdt.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=272k bytes
+SCENE_COMPILED_JS_SIZE_PROD=272.1k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/append-value-crdt.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 88k
-  MALLOC_COUNT = 15849
+  MALLOC_COUNT = 15860
   ALIVE_OBJS_DELTA ~= 3.55k
 CALL onStart()
   Renderer: APPEND_VALUE e=0x200 c=1063 t=0 data={"button":0,"hit":{"position":{"x":1,"y":2,"z":3},"globalOrigin":{"x":1,"y":2,"z":3},"direction":{"x":1,"y":2,"z":3},"normalHit":{"x":1,"y":2,"z":3},"length":10,"meshName":"mesh","entityId":512},"state":1,"timestamp":1,"analog":5,"tickNumber":0}
@@ -54,4 +54,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 15k
   MALLOC_COUNT = 31
   ALIVE_OBJS_DELTA ~= 0.01k
-  MEMORY_USAGE_COUNT ~= 1145.46k bytes
+  MEMORY_USAGE_COUNT ~= 1146.21k bytes

--- a/test/snapshots/production-bundles/billboard.ts.crdt
+++ b/test/snapshots/production-bundles/billboard.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=312.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=313k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/billboard.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 90k
-  MALLOC_COUNT = 18355
+  MALLOC_COUNT = 18362
   ALIVE_OBJS_DELTA ~= 4.03k
 CALL onStart()
   OPCODES ~= 0k
@@ -76,4 +76,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 13k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1331.37k bytes
+  MEMORY_USAGE_COUNT ~= 1332.01k bytes

--- a/test/snapshots/production-bundles/cube-deleted.ts.crdt
+++ b/test/snapshots/production-bundles/cube-deleted.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=268.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=268.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cube-deleted.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 14966
+  MALLOC_COUNT = 14973
   ALIVE_OBJS_DELTA ~= 3.32k
 CALL onStart()
   OPCODES ~= 0k
@@ -41,4 +41,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 7k
   MALLOC_COUNT = 1
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1107.54k bytes
+  MEMORY_USAGE_COUNT ~= 1108.22k bytes

--- a/test/snapshots/production-bundles/cube.ts.crdt
+++ b/test/snapshots/production-bundles/cube.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=268.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=268.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,8 +8,8 @@ EVAL test/snapshots/production-bundles/cube.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 78k
-  MALLOC_COUNT = 14939
-  ALIVE_OBJS_DELTA ~= 3.31k
+  MALLOC_COUNT = 14946
+  ALIVE_OBJS_DELTA ~= 3.32k
 CALL onStart()
   OPCODES ~= 0k
   MALLOC_COUNT = 6
@@ -31,4 +31,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1097.36k bytes
+  MEMORY_USAGE_COUNT ~= 1098.04k bytes

--- a/test/snapshots/production-bundles/cubes.ts.crdt
+++ b/test/snapshots/production-bundles/cubes.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=313.3k bytes
+SCENE_COMPILED_JS_SIZE_PROD=313.4k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/cubes.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 130k
-  MALLOC_COUNT = 21692
+  MALLOC_COUNT = 21699
   ALIVE_OBJS_DELTA ~= 5.31k
 CALL onStart()
   OPCODES ~= 0k
@@ -1651,4 +1651,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 742k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1555.85k bytes
+  MEMORY_USAGE_COUNT ~= 1556.48k bytes

--- a/test/snapshots/production-bundles/pointer-events.ts.crdt
+++ b/test/snapshots/production-bundles/pointer-events.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=269.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=269.2k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/pointer-events.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15232
+  MALLOC_COUNT = 15239
   ALIVE_OBJS_DELTA ~= 3.40k
 CALL onStart()
   OPCODES ~= 0k
@@ -42,4 +42,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1117.06k bytes
+  MEMORY_USAGE_COUNT ~= 1117.74k bytes

--- a/test/snapshots/production-bundles/schema-components.ts.crdt
+++ b/test/snapshots/production-bundles/schema-components.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=268.2k bytes
+SCENE_COMPILED_JS_SIZE_PROD=268.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/schema-components.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 82k
-  MALLOC_COUNT = 15071
+  MALLOC_COUNT = 15078
   ALIVE_OBJS_DELTA ~= 3.35k
 CALL onStart()
   OPCODES ~= 0k
@@ -30,4 +30,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 3k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1099.81k bytes
+  MEMORY_USAGE_COUNT ~= 1100.49k bytes

--- a/test/snapshots/production-bundles/ui.ts.crdt
+++ b/test/snapshots/production-bundles/ui.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=432.9k bytes
+SCENE_COMPILED_JS_SIZE_PROD=433k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -9,7 +9,7 @@ EVAL test/snapshots/production-bundles/ui.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 91k
-  MALLOC_COUNT = 23245
+  MALLOC_COUNT = 23252
   ALIVE_OBJS_DELTA ~= 4.72k
 CALL onStart()
   OPCODES ~= 0k
@@ -66,4 +66,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 81k
   MALLOC_COUNT = 0
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1987.04k bytes
+  MEMORY_USAGE_COUNT ~= 1987.66k bytes

--- a/test/snapshots/production-bundles/with-main-function.ts.crdt
+++ b/test/snapshots/production-bundles/with-main-function.ts.crdt
@@ -1,4 +1,4 @@
-SCENE_COMPILED_JS_SIZE_PROD=269.1k bytes
+SCENE_COMPILED_JS_SIZE_PROD=269.3k bytes
 (start empty vm 0.21.0-3680274614.commit-1808aa1)
   OPCODES ~= 0k
   MALLOC_COUNT = 1005
@@ -8,7 +8,7 @@ EVAL test/snapshots/production-bundles/with-main-function.js
   REQUIRE: ~system/EngineApi
   REQUIRE: ~system/Runtime
   OPCODES ~= 79k
-  MALLOC_COUNT = 15175
+  MALLOC_COUNT = 15182
   ALIVE_OBJS_DELTA ~= 3.37k
 CALL onStart()
   OPCODES ~= 0k
@@ -36,4 +36,4 @@ CALL onUpdate(0.1)
   OPCODES ~= 5k
   MALLOC_COUNT = 13
   ALIVE_OBJS_DELTA ~= 0.00k
-  MEMORY_USAGE_COUNT ~= 1116.84k bytes
+  MEMORY_USAGE_COUNT ~= 1117.52k bytes


### PR DESCRIPTION
## What

A network CRDT message names its target entity with the pair `(networkId, entityId)`. When the receiving engine has no local entity mapped to that pair, `crdtSceneSystem` calls `engine.addEntity()` and creates one. It does this for whatever pair arrives, from whoever sends it.

`networkId` is written by the sending peer. Nothing checked it against who actually sent the message, so one peer could walk the 16-bit `entityId` range under another peer's `networkId` and drain the local entity pool — which is the same pool the scene's own `addEntity()` draws from. `DELETE_COMPONENT_NETWORK` costs 24 bytes on the wire and consumes an entity permanently, with no payload needed.

The fix uses the one field a peer cannot choose for itself. The comms runtime stamps the sender's address onto a chunk before the scene sees it (`craftCommsMessage` writes only `[type][payload]`; `decodeCommsMessage` reads a sender prefix, so the prefix is added in between). `BinaryMessageBus` already decoded it and threw it away one line before the engine.

So: transports that know the origin now hand it to the engine as a `TransportSender`, and **creating** an entity requires the message's `networkId` to be the sender's own.

## What is deliberately *not* restricted

**Writes to entities that already exist stay open to every peer.** `networkId` identifies whose id space an entity belongs to, not who is allowed to touch it — shared mutable state is the entire point of `syncEntity`, and whoever placed the door is not the only one allowed to open it. Binding writes to the sender breaks that outright (`test/sdk/network/sync-engines.spec.ts` catches it immediately).

**The `networkId: 0` shared namespace can never be created from the wire.** Those entities are the ones each client registers for itself with `syncEntity(entity, components, enumId)` during `main()`, so an unknown one is never something to take on faith. Without this the namespace would remain an open allocation vector.

**Join snapshots (`RES_CRDT_STATE`) are not validated.** One peer relays the whole scene there, other peers' entities included, so nothing in it can be attributed to the sender. Same trust model as before this PR.

**Transports with no notion of an origin pass no sender and behave exactly as before** — the renderer transport, local test transports, the editor.

## Known trade-off

If a peer's write to an entity reaches you *before* the message that creates it — possible when the two come from different senders and comms reorders across them — the write is now dropped instead of implicitly creating the entity. The entity is created when its owner's message lands, and CRDT state converges on the next update. This is the cost of not letting arbitrary peers mint entities; it is narrow, and worth naming.

## Still open after this

This bounds *who* may spend from an id space, not *how much*. A peer can still create up to ~65k entities under its own legitimate `networkId`. Because allocation is now attributable to a stamped address, a per-sender budget and reclaim-on-leave become possible to write — `players.onLeaveScene` already receives the same address. That is a policy decision and is not in this PR.

CRC32 is also not collision-resistant, so `networkId` should stay a routing key: any future quota or attribution should key on the stamped address string, which is exact.

## How to test

```bash
node_modules/.bin/jest --testPathPatterns='network-sender-validation'
```

`test/ecs/network-sender-validation.spec.ts` (12 cases) drives a transport directly. Five of them fail on `main` and pass here:

- a new entity announced in another peer's id space does not consume a local entity
- a chunk mixing an owned and an unowned entity creates only the owned one
- 200 unowned entities in one chunk allocate zero
- `DELETE_COMPONENT_NETWORK` / `DELETE_ENTITY_NETWORK` naming a non-existent foreign entity spend nothing

The other seven pin behaviour that must *not* change: creation in the peer's own space, writes to another peer's existing entity, writes to a locally registered shared-namespace entity, plain non-network messages, and transports that report no sender at all.

Full regression run:

```bash
node_modules/.bin/jest --testPathPatterns='test/(ecs|sdk|react-ecs|snapshots)'
```

1291 pass. `test/sdk/network/sync-engines.spec.ts` is the meaningful one — it runs two real engines through `addSyncTransport` and exercises cross-peer writes and deletes end to end.

Golden snapshots are regenerated (bundled SDK changed) and carry no `ERR!` lines. `playground-assets.api.md` is regenerated for the new `TransportSender` export and the `onmessage` signature.