### PR TITLE
fix(sdk): only the authoritative server answers a state request

### DIFF
--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -115,9 +115,7 @@ export function addSyncTransport(
 
   // Receive & Process CRDT_STATE
   binaryMessageBus.on(CommsMessage.REQ_CRDT_STATE, async (data, sender) => {
-    // The RES handler drops anything not from the authoritative server, so a client
-    // answering dumps its whole scene for a recipient that discards it. The atom
-    // resolves asynchronously; a request that beats it is covered by the retry.
+    // Requests arriving before role resolution are recovered by the requester's retry.
     if (!isServerAtom.getOrNull()) return
 
     DEBUG_NETWORK_MESSAGES() && console.log('[REQ_CRDT_STATE]', sender, Date.now())

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -115,6 +115,11 @@ export function addSyncTransport(
 
   // Receive & Process CRDT_STATE
   binaryMessageBus.on(CommsMessage.REQ_CRDT_STATE, async (data, sender) => {
+    // The RES handler drops anything not from the authoritative server, so a client
+    // answering dumps its whole scene for a recipient that discards it. The atom
+    // resolves asynchronously; a request that beats it is covered by the retry.
+    if (!isServerAtom.getOrNull()) return
+
     DEBUG_NETWORK_MESSAGES() && console.log('[REQ_CRDT_STATE]', sender, Date.now())
     const chunks = engineToCrdt(engine)
     if (chunks.length === 0) {

--- a/test/sdk/network/state-request-responder.spec.ts
+++ b/test/sdk/network/state-request-responder.spec.ts
@@ -1,0 +1,110 @@
+const ME = 'me'
+const ASKING_PEER = 'asking-peer'
+
+describe('when a peer asks the room for the CRDT state', () => {
+  // addSyncTransport binds to the global engine, so each case needs its own registry.
+  let engine: any
+  let RealmInfo: any
+  let EngineInfo: any
+  let CommsMessage: any
+  let encodeString: (value: string) => Uint8Array
+  let inbox: Uint8Array[]
+  let answers: number
+
+  function commsMessage(sender: string, type: number): Uint8Array {
+    const encoded = encodeString(sender)
+    const out = new Uint8Array(1 + encoded.byteLength + 1)
+    out.set([encoded.byteLength], 0)
+    out.set(encoded, 1)
+    out.set([type], 1 + encoded.byteLength)
+    return out
+  }
+
+  async function boot(isServer: boolean) {
+    jest.resetModules()
+    const ecs = require('../../../packages/@dcl/ecs/dist')
+    const bus = require('../../../packages/@dcl/sdk/network/binary-message-bus')
+    const { addSyncTransport } = require('../../../packages/@dcl/sdk/network/message-bus-sync')
+    const comps = require('../../../packages/@dcl/ecs/src/components')
+
+    engine = ecs.engine
+    RealmInfo = ecs.RealmInfo
+    EngineInfo = ecs.EngineInfo
+    CommsMessage = bus.CommsMessage
+    encodeString = bus.encodeString
+    inbox = []
+    answers = 0
+
+    addSyncTransport(
+      engine,
+      async (message: any) => {
+        for (const peer of message.peerData ?? []) {
+          for (const data of peer.data ?? []) {
+            if (data.byteLength && data[0] === CommsMessage.RES_CRDT_STATE) answers++
+          }
+        }
+        const pending = inbox
+        inbox = []
+        return { data: pending }
+      },
+      async () => ({ data: { userId: ME, version: 1, displayName: ME, hasConnectedWeb3: true } }),
+      async () => ({ isServer }),
+      'test'
+    )
+
+    // A synced entity, so there is state worth dumping.
+    const Transform = comps.Transform(engine)
+    const NetworkEntity = comps.NetworkEntity(engine)
+    const SyncComponents = comps.SyncComponents(engine)
+    const entity = engine.addEntity()
+    Transform.create(entity, {
+      position: { x: 1, y: 1, z: 1 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+      scale: { x: 1, y: 1, z: 1 },
+      parent: 0
+    })
+    NetworkEntity.create(entity, { networkId: 7, entityId: entity })
+    SyncComponents.create(entity, { componentIds: [Transform.componentId] })
+
+    EngineInfo.createOrReplace(engine.RootEntity, {
+      tickNumber: 400,
+      frameNumber: 400,
+      totalRuntime: 1,
+      sceneHidden: false
+    })
+    RealmInfo.createOrReplace(engine.RootEntity, {
+      baseUrl: 'http://localhost',
+      realmName: 'test',
+      networkId: 1,
+      commsAdapter: 'offline',
+      isPreview: true,
+      room: 'room',
+      isConnectedSceneRoom: true
+    })
+    for (let i = 0; i < 3; i++) await engine.update(0.1)
+    answers = 0
+
+    inbox.push(commsMessage(ASKING_PEER, CommsMessage.REQ_CRDT_STATE))
+    for (let i = 0; i < 3; i++) await engine.update(0.1)
+  }
+
+  describe('and this participant is a client', () => {
+    beforeEach(async () => {
+      await boot(false)
+    })
+
+    it('should not answer, since only the server state is ever accepted', () => {
+      expect(answers).toBe(0)
+    })
+  })
+
+  describe('and this participant is the authoritative server', () => {
+    beforeEach(async () => {
+      await boot(true)
+    })
+
+    it('should answer with its state', () => {
+      expect(answers).toBeGreaterThan(0)
+    })
+  })
+})


### PR DESCRIPTION
Part of the state-handshake issue. The response side is pinned to the authoritative server; the **request** side is not gated at all.

## The problem

```ts
binaryMessageBus.on(CommsMessage.REQ_CRDT_STATE, async (data, sender) => {
  const chunks = engineToCrdt(engine)
  ...
})
```

Every participant answers, clients included. But a client's answer is never consumed — the RES handler drops anything whose sender isn't `AUTH_SERVER_PEER_ID`, so the recipient throws the whole thing away.

That makes it an amplifier. `engineToCrdt` serialises the entire scene, and one 1-byte broadcast makes **every client in the room** do it simultaneously:

| synced entities | chunks | bytes | time |
| --- | --- | --- | --- |
| 200 | 3 | 30 KB | 4 ms |
| 1,000 | 13 | 148 KB | 21 ms |
| 3,000 | 38 | 445 KB | 44 ms |

Per client, per request, repeatable at will. Twenty clients in a 3,000-entity scene turn one request into roughly 9 MB emitted and ~0.9 s of aggregate CPU — for output nobody reads.

## What it does

Answers only when this participant is the authoritative server.

Nothing a recipient can observe changes, because those client answers were already being discarded. This only stops the work being done and the bytes being sent.

## One timing note

`isServerAtom` is populated asynchronously from `isServerFn`, so a request arriving before the runtime has answered is dropped. The requester retries every 2 s, which is the same path that already covers a server that hasn't finished starting — and in practice the atom resolves well before comms connects.

## How to test

```bash
node_modules/.bin/jest --testPathPatterns='state-request-responder'
```

Two cases, driving the real join flow through `addSyncTransport` on a connected `RealmInfo` with a synced entity present. One fails on `auth-server`: a client answers a peer's request. The other pins the behaviour that must survive — the server still answers with its state.

```bash
node_modules/.bin/jest --testPathPatterns='test/(ecs|sdk|react-ecs)/'   # 1089 pass
```

`Generated OnPointerDown ProtoBuf › should serialize/deserialize OnPointerUp` fails on a pristine `auth-server` checkout here too — the installed `@dcl/protocol` is newer than the committed artifacts. Unrelated, untouched.