### PR TITLE
fix: only accept a CRDT state snapshot that answers an outstanding request

### DIFF
--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -1,4 +1,5 @@
-import { IEngine, Transport, RealmInfo, PlayerIdentityData } from '@dcl/ecs'
+import { IEngine, Transport } from '@dcl/ecs'
+import { RealmInfo as defineRealmInfo, PlayerIdentityData as definePlayerIdentityData } from '@dcl/ecs/dist/components'
 import { type SendBinaryRequest, type SendBinaryResponse } from '~system/CommunicationsController'
 
 import { syncFilter } from './filter'
@@ -22,6 +23,11 @@ export function addSyncTransport(
   const myProfile: IProfile = {} as IProfile
   fetchProfile(myProfile!, getUserData)
 
+  // Resolved from the engine we were handed rather than the global one, so the
+  // join flow belongs to that engine.
+  const RealmInfo = defineRealmInfo(engine)
+  const PlayerIdentityData = definePlayerIdentityData(engine)
+
   // Entity utils
   const entityDefinitions = entityUtils(engine, myProfile)
 
@@ -41,6 +47,9 @@ export function addSyncTransport(
 
   let stateIsSyncronized = false
   let transportInitialzed = false
+  // Whether a state request is outstanding. A snapshot only means anything as an
+  // answer to one; outside that window nobody asked for it.
+  let awaitingState = false
 
   // Add Sync Transport
   const transport: Transport = {
@@ -74,9 +83,18 @@ export function addSyncTransport(
 
   // Receive & Process CRDT_STATE
   binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, (value) => {
-    const { sender, data } = decodeCRDTState(value)
-    if (sender !== myProfile.userId) return
+    // A snapshot nobody asked for is not state transfer, it is an injection, and
+    // this handler used to stay open for the life of the scene.
+    if (!awaitingState) return
+
+    const { addressee, data } = decodeCRDTState(value)
+    if (addressee !== myProfile.userId) return
+
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
+    // Every peer answers the same broadcast and each relays the whole scene rather
+    // than only its own entities, so a snapshot cannot be attributed to whoever
+    // sent it and is deliberately not validated per message. Taking all of them
+    // keeps a peer that answers with nothing from deciding the scene is empty.
     transport.onmessage!(data)
     stateIsSyncronized = true
   })
@@ -103,9 +121,12 @@ export function addSyncTransport(
 
     if (!RealmInfo.getOrNull(engine.RootEntity)?.isConnectedSceneRoom) {
       DEBUG_NETWORK_MESSAGES() && console.log(`Aborting Requesting state?. Disconnected`)
+      awaitingState = false
       return
     }
 
+    // Open the window before asking; a retry reopens it.
+    awaitingState = true
     binaryMessageBus.emit(CommsMessage.REQ_CRDT_STATE, new Uint8Array())
 
     // Wait ~5s for the response.
@@ -121,7 +142,10 @@ export function addSyncTransport(
       } else {
         DEBUG_NETWORK_MESSAGES() && console.log('No active players. State syncronized')
         stateIsSyncronized = true
+        awaitingState = false
       }
+    } else {
+      awaitingState = false
     }
   }
 
@@ -134,6 +158,7 @@ export function addSyncTransport(
     if (!value?.isConnectedSceneRoom) {
       DEBUG_NETWORK_MESSAGES() && console.log('Disconnected from comms')
       stateIsSyncronized = false
+      awaitingState = false
     }
 
     if (value?.isConnectedSceneRoom) {
@@ -179,19 +204,22 @@ export function addSyncTransport(
  *
  * CRDT: Plain Uint8Array
  *
- * CRDT_STATE_RES { sender: string, data: Uint8Array}
+ * CRDT_STATE_RES { addressee: string, data: Uint8Array}
+ *
+ * The address in the payload is written by the responder and names who asked for
+ * the state, so it identifies the recipient and never the sender.
  */
 function decodeCRDTState(data: Uint8Array) {
   let offset = 0
   const r = new Uint8Array(data)
   const view = new DataView(r.buffer)
-  const senderLength = view.getUint8(offset)
+  const addresseeLength = view.getUint8(offset)
   offset += 1
-  const sender = decodeString(data.subarray(1, senderLength + 1))
-  offset += senderLength
+  const addressee = decodeString(data.subarray(1, addresseeLength + 1))
+  offset += addresseeLength
   const state = r.subarray(offset)
 
-  return { sender, data: state }
+  return { addressee, data: state }
 }
 
 function encodeCRDTState(address: string, data: Uint8Array) {

--- a/test/sdk/network/crdt-state-request-window.spec.ts
+++ b/test/sdk/network/crdt-state-request-window.spec.ts
@@ -1,0 +1,231 @@
+import { Engine } from '../../../packages/@dcl/ecs/src/engine'
+import { Entity } from '../../../packages/@dcl/ecs/src/engine/entity'
+import { IEngine } from '../../../packages/@dcl/ecs/src'
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { componentNumberFromName } from '../../../packages/@dcl/ecs/src/components/component-number'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutNetworkComponentOperation } from '../../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
+import { addSyncTransport } from '../../../packages/@dcl/sdk/network/message-bus-sync'
+import { CommsMessage, encodeString } from '../../../packages/@dcl/sdk/network/binary-message-bus'
+
+const ME = 'me'
+const FIRST_RESPONDER = 'firstpeer'
+const OTHER_PEER = 'otherpeer'
+
+/** The framing the runtime produces: [senderLen][sender][commsType][payload]. */
+function commsMessage(sender: string, type: CommsMessage, payload: Uint8Array): Uint8Array {
+  const encoded = encodeString(sender)
+  const out = new Uint8Array(1 + encoded.byteLength + 1 + payload.byteLength)
+  out.set([encoded.byteLength], 0)
+  out.set(encoded, 1)
+  out.set([type], 1 + encoded.byteLength)
+  out.set(payload, 1 + encoded.byteLength + 1)
+  return out
+}
+
+/** encodeCRDTState's shape: [addresseeLen][addressee][crdt]. */
+function stateResponse(addressee: string, crdt: Uint8Array): Uint8Array {
+  const encoded = encodeString(addressee)
+  const out = new Uint8Array(1 + encoded.byteLength + crdt.byteLength)
+  out.set([encoded.byteLength], 0)
+  out.set(encoded, 1)
+  out.set(crdt, 1 + encoded.byteLength)
+  return out
+}
+
+describe('when a peer sends a CRDT state snapshot', () => {
+  let engine: IEngine
+  let inbox: Uint8Array[]
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let Transform: ReturnType<typeof components.Transform>
+  let RealmInfo: ReturnType<typeof components.RealmInfo>
+  let snapshotOf: (entityId: number, owner: string) => Uint8Array
+
+  async function tick(times: number) {
+    for (let i = 0; i < times; i++) await engine.update(1)
+  }
+
+  function mappedEntityIds(): number[] {
+    return Array.from(engine.getEntitiesWith(NetworkEntity)).map(([, network]) => network.entityId as number)
+  }
+
+  async function connectToComms() {
+    RealmInfo.createOrReplace(engine.RootEntity, {
+      baseUrl: 'http://localhost',
+      realmName: 'test',
+      networkId: 1,
+      commsAdapter: 'offline',
+      isPreview: true,
+      room: 'room',
+      isConnectedSceneRoom: true
+    })
+    await tick(1)
+  }
+
+  beforeEach(async () => {
+    engine = Engine()
+    inbox = []
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    RealmInfo = components.RealmInfo(engine)
+    components.NetworkParent(engine)
+    components.SyncComponents(engine)
+    components.PlayerIdentityData(engine)
+    components.AvatarBase(engine)
+    const EngineInfo = components.EngineInfo(engine)
+
+    addSyncTransport(
+      engine,
+      async () => {
+        const pending = inbox
+        inbox = []
+        return { data: pending }
+      },
+      async () => ({ data: { userId: ME, version: 1, displayName: ME, hasConnectedWeb3: true } }) as any
+    )
+
+    EngineInfo.create(engine.RootEntity, { tickNumber: 400, frameNumber: 400, totalRuntime: 1, sceneHidden: false })
+
+    snapshotOf = (entityId: number, owner: string) => {
+      const data = new ReadWriteByteBuffer()
+      Transform.schema.serialize(
+        {
+          position: { x: 1, y: 1, z: 1 },
+          rotation: { x: 0, y: 0, z: 0, w: 1 },
+          scale: { x: 1, y: 1, z: 1 },
+          parent: 0 as Entity
+        },
+        data
+      )
+      const crdt = new ReadWriteByteBuffer()
+      PutNetworkComponentOperation.write(
+        entityId as Entity,
+        1,
+        Transform.componentId,
+        componentNumberFromName(owner),
+        data.toBinary(),
+        crdt
+      )
+      return crdt.toBinary()
+    }
+
+    await tick(2)
+  })
+
+  describe('and this client never requested state', () => {
+    beforeEach(async () => {
+      inbox.push(
+        commsMessage(FIRST_RESPONDER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(512, 'someone')))
+      )
+      await tick(3)
+    })
+
+    it('should ignore the snapshot entirely', () => {
+      expect(mappedEntityIds()).toEqual([])
+    })
+  })
+
+  describe('and a state request is outstanding', () => {
+    beforeEach(async () => {
+      await connectToComms()
+    })
+
+    describe('and the first peer answers it', () => {
+      beforeEach(async () => {
+        inbox.push(
+          commsMessage(FIRST_RESPONDER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(512, 'someone')))
+        )
+        await tick(3)
+      })
+
+      it('should apply the snapshot', () => {
+        expect(mappedEntityIds()).toEqual([512])
+      })
+    })
+
+    describe('and that same peer sends several chunks', () => {
+      beforeEach(async () => {
+        // engineToCrdt splits the state and the responder emits every chunk in one
+        // go, so they reach us in a single batch.
+        for (const entityId of [512, 513, 514]) {
+          inbox.push(
+            commsMessage(
+              FIRST_RESPONDER,
+              CommsMessage.RES_CRDT_STATE,
+              stateResponse(ME, snapshotOf(entityId, 'someone'))
+            )
+          )
+        }
+        await tick(3)
+      })
+
+      it('should apply every chunk from it', () => {
+        expect(mappedEntityIds().sort()).toEqual([512, 513, 514])
+      })
+    })
+
+    describe('and several peers answer it', () => {
+      beforeEach(async () => {
+        inbox.push(
+          commsMessage(FIRST_RESPONDER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(512, 'someone')))
+        )
+        await tick(3)
+        inbox.push(commsMessage(OTHER_PEER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(513, 'someone'))))
+        await tick(3)
+      })
+
+      it('should merge every answer, so a peer replying with nothing cannot empty the scene', () => {
+        expect(mappedEntityIds().sort()).toEqual([512, 513])
+      })
+    })
+
+    describe('and the first peer to answer sends an empty snapshot', () => {
+      beforeEach(async () => {
+        inbox.push(commsMessage(OTHER_PEER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, new Uint8Array())))
+        await tick(3)
+        inbox.push(
+          commsMessage(FIRST_RESPONDER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(512, 'someone')))
+        )
+        await tick(3)
+      })
+
+      it('should still take the real state from the peer that answers after it', () => {
+        expect(mappedEntityIds()).toEqual([512])
+      })
+    })
+
+    describe('and the snapshot is addressed to a different player', () => {
+      beforeEach(async () => {
+        inbox.push(
+          commsMessage(
+            FIRST_RESPONDER,
+            CommsMessage.RES_CRDT_STATE,
+            stateResponse('somebodyelse', snapshotOf(512, 'someone'))
+          )
+        )
+        await tick(3)
+      })
+
+      it('should ignore it', () => {
+        expect(mappedEntityIds()).toEqual([])
+      })
+    })
+  })
+
+  describe('and the request window has already closed', () => {
+    beforeEach(async () => {
+      await connectToComms()
+      // requestState waits 5s of engine time and, with nobody else in the scene,
+      // gives up and marks the state synchronized.
+      await tick(12)
+      inbox.push(
+        commsMessage(OTHER_PEER, CommsMessage.RES_CRDT_STATE, stateResponse(ME, snapshotOf(512, 'thirdparty')))
+      )
+      await tick(3)
+    })
+
+    it('should ignore a snapshot that arrives after it', () => {
+      expect(mappedEntityIds()).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## The problem

`RES_CRDT_STATE` hands a joining client the scene state from a peer. It was accepted from anyone, at any time, whether or not this client had asked for it.

The check that looks like authentication isn't one:

```ts
const { sender, data } = decodeCRDTState(value)
if (sender !== myProfile.userId) return
```

`encodeCRDTState(userId, chunk)` is called by the *responder* and fills that field with the address of whoever asked. So it means "is this addressed to me?", against a value that is public — the runtime stamps my address on every message I send, so anyone can write it into a payload.

The handler was also never gated. `stateIsSyncronized` is written inside it and read nowhere in it, so it stopped the retry loop and nothing else; the handler stayed live for the whole session. A peer who was never asked for anything could therefore inject arbitrary CRDT at any moment. Verified with an entity belonging to a *third party*, landing after the client's sync had already completed.

## What it does now

A snapshot is accepted only while a state request is outstanding. `requestState` opens the window before broadcasting and closes it when state arrives, when the retries give up, or when comms disconnects; a retry reopens it, so the three attempts behave as one window of roughly fifteen seconds. Outside it, nothing is applied.

`decodeCRDTState` returns `addressee`, because calling it `sender` is what made a recipient check look like authentication.

## Why every answer is still merged

Pinning to a single responder looks safer and isn't. LWW resolves on a sender-chosen `uint32`, so one peer writing `MAX_U32` beats every honest peer however many answer — narrowing the source buys nothing against that. It costs real robustness: a peer answering with an empty snapshot would decide the scene is empty, and the honest answer behind it would be refused. I built that version first and reverted it; the tests pin the behaviour so it doesn't come back by accident.

Bounding how far a timestamp may jump is what would make merged peer state genuinely safe, and that is a separate change.

## Scope

The window bounds *when* a snapshot is accepted, not what one may contain — whoever answers during it can still fabricate entities or send unbounded numbers of them. Contents cannot be validated per message: `engineToCrdt` dumps every `NetworkEntity` in the scene, so an answer legitimately carries other peers' entities and none of it is attributable to whoever sent it.

Two smaller notes. An answer arriving after the window closes is dropped; in practice chunks are emitted in one `sendBinary` batch and arrive together. And the join flow resolves `RealmInfo` and `PlayerIdentityData` from the engine it was handed rather than the global one, matching `definePlayerHelper` in this package — identical in production, and what makes the flow testable at all.

## How to test

```bash
node_modules/.bin/jest --testPathPatterns='crdt-state-request-window'
```

Seven cases driving the real join flow through `addSyncTransport`. Two fail on `main`: a snapshot arriving when nothing was requested, and one arriving after the window closed. The other five hold what must keep working — the first answer is applied, every chunk of one answer is applied, several peers' answers merge, an answer following an empty one still delivers the real state, and a snapshot addressed to a different player is ignored.

```bash
node_modules/.bin/jest --testPathPatterns='test/(ecs|sdk|react-ecs)/'   # 1064 pass
node_modules/.bin/jest --testPathPatterns='test/snapshots'              # 17 pass, no regeneration
```

`test/sdk/network/sync-engines.spec.ts` is the regression check that matters: two real engines through `addSyncTransport`, state handshake included. Goldens don't move (the sync transport is opt-in), there's no public API change, and `make lint` exits 0 with the same findings as `main`.