### PR TITLE
feat(sdk): report synchronized entity removal outcomes

### DIFF
--- a/packages/@dcl/sdk/README.md
+++ b/packages/@dcl/sdk/README.md
@@ -58,8 +58,34 @@ GltfContainer.create(entity, {
 On a client using the synchronization transport, `engine.removeEntity(entity)` requests
 server approval for a synchronized entity and returns `false` while its ID remains in use.
 Its components, local state, and references stay intact until the authoritative server
-accepts the deletion. A rejected request leaves the entity unchanged. Calling
-`removeEntity` again retries the request, including after a lost acceptance response.
+accepts the deletion. A rejected request leaves the entity unchanged. The SDK retries
+unanswered requests every second and stops after ten seconds of engine update time.
+Repeated calls while a request is pending share that attempt. Calling `removeEntity`
+after a rejection or timeout starts a new attempt.
+
+Scenes can optionally observe the outcome without changing how they remove entities:
+
+```ts
+import { engine } from '@dcl/sdk/ecs'
+import { onEntityRemovalResult } from '@dcl/sdk/network'
+
+const unsubscribe = onEntityRemovalResult(({ entity, requestId, status }) => {
+  console.log('Removal attempt', entity, requestId, status)
+})
+
+engine.removeEntity(entity)
+// Call unsubscribe() when the listener is no longer needed.
+```
+
+The listener receives one result per attempt: `accepted` after local removal,
+`rejected` when the server refuses the request, or `timeout` when confirmation does
+not arrive in time. A timeout means the outcome is unknown: an authoritative deletion
+can still arrive later. Results are emitted only for client requests to remove
+synchronized entities. Listener failures are isolated from networking.
+
+Clients and the authoritative server must both use an SDK supporting these request
+and result messages. An older server ignores the new request and the client times out.
+The transport interface and CRDT operation formats are unchanged.
 
 `removeEntityWithChildren` requests approval for each synchronized entity in the tree;
 validators can accept or reject them independently. Unsynchronized entities and entities
@@ -77,6 +103,14 @@ The hook coordinates local removal and is not an authorization boundary. The ser
 still validates peer deletion requests, and the synchronization transport only accepts
 network deletions from the authoritative server. Incoming CRDT deletions bypass these
 handlers, so a local handler cannot veto an authoritative deletion.
+
+Results are accepted only from the authoritative server and matched to the pending
+session, request, and entity identity. Server replay tracking is bounded per peer:
+eight sessions, each retaining a window of 128 request IDs. Older requests cannot
+run validators again, but can still recover an acceptance for an already deleted
+identity. An authoritative deletion also supersedes a cached rejection for that
+identity. Leaving the room clears that peer's tracking; deduplication does not
+provide permanent exactly-once execution across reconnects.
 
 ### Components
 

--- a/packages/@dcl/sdk/src/network/binary-message-bus.ts
+++ b/packages/@dcl/sdk/src/network/binary-message-bus.ts
@@ -6,7 +6,9 @@ export enum CommsMessage {
   RES_CRDT_STATE = 9,
   CRDT_SERVER = 4,
   CRDT_AUTHORITATIVE = 5,
-  CUSTOM_EVENT = 6
+  CUSTOM_EVENT = 6,
+  REQUEST_ENTITY_REMOVAL = 10,
+  ENTITY_REMOVAL_RESULT = 11
 }
 
 export function BinaryMessageBus<T extends CommsMessage>(

--- a/packages/@dcl/sdk/src/network/entity-removal-protocol.ts
+++ b/packages/@dcl/sdk/src/network/entity-removal-protocol.ts
@@ -1,0 +1,56 @@
+import type { Entity } from '@dcl/ecs'
+
+export type EntityRemovalRequest = {
+  sessionIdHigh: number
+  sessionIdLow: number
+  requestId: number
+  networkId: number
+  entityId: Entity
+}
+
+export type EntityRemovalResponse = EntityRemovalRequest & {
+  status: 'accepted' | 'rejected'
+}
+
+const REQUEST_LENGTH = 20
+const RESPONSE_LENGTH = REQUEST_LENGTH + 1
+
+export function encodeEntityRemovalRequest(request: EntityRemovalRequest): Uint8Array {
+  const values = [request.sessionIdHigh, request.sessionIdLow, request.requestId, request.networkId, request.entityId]
+  const bytes = new Uint8Array(REQUEST_LENGTH)
+  const view = new DataView(bytes.buffer)
+  for (let index = 0; index < values.length; index++) {
+    const value = values[index]
+    if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
+      throw new RangeError('Entity removal request fields must be unsigned 32-bit integers')
+    }
+    view.setUint32(index * 4, value, true)
+  }
+  return bytes
+}
+
+export function decodeEntityRemovalRequest(bytes: Uint8Array): EntityRemovalRequest | null {
+  if (bytes.byteLength !== REQUEST_LENGTH) return null
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  return {
+    sessionIdHigh: view.getUint32(0, true),
+    sessionIdLow: view.getUint32(4, true),
+    requestId: view.getUint32(8, true),
+    networkId: view.getUint32(12, true),
+    entityId: view.getUint32(16, true) as Entity
+  }
+}
+
+export function encodeEntityRemovalResponse(response: EntityRemovalResponse): Uint8Array {
+  const bytes = new Uint8Array(RESPONSE_LENGTH)
+  bytes.set(encodeEntityRemovalRequest(response))
+  bytes[REQUEST_LENGTH] = response.status === 'accepted' ? 0 : 1
+  return bytes
+}
+
+export function decodeEntityRemovalResponse(bytes: Uint8Array): EntityRemovalResponse | null {
+  if (bytes.byteLength !== RESPONSE_LENGTH || bytes[REQUEST_LENGTH] > 1) return null
+  const request = decodeEntityRemovalRequest(bytes.subarray(0, REQUEST_LENGTH))
+  if (!request) return null
+  return { ...request, status: bytes[REQUEST_LENGTH] === 0 ? 'accepted' : 'rejected' }
+}

--- a/packages/@dcl/sdk/src/network/entity-removal.ts
+++ b/packages/@dcl/sdk/src/network/entity-removal.ts
@@ -1,0 +1,135 @@
+import { Entity, EntityState, IEngine } from '@dcl/ecs'
+import { EntityRemovalRequest, EntityRemovalResponse } from './entity-removal-protocol'
+
+/** @public */
+export type EntityRemovalResult = {
+  readonly entity: Entity
+  readonly requestId: number
+  readonly status: 'accepted' | 'rejected' | 'timeout'
+}
+
+type PendingRemoval = {
+  entity: Entity
+  request: EntityRemovalRequest
+  elapsed: number
+  lastSent: number
+  accepted: boolean
+}
+
+const RETRY_INTERVAL_SECONDS = 1
+const TIMEOUT_SECONDS = 10
+const MAX_REQUEST_ID = 0xffffffff
+
+/** @internal */
+export function createEntityRemovalClient(
+  engine: IEngine,
+  send: (request: EntityRemovalRequest) => void,
+  applyAccepted: (request: EntityRemovalRequest) => void
+) {
+  const byEntity = new Map<Entity, PendingRemoval>()
+  const byRequest = new Map<string, PendingRemoval>()
+  const listeners = new Set<(result: EntityRemovalResult) => void>()
+  let sessionIdHigh = Math.floor(Math.random() * 0x100000000)
+  let sessionIdLow = Math.floor(Math.random() * 0x100000000)
+  let nextRequestId = 1
+
+  function key(request: EntityRemovalRequest): string {
+    return `${request.sessionIdHigh}:${request.sessionIdLow}:${request.requestId}`
+  }
+
+  function remove(pending: PendingRemoval): void {
+    byEntity.delete(pending.entity)
+    byRequest.delete(key(pending.request))
+  }
+
+  function complete(pending: PendingRemoval, status: EntityRemovalResult['status']): void {
+    remove(pending)
+    const result: EntityRemovalResult = Object.freeze({
+      entity: pending.entity,
+      requestId: pending.request.requestId,
+      status
+    })
+    for (const listener of Array.from(listeners)) {
+      try {
+        void Promise.resolve(listener(result)).catch((error) => console.error('Entity removal listener failed', error))
+      } catch (error) {
+        console.error('Entity removal listener failed', error)
+      }
+    }
+  }
+
+  function request(entity: Entity, network: { networkId: number; entityId: Entity }): void {
+    if (byEntity.has(entity)) return
+    if (nextRequestId > MAX_REQUEST_ID) {
+      sessionIdHigh = Math.floor(Math.random() * 0x100000000)
+      sessionIdLow = Math.floor(Math.random() * 0x100000000)
+      nextRequestId = 1
+    }
+    const pending: PendingRemoval = {
+      entity,
+      request: {
+        sessionIdHigh,
+        sessionIdLow,
+        requestId: nextRequestId++,
+        networkId: network.networkId,
+        entityId: network.entityId
+      },
+      elapsed: 0,
+      lastSent: -Infinity,
+      accepted: false
+    }
+    byEntity.set(entity, pending)
+    byRequest.set(key(pending.request), pending)
+  }
+
+  function receive(response: EntityRemovalResponse): void {
+    const pending = byRequest.get(key(response))
+    if (
+      !pending ||
+      pending.accepted ||
+      pending.request.networkId !== response.networkId ||
+      pending.request.entityId !== response.entityId
+    )
+      return
+    if (response.status === 'rejected') {
+      complete(pending, 'rejected')
+    } else {
+      pending.accepted = true
+      applyAccepted(pending.request)
+    }
+  }
+
+  function update(dt: number): void {
+    for (const pending of Array.from(byEntity.values())) {
+      // This system runs after incoming CRDT deletions have been applied.
+      if (engine.getEntityState(pending.entity) === EntityState.Removed) {
+        complete(pending, 'accepted')
+        continue
+      }
+      pending.elapsed += dt
+      if (pending.elapsed >= TIMEOUT_SECONDS) complete(pending, 'timeout')
+    }
+  }
+
+  function flush(isServer: boolean | null): void {
+    if (isServer === null) return
+    for (const pending of Array.from(byEntity.values())) {
+      if (isServer) {
+        remove(pending)
+        engine.removeEntity(pending.entity)
+      } else if (!pending.accepted && pending.elapsed - pending.lastSent >= RETRY_INTERVAL_SECONDS) {
+        pending.lastSent = pending.elapsed
+        send(pending.request)
+      }
+    }
+  }
+
+  function onEntityRemovalResult(listener: (result: EntityRemovalResult) => void): () => void {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  return { request, receive, update, flush, onEntityRemovalResult }
+}

--- a/packages/@dcl/sdk/src/network/index.ts
+++ b/packages/@dcl/sdk/src/network/index.ts
@@ -27,11 +27,13 @@ const {
   getFirstChild,
   isStateSyncronized,
   binaryMessageBus,
+  onEntityRemovalResult,
   eventBus
 } = addSyncTransport(engine, sendBinary, getUserData, isServerApi, 'network')
 
 // Re-export the room messaging system
 export { registerMessages, getRoom } from './events'
+export type { EntityRemovalResult } from './entity-removal'
 
 export {
   getFirstChild,
@@ -43,5 +45,6 @@ export {
   removeParent,
   isStateSyncronized,
   binaryMessageBus,
+  onEntityRemovalResult,
   eventBus
 }

--- a/packages/@dcl/sdk/src/network/message-bus-sync.ts
+++ b/packages/@dcl/sdk/src/network/message-bus-sync.ts
@@ -1,5 +1,6 @@
-import { IEngine, Transport, RealmInfo, Entity, EntityState, CrdtMessageType } from '@dcl/ecs'
+import { IEngine, Transport, RealmInfo, EntityState, CrdtMessageType } from '@dcl/ecs'
 import * as components from '@dcl/ecs/dist/components'
+import { SYSTEMS_REGULAR_PRIORITY } from '@dcl/ecs/dist/engine/systems'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist/serialization/ByteBuffer'
 import { DeleteEntityNetwork } from '@dcl/ecs/dist/serialization/crdt/network/deleteEntityNetwork'
 import type { SendBinaryRequest, SendBinaryResponse } from '~system/CommunicationsController'
@@ -11,6 +12,13 @@ import { fetchProfile } from './utils'
 import { entityUtils } from './entities'
 import { createServerValidator } from './server'
 import { readMessages } from './server/utils'
+import { createEntityRemovalClient } from './entity-removal'
+import {
+  EntityRemovalRequest,
+  encodeEntityRemovalRequest,
+  decodeEntityRemovalRequest,
+  decodeEntityRemovalResponse
+} from './entity-removal-protocol'
 import type { GetUserDataRequest, GetUserDataResponse } from '~system/UserIdentity'
 import { definePlayerHelper } from '../players'
 import { serializeCrdtMessages } from '../internal/transports/logger'
@@ -48,8 +56,8 @@ export function addSyncTransport(
   const isServerAtom = Atom<boolean>()
   const isRoomReadyAtom = Atom<boolean>(false)
   const NetworkEntity = components.NetworkEntity(engine)
-  const pendingEntityRemovals = new Set<Entity>()
   const pendingServerRemovals: { data: Uint8Array; sender: string }[] = []
+  const pendingServerRequests: { request: EntityRemovalRequest; sender: string }[] = []
 
   void isServerFn({}).then(($: IsServerResponse) => {
     return isServerAtom.swap(!!$.isServer)
@@ -82,18 +90,6 @@ export function addSyncTransport(
    */
   let tick = 0
   const TRANSPORT_INITIALIZED_NUMBER = isTestEnvironment() ? 0 : 2
-  engine.addEntityRemovalHandler((entity) => {
-    if (
-      isServerAtom.getOrNull() === true ||
-      engine.getEntityState(entity) !== EntityState.UsedEntity ||
-      !NetworkEntity.has(entity)
-    ) {
-      return false
-    }
-    pendingEntityRemovals.add(entity)
-    return true
-  })
-
   // Add Sync Transport
   const transport: Transport = {
     filter: syncFilter(engine),
@@ -110,23 +106,12 @@ export function addSyncTransport(
           }
         }
       }
-      const isServer = isServerAtom.getOrNull()
-      if (isServer !== null && tick > TRANSPORT_INITIALIZED_NUMBER) {
-        for (const entity of pendingEntityRemovals) {
-          const network = NetworkEntity.getOrNull(entity)
-          if (!network || engine.getEntityState(entity) !== EntityState.UsedEntity) continue
-          if (isServer) {
-            engine.removeEntity(entity)
-          } else {
-            const buffer = new ReadWriteByteBuffer()
-            DeleteEntityNetwork.write(network.entityId, network.networkId, buffer)
-            binaryMessageBus.emit(CommsMessage.CRDT, buffer.toBinary(), [AUTH_SERVER_PEER_ID])
-          }
-        }
-        pendingEntityRemovals.clear()
-      }
+      if (tick > TRANSPORT_INITIALIZED_NUMBER) entityRemovals.flush(isServerAtom.getOrNull())
       for (const request of pendingServerRemovals.splice(0)) {
         transport.onmessage!(serverValidator.processServerMessages(request.data, request.sender))
+      }
+      for (const { request, sender } of pendingServerRequests.splice(0)) {
+        transport.onmessage!(serverValidator.processEntityRemovalRequest(request, sender))
       }
       const peerMessages = getMessagesToSend()
       const response = await sendBinary({ data: [], peerData: peerMessages })
@@ -139,6 +124,38 @@ export function addSyncTransport(
   const serverValidator = createServerValidator({
     engine,
     binaryMessageBus
+  })
+
+  const entityRemovals = createEntityRemovalClient(
+    engine,
+    (request) =>
+      binaryMessageBus.emit(CommsMessage.REQUEST_ENTITY_REMOVAL, encodeEntityRemovalRequest(request), [
+        AUTH_SERVER_PEER_ID
+      ]),
+    (request) => {
+      const buffer = new ReadWriteByteBuffer()
+      DeleteEntityNetwork.write(request.entityId, request.networkId, buffer)
+      transport.onmessage!(serverValidator.processClientMessages(buffer.toBinary(), AUTH_SERVER_PEER_ID))
+    }
+  )
+  engine.addEntityRemovalHandler((entity) => {
+    const network = NetworkEntity.getOrNull(entity)
+    if (isServerAtom.getOrNull() === true || engine.getEntityState(entity) !== EntityState.UsedEntity || !network)
+      return false
+    entityRemovals.request(entity, network)
+    return true
+  })
+  engine.addSystem(entityRemovals.update, SYSTEMS_REGULAR_PRIORITY + 1)
+
+  binaryMessageBus.on(CommsMessage.REQUEST_ENTITY_REMOVAL, (data, sender) => {
+    if (isServerAtom.getOrNull() !== true) return
+    const request = decodeEntityRemovalRequest(data)
+    if (request) pendingServerRequests.push({ request, sender })
+  })
+  binaryMessageBus.on(CommsMessage.ENTITY_REMOVAL_RESULT, (data, sender) => {
+    if (sender !== AUTH_SERVER_PEER_ID || isServerAtom.getOrNull() === true) return
+    const response = decodeEntityRemovalResponse(data)
+    if (response) entityRemovals.receive(response)
   })
 
   // Initialize Event Bus with registered schemas
@@ -300,6 +317,7 @@ export function addSyncTransport(
   })
 
   players.onLeaveScene((userId) => {
+    serverValidator.forgetPeer(userId)
     DEBUG_NETWORK_MESSAGES() && console.log('[onLeaveScene]', userId)
   })
 
@@ -313,6 +331,7 @@ export function addSyncTransport(
     isStateSyncronized,
     binaryMessageBus,
     eventBus,
+    onEntityRemovalResult: entityRemovals.onEntityRemovalResult,
     isRoomReadyAtom
   }
 }

--- a/packages/@dcl/sdk/src/network/server/index.ts
+++ b/packages/@dcl/sdk/src/network/server/index.ts
@@ -11,7 +11,10 @@ import {
 import * as components from '@dcl/ecs/dist/components'
 import { ReadWriteByteBuffer } from '@dcl/ecs/dist/serialization/ByteBuffer'
 import { createVersionGSet } from '@dcl/ecs/dist/systems/crdt/gset'
+import { DeleteEntity } from '@dcl/ecs/dist/serialization/crdt/deleteEntity'
+import { DeleteEntityNetwork } from '@dcl/ecs/dist/serialization/crdt/network/deleteEntityNetwork'
 import { CommsMessage } from '../binary-message-bus'
+import { EntityRemovalRequest, EntityRemovalResponse, encodeEntityRemovalResponse } from '../entity-removal-protocol'
 import { chunkCrdtMessages } from '../chunking'
 import * as utils from './utils'
 import { AUTH_SERVER_PEER_ID, DEBUG_NETWORK_MESSAGES } from '../message-bus-sync'
@@ -24,6 +27,14 @@ import {
 } from '@dcl/ecs/dist/engine/component'
 
 export const LIVEKIT_MAX_SIZE = 12
+
+const MAX_REMOVAL_SESSIONS_PER_PEER = 8
+const MAX_REMOVAL_RESULTS_PER_SESSION = 128
+
+type RemovalSession = {
+  highestRequestId: number
+  results: Map<number, EntityRemovalResponse>
+}
 
 export interface ServerValidationConfig {
   engine: IEngine
@@ -39,6 +50,7 @@ export function createServerValidator(config: ServerValidationConfig) {
   const NetworkParent = components.NetworkParent(engine)
   const removedEntities = new Map<number, ReturnType<typeof createVersionGSet>>()
   const removedSharedEntities = new Set<Entity>()
+  const removalSessions = new Map<string, Map<string, RemovalSession>>()
 
   function wasRemoved(message: { networkId: number; entityId: Entity }): boolean {
     if (message.networkId === 0) return removedSharedEntities.has(message.entityId)
@@ -72,7 +84,7 @@ export function createServerValidator(config: ServerValidationConfig) {
     )
   }
 
-  function findExistingNetworkEntity(message: utils.NetworkMessage): Entity | null {
+  function findExistingNetworkEntity(message: { networkId: number; entityId: Entity }): Entity | null {
     // Look for existing network entity mapping (don't create new ones)
     for (const [entityId, networkData] of engine.getEntitiesWith(NetworkEntity)) {
       if (networkData.networkId === message.networkId && networkData.entityId === message.entityId) {
@@ -245,7 +257,103 @@ export function createServerValidator(config: ServerValidationConfig) {
     }
   }
 
+  function sendRemovalResult(response: EntityRemovalResponse, sender: string): void {
+    binaryMessageBus.emit(CommsMessage.ENTITY_REMOVAL_RESULT, encodeEntityRemovalResponse(response), [sender])
+  }
+
+  function processEntityRemovalRequest(request: EntityRemovalRequest, sender: string): Uint8Array {
+    const empty = new Uint8Array()
+    if (!sender || sender === AUTH_SERVER_PEER_ID) return empty
+
+    let sessions = removalSessions.get(sender)
+    if (!sessions) {
+      sessions = new Map()
+      removalSessions.set(sender, sessions)
+    }
+    const sessionKey = `${request.sessionIdHigh}:${request.sessionIdLow}`
+    let session = sessions.get(sessionKey)
+    if (!session) {
+      if (sessions.size >= MAX_REMOVAL_SESSIONS_PER_PEER) {
+        sendRemovalResult({ ...request, status: wasRemoved(request) ? 'accepted' : 'rejected' }, sender)
+        return empty
+      }
+      session = { highestRequestId: -1, results: new Map() }
+      sessions.set(sessionKey, session)
+    }
+
+    const previous = session.results.get(request.requestId)
+    if (previous) {
+      const sameEntity = previous.networkId === request.networkId && previous.entityId === request.entityId
+      const response: EntityRemovalResponse = sameEntity
+        ? { ...previous, status: wasRemoved(request) ? 'accepted' : previous.status }
+        : { ...request, status: 'rejected' }
+      sendRemovalResult(response, sender)
+      return empty
+    }
+    // Unseen IDs may arrive out of order within the window; older IDs cannot be revalidated.
+    if (request.requestId <= session.highestRequestId - MAX_REMOVAL_RESULTS_PER_SESSION) {
+      sendRemovalResult({ ...request, status: wasRemoved(request) ? 'accepted' : 'rejected' }, sender)
+      return empty
+    }
+    session.highestRequestId = Math.max(session.highestRequestId, request.requestId)
+    for (const requestId of session.results.keys()) {
+      if (requestId <= session.highestRequestId - MAX_REMOVAL_RESULTS_PER_SESSION) {
+        session.results.delete(requestId)
+      }
+    }
+
+    let status: EntityRemovalResponse['status'] = 'rejected'
+    let regularBytes = empty
+    let broadcast: utils.NetworkMessage | null = null
+    if (wasRemoved(request)) {
+      status = 'accepted'
+    } else {
+      const entity = findExistingNetworkEntity(request)
+      if (entity !== null) {
+        const regularBuffer = new ReadWriteByteBuffer()
+        DeleteEntity.write(entity, regularBuffer)
+        const regularMessage: utils.RegularMessage = {
+          type: CrdtMessageType.DELETE_ENTITY,
+          entityId: entity,
+          length: regularBuffer.currentWriteOffset(),
+          messageBuffer: regularBuffer.toBinary()
+        }
+        let allowed = false
+        try {
+          allowed = validateMessagePermissions(regularMessage, sender, entity)
+        } catch {
+          allowed = false
+        }
+        if (allowed) {
+          status = 'accepted'
+          markRemoved(request)
+          regularBytes = regularMessage.messageBuffer
+          const networkBuffer = new ReadWriteByteBuffer()
+          DeleteEntityNetwork.write(request.entityId, request.networkId, networkBuffer)
+          broadcast = {
+            type: CrdtMessageType.DELETE_ENTITY_NETWORK,
+            entityId: request.entityId,
+            networkId: request.networkId,
+            length: networkBuffer.getUint32(0),
+            messageBuffer: networkBuffer.toBinary()
+          }
+        }
+      }
+    }
+
+    const response: EntityRemovalResponse = { ...request, status }
+    session.results.set(request.requestId, response)
+    if (broadcast) broadcastBatchedMessages([broadcast], sender)
+    sendRemovalResult(response, sender)
+    return regularBytes
+  }
+
   return {
+    processEntityRemovalRequest,
+    // Replay protection lasts for the peer's room lifetime; reconnects use a new session nonce.
+    forgetPeer: (sender: string): void => {
+      removalSessions.delete(sender)
+    },
     findExistingNetworkEntity,
     // transform Network messages to CRDT Common Messages.
     processClientMessages: function processClientMessages(value: Uint8Array, sender: string, forceCorrections = false) {

--- a/test/sdk/network/entity-removal-client.spec.ts
+++ b/test/sdk/network/entity-removal-client.spec.ts
@@ -1,0 +1,56 @@
+import { Engine, IEngine, Entity } from '../../../packages/@dcl/ecs/src/engine'
+import { createEntityRemovalClient, EntityRemovalResult } from '../../../packages/@dcl/sdk/network/entity-removal'
+import { EntityRemovalRequest } from '../../../packages/@dcl/sdk/network/entity-removal-protocol'
+
+describe('when the entity removal client receives server acceptance', () => {
+  let engine: IEngine
+  let entity: Entity
+  let client: ReturnType<typeof createEntityRemovalClient>
+  let send: jest.Mock<void, [EntityRemovalRequest]>
+  let applyAccepted: jest.Mock<void, [EntityRemovalRequest]>
+  let onResult: jest.Mock<void, [EntityRemovalResult]>
+  let unsubscribe: () => void
+  let request: EntityRemovalRequest
+
+  beforeEach(() => {
+    engine = Engine()
+    entity = engine.addEntity()
+    send = jest.fn<void, [EntityRemovalRequest]>()
+    applyAccepted = jest.fn<void, [EntityRemovalRequest]>()
+    onResult = jest.fn<void, [EntityRemovalResult]>()
+    client = createEntityRemovalClient(engine, send, applyAccepted)
+    unsubscribe = client.onEntityRemovalResult(onResult)
+    client.request(entity, { networkId: 7, entityId: 100 as Entity })
+    client.flush(false)
+    request = send.mock.calls[0][0]
+    client.receive({ ...request, status: 'accepted' })
+  })
+
+  afterEach(() => {
+    unsubscribe()
+    jest.resetAllMocks()
+  })
+
+  describe('and the accepted deletion has not been applied locally', () => {
+    beforeEach(() => {
+      client.update(0.1)
+    })
+
+    it('should wait for actual entity removal before notifying listeners', () => {
+      expect(onResult).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the local deletion is subsequently applied', () => {
+    beforeEach(async () => {
+      client.update(0.1)
+      engine.removeEntity(entity)
+      await engine.update(0.1)
+      client.update(0.1)
+    })
+
+    it('should emit the accepted outcome exactly once', () => {
+      expect(onResult.mock.calls).toEqual([[{ entity, requestId: request.requestId, status: 'accepted' }]])
+    })
+  })
+})

--- a/test/sdk/network/entity-removal-protocol.spec.ts
+++ b/test/sdk/network/entity-removal-protocol.spec.ts
@@ -1,0 +1,97 @@
+import { Entity } from '../../../packages/@dcl/ecs/src/engine/entity'
+import {
+  EntityRemovalRequest,
+  EntityRemovalResponse,
+  encodeEntityRemovalRequest,
+  decodeEntityRemovalRequest,
+  encodeEntityRemovalResponse,
+  decodeEntityRemovalResponse
+} from '../../../packages/@dcl/sdk/src/network/entity-removal-protocol'
+
+describe('when encoding an entity removal request', () => {
+  let request: EntityRemovalRequest
+  let bytes: Uint8Array
+
+  beforeEach(() => {
+    request = { sessionIdHigh: 0xffffffff, sessionIdLow: 2, requestId: 3, networkId: 4, entityId: 5 as Entity }
+    bytes = encodeEntityRemovalRequest(request)
+  })
+
+  it('should write five little-endian unsigned integers', () => {
+    expect(Array.from(bytes)).toEqual([255, 255, 255, 255, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0])
+  })
+
+  it('should preserve every correlation and entity field', () => {
+    expect(decodeEntityRemovalRequest(bytes)).toEqual(request)
+  })
+
+  describe('and the bytes occupy a view inside a larger buffer', () => {
+    let view: Uint8Array
+
+    beforeEach(() => {
+      view = new Uint8Array(30).subarray(5, 25)
+      view.set(bytes)
+    })
+
+    it('should read the view without reading its surrounding bytes', () => {
+      expect(decodeEntityRemovalRequest(view)).toEqual(request)
+    })
+  })
+
+  describe.each([0, 19, 21])('and the payload length is %i bytes', (length) => {
+    beforeEach(() => {
+      bytes = new Uint8Array(length)
+    })
+
+    it('should reject the malformed request', () => {
+      expect(decodeEntityRemovalRequest(bytes)).toBeNull()
+    })
+  })
+
+  describe.each([-1, 0x100000000, 1.5, Number.NaN])('and a field contains %s', (value) => {
+    beforeEach(() => {
+      request.requestId = value
+    })
+
+    it('should reject a value that cannot be represented on the wire', () => {
+      expect(() => encodeEntityRemovalRequest(request)).toThrow(RangeError)
+    })
+  })
+})
+
+describe.each<EntityRemovalResponse['status']>(['accepted', 'rejected'])(
+  'when encoding an %s entity removal response',
+  (status) => {
+    let response: EntityRemovalResponse
+    let bytes: Uint8Array
+
+    beforeEach(() => {
+      response = { sessionIdHigh: 1, sessionIdLow: 2, requestId: 3, networkId: 4, entityId: 5 as Entity, status }
+      bytes = encodeEntityRemovalResponse(response)
+    })
+
+    it('should preserve the correlation fields and result', () => {
+      expect(decodeEntityRemovalResponse(bytes)).toEqual(response)
+    })
+
+    describe('and the status byte is unknown', () => {
+      beforeEach(() => {
+        bytes[20] = 2
+      })
+
+      it('should reject the response', () => {
+        expect(decodeEntityRemovalResponse(bytes)).toBeNull()
+      })
+    })
+
+    describe.each([0, 20, 22])('and the payload length is %i bytes', (length) => {
+      beforeEach(() => {
+        bytes = new Uint8Array(length)
+      })
+
+      it('should reject the malformed response', () => {
+        expect(decodeEntityRemovalResponse(bytes)).toBeNull()
+      })
+    })
+  }
+)

--- a/test/sdk/network/server/entity-delete-convergence.spec.ts
+++ b/test/sdk/network/server/entity-delete-convergence.spec.ts
@@ -413,7 +413,7 @@ describe('when a client requests deletion through its synchronization transport'
       beforeEach(async () => {
         dropServerResponse = false
         requester.engine.removeEntity(requesterEntity)
-        await tick()
+        await tick(20)
       })
 
       it('should accept the retry without recreating the deleted entity', () => {

--- a/test/sdk/network/server/entity-removal-outcomes.spec.ts
+++ b/test/sdk/network/server/entity-removal-outcomes.spec.ts
@@ -1,0 +1,347 @@
+import { Engine, IEngine, Entity } from '../../../../packages/@dcl/ecs/src/engine'
+import * as components from '../../../../packages/@dcl/ecs/src/components'
+import { createServerValidator } from '../../../../packages/@dcl/sdk/src/network/server'
+import { BinaryMessageBus, CommsMessage } from '../../../../packages/@dcl/sdk/src/network/binary-message-bus'
+import {
+  EntityRemovalRequest,
+  EntityRemovalResponse,
+  decodeEntityRemovalResponse
+} from '../../../../packages/@dcl/sdk/src/network/entity-removal-protocol'
+import { Transport } from '../../../../packages/@dcl/ecs/src/systems/crdt/types'
+
+describe('when the server receives an entity removal request', () => {
+  let engine: IEngine
+  let validator: ReturnType<typeof createServerValidator>
+  let Transform: ReturnType<typeof components.Transform>
+  let NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  let entity: Entity
+  let request: EntityRemovalRequest
+  let validateDeletion: jest.Mock<boolean, []>
+  let emitted: { type: CommsMessage; data: Uint8Array; recipients?: string[] }[]
+  let binaryMessageBus: ReturnType<typeof BinaryMessageBus>
+  let transport: Transport
+  let regularBytes: Uint8Array
+
+  function responses(): EntityRemovalResponse[] {
+    return emitted
+      .filter((message) => message.type === CommsMessage.ENTITY_REMOVAL_RESULT)
+      .map((message) => decodeEntityRemovalResponse(message.data)!)
+  }
+
+  beforeEach(() => {
+    engine = Engine()
+    Transform = components.Transform(engine)
+    NetworkEntity = components.NetworkEntity(engine)
+    entity = engine.addEntity()
+    Transform.create(entity)
+    NetworkEntity.create(entity, { networkId: 7, entityId: 900 as Entity })
+    request = { sessionIdHigh: 1, sessionIdLow: 2, requestId: 1, networkId: 7, entityId: 900 as Entity }
+    validateDeletion = jest.fn<boolean, []>().mockReturnValue(true)
+    Transform.validateBeforeChange(() => validateDeletion())
+    emitted = []
+    binaryMessageBus = {
+      emit: (type: CommsMessage, data: Uint8Array, recipients?: string[]) => {
+        emitted.push({ type, data, recipients })
+      }
+    } as ReturnType<typeof BinaryMessageBus>
+    validator = createServerValidator({ engine, binaryMessageBus })
+    transport = { filter: () => false, send: async () => {} }
+    engine.addTransport(transport)
+    regularBytes = new Uint8Array()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the component permits removal', () => {
+    beforeEach(() => {
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should return a correlated acceptance to the requester', () => {
+      expect(responses()).toEqual([{ ...request, status: 'accepted' }])
+      expect(emitted.find((message) => message.type === CommsMessage.ENTITY_REMOVAL_RESULT)?.recipients).toEqual([
+        'requester'
+      ])
+    })
+
+    it('should broadcast the accepted entity deletion once', () => {
+      expect(emitted.filter((message) => message.type === CommsMessage.CRDT)).toHaveLength(1)
+    })
+
+    describe('and the engine applies the returned CRDT', () => {
+      beforeEach(async () => {
+        transport.onmessage!(regularBytes)
+        await engine.update(0.1)
+      })
+
+      it('should remove the entity state', () => {
+        expect(Transform.has(entity)).toBe(false)
+      })
+    })
+
+    describe('and the requester retransmits the request', () => {
+      beforeEach(() => {
+        regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should replay the acceptance without running validation again', () => {
+        expect(responses()).toEqual([
+          { ...request, status: 'accepted' },
+          { ...request, status: 'accepted' }
+        ])
+        expect(validateDeletion).toHaveBeenCalledTimes(1)
+      })
+
+      it('should not apply or broadcast the deletion again', () => {
+        expect(regularBytes.byteLength).toBe(0)
+        expect(emitted.filter((message) => message.type === CommsMessage.CRDT)).toHaveLength(1)
+      })
+    })
+
+    describe('and a fresh request targets the retired identity', () => {
+      beforeEach(() => {
+        request = { ...request, requestId: 2 }
+        regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should acknowledge that the entity was already removed', () => {
+        expect(responses()[1]).toEqual({ ...request, status: 'accepted' })
+        expect(validateDeletion).toHaveBeenCalledTimes(1)
+        expect(regularBytes.byteLength).toBe(0)
+      })
+    })
+
+    describe('and the requester reuses the request ID for another entity', () => {
+      beforeEach(() => {
+        request = { ...request, entityId: 901 as Entity }
+        validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should reject the changed identity rather than replaying an unrelated acceptance', () => {
+        expect(responses()[1]).toEqual({ ...request, status: 'rejected' })
+      })
+    })
+
+    describe('and later requests move the acceptance outside the replay window', () => {
+      beforeEach(() => {
+        for (let requestId = 2; requestId <= 130; requestId++) {
+          validator.processEntityRemovalRequest({ ...request, requestId, entityId: 901 as Entity }, 'requester')
+        }
+        validateDeletion.mockClear()
+        regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should recover the acceptance from authoritative retirement without revalidation or another broadcast', () => {
+        expect(responses()[130]).toEqual({ ...request, status: 'accepted' })
+        expect(validateDeletion).not.toHaveBeenCalled()
+        expect(regularBytes.byteLength).toBe(0)
+        expect(emitted.filter((message) => message.type === CommsMessage.CRDT)).toHaveLength(1)
+      })
+    })
+  })
+
+  describe('and different requests arrive out of order inside the replay window', () => {
+    let newerRequest: EntityRemovalRequest
+    let otherEntity: Entity
+
+    beforeEach(() => {
+      otherEntity = engine.addEntity()
+      Transform.create(otherEntity)
+      NetworkEntity.create(otherEntity, { networkId: 7, entityId: 901 as Entity })
+      newerRequest = { ...request, requestId: 128, entityId: 901 as Entity }
+      validator.processEntityRemovalRequest(newerRequest, 'requester')
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should validate and accept an unseen request at the oldest retained ID', () => {
+      expect(responses()).toEqual([
+        { ...newerRequest, status: 'accepted' },
+        { ...request, status: 'accepted' }
+      ])
+      expect(validateDeletion).toHaveBeenCalledTimes(2)
+      expect(regularBytes.byteLength).toBeGreaterThan(0)
+    })
+
+    describe('and both requests are retransmitted', () => {
+      beforeEach(() => {
+        validateDeletion.mockClear()
+        validator.processEntityRemovalRequest(newerRequest, 'requester')
+        validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should retain both outcomes without revalidating either request', () => {
+        expect(responses().slice(2)).toEqual([
+          { ...newerRequest, status: 'accepted' },
+          { ...request, status: 'accepted' }
+        ])
+        expect(validateDeletion).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('and a first delivery is older than the replay window', () => {
+    beforeEach(() => {
+      validator.processEntityRemovalRequest({ ...request, requestId: 129, entityId: 901 as Entity }, 'requester')
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should reject the stale request without validating or removing its entity', () => {
+      expect(responses()[1]).toEqual({ ...request, status: 'rejected' })
+      expect(validateDeletion).not.toHaveBeenCalled()
+      expect(regularBytes.byteLength).toBe(0)
+      expect(Transform.has(entity)).toBe(true)
+    })
+  })
+
+  describe('and the component rejects removal', () => {
+    beforeEach(() => {
+      validateDeletion.mockReturnValue(false)
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should return a correlated rejection without removing state or broadcasting', () => {
+      expect(responses()).toEqual([{ ...request, status: 'rejected' }])
+      expect(regularBytes.byteLength).toBe(0)
+      expect(Transform.has(entity)).toBe(true)
+      expect(emitted.filter((message) => message.type === CommsMessage.CRDT)).toHaveLength(0)
+    })
+
+    describe('and the component later allows removal', () => {
+      beforeEach(() => {
+        validateDeletion.mockReturnValue(true)
+        validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should replay the rejection without revalidating the duplicate', () => {
+        expect(responses()[1]).toEqual({ ...request, status: 'rejected' })
+        expect(validateDeletion).toHaveBeenCalledTimes(1)
+        expect(Transform.has(entity)).toBe(true)
+      })
+
+      describe('and the client explicitly starts a fresh request', () => {
+        beforeEach(() => {
+          request = { ...request, requestId: 2 }
+          validator.processEntityRemovalRequest(request, 'requester')
+        })
+
+        it('should validate the new attempt and accept it', () => {
+          expect(responses()[2]).toEqual({ ...request, status: 'accepted' })
+          expect(validateDeletion).toHaveBeenCalledTimes(2)
+        })
+      })
+    })
+
+    describe('and newer requests evict the result from the response cache', () => {
+      beforeEach(() => {
+        for (let requestId = 2; requestId <= 130; requestId++) {
+          validator.processEntityRemovalRequest({ ...request, requestId }, 'requester')
+        }
+        validateDeletion.mockClear().mockReturnValue(true)
+        validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should reject the stale request without revalidating it', () => {
+        expect(responses()[130]).toEqual({ ...request, status: 'rejected' })
+        expect(validateDeletion).not.toHaveBeenCalled()
+        expect(Transform.has(entity)).toBe(true)
+      })
+    })
+
+    describe('and another peer subsequently removes the entity', () => {
+      beforeEach(() => {
+        validateDeletion.mockReturnValue(true)
+        validator.processEntityRemovalRequest(request, 'other')
+        validateDeletion.mockClear()
+        regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should report authoritative absence instead of replaying the earlier rejection', () => {
+        expect(responses()[2]).toEqual({ ...request, status: 'accepted' })
+        expect(validateDeletion).not.toHaveBeenCalled()
+        expect(regularBytes.byteLength).toBe(0)
+        expect(emitted.filter((message) => message.type === CommsMessage.CRDT)).toHaveLength(1)
+      })
+    })
+  })
+
+  describe('and a validation callback throws', () => {
+    beforeEach(() => {
+      validateDeletion.mockImplementation(() => {
+        throw new Error('Scene validation failed')
+      })
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should reject the request and leave the entity intact', () => {
+      expect(responses()).toEqual([{ ...request, status: 'rejected' }])
+      expect(regularBytes.byteLength).toBe(0)
+      expect(Transform.has(entity)).toBe(true)
+    })
+  })
+
+  describe('and the requested network identity is unknown', () => {
+    beforeEach(() => {
+      request = { ...request, entityId: 901 as Entity }
+      regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should reject the request without creating a mapping or invoking validators', () => {
+      expect(responses()).toEqual([{ ...request, status: 'rejected' }])
+      expect(Array.from(engine.getEntitiesWith(NetworkEntity))).toHaveLength(1)
+      expect(validateDeletion).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and one peer exhausts its session quota', () => {
+    beforeEach(() => {
+      validateDeletion.mockReturnValue(false)
+      for (let sessionIdLow = 1; sessionIdLow <= 8; sessionIdLow++) {
+        validator.processEntityRemovalRequest({ ...request, sessionIdLow }, 'requester')
+      }
+      request = { ...request, sessionIdLow: 9 }
+      validateDeletion.mockClear().mockReturnValue(true)
+      validator.processEntityRemovalRequest(request, 'requester')
+    })
+
+    it('should reject new sessions without growing that peer cache', () => {
+      expect(responses()[8]).toEqual({ ...request, status: 'rejected' })
+      expect(validateDeletion).not.toHaveBeenCalled()
+    })
+
+    describe('and another peer requests removal', () => {
+      beforeEach(() => {
+        validator.processEntityRemovalRequest(request, 'other')
+      })
+
+      it('should leave the other peer able to request removal', () => {
+        expect(responses()[9]).toEqual({ ...request, status: 'accepted' })
+      })
+
+      describe('and the quota-limited peer retries its request', () => {
+        beforeEach(() => {
+          validateDeletion.mockClear()
+          regularBytes = validator.processEntityRemovalRequest(request, 'requester')
+        })
+
+        it('should acknowledge authoritative retirement even though its session quota is full', () => {
+          expect(responses()[10]).toEqual({ ...request, status: 'accepted' })
+          expect(validateDeletion).not.toHaveBeenCalled()
+          expect(regularBytes.byteLength).toBe(0)
+        })
+      })
+    })
+
+    describe('and the peer leaves and reconnects with a fresh session', () => {
+      beforeEach(() => {
+        validator.forgetPeer('requester')
+        validator.processEntityRemovalRequest(request, 'requester')
+      })
+
+      it('should allow the new room lifetime to register a session', () => {
+        expect(responses()[9]).toEqual({ ...request, status: 'accepted' })
+      })
+    })
+  })
+})

--- a/test/sdk/network/server/entity-removal-results.spec.ts
+++ b/test/sdk/network/server/entity-removal-results.spec.ts
@@ -1,0 +1,482 @@
+import { Engine, IEngine } from '../../../../packages/@dcl/ecs/src/engine'
+import { Entity, EntityState } from '../../../../packages/@dcl/ecs/src/engine/entity'
+import * as components from '../../../../packages/@dcl/ecs/src/components'
+import { addSyncTransport, AUTH_SERVER_PEER_ID } from '../../../../packages/@dcl/sdk/network/message-bus-sync'
+import { CommsMessage, encodeString } from '../../../../packages/@dcl/sdk/network/binary-message-bus'
+
+type RemovalResult = { entity: Entity; requestId: number; status: 'accepted' | 'rejected' | 'timeout' }
+type Peer = {
+  address: string
+  engine: IEngine
+  inbox: Uint8Array[]
+  Transform: ReturnType<typeof components.Transform>
+  NetworkEntity: ReturnType<typeof components.NetworkEntity>
+  SyncComponents: ReturnType<typeof components.SyncComponents>
+  UiText: ReturnType<typeof components.UiText>
+  sync: ReturnType<typeof addSyncTransport>
+}
+type Packet = { sender: string; addresses: string[]; data: Uint8Array }
+
+describe('when a synchronized entity removal reports its outcome', () => {
+  let peers: Peer[]
+  let requester: Peer
+  let server: Peer
+  let observer: Peer
+  let requesterEntity: Entity
+  let serverEntity: Entity
+  let observerEntity: Entity
+  let packets: Packet[]
+  let allowDeletion: boolean
+  let blockRequests: boolean
+  let blockServerReplies: boolean
+  let dropRequests: number
+  let dropResults: number
+  let onResult: jest.Mock<void, [RemovalResult]>
+  let unsubscribe: () => void
+  let statesAtResult: EntityState[]
+  let deleteChecks: jest.Mock<boolean, []>
+
+  function frame(sender: string, data: Uint8Array): Uint8Array {
+    const address = encodeString(sender)
+    const framed = new Uint8Array(1 + address.length + data.length)
+    framed[0] = address.length
+    framed.set(address, 1)
+    framed.set(data, address.length + 1)
+    return framed
+  }
+
+  function createPeer(address: string): Peer {
+    const engine = Engine()
+    const Transform = components.Transform(engine)
+    const NetworkEntity = components.NetworkEntity(engine)
+    const SyncComponents = components.SyncComponents(engine)
+    const UiText = components.UiText(engine)
+    components.NetworkParent(engine)
+    const sync = addSyncTransport(
+      engine,
+      async (message) => {
+        for (const packet of message.peerData ?? []) {
+          for (const data of packet.data ?? []) {
+            packets.push({ sender: address, addresses: [...packet.address], data: data.slice() })
+            for (const recipient of peers) {
+              if (
+                recipient.address === address ||
+                (packet.address.length && !packet.address.includes(recipient.address))
+              )
+                continue
+              if (
+                address === requester.address &&
+                recipient === server &&
+                data[0] === CommsMessage.REQUEST_ENTITY_REMOVAL
+              ) {
+                if (blockRequests) continue
+                if (dropRequests > 0) {
+                  dropRequests--
+                  continue
+                }
+              }
+              if (address === AUTH_SERVER_PEER_ID && recipient === requester) {
+                if (blockServerReplies) continue
+                if (data[0] === CommsMessage.ENTITY_REMOVAL_RESULT && dropResults > 0) {
+                  dropResults--
+                  continue
+                }
+              }
+              recipient.inbox.push(frame(address, data))
+            }
+          }
+        }
+        return { data: peers.find((peer) => peer.address === address)!.inbox.splice(0) }
+      },
+      async () => ({ data: { userId: address, version: 1, displayName: address, hasConnectedWeb3: true } }),
+      async () => ({ isServer: address === AUTH_SERVER_PEER_ID }),
+      address
+    )
+    const peer: Peer = { address, engine, inbox: [], Transform, NetworkEntity, SyncComponents, UiText, sync }
+    peers.push(peer)
+    return peer
+  }
+
+  function findEntity(peer: Peer): Entity {
+    const entry = Array.from(peer.engine.getEntitiesWith(peer.NetworkEntity)).find(
+      ([, network]) => network.networkId === 7 && network.entityId === 100
+    )
+    if (!entry) throw new Error(`Missing network entity on ${peer.address}`)
+    return entry[0]
+  }
+
+  async function tick(count: number = 6, dt: number = 0.1): Promise<void> {
+    for (let frameNumber = 0; frameNumber < count; frameNumber++) {
+      for (const peer of peers) await peer.engine.update(dt)
+    }
+  }
+
+  function requests(): Packet[] {
+    return packets.filter(
+      (packet) => packet.sender === requester.address && packet.data[0] === CommsMessage.REQUEST_ENTITY_REMOVAL
+    )
+  }
+
+  function results(): Packet[] {
+    return packets.filter(
+      (packet) => packet.sender === AUTH_SERVER_PEER_ID && packet.data[0] === CommsMessage.ENTITY_REMOVAL_RESULT
+    )
+  }
+
+  function requestId(packet: Packet): number {
+    return new DataView(packet.data.buffer, packet.data.byteOffset + 1, packet.data.byteLength - 1).getUint32(8, true)
+  }
+
+  beforeEach(async () => {
+    peers = []
+    packets = []
+    allowDeletion = false
+    blockRequests = false
+    blockServerReplies = false
+    dropRequests = 0
+    dropResults = 0
+    statesAtResult = []
+    requester = createPeer('requester')
+    server = createPeer(AUTH_SERVER_PEER_ID)
+    observer = createPeer('observer')
+    requester.engine.addEntity()
+    observer.engine.addEntity()
+    observer.engine.addEntity()
+    await tick(2)
+    serverEntity = server.engine.addEntity()
+    server.Transform.create(serverEntity, { position: { x: 4, y: 5, z: 6 } })
+    server.NetworkEntity.create(serverEntity, { networkId: 7, entityId: 100 as Entity })
+    server.SyncComponents.create(serverEntity, { componentIds: [server.Transform.componentId] })
+    await tick()
+    requesterEntity = findEntity(requester)
+    observerEntity = findEntity(observer)
+    requester.UiText.create(requesterEntity, { value: 'local state' })
+    await tick()
+    deleteChecks = jest.fn<boolean, []>().mockImplementation(() => allowDeletion)
+    server.Transform.validateBeforeChange(({ newValue }) => newValue !== undefined || deleteChecks())
+    onResult = jest.fn<void, [RemovalResult]>().mockImplementation(() => {
+      statesAtResult.push(requester.engine.getEntityState(requesterEntity))
+    })
+    unsubscribe = requester.sync.onEntityRemovalResult(onResult)
+    packets = []
+  })
+
+  afterEach(() => {
+    unsubscribe()
+    jest.restoreAllMocks()
+    peers.length = 0
+  })
+
+  describe('and the server accepts deletion', () => {
+    beforeEach(async () => {
+      allowDeletion = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick()
+    })
+
+    it('should report the accepted request once after local deletion is committed', () => {
+      expect(onResult.mock.calls).toEqual([
+        [{ entity: requesterEntity, requestId: requestId(requests()[0]), status: 'accepted' }]
+      ])
+      expect(statesAtResult).toEqual([EntityState.Removed])
+    })
+
+    it('should remove the entity on every participant', () => {
+      expect([
+        requester.Transform.has(requesterEntity),
+        server.Transform.has(serverEntity),
+        observer.Transform.has(observerEntity)
+      ]).toEqual([false, false, false])
+    })
+
+    it('should target the result to the requester', () => {
+      expect(
+        results().every((packet) => packet.addresses.length === 1 && packet.addresses[0] === requester.address)
+      ).toBe(true)
+      expect(results().length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('and the server rejects deletion', () => {
+    beforeEach(async () => {
+      requester.engine.removeEntity(requesterEntity)
+      await tick()
+    })
+
+    it('should report rejection while retaining synchronized and local state', () => {
+      expect(onResult.mock.calls).toEqual([
+        [{ entity: requesterEntity, requestId: requestId(requests()[0]), status: 'rejected' }]
+      ])
+      expect(statesAtResult).toEqual([EntityState.UsedEntity])
+      expect(requester.UiText.get(requesterEntity).value).toBe('local state')
+      expect([
+        requester.Transform.has(requesterEntity),
+        server.Transform.has(serverEntity),
+        observer.Transform.has(observerEntity)
+      ]).toEqual([true, true, true])
+    })
+
+    describe('and the scene requests deletion again', () => {
+      let firstId: number
+
+      beforeEach(async () => {
+        firstId = requestId(requests()[0])
+        allowDeletion = true
+        requester.engine.removeEntity(requesterEntity)
+        await tick()
+      })
+
+      it('should use a fresh request ID and report the new outcome', () => {
+        expect(requestId(requests()[requests().length - 1])).not.toBe(firstId)
+        expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['rejected', 'accepted'])
+      })
+    })
+  })
+
+  describe('and no request reaches the server', () => {
+    beforeEach(async () => {
+      blockRequests = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick(12, 1)
+    })
+
+    it('should report timeout without deleting the entity', () => {
+      expect(onResult.mock.calls).toEqual([
+        [{ entity: requesterEntity, requestId: requestId(requests()[0]), status: 'timeout' }]
+      ])
+      expect(requester.engine.getEntityState(requesterEntity)).toBe(EntityState.UsedEntity)
+      expect(requester.UiText.get(requesterEntity).value).toBe('local state')
+    })
+
+    it('should retry the same request instead of creating new attempts', () => {
+      expect(requests().length).toBeGreaterThan(1)
+      expect(new Set(requests().map(requestId)).size).toBe(1)
+    })
+
+    describe('and the deadline has already elapsed', () => {
+      let countAtTimeout: number
+
+      beforeEach(async () => {
+        countAtTimeout = requests().length
+        await tick(5, 1)
+      })
+
+      it('should stop retrying after the terminal result', () => {
+        expect(requests().length).toBe(countAtTimeout)
+        expect(onResult).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('and the server accepts but all its replies are lost', () => {
+    beforeEach(async () => {
+      allowDeletion = true
+      blockServerReplies = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick(12, 1)
+    })
+
+    it('should report timeout without treating it as authoritative rejection', () => {
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['timeout'])
+      expect([
+        requester.Transform.has(requesterEntity),
+        server.Transform.has(serverEntity),
+        observer.Transform.has(observerEntity)
+      ]).toEqual([true, false, false])
+    })
+  })
+
+  describe('and the first request packet is lost', () => {
+    beforeEach(async () => {
+      allowDeletion = true
+      dropRequests = 1
+      requester.engine.removeEntity(requesterEntity)
+      await tick(8, 0.5)
+    })
+
+    it('should recover by retrying the same request ID', () => {
+      expect(requests().length).toBeGreaterThan(1)
+      expect(new Set(requests().map(requestId)).size).toBe(1)
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['accepted'])
+    })
+  })
+
+  describe('and the first rejection result is lost', () => {
+    beforeEach(async () => {
+      dropResults = 1
+      requester.engine.removeEntity(requesterEntity)
+      await tick(6, 0.5)
+    })
+
+    it('should return the cached decision on retry without validating twice', () => {
+      expect(requests().length).toBeGreaterThan(1)
+      expect(new Set(requests().map(requestId)).size).toBe(1)
+      expect(deleteChecks).toHaveBeenCalledTimes(1)
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['rejected'])
+    })
+  })
+
+  describe('and an older result arrives during a newer attempt', () => {
+    let oldResult: Uint8Array
+    let newRequestId: number
+
+    beforeEach(async () => {
+      requester.engine.removeEntity(requesterEntity)
+      await tick()
+      oldResult = results()[0].data.slice()
+      onResult.mockClear()
+      blockRequests = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick(1)
+      newRequestId = requestId(requests()[requests().length - 1])
+      requester.inbox.push(frame(AUTH_SERVER_PEER_ID, oldResult))
+      await tick()
+    })
+
+    it('should ignore the previous attempt result', () => {
+      expect(onResult).not.toHaveBeenCalled()
+      expect(requester.Transform.has(requesterEntity)).toBe(true)
+    })
+
+    describe('and the current attempt later reaches the server', () => {
+      beforeEach(async () => {
+        allowDeletion = true
+        blockRequests = false
+        await tick(6, 0.5)
+      })
+
+      it('should still complete the current attempt', () => {
+        expect(onResult.mock.calls).toEqual([
+          [{ entity: requesterEntity, requestId: newRequestId, status: 'accepted' }]
+        ])
+      })
+    })
+  })
+
+  describe('and a non-server peer forges an accepted result', () => {
+    let forged: Uint8Array
+
+    beforeEach(async () => {
+      blockRequests = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick(1)
+      forged = new Uint8Array(22)
+      forged[0] = CommsMessage.ENTITY_REMOVAL_RESULT
+      forged.set(requests()[0].data.subarray(1), 1)
+      forged[21] = 0
+      requester.inbox.push(frame(observer.address, forged))
+      await tick()
+    })
+
+    it('should ignore the unauthenticated result', () => {
+      expect(onResult).not.toHaveBeenCalled()
+      expect(requester.Transform.has(requesterEntity)).toBe(true)
+    })
+  })
+
+  describe('and repeated calls target the same pending entity', () => {
+    beforeEach(async () => {
+      blockRequests = true
+      requester.engine.removeEntity(requesterEntity)
+      requester.engine.removeEntity(requesterEntity)
+      await tick(2)
+      requester.engine.removeEntity(requesterEntity)
+      await tick(2)
+      blockRequests = false
+      allowDeletion = true
+      await tick(6, 0.5)
+    })
+
+    it('should coalesce the calls into one attempt and one outcome', () => {
+      expect(new Set(requests().map(requestId)).size).toBe(1)
+      expect(onResult).toHaveBeenCalledTimes(1)
+      expect(onResult.mock.calls[0][0].status).toBe('accepted')
+    })
+  })
+
+  describe('and a listener unsubscribes before the result', () => {
+    beforeEach(async () => {
+      unsubscribe()
+      allowDeletion = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick()
+    })
+
+    it('should still synchronize deletion without notifying the removed listener', () => {
+      expect(onResult).not.toHaveBeenCalled()
+      expect([
+        requester.Transform.has(requesterEntity),
+        server.Transform.has(serverEntity),
+        observer.Transform.has(observerEntity)
+      ]).toEqual([false, false, false])
+    })
+  })
+
+  describe('and one result listener throws', () => {
+    let throwingListener: jest.Mock
+    let removeThrowingListener: () => void
+
+    beforeEach(async () => {
+      unsubscribe()
+      throwingListener = jest.fn().mockImplementation(() => {
+        throw new Error('listener failure')
+      })
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+      removeThrowingListener = requester.sync.onEntityRemovalResult(throwingListener)
+      unsubscribe = requester.sync.onEntityRemovalResult(onResult)
+      allowDeletion = true
+      requester.engine.removeEntity(requesterEntity)
+      await tick()
+    })
+
+    afterEach(() => {
+      removeThrowingListener()
+    })
+
+    it('should notify the other listener and finish deletion', () => {
+      expect(throwingListener).toHaveBeenCalledTimes(1)
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['accepted'])
+      expect(requester.Transform.has(requesterEntity)).toBe(false)
+    })
+  })
+
+  describe('and a rejection listener immediately retries the deletion', () => {
+    beforeEach(async () => {
+      onResult.mockImplementation((result) => {
+        if (result.status === 'rejected') {
+          allowDeletion = true
+          requester.engine.removeEntity(requesterEntity)
+        }
+      })
+      requester.engine.removeEntity(requesterEntity)
+      await tick(12)
+    })
+
+    it('should complete the fresh attempt without losing it to cleanup of the rejected one', () => {
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['rejected', 'accepted'])
+      expect(new Set(onResult.mock.calls.map(([result]) => result.requestId)).size).toBe(2)
+      expect(requester.Transform.has(requesterEntity)).toBe(false)
+    })
+  })
+
+  describe('and a timeout listener immediately retries after delivery resumes', () => {
+    beforeEach(async () => {
+      blockRequests = true
+      onResult.mockImplementation((result) => {
+        if (result.status === 'timeout') {
+          allowDeletion = true
+          blockRequests = false
+          requester.engine.removeEntity(requesterEntity)
+        }
+      })
+      requester.engine.removeEntity(requesterEntity)
+      await tick(16, 1)
+    })
+
+    it('should complete a new attempt after reporting the timed-out one', () => {
+      expect(onResult.mock.calls.map(([result]) => result.status)).toEqual(['timeout', 'accepted'])
+      expect(new Set(onResult.mock.calls.map(([result]) => result.requestId)).size).toBe(2)
+      expect(requester.Transform.has(requesterEntity)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Stacked on #1615. `engine.removeEntity()` now retries unanswered synchronized deletion requests and optionally reports `accepted`, `rejected`, or `timeout` through `onEntityRemovalResult()`. Scenes keep their existing removal calls; accepted notifications wait for local removal, and a timeout means the server outcome is unknown.

Requests and responses are correlated to the session, attempt, and entity. Server replay tracking is bounded per peer and handles reordered packets and lost acceptance responses. Both client and server need the updated SDK; the transport interface and CRDT operation formats stay unchanged. Usage and replay limits are documented in the SDK README.

### How to test

After `make build`, run:

```sh
node_modules/.bin/jest --runInBand --testPathPatterns='entity-removal|entity-delete-convergence|validate-entity-delete'
```

The requester/server/observer integration suite covers retained state on rejection, accepted notifications after removal, automatic retries, timeouts, stale/spoofed results, and listener cleanup. A rejection-feedback probe against the #1615 base fails with no result; the same probe passes on this branch.

Validation: 122 focused tests and 1,210 broader tests pass (25 skipped); SDK/playground builds pass. All 13 snapshot comparisons pass with no artifact changes or `ERR!`; two existing scene-error fixtures still make the full snapshot command exit 1. Lint completes with existing violations only.
