### PR TITLE
fix(sdk): keep an unprivileged peer from cancelling the state request

### DIFF
--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -128,9 +128,6 @@ export function addSyncTransport(
     }
   })
   binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, async (data, sender) => {
-    // Anyone in the room can send this. Clearing the in-flight request before knowing
-    // who sent it let an unprivileged peer cancel the retry, so the client stopped
-    // asking and the state never arrived.
     if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
 
     requestingState = false

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -128,9 +128,13 @@ export function addSyncTransport(
     }
   })
   binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, async (data, sender) => {
+    // Anyone in the room can send this. Clearing the in-flight request before knowing
+    // who sent it let an unprivileged peer cancel the retry, so the client stopped
+    // asking and the state never arrived.
+    if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
+
     requestingState = false
     elapsedTimeSinceRequest = 0
-    if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
     DEBUG_NETWORK_MESSAGES() && console.log('[Processing CRDT State]', data.byteLength / 1024, 'KB')
     if (data.byteLength > 0) {
       transport.onmessage!(serverValidator.processClientMessages(data, sender))

--- a/test/sdk/network/state-request-retry.spec.ts
+++ b/test/sdk/network/state-request-retry.spec.ts
@@ -1,0 +1,106 @@
+const ME = 'me'
+const OTHER_PEER = 'someotherpeer'
+const AUTH_SERVER = 'authoritative-server'
+const RETRY_INTERVAL_SECONDS = 2
+
+describe('when a client is waiting for the authoritative server to send it the state', () => {
+  // addSyncTransport binds to the global engine and installs a retry system on it, so
+  // each case needs its own module registry to get a clean one.
+  let engine: any
+  let RealmInfo: any
+  let EngineInfo: any
+  let CommsMessage: any
+  let encodeString: (value: string) => Uint8Array
+  let inbox: Uint8Array[]
+  let stateRequests: number
+
+  function commsMessage(sender: string, type: number, payload: Uint8Array): Uint8Array {
+    const encoded = encodeString(sender)
+    const out = new Uint8Array(1 + encoded.byteLength + 1 + payload.byteLength)
+    out.set([encoded.byteLength], 0)
+    out.set(encoded, 1)
+    out.set([type], 1 + encoded.byteLength)
+    out.set(payload, 1 + encoded.byteLength + 1)
+    return out
+  }
+
+  async function tick(seconds: number) {
+    await engine.update(seconds)
+  }
+
+  beforeEach(async () => {
+    jest.resetModules()
+    const ecs = require('../../../packages/@dcl/ecs/dist')
+    const bus = require('../../../packages/@dcl/sdk/network/binary-message-bus')
+    const { addSyncTransport } = require('../../../packages/@dcl/sdk/network/message-bus-sync')
+    engine = ecs.engine
+    RealmInfo = ecs.RealmInfo
+    EngineInfo = ecs.EngineInfo
+    CommsMessage = bus.CommsMessage
+    encodeString = bus.encodeString
+
+    inbox = []
+    stateRequests = 0
+
+    addSyncTransport(
+      engine,
+      async (message: any) => {
+        for (const peer of message.peerData ?? []) {
+          for (const data of peer.data ?? []) {
+            if (data.byteLength && data[0] === CommsMessage.REQ_CRDT_STATE) stateRequests++
+          }
+        }
+        const pending = inbox
+        inbox = []
+        return { data: pending }
+      },
+      async () => ({ data: { userId: ME, version: 1, displayName: ME, hasConnectedWeb3: true } }),
+      async () => ({ isServer: false }),
+      'test'
+    )
+
+    EngineInfo.createOrReplace(engine.RootEntity, {
+      tickNumber: 400,
+      frameNumber: 400,
+      totalRuntime: 1,
+      sceneHidden: false
+    })
+    RealmInfo.createOrReplace(engine.RootEntity, {
+      baseUrl: 'http://localhost',
+      realmName: 'test',
+      networkId: 1,
+      commsAdapter: 'offline',
+      isPreview: true,
+      room: 'room',
+      isConnectedSceneRoom: true
+    })
+    await tick(0.1)
+    stateRequests = 0
+  })
+
+  describe('and a peer that is not the server answers the request', () => {
+    beforeEach(async () => {
+      inbox.push(commsMessage(OTHER_PEER, CommsMessage.RES_CRDT_STATE, new Uint8Array()))
+      await tick(0.1)
+      await tick(RETRY_INTERVAL_SECONDS + 1)
+      await tick(0.1)
+    })
+
+    it('should still retry the request, since the state never arrived', () => {
+      expect(stateRequests).toBeGreaterThan(0)
+    })
+  })
+
+  describe('and the authoritative server answers the request', () => {
+    beforeEach(async () => {
+      inbox.push(commsMessage(AUTH_SERVER, CommsMessage.RES_CRDT_STATE, new Uint8Array()))
+      await tick(0.1)
+      await tick(RETRY_INTERVAL_SECONDS + 1)
+      await tick(0.1)
+    })
+
+    it('should stop asking', () => {
+      expect(stateRequests).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Found while checking whether **#1610** still applies to this branch. It doesn't — the state handler here already pins acceptance to the authoritative server, which is stronger than what #1610 does on `main`. But two lines above that check have a problem of their own.

## The problem

```ts
binaryMessageBus.on(CommsMessage.RES_CRDT_STATE, async (data, sender) => {
  requestingState = false
  elapsedTimeSinceRequest = 0
  if (isServerAtom.getOrNull() || sender !== AUTH_SERVER_PEER_ID) return
  ...
```

Only the server's answer is ever *applied* — that part is right. But **any** peer in the room can send a `RES_CRDT_STATE`, and the two assignments run before the sender is known.

The retry system fires on `requestingState && !stateIsSyncronized`, and nothing outside a `RealmInfo` connect calls `requestState()` again. So an unprivileged peer sending a single empty `RES_CRDT_STATE` clears the in-flight flag, the retry never runs, the client stops asking, and the state never arrives. The player sits in an empty scene until they reconnect — and a peer that keeps sending them holds it there.

## What it does

Runs the sender guard first. An answer from anyone but the authoritative server now changes nothing at all.

## How to test

```bash
node_modules/.bin/jest --testPathPatterns='state-request-retry'
```

Two cases, driving the real join flow through `addSyncTransport` on a connected `RealmInfo`. One fails on `auth-server` and passes here: after a non-server peer answers, the client should still retry, and today it never does. The other pins the normal path — when the authoritative server answers, the client stops asking.

Each case resets the module registry, because `addSyncTransport` binds to the global engine and installs a retry system on it; without that the second case sees the first one's transport still running.

```bash
node_modules/.bin/jest --testPathPatterns='test/(ecs|sdk|react-ecs)/'   # 1089 pass
```

`Generated OnPointerDown ProtoBuf › should serialize/deserialize OnPointerUp` fails on a pristine `auth-server` checkout here too — the installed `@dcl/protocol` is newer than the committed artifacts. Unrelated, and untouched.