### PR TITLE
fix(sdk-commands): keep the editor's own autosaves out of hot-reload notifications

### DIFF
--- a/packages/@dcl/sdk-commands/src/commands/build/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/build/index.ts
@@ -4,7 +4,7 @@ import { declareArgs } from '../../logic/args'
 import { installDependencies, needsDependencies, SceneProject, WearableProject } from '../../logic/project-validations'
 import { getBaseCoords } from '../../logic/scene-validations'
 import { b64HashingFunction } from '../../logic/project-files'
-import { bundleProject } from '../../logic/bundle'
+import { bundleProject, CompileOptions } from '../../logic/bundle'
 import { printCurrentProjectStarting } from '../../logic/beautiful-logs'
 import { getValidWorkspace } from '../../logic/workspace-validations'
 import { Result } from 'arg'
@@ -56,7 +56,11 @@ export async function main(options: Options) {
   }
 }
 
-export async function buildScene(options: Options, project: SceneProject | WearableProject) {
+export async function buildScene(
+  options: Options,
+  project: SceneProject | WearableProject,
+  bundleOptions: Pick<CompileOptions, 'writeTracker'> = {}
+) {
   const canInstall = !options.args['--skip-install']
 
   if (canInstall) {
@@ -76,7 +80,8 @@ export async function buildScene(options: Options, project: SceneProject | Weara
       production: !!options.args['--production'],
       emitDeclaration: !!options.args['--emitDeclaration'],
       ignoreComposite: !!options.args['--ignoreComposite'],
-      customEntryPoint: !!options.args['--customEntryPoint']
+      customEntryPoint: !!options.args['--customEntryPoint'],
+      ...bundleOptions
     },
     project.scene
   )

--- a/packages/@dcl/sdk-commands/src/commands/start/data-layer/fs.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/data-layer/fs.ts
@@ -1,6 +1,7 @@
 import { FileSystemInterface } from '@dcl/inspector'
 import path from 'path'
 import { CliComponents } from '../../../components'
+import { EditorWriteTracker } from '../../../logic/editor-write-tracker'
 
 /**
  * Convert paths to posix stlye
@@ -10,10 +11,25 @@ export function pathToPosix(value: string): string {
   return value.replace(/\\/g, '/')
 }
 
+/**
+ * Source the editor writes (e.g. UI Designer roots under `src/ui/`) changes the compiled
+ * scene, so it must hot-reload exactly like a hand edit. Everything else the data layer
+ * writes (composite, generated entity names, imported assets) is already reflected live.
+ */
+function isSceneSourceFile(projectWorkingDirectory: string, absolutePath: string): boolean {
+  const relative = path.relative(projectWorkingDirectory, absolutePath)
+  return relative === 'src' || relative.startsWith(`src${path.sep}`)
+}
+
 export function createFileSystemInterfaceFromFsComponent(
   { fs }: Pick<CliComponents, 'fs'>,
-  projectWorkingDirectory: string = process.cwd()
+  projectWorkingDirectory: string = process.cwd(),
+  writeTracker?: EditorWriteTracker
 ): FileSystemInterface {
+  const markEditorWrite = (absolutePath: string) => {
+    if (!isSceneSourceFile(projectWorkingDirectory, absolutePath)) writeTracker?.markEditorWrite(absolutePath)
+  }
+
   return {
     dirname(value: string): string {
       return pathToPosix(path.dirname(value))
@@ -35,17 +51,27 @@ export function createFileSystemInterfaceFromFsComponent(
     async writeFile(filePath: string, content: Buffer): Promise<void> {
       const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
       const folder = path.dirname(resolvedPath)
-      if (!(await fs.directoryExists(folder))) {
+      const missingFolders: string[] = []
+      for (let dir = folder; !(await fs.directoryExists(dir)); dir = path.dirname(dir)) {
+        if (dir === path.dirname(dir)) break
+        missingFolders.push(dir)
+      }
+      if (missingFolders.length > 0) {
+        // the watcher reports each new folder as its own event, so mark them too
+        missingFolders.forEach(markEditorWrite)
         await fs.mkdir(folder, { recursive: true })
       }
+      markEditorWrite(resolvedPath)
       await fs.writeFile(resolvedPath, content as Uint8Array)
     },
     async rm(filePath: string) {
       const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectWorkingDirectory, filePath)
+      markEditorWrite(resolvedPath)
       await fs.rm(resolvedPath)
     },
     async rmdir(dirPath: string) {
       const resolvedPath = path.isAbsolute(dirPath) ? dirPath : path.resolve(projectWorkingDirectory, dirPath)
+      markEditorWrite(resolvedPath)
       await fs.rm(resolvedPath, { recursive: true })
     },
     async readdir(dirPath: string): Promise<{ name: string; isDirectory: boolean }[]> {

--- a/packages/@dcl/sdk-commands/src/commands/start/data-layer/rpc.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/data-layer/rpc.ts
@@ -4,6 +4,7 @@ import * as codegen from '@dcl/rpc/dist/codegen'
 
 import { CliComponents } from '../../../components'
 import { createFileSystemInterfaceFromFsComponent } from './fs'
+import { EditorWriteTracker } from '../../../logic/editor-write-tracker'
 
 export type DataLayer = {
   rpcServer: RpcServer<DataLayerContext>
@@ -12,9 +13,10 @@ export type DataLayer = {
 
 export async function createDataLayer(
   components: Pick<CliComponents, 'fs' | 'logger'>,
-  workingDirectory: string
+  workingDirectory: string,
+  writeTracker?: EditorWriteTracker
 ): Promise<DataLayer> {
-  const fs = createFileSystemInterfaceFromFsComponent({ fs: components.fs }, workingDirectory)
+  const fs = createFileSystemInterfaceFromFsComponent({ fs: components.fs }, workingDirectory, writeTracker)
   const dataLayerHost = await createDataLayerHost(fs)
   const context: DataLayerContext = {
     fs,

--- a/packages/@dcl/sdk-commands/src/commands/start/index.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/index.ts
@@ -22,6 +22,7 @@ import { wireRouter } from './server/routes'
 import { createWsComponent } from './server/ws'
 import { b64HashingFunction } from '../../logic/project-files'
 import { DataLayer, createDataLayer } from './data-layer/rpc'
+import { createEditorWriteTracker } from '../../logic/editor-write-tracker'
 import { createExitSignalComponent } from '../../components/exit-signal'
 import { getValidWorkspace } from '../../logic/workspace-validations'
 import { printCurrentProjectStarting, printProgressInfo, printWarning } from '../../logic/beautiful-logs'
@@ -140,6 +141,11 @@ export async function main(options: Options) {
 
   const workspace = await getValidWorkspace(options.components, workingDirectory)
 
+  // With a data layer the editor saves through THIS process, so its own autosaves
+  // (and the rebuilds they trigger) can be told apart from IDE edits and kept out of
+  // the hot-reload notifications — otherwise every gizmo drag can reload the scene.
+  const editorWrites = withDataLayer ? createEditorWriteTracker() : undefined
+
   /* istanbul ignore if */
   if (workspace.projects.length > 1)
     printWarning(options.components.logger, 'Support for multiple projects is still experimental.')
@@ -151,7 +157,13 @@ export async function main(options: Options) {
       // first run `npm run build`, this can be disabled with --skip-build
       // then start the embedded compiler, this can be disabled with --no-watch
       if (watch || build) {
-        await buildScene({ ...options, args: { '--dir': project.workingDirectory, '--watch': watch, _: [] } }, project)
+        await buildScene(
+          { ...options, args: { '--dir': project.workingDirectory, '--watch': watch, _: [] } },
+          project,
+          {
+            writeTracker: editorWrites
+          }
+        )
         await startValidations(options.components, project.workingDirectory)
       }
 
@@ -206,7 +218,7 @@ export async function main(options: Options) {
       if (withDataLayer) {
         try {
           const projectWorkingDir = workspace.projects[0]?.workingDirectory || workingDirectory
-          dataLayer = await createDataLayer(components, projectWorkingDir)
+          dataLayer = await createDataLayer(components, projectWorkingDir, editorWrites)
         } catch (e: unknown) {
           components.logger.error(e as Error)
         }
@@ -215,7 +227,7 @@ export async function main(options: Options) {
       await wireRouter(components, workspace, dataLayer)
       if (watch) {
         for (const project of workspace.projects) {
-          await wireFileWatcherToWebSockets(components, project.workingDirectory, project.kind)
+          await wireFileWatcherToWebSockets(components, project.workingDirectory, project.kind, editorWrites)
         }
       }
       await startComponents()

--- a/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
+++ b/packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier.ts
@@ -12,6 +12,7 @@ import {
   UpdateModelType
 } from '@dcl/protocol/out-js/decentraland/sdk/development/local_development.gen'
 import { debounce } from '../../../logic/debounce'
+import { EditorWriteTracker } from '../../../logic/editor-write-tracker'
 
 /**
  * This function gets file modification events and sends them to all the connected
@@ -20,12 +21,20 @@ import { debounce } from '../../../logic/debounce'
 export async function wireFileWatcherToWebSockets(
   components: Pick<PreviewComponents, 'fs' | 'ws' | 'logger'>,
   projectRoot: string,
-  projectKind: ProjectUnion['kind']
+  projectKind: ProjectUnion['kind'],
+  editorWrites?: EditorWriteTracker
 ) {
   const ignored = await getDCLIgnorePatterns(components, projectRoot)
   const sceneId = b64HashingFunction(projectRoot)
 
-  chokidar
+  const notifySceneChanged = debounce((file: string) => {
+    updateScene(sceneId, file)
+    // Legacy JSON protocol: still the only one Bevy and Godot explorers understand.
+    // Remove once both consume the protobuf WsSceneMessage.
+    __LEGACY__updateScene(projectRoot, sceneUpdateClients, projectKind)
+  }, 800)
+
+  return chokidar
     .watch(path.resolve(projectRoot), {
       atomic: false,
       ignored,
@@ -35,15 +44,13 @@ export async function wireFileWatcherToWebSockets(
     .on('unlink', (file: string) => {
       removeModel(sceneId, file)
     })
-    .on(
-      'all',
-      debounce(async (_, file) => {
-        updateScene(sceneId, file)
-        // Legacy JSON protocol: still the only one Bevy and Godot explorers understand.
-        // Remove once both consume the protobuf WsSceneMessage.
-        __LEGACY__updateScene(projectRoot, sceneUpdateClients, projectKind)
-      }, 800)
-    )
+    .on('all', (_, file) => {
+      // A write by the editor's own data layer (`--data-layer` autosave) or the
+      // rebuild it triggered is not a code change: the editor already shows that edit
+      // live, and a SCENE_UPDATE would make it reload the whole scene mid-edit.
+      if (editorWrites?.isEditorWrite(path.resolve(projectRoot, file))) return
+      notifySceneChanged(file)
+    })
 }
 
 function isGLTFModel(file: string) {

--- a/packages/@dcl/sdk-commands/src/logic/bundle.ts
+++ b/packages/@dcl/sdk-commands/src/logic/bundle.ts
@@ -19,6 +19,7 @@ import { getAllComposites, type Script } from './composite'
 import { isEditorScene } from './project-validations'
 import { watch } from 'chokidar'
 import { debounce } from './debounce'
+import { EditorWriteTracker } from './editor-write-tracker'
 
 export type BundleComponents = Pick<CliComponents, 'logger' | 'fs'>
 
@@ -42,6 +43,10 @@ export type CompileOptions = {
 
   ignoreComposite: boolean
   customEntryPoint: boolean
+
+  // watch mode only: lets the rebuild outputs inherit the origin of the change that
+  // triggered them, so an editor autosave does not read as a code change downstream
+  writeTracker?: EditorWriteTracker
 }
 
 const MAX_STEP = 2
@@ -303,7 +308,14 @@ export async function bundleSingleProject(components: BundleComponents, options:
       ignoreInitial: true
     })
 
+    // Every rebuild rewrites main.crdt (via the composite loader) and the bundle. Mark
+    // them BEFORE rebuilding so the notifier's watcher can never see the write first.
+    const rebuildOutputs = [path.resolve(options.outputFile), path.join(options.workingDirectory, 'main.crdt')]
+    let pendingTriggers: string[] = []
     const debouncedRebuild = debounce(async () => {
+      const triggers = pendingTriggers
+      pendingTriggers = []
+      options.writeTracker?.markRebuildOutputs(triggers, rebuildOutputs)
       try {
         await context.rebuild()
         printProgressInfo(components.logger, `Bundle saved ${colors.bold(options.outputFile)}`)
@@ -317,6 +329,7 @@ export async function bundleSingleProject(components: BundleComponents, options:
       // Rebuild for TypeScript, JavaScript, and composite files
       if (/\.(ts|tsx|js|jsx|composite)$/.test(filePath)) {
         printProgressInfo(components.logger, `File ${filePath} changed, rebuilding...`)
+        pendingTriggers.push(path.resolve(options.workingDirectory, filePath))
         debouncedRebuild()
       }
     })

--- a/packages/@dcl/sdk-commands/src/logic/editor-write-tracker.ts
+++ b/packages/@dcl/sdk-commands/src/logic/editor-write-tracker.ts
@@ -1,0 +1,73 @@
+import path from 'path'
+
+/**
+ * Records which project files were last written by the editor itself — the
+ * `--data-layer` autosave (`main.composite`, `entity-names.ts`, imported assets) and
+ * the bundle rebuild those writes trigger (`bin/index.js`, `main.crdt`) — so the
+ * hot-reload notifier can tell them apart from a code change made in an IDE.
+ *
+ * Why this exists: the inspector already applies its own edits to the running scene
+ * live, so a SCENE_UPDATE for the files it just saved makes the editor reload the
+ * whole scene for nothing. The editor cannot filter that on its side: the message
+ * carries no file name, and only this process knows a rebuild was caused by its own
+ * autosave. See `file-watch-notifier.ts` for the consumer.
+ *
+ * Marks expire so a hand edit of a marked file long after the autosave is still
+ * reported. The TTL only has to outlive the watcher latency between a write and its
+ * chokidar event; it is generous because the rebuild runs in between for outputs.
+ */
+export type EditorWriteTracker = {
+  /** Record that the editor wrote (or removed) `absolutePath`, or the directory it names. */
+  markEditorWrite(absolutePath: string): void
+  /**
+   * Record the outputs a rebuild is about to write. They inherit the editor origin
+   * only when every file that triggered the rebuild was an editor write; a rebuild
+   * caused by any other change (an IDE save) is a real code change and clears any
+   * earlier editor mark on those outputs.
+   */
+  markRebuildOutputs(triggerPaths: string[], outputPaths: string[]): void
+  /** Was `absolutePath` (or a directory containing it) last written by the editor, within the TTL? */
+  isEditorWrite(absolutePath: string): boolean
+}
+
+export const EDITOR_WRITE_TTL_MS = 10_000
+
+export function createEditorWriteTracker(options: { ttlMs?: number; now?: () => number } = {}): EditorWriteTracker {
+  const ttlMs = options.ttlMs ?? EDITOR_WRITE_TTL_MS
+  const now = options.now ?? Date.now
+  const markedAt = new Map<string, number>()
+
+  const normalize = (absolutePath: string) => path.normalize(absolutePath)
+
+  const isFresh = (candidate: string, at: number) => {
+    const marked = markedAt.get(candidate)
+    return marked !== undefined && at - marked < ttlMs
+  }
+
+  const markEditorWrite = (absolutePath: string) => {
+    markedAt.set(normalize(absolutePath), now())
+  }
+
+  const isEditorWrite = (absolutePath: string) => {
+    const at = now()
+    let candidate = normalize(absolutePath)
+    while (true) {
+      if (isFresh(candidate, at)) return true
+      const parent = path.dirname(candidate)
+      if (parent === candidate) return false
+      candidate = parent
+    }
+  }
+
+  return {
+    markEditorWrite,
+    isEditorWrite,
+    markRebuildOutputs(triggerPaths, outputPaths) {
+      const editorTriggered = triggerPaths.length > 0 && triggerPaths.every(isEditorWrite)
+      for (const outputPath of outputPaths) {
+        if (editorTriggered) markEditorWrite(outputPath)
+        else markedAt.delete(normalize(outputPath))
+      }
+    }
+  }
+}

--- a/test/sdk-commands/commands/start/file-watch-notifier.spec.ts
+++ b/test/sdk-commands/commands/start/file-watch-notifier.spec.ts
@@ -1,0 +1,74 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { wireFileWatcherToWebSockets } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/file-watch-notifier'
+import { sceneUpdateClients } from '../../../../packages/@dcl/sdk-commands/src/commands/start/server/routes'
+import { createFsComponent } from '../../../../packages/@dcl/sdk-commands/src/components/fs'
+import { createEditorWriteTracker } from '../../../../packages/@dcl/sdk-commands/src/logic/editor-write-tracker'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitFor(condition: () => boolean, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs
+  while (!condition() && Date.now() < deadline) await sleep(50)
+  return condition()
+}
+
+describe('file watch notifier + editor write tracker', () => {
+  const components = { fs: createFsComponent(), ws: {} as any, logger: console as any }
+  const OPEN = 1 // ws.WebSocket.OPEN; `ws` is a dependency of the package, not resolvable from test/
+  const client = { readyState: OPEN, send: jest.fn() }
+  const sceneUpdates = () =>
+    client.send.mock.calls.filter(([payload]) => typeof payload === 'string' && payload.includes('SCENE_UPDATE'))
+
+  let project: string
+  let watcher: Awaited<ReturnType<typeof wireFileWatcherToWebSockets>>
+
+  beforeEach(async () => {
+    project = fs.mkdtempSync(path.join(os.tmpdir(), 'dcl-notifier-'))
+    fs.mkdirSync(path.join(project, 'assets/scene'), { recursive: true })
+    fs.mkdirSync(path.join(project, 'bin'))
+    sceneUpdateClients.add(client as any)
+  })
+
+  afterEach(async () => {
+    await watcher.close()
+    sceneUpdateClients.delete(client as any)
+    client.send.mockClear()
+    fs.rmSync(project, { recursive: true, force: true })
+  })
+
+  test('an autosave by the editor and the rebuild it caused are NOT broadcast, an IDE edit still is', async () => {
+    const tracker = createEditorWriteTracker()
+    watcher = await wireFileWatcherToWebSockets(components, project, 'scene', tracker)
+    await new Promise((resolve) => watcher.on('ready', resolve))
+    // the initial scan notifies once; let that settle so only our writes count
+    await sleep(1200)
+    client.send.mockClear()
+
+    // the data layer saves the composite (see data-layer/fs.ts) and the bundler
+    // rebuilds from it (see logic/bundle.ts): every one of those writes is marked
+    const composite = path.join(project, 'assets/scene/main.composite')
+    const outputs = [path.join(project, 'bin/index.js'), path.join(project, 'main.crdt')]
+    tracker.markEditorWrite(composite)
+    fs.writeFileSync(composite, '{}')
+    tracker.markRebuildOutputs([composite], outputs)
+    for (const output of outputs) fs.writeFileSync(output, 'built')
+    await sleep(1500)
+    expect(sceneUpdates()).toHaveLength(0)
+
+    // a change nobody marked (an asset dropped in from the file system) is broadcast
+    fs.writeFileSync(path.join(project, 'assets/readme.txt'), 'hello')
+    expect(await waitFor(() => sceneUpdates().length > 0, 3000)).toBe(true)
+  })
+
+  test('without a tracker every change is broadcast, as before', async () => {
+    watcher = await wireFileWatcherToWebSockets(components, project, 'scene')
+    await new Promise((resolve) => watcher.on('ready', resolve))
+    await sleep(1200)
+    client.send.mockClear()
+
+    fs.writeFileSync(path.join(project, 'assets/scene/main.composite'), '{}')
+    expect(await waitFor(() => sceneUpdates().length > 0, 3000)).toBe(true)
+  })
+})

--- a/test/sdk-commands/logic/editor-write-tracker.spec.ts
+++ b/test/sdk-commands/logic/editor-write-tracker.spec.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+import {
+  createEditorWriteTracker,
+  EDITOR_WRITE_TTL_MS
+} from '../../../packages/@dcl/sdk-commands/src/logic/editor-write-tracker'
+
+const project = path.resolve('/scene')
+const composite = path.join(project, 'assets/scene/main.composite')
+const entityNames = path.join(project, 'assets/scene/entity-names.ts')
+const source = path.join(project, 'src/index.ts')
+const outputs = [path.join(project, 'bin/index.js'), path.join(project, 'main.crdt')]
+
+describe('editor write tracker', () => {
+  test('a path nobody marked is not an editor write', () => {
+    const tracker = createEditorWriteTracker()
+    expect(tracker.isEditorWrite(composite)).toBe(false)
+  })
+
+  test('a marked path is an editor write, also through a non-normalized spelling', () => {
+    const tracker = createEditorWriteTracker()
+    tracker.markEditorWrite(composite)
+    expect(tracker.isEditorWrite(composite)).toBe(true)
+    expect(tracker.isEditorWrite(path.join(project, 'assets/./scene/main.composite'))).toBe(true)
+  })
+
+  test('a removed directory covers the files under it, but not a sibling with the same prefix', () => {
+    const tracker = createEditorWriteTracker()
+    tracker.markEditorWrite(path.join(project, 'assets/models'))
+    expect(tracker.isEditorWrite(path.join(project, 'assets/models/tree.glb'))).toBe(true)
+    expect(tracker.isEditorWrite(path.join(project, 'assets/models-old/tree.glb'))).toBe(false)
+  })
+
+  test('a mark expires after the TTL so a later hand edit is reported again', () => {
+    let clock = 1000
+    const tracker = createEditorWriteTracker({ now: () => clock })
+    tracker.markEditorWrite(composite)
+    clock += EDITOR_WRITE_TTL_MS - 1
+    expect(tracker.isEditorWrite(composite)).toBe(true)
+    clock += 1
+    expect(tracker.isEditorWrite(composite)).toBe(false)
+  })
+
+  test('the TTL is configurable', () => {
+    let clock = 0
+    const tracker = createEditorWriteTracker({ ttlMs: 5, now: () => clock })
+    tracker.markEditorWrite(composite)
+    clock = 5
+    expect(tracker.isEditorWrite(composite)).toBe(false)
+  })
+
+  describe('rebuild outputs', () => {
+    test('inherit the editor origin when every trigger was an editor write (an autosave)', () => {
+      const tracker = createEditorWriteTracker()
+      tracker.markEditorWrite(composite)
+      tracker.markEditorWrite(entityNames)
+      tracker.markRebuildOutputs([composite, entityNames], outputs)
+      for (const output of outputs) expect(tracker.isEditorWrite(output)).toBe(true)
+    })
+
+    test('are a code change when any trigger was not an editor write (an IDE save)', () => {
+      const tracker = createEditorWriteTracker()
+      tracker.markEditorWrite(composite)
+      tracker.markRebuildOutputs([composite, source], outputs)
+      for (const output of outputs) expect(tracker.isEditorWrite(output)).toBe(false)
+    })
+
+    test('a code change clears an earlier editor mark on the same outputs', () => {
+      const tracker = createEditorWriteTracker()
+      tracker.markEditorWrite(composite)
+      tracker.markRebuildOutputs([composite], outputs)
+      tracker.markRebuildOutputs([source], outputs)
+      for (const output of outputs) expect(tracker.isEditorWrite(output)).toBe(false)
+    })
+
+    test('a rebuild with no recorded trigger is treated as a code change', () => {
+      const tracker = createEditorWriteTracker()
+      tracker.markRebuildOutputs([], outputs)
+      for (const output of outputs) expect(tracker.isEditorWrite(output)).toBe(false)
+    })
+  })
+})

--- a/test/sdk-commands/utils/data-layer-fs.spec.ts
+++ b/test/sdk-commands/utils/data-layer-fs.spec.ts
@@ -98,3 +98,58 @@ describe('FsInterface', () => {
     })
   })
 })
+
+describe('FsInterface editor write tracking', () => {
+  const os = require('os') as typeof import('os')
+  const nodeFs = require('fs') as typeof import('fs')
+  const fs = createFsComponent()
+
+  let project: string
+  beforeEach(() => {
+    project = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'dcl-data-layer-fs-'))
+  })
+  afterEach(() => {
+    nodeFs.rmSync(project, { recursive: true, force: true })
+  })
+
+  test('marks scene data it writes or removes, and the folders it creates, so the notifier can skip them', async () => {
+    const marked: string[] = []
+    const tracker = {
+      markEditorWrite: (p: string) => marked.push(p),
+      markRebuildOutputs: jest.fn(),
+      isEditorWrite: jest.fn()
+    }
+    const fsInterface = createFileSystemInterfaceFromFsComponent({ fs }, project, tracker)
+
+    await fsInterface.writeFile('assets/scene/main.composite', Buffer.from('{}'))
+    await fsInterface.writeFile('assets/models/tree.glb', Buffer.from('glb'))
+    await fsInterface.rm('assets/models/tree.glb')
+    await fsInterface.rmdir('assets/models')
+
+    expect(marked).toEqual([
+      path.join(project, 'assets/scene'),
+      path.join(project, 'assets'),
+      path.join(project, 'assets/scene/main.composite'),
+      path.join(project, 'assets/models'),
+      path.join(project, 'assets/models/tree.glb'),
+      path.join(project, 'assets/models/tree.glb'),
+      path.join(project, 'assets/models')
+    ])
+  })
+
+  test('does not mark scene source it writes: that changes the compiled scene and must hot-reload', async () => {
+    const tracker = { markEditorWrite: jest.fn(), markRebuildOutputs: jest.fn(), isEditorWrite: jest.fn() }
+    const fsInterface = createFileSystemInterfaceFromFsComponent({ fs }, project, tracker)
+
+    await fsInterface.writeFile('src/ui/root.tsx', Buffer.from('export {}'))
+    await fsInterface.rm('src/ui/root.tsx')
+
+    expect(tracker.markEditorWrite).not.toHaveBeenCalled()
+  })
+
+  test('works without a tracker', async () => {
+    const fsInterface = createFileSystemInterfaceFromFsComponent({ fs }, project)
+    await fsInterface.writeFile('assets/scene/main.composite', Buffer.from('{}'))
+    expect(await fsInterface.existFile('assets/scene/main.composite')).toBe(true)
+  })
+})


### PR DESCRIPTION
## The use case

You are editing a scene in the **Creator Hub with the Bevy renderer**. You drag an entity with the gizmo, or change a material colour in the inspector. The change shows up in the viewport immediately (the inspector forwards its own edits to the running scene live). Then, about two seconds later, **the whole scene sometimes reloads**: everything blinks out, `main()` runs again, animations restart, the scene lands frozen. The same edit will reload the scene one time and not the next.

Nothing about that edit needs a reload. The reload is the scene-code **hot-reload** path firing by mistake, and this PR stops it at the only place that can tell the two cases apart.

## Why it happens

The editor's realm is `sdk-commands start --data-layer`. That one process hosts both the inspector's **data layer** (which autosaves the scene) and the **bundler** (which rebuilds on file changes). After one inspector edit:

1. The data layer autosaves `assets/scene/main.composite` and `entity-names.ts`.
2. The bundler's watcher matches `.composite`/`.ts`, waits 100 ms and rebuilds, rewriting `bin/index.js` and `main.crdt` (`logic/bundle.ts`).
3. The file-watch notifier sees those outputs (none are dclignored), waits 800 ms after the last one, and broadcasts `SCENE_UPDATE` (`server/file-watch-notifier.ts`).

The inspector treats `SCENE_UPDATE` as "the scene code changed" and reloads the scene through its Stop/reset path. Because the message carries no file name, the inspector's only defence is a heuristic: ignore `SCENE_UPDATE` if one of its own ECS edits happened in the last 1.5 s. Measured against a real Creator Hub scene (6.4 MB bundle), the message lands **1.32–1.33 s after the save** on an idle machine. That leaves under 200 ms of slack, so any CPU contention (the Bevy wasm engine and Electron are both busy during a drag) or a bigger bundle pushes it past the window and the scene reloads. Hence "sometimes".

The same guard has a second cost: a **real** code save made within 1.5 s of an inspector edit is dropped outright, not deferred.

## The fix

The inspector cannot distinguish its own autosave from an IDE edit, but this process can: it performed the write, and it knows what triggered each rebuild. So track the origin here and skip the notification for editor-originated writes.

- **`logic/editor-write-tracker.ts`** (new) records which absolute paths were last written by the editor, with a 10 s TTL so a hand edit of the same file later is still reported. `markRebuildOutputs(triggers, outputs)` gives the rebuild outputs the editor origin only when **every** file that triggered the rebuild was an editor write; a rebuild caused by any other change (an IDE save) clears the mark, so a code change made right after an autosave is still delivered.
- **`data-layer/fs.ts`** marks every file (and every folder it has to create, since chokidar reports those as their own events) that the data layer writes or removes. **Exception: anything under `src/`.** Source the editor writes there (UI Designer roots) changes the compiled scene and must hot-reload exactly like a hand edit.
- **`logic/bundle.ts`** collects the paths that triggered a rebuild and marks `bin/index.js` + `main.crdt` *before* rebuilding, so the notifier's watcher can never observe the write first.
- **`server/file-watch-notifier.ts`** drops an event whose path is an editor write before it reaches the 800 ms debounce.
- **`start/index.ts`** creates the tracker only with `--data-layer` and threads it to the three places above. Plain `sdk-commands start` (the preview) is unchanged.

## What still reloads, on purpose

- Editing `src/**` in an IDE or through the AI assistant (the notifier sees the source change and/or the user-attributed rebuild output).
- Replacing a model or other asset from the file system (not a data-layer write).
- A UI Designer edit written under `src/ui/` (excluded from marking, see above).

## Tests

- `test/sdk-commands/logic/editor-write-tracker.spec.ts`: mark / lookup / ancestor-folder match / TTL expiry / rebuild-origin rules (100% coverage, the `logic/` threshold).
- `test/sdk-commands/utils/data-layer-fs.spec.ts`: the fs adapter marks scene data and created folders, does not mark `src/`, and works without a tracker.
- `test/sdk-commands/commands/start/file-watch-notifier.spec.ts`: real chokidar watcher on a temp project. An editor write plus its rebuild outputs produce **no** `SCENE_UPDATE` within 1.5 s; an unmarked write still does; without a tracker behaviour is as before. This test is what caught the folder-creation case.

## Verifying in the Creator Hub

Point the app at this build of `@dcl/sdk-commands`, open a scene with the Bevy renderer, and drag an entity or change a material colour repeatedly: the viewport updates live and the scene never reloads. Edit `src/index.ts` in an IDE: the scene still hot-reloads.

Related inspector code: `packages/inspector/src/lib/renderer/bevy/register.ts` (`LOCAL_EDIT_QUIET_MS`) in creator-hub. Once this ships, that heuristic can be relaxed or removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
