### PR TITLE
fix(sdk): survive a drained entity range when mapping network entities

### DIFF
--- a/packages/@dcl/sdk/src/network/server/index.ts
+++ b/packages/@dcl/sdk/src/network/server/index.ts
@@ -58,10 +58,6 @@ export function createServerValidator(config: ServerValidationConfig) {
     return null
   }
 
-  // Every peer draws from the same 65k range, so a peer announcing entities faster
-  // than they are freed drains it for everyone. Running out is not an error to raise
-  // per message: it means every later announcement is refused too, so it is said once,
-  // and not from behind a debug flag.
   let reportedEntityExhaustion = false
 
   function findOrCreateNetworkEntity(message: utils.NetworkMessage, sender: string, isServer: boolean): Entity | null {
@@ -72,10 +68,6 @@ export function createServerValidator(config: ServerValidationConfig) {
       return existingEntity
     }
 
-    // Create new entity and network mapping. `addEntity` throws only when the range is
-    // drained, which used to escape this function: the server swallowed it in its own
-    // per-message catch, and the client, which has none, rejected engine.update and
-    // took the whole tick with it.
     let newEntityId: Entity
     try {
       newEntityId = engine.addEntity()

--- a/packages/@dcl/sdk/src/network/server/index.ts
+++ b/packages/@dcl/sdk/src/network/server/index.ts
@@ -58,7 +58,13 @@ export function createServerValidator(config: ServerValidationConfig) {
     return null
   }
 
-  function findOrCreateNetworkEntity(message: utils.NetworkMessage, sender: string, isServer: boolean): Entity {
+  // Every peer draws from the same 65k range, so a peer announcing entities faster
+  // than they are freed drains it for everyone. Running out is not an error to raise
+  // per message: it means every later announcement is refused too, so it is said once,
+  // and not from behind a debug flag.
+  let reportedEntityExhaustion = false
+
+  function findOrCreateNetworkEntity(message: utils.NetworkMessage, sender: string, isServer: boolean): Entity | null {
     // Look for existing network entity mapping first
     const existingEntity = findExistingNetworkEntity(message)
 
@@ -66,8 +72,25 @@ export function createServerValidator(config: ServerValidationConfig) {
       return existingEntity
     }
 
-    // Create new entity and network mapping
-    const newEntityId = engine.addEntity()
+    // Create new entity and network mapping. `addEntity` throws only when the range is
+    // drained, which used to escape this function: the server swallowed it in its own
+    // per-message catch, and the client, which has none, rejected engine.update and
+    // took the whole tick with it.
+    let newEntityId: Entity
+    try {
+      newEntityId = engine.addEntity()
+    } catch (error) {
+      if (!reportedEntityExhaustion) {
+        reportedEntityExhaustion = true
+        console.error(
+          'Ran out of entities while mapping entities announced over the network. ' +
+            'These announcements are ignored until entities are freed and their numbers recycled.',
+          error
+        )
+      }
+      return null
+    }
+
     NetworkEntity.createOrReplace(newEntityId, {
       networkId: message.networkId,
       entityId: message.entityId
@@ -227,6 +250,7 @@ export function createServerValidator(config: ServerValidationConfig) {
 
           // Find or create network entity mapping
           const localEntityId = findOrCreateNetworkEntity(networkMessage, sender, false)
+          if (localEntityId === null) continue
 
           // Convert network message to regular message or correction message
           const regularMessage = convertNetworkToRegularMessage(networkMessage, localEntityId, forceCorrections)
@@ -253,6 +277,7 @@ export function createServerValidator(config: ServerValidationConfig) {
             const networkMessage = message as utils.NetworkMessage
             // 1. Find or create network entity mapping
             const localEntityId = findOrCreateNetworkEntity(networkMessage, sender, true)
+            if (localEntityId === null) continue
 
             // 2. Convert network message to regular message and collect for local application
             const regularMessage = convertNetworkToRegularMessage(networkMessage, localEntityId)

--- a/test/sdk/network/server-entity-exhaustion.spec.ts
+++ b/test/sdk/network/server-entity-exhaustion.spec.ts
@@ -1,0 +1,116 @@
+import { Engine } from '../../../packages/@dcl/ecs/src/engine'
+import { Entity } from '../../../packages/@dcl/ecs/src/engine/entity'
+import { IEngine, Transport } from '../../../packages/@dcl/ecs/src'
+import * as components from '../../../packages/@dcl/ecs/src/components'
+import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutNetworkComponentOperation } from '../../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
+import { createServerValidator } from '../../../packages/@dcl/sdk/network/server'
+
+const NETWORK_ID = 7
+const AUTH_SERVER = 'authoritative-server'
+const EXHAUSTED = 'It fails trying to generate an entity out of range 65535.'
+
+describe('when the entity range is drained', () => {
+  let engine: IEngine
+  let transport: Transport
+  let validator: ReturnType<typeof createServerValidator>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let errors: string[]
+
+  function chunk(entityId: number, x: number, timestamp = 1): Uint8Array {
+    const data = new ReadWriteByteBuffer()
+    Transform.schema.serialize(
+      {
+        position: { x, y: 1, z: 1 },
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        parent: 0 as Entity
+      },
+      data
+    )
+    const buf = new ReadWriteByteBuffer()
+    PutNetworkComponentOperation.write(
+      entityId as Entity,
+      timestamp,
+      Transform.componentId,
+      NETWORK_ID,
+      data.toBinary(),
+      buf
+    )
+    return buf.toBinary()
+  }
+
+  function drain() {
+    engine.addEntity = () => {
+      throw new Error(EXHAUSTED)
+    }
+  }
+
+  beforeEach(() => {
+    engine = Engine()
+    transport = { type: 'network', filter: () => false, send: async () => {} }
+    engine.addTransport(transport)
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    components.NetworkParent(engine)
+    components.CreatedBy(engine)
+    errors = []
+    jest.spyOn(console, 'error').mockImplementation((message: unknown) => {
+      errors.push(String(message))
+    })
+    validator = createServerValidator({
+      engine,
+      binaryMessageBus: { emit: () => {}, on: () => {} } as any
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('and the authoritative server announces an entity to a client', () => {
+    beforeEach(() => {
+      drain()
+    })
+
+    it('should not throw out of the client message handler', () => {
+      expect(() => validator.processClientMessages(chunk(900, 1), AUTH_SERVER)).not.toThrow()
+    })
+
+    it('should report it once rather than per announcement', () => {
+      for (let i = 0; i < 5; i++) validator.processClientMessages(chunk(900 + i, 1), AUTH_SERVER)
+      expect(errors.filter((message) => message.includes('Ran out of entities'))).toHaveLength(1)
+    })
+  })
+
+  describe('and a peer announces an entity to the server', () => {
+    beforeEach(() => {
+      drain()
+    })
+
+    it('should not throw out of the server message handler', () => {
+      expect(() => validator.processServerMessages(chunk(901, 1), 'peer')).not.toThrow()
+    })
+  })
+
+  describe('and an entity mapped before the range drained is updated', () => {
+    let mapped: Entity
+
+    beforeEach(async () => {
+      const applied = validator.processClientMessages(chunk(902, 1), AUTH_SERVER)
+      transport.onmessage!(applied)
+      await engine.update(1)
+      mapped = Array.from(engine.getEntitiesWith(NetworkEntity))[0][0]
+      drain()
+
+      const next = validator.processClientMessages(chunk(902, 42, 2), AUTH_SERVER)
+      if (next.byteLength) transport.onmessage!(next)
+      await engine.update(1)
+    })
+
+    it('should still apply the update, since it needs no new entity', () => {
+      expect(Transform.get(mapped).position.x).toBe(42)
+    })
+  })
+})

--- a/test/sdk/network/server/entity-exhaustion.spec.ts
+++ b/test/sdk/network/server/entity-exhaustion.spec.ts
@@ -1,10 +1,10 @@
-import { Engine } from '../../../packages/@dcl/ecs/src/engine'
-import { Entity } from '../../../packages/@dcl/ecs/src/engine/entity'
-import { IEngine, Transport } from '../../../packages/@dcl/ecs/src'
-import * as components from '../../../packages/@dcl/ecs/src/components'
-import { ReadWriteByteBuffer } from '../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
-import { PutNetworkComponentOperation } from '../../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
-import { createServerValidator } from '../../../packages/@dcl/sdk/network/server'
+import { Engine } from '../../../../packages/@dcl/ecs/src/engine'
+import { Entity } from '../../../../packages/@dcl/ecs/src/engine/entity'
+import { IEngine, Transport } from '../../../../packages/@dcl/ecs/src'
+import * as components from '../../../../packages/@dcl/ecs/src/components'
+import { ReadWriteByteBuffer } from '../../../../packages/@dcl/ecs/src/serialization/ByteBuffer'
+import { PutNetworkComponentOperation } from '../../../../packages/@dcl/ecs/src/serialization/crdt/network/putComponentNetwork'
+import { createServerValidator } from '../../../../packages/@dcl/sdk/network/server'
 
 const NETWORK_ID = 7
 const AUTH_SERVER = 'authoritative-server'


### PR DESCRIPTION
Prevent exhausted entity allocation from throwing out of the client network handler and rejecting the engine tick. New mappings are skipped, the error is reported once, and updates to existing mappings continue. This does not impose per-peer entity limits.

## How to test

After installing dependencies and building the packages (`make build`):

```bash
node_modules/.bin/jest --runInBand --testPathPatterns='entity-exhaustion'
```

The four tests cover client/server exhaustion, one-time reporting, and updates to existing mappings. The client-handler and reporting cases fail with the base implementation and pass with this change.
